### PR TITLE
Accessibility Fixes in Form Generator

### DIFF
--- a/components/forms/Dropdown/Dropdown.tsx
+++ b/components/forms/Dropdown/Dropdown.tsx
@@ -45,7 +45,7 @@ export const Dropdown = (props: DropdownProps): React.ReactElement => {
       ref={inputRef}
       {...inputProps}
     >
-      <>{options}</>
+      {options}
     </select>
   );
 };

--- a/components/forms/FormGroup/FormGroup.tsx
+++ b/components/forms/FormGroup/FormGroup.tsx
@@ -3,12 +3,13 @@ import classnames from "classnames";
 
 interface FormGroupProps {
   children: React.ReactNode;
+  name: string;
   className?: string;
   error?: boolean;
 }
 
 export const FormGroup = (props: FormGroupProps): React.ReactElement => {
-  const { children, className, error } = props;
+  const { children, name, className, error } = props;
 
   const classes = classnames(
     "gc-form-group",
@@ -17,9 +18,9 @@ export const FormGroup = (props: FormGroupProps): React.ReactElement => {
   );
 
   return (
-    <div data-testid="formGroup" className={classes}>
+    <fieldset name={name} data-testid="formGroup" className={classes}>
       {children}
-    </div>
+    </fieldset>
   );
 };
 

--- a/components/forms/Forms.js
+++ b/components/forms/Forms.js
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import { getProperty, buildForm } from "../../lib/formBuilder";
 import PropTypes from "prop-types";
 import { useFormik } from "formik";
+import Head from "next/head";
 
 const Form = ({ formModel, i18n }) => {
   const formToRender = formModel;
@@ -50,6 +51,9 @@ const Form = ({ formModel, i18n }) => {
 
   return (
     <div>
+      <Head>
+        <title>{formToRender[getProperty("title", i18n.language)]}</title>
+      </Head>
       <h1>{formToRender[getProperty("title", i18n.language)]}</h1>
       <form id="form" onSubmit={formik.handleSubmit} method="POST">
         {formToRender.layout.map((item) => {

--- a/components/globals/LanguageToggle.js
+++ b/components/globals/LanguageToggle.js
@@ -1,9 +1,15 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { withTranslation } from "../../i18n";
 
 const LanguageToggle = ({ t, i18n }) => {
   const locale = i18n.language;
+
+  useEffect(() => {
+    const html = document.querySelector("html");
+
+    if (html) html.setAttribute("lang", locale);
+  }, [locale]);
 
   return (
     <>

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -117,8 +117,8 @@ function buildForm(
         return (
           <Checkbox
             {...inputProps}
-            key={`key-${index}`}
-            id={`id-${choice}`}
+            key={`key-${inputProps.id}-${index}`}
+            id={`id-${inputProps.id}-${index}`}
             label={choice}
             value={choice}
           />
@@ -137,8 +137,8 @@ function buildForm(
         return (
           <Radio
             {...inputProps}
-            key={`key-${index}`}
-            id={`id-${choice}`}
+            key={`key-${inputProps.id}-${index}`}
+            id={`id-${inputProps.id}-${index}`}
             label={choice}
             value={choice}
           />

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -125,7 +125,7 @@ function buildForm(
       });
 
       return (
-        <FormGroup key={`formGroup-${inputProps.id}`}>
+        <FormGroup key={`formGroup-${inputProps.id}`} name={inputProps.name}>
           {label}
           {checkboxItems}
         </FormGroup>
@@ -145,7 +145,7 @@ function buildForm(
       });
 
       return (
-        <FormGroup key={`formGroup-${inputProps.id}`}>
+        <FormGroup key={`formGroup-${inputProps.id}`} name={inputProps.name}>
           {label}
           {radioButtons}
         </FormGroup>


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the follwoing accessibility issues:
- [x] Lang attribute identified in html element
- [x] Title of the page identified in the <Head> of the document
- [x] Each label can be associated to a single input  
- [x] Aria labels cannot have repeated id's 

# Test instructions | Instructions pour tester la modification

Using Google Dev Tools Lighthouse or Deque Axe plugin scan any form page.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

There are still questions surrounding how the accessibility of the Form section headings as well as instructions should be implemented.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?
