### PR TITLE
Desc text

### DIFF
--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -199,7 +199,7 @@ function buildForm(
     case "plainText":
       return (
         <div className="gc-plain-text" key={`formGroup-${inputProps.id}`}>
-          {inputProps.label ? <h2>inputProps.label</h2> : null}
+          {inputProps.label ? <h2>{inputProps.label}</h2> : null}
           {descriptiveText}
         </div>
       );

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -90,17 +90,22 @@ function buildForm(
     </Label>
   ) : null;
 
+  const descriptiveText = inputProps.description ? (
+    <span key={`desc-${element.id}`}>{inputProps.description}</span>
+  ) : null;
+
   switch (element.type) {
     case "alert":
       return (
         <Alert type="info" noIcon>
-          {inputProps.description}
+          {descriptiveText}
         </Alert>
       );
     case "textField":
       return (
         <Fragment key={inputProps.id}>
           {label}
+          {descriptiveText}
           <TextInput type="text" {...inputProps} />
         </Fragment>
       );
@@ -108,6 +113,7 @@ function buildForm(
       return (
         <Fragment key={inputProps.id}>
           {label}
+          {descriptiveText}
           <TextArea {...inputProps} />
         </Fragment>
       );
@@ -127,6 +133,7 @@ function buildForm(
       return (
         <FormGroup key={`formGroup-${inputProps.id}`}>
           {label}
+          {descriptiveText}
           {checkboxItems}
         </FormGroup>
       );
@@ -147,6 +154,7 @@ function buildForm(
       return (
         <FormGroup key={`formGroup-${inputProps.id}`}>
           {label}
+          {descriptiveText}
           {radioButtons}
         </FormGroup>
       );
@@ -155,20 +163,22 @@ function buildForm(
       return (
         <Fragment key={inputProps.id}>
           {label}
+          {descriptiveText}
           <Dropdown {...inputProps} />
         </Fragment>
       );
     case "plainText":
       return (
         <div className="gc-plain-text" key={`formGroup-${inputProps.id}`}>
-          {label}
-          {inputProps.description}
+          {inputProps.label ? <h2>inputProps.label</h2> : null}
+          {descriptiveText}
         </div>
       );
     case "fileInput":
       return (
         <Fragment key={inputProps.id}>
           {label}
+          {descriptiveText}
           <FileInput {...inputProps} fileType={element.properties.fileType} />
         </Fragment>
       );

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -91,7 +91,7 @@ function buildForm(
   ) : null;
 
   const descriptiveText = inputProps.description ? (
-    <span key={`desc-${element.id}`}>{inputProps.description}</span>
+    <p key={`desc-${element.id}`}>{inputProps.description}</p>
   ) : null;
 
   switch (element.type) {
@@ -131,7 +131,13 @@ function buildForm(
       });
 
       return (
-        <FormGroup key={`formGroup-${inputProps.id}`} name={inputProps.name}>
+        <FormGroup
+          key={`formGroup-${inputProps.id}`}
+          name={inputProps.name}
+          aria-describedby={
+            inputProps.description ? `desc-${element.id}` : undefined
+          }
+        >
           {label}
           {descriptiveText}
           {checkboxItems}

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -92,7 +92,7 @@ function buildForm(
   ) : null;
 
   const descriptiveText = inputProps.description ? (
-    <p key={`desc-${element.id}`}>{inputProps.description}</p>
+    <div id={`desc-${element.id}`}>{inputProps.description}</div>
   ) : null;
 
   switch (element.type) {
@@ -107,7 +107,13 @@ function buildForm(
         <Fragment key={inputProps.id}>
           {label}
           {descriptiveText}
-          <TextInput type="text" {...inputProps} />
+          <TextInput
+            type="text"
+            aria-describedby={
+              inputProps.description ? `desc-${element.id}` : undefined
+            }
+            {...inputProps}
+          />
         </Fragment>
       );
     case "textArea":
@@ -115,7 +121,12 @@ function buildForm(
         <Fragment key={inputProps.id}>
           {label}
           {descriptiveText}
-          <TextArea {...inputProps} />
+          <TextArea
+            aria-describedby={
+              inputProps.description ? `desc-${element.id}` : undefined
+            }
+            {...inputProps}
+          />
         </Fragment>
       );
     case "checkbox": {
@@ -159,7 +170,13 @@ function buildForm(
       });
 
       return (
-        <FormGroup key={`formGroup-${inputProps.id}`} name={inputProps.name}>
+        <FormGroup
+          key={`formGroup-${inputProps.id}`}
+          name={inputProps.name}
+          aria-describedby={
+            inputProps.description ? `desc-${element.id}` : undefined
+          }
+        >
           {label}
           {descriptiveText}
           {radioButtons}
@@ -171,7 +188,12 @@ function buildForm(
         <Fragment key={inputProps.id}>
           {label}
           {descriptiveText}
-          <Dropdown {...inputProps} />
+          <Dropdown
+            aria-describedby={
+              inputProps.description ? `desc-${element.id}` : undefined
+            }
+            {...inputProps}
+          />
         </Fragment>
       );
     case "plainText":
@@ -186,7 +208,13 @@ function buildForm(
         <Fragment key={inputProps.id}>
           {label}
           {descriptiveText}
-          <FileInput {...inputProps} fileType={element.properties.fileType} />
+          <FileInput
+            aria-describedby={
+              inputProps.description ? `desc-${element.id}` : undefined
+            }
+            {...inputProps}
+            fileType={element.properties.fileType}
+          />
         </Fragment>
       );
     default:


### PR DESCRIPTION
# Summary | Résumé

This PR adds descriptive text to a form input that follows WCAG guidance by associating the descriptive text to the input with `aria-describedby`.  The titles of the `plainText` have also been modified to H2 elements to ensure page structure for screen readers.
