### PR TITLE
Small quick changes

### DIFF
--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -2,7 +2,7 @@ import Forms from "../forms/forms";
 
 // Get the form json object by using the form ID
 // Returns => json object of form
-function getFormByID(formID: number): Record<string, unknown> {
+function getFormByID(formID: string): Record<string, unknown> {
   // Need to get these forms from a DB or API in the future
   let formToReturn = null;
   for (const form of Object.values(Forms)) {
@@ -16,7 +16,7 @@ function getFormByID(formID: number): Record<string, unknown> {
 
 // Get the submission format by using the form ID
 // Returns => json object of the submission details.
-function getSubmissionByID(formID: number): Record<string, unknown> {
+function getSubmissionByID(formID: string): Record<string, unknown> {
   let submissionFormat = null;
   for (const submission of Object.values(Forms)) {
     if (submission.form.id == formID) {

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -33,6 +33,7 @@ interface ElementProperties {
 interface PropertyChoices {
   en: string;
   fr: string;
+  [key: string]: string;
 }
 
 // This function is used for the i18n change of form labels
@@ -44,7 +45,10 @@ function getProperty(field: string, lang: string): string {
 }
 
 // This function is used for select/radio/checkbox i18n change of form labels
-function getLocaleChoices(choices: Array<any> | undefined, lang: string) {
+function getLocaleChoices(
+  choices: Array<PropertyChoices> | undefined,
+  lang: string
+) {
   if (!choices || !choices.length) {
     return [];
   }


### PR DESCRIPTION
# Summary | Résumé

Quick fix for typescript warning about using type `any`.  Also quick type change for dataLayer formID input from number to string.