### PR TITLE
Feature/add referrerurl confirmation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
 # Required for Notify integration
-NOTIFY_ENDPOINT=
 NOTIFY_API_KEY=
-NOTIFY_TEMPLATE_ID=

--- a/README.md
+++ b/README.md
@@ -44,12 +44,10 @@ There are some environment variables that can optionally be configured. You can 
 
 ### Notify integration
 
-To send a form submission to an email address, you should configure the following environment variables:
+To send a form submission to an email address, you should configure the following environment variables in a `.env` file:
 
 ```sh
-NOTIFY_ENDPOINT=
 NOTIFY_API_KEY=
-NOTIFY_TEMPLATE_ID=
 ```
 
 ## ---------------------------------------------------------------------
@@ -108,6 +106,5 @@ Certaines valeurs d'environnement peuvent être configurés. Cette étape est op
 Pour envoyer les réponses d'une formulaire à une adresse courriel, vous devez configurer les variables suivantes :
 
 ```sh
-NOTIFY_ENDPOINT=
 NOTIFY_API_KEY=
 ```

--- a/components/forms/Forms.js
+++ b/components/forms/Forms.js
@@ -40,7 +40,16 @@ const Form = ({ formModel, i18n }) => {
       })
         .then((response) => response.json())
         .then(() => {
-          router.push("/confirmation");
+          const referrerUrl =
+            formToRender &&
+            formToRender.endPage &&
+            formToRender.endPage.referrerUrl
+              ? { referrerUrl: formToRender.endPage.referrerUrl }
+              : {};
+          router.push({
+            pathname: `${i18n.language}/confirmation`,
+            query: referrerUrl,
+          });
         })
         .catch((error) => {
           console.log(error);

--- a/forms/esdc.json
+++ b/forms/esdc.json
@@ -1,4 +1,11 @@
 {
+  "internalTitleEn": "ESDC Grant Application for Funding",
+  "internalTitleFr": "Demande de financement de subvention",
+  "publishingStatus": true,
+  "submission": {
+    "templateID": "",
+    "email": "steven.talbot@cds-snc.ca"
+  },
   "form": {
     "id": 8,
     "version": 1,
@@ -153,6 +160,9 @@
       146,
       147
     ],
+    "endPage": {
+      "referrerUrl": "https://www.canada.ca/en/employment-social-development/services/funding/enabling-accessibility-fund-small-projects.html#h2.06-h3.02"
+    },
     "elements": [
       {
         "id": 1,
@@ -2368,7 +2378,7 @@
           "titleEn": "",
           "titleFr": "",
           "description": "",
-          "required": false,
+          "required": true,
           "choices": [
             {
               "en": "I have provided a digital picture of the workspace or community space I want to improve, if my project is for a renovation.",
@@ -2422,7 +2432,7 @@
           "titleEn": "",
           "titleFr": "",
           "description": "",
-          "required": false,
+          "required": true,
           "choices": [
             {
               "en": "I have the capacity and the authority to submit this Application for Funding on behalf of the applicant organization.",

--- a/forms/intake.json
+++ b/forms/intake.json
@@ -4,7 +4,7 @@
   "publishingStatus": true,
   "submission": {
     "templateID": "",
-    "email": "bryan.robitaille@cds-snc.ca"
+    "email": "fitore.jaha.price@cds-snc.ca"
   },
   "form": {
     "id": 1,
@@ -12,6 +12,12 @@
     "titleEn": "CDS Intake Form",
     "titleFr": "SNC Formulaire d'admission",
     "layout": [1, 2, 3, 4, 5, 6, 7],
+    "startPage": {},
+    "endPage": {
+      "descriptionEn": "",
+      "descriptionFr": "",
+      "referrerUrl": "https://digital.canada.ca/"
+    },
 
     "elements": [
       {

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -72,6 +72,7 @@ function buildForm(
     key: element.id,
     id: element.id,
     name: element.id.toString(),
+    required: element.properties.required,
     label: element.properties[getProperty("title", lang)]?.toString(),
     value: value ? value.toString() : "",
     choices:

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -19,7 +19,7 @@ const Confirmation = ({ t }) => {
         <p>{t("body")}</p>
       </div>
 
-      <div class="gc-form-confirmation">{backToLink}</div>
+      <div className="gc-form-confirmation">{backToLink}</div>
     </>
   );
 };

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -1,16 +1,28 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { withTranslation } from "../i18n";
+import { useRouter } from "next/router";
 
-const Confirmation = ({ t }) => (
-  <>
-    <h1>{t("title")}</h1>
+const Confirmation = ({ t }) => {
+  const router = useRouter();
+  const urlQuery = router.query;
+  const backToLink =
+    urlQuery && urlQuery.referrerUrl ? (
+      <a href={urlQuery.referrerUrl}>{t("backLink")}</a>
+    ) : null;
 
-    <div>
-      <p>{t("body")}</p>
-    </div>
-  </>
-);
+  return (
+    <>
+      <h1>{t("title")}</h1>
+
+      <div>
+        <p>{t("body")}</p>
+      </div>
+
+      <div class="gc-form-confirmation">{backToLink}</div>
+    </>
+  );
+};
 
 Confirmation.getInitialProps = async () => ({
   namespacesRequired: ["confirmation"],

--- a/public/static/locales/en/confirmation.json
+++ b/public/static/locales/en/confirmation.json
@@ -1,4 +1,5 @@
 {
   "title": "Forms - Confirmation",
-  "body": "Thank you, you request has been submitted."
+  "body": "Thank you, you request has been submitted.",
+  "backLink": "Back"
 }

--- a/public/static/locales/fr/confirmation.json
+++ b/public/static/locales/fr/confirmation.json
@@ -1,4 +1,5 @@
 {
   "title": "Formulaires - Confirmation",
-  "body": "Merci, votre demande a été soumise."
+  "body": "Merci, votre demande a été soumise.",
+  "backLink": "Retour"
 }


### PR DESCRIPTION
# Summary | Résumé

An interim solution to pass a "Back/Retour" link to the confirmation page, from the JSON. The CDS intake form has an example: https://forms-staging.cdssandbox.xyz/en/1

Also, there's a separate PR for the Storybook documentation. We'll revisit as we define the FormBuilder.



<img width="666" alt="ConfirmationReferrerURL" src="https://user-images.githubusercontent.com/73135530/105200680-1b435780-5b0e-11eb-8f61-f538c541c1e3.png">
