### PR TITLE
Welcome page for Staging

### DIFF
--- a/forms/award.json
+++ b/forms/award.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "Public Service Award of Excellence 2020",
   "internalTitleFr": "Prix d’excellence de la fonction publique 2020",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "steven.talbot@cds-snc.ca"

--- a/forms/baggage.json
+++ b/forms/baggage.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "Delayed Baggage Report",
   "internalTitleFr": "Rapport de bagages retardés",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "steven.talbot@cds-snc.ca"

--- a/forms/callback.json
+++ b/forms/callback.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "SC Callback form",
   "internalTitleFr": "SC Demandes des Services",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "cayce.fischerb@cds-snc.ca"

--- a/forms/esdc.json
+++ b/forms/esdc.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "ESDC Grant Application for Funding",
   "internalTitleFr": "Demande de financement de subvention",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "steven.talbot@cds-snc.ca"

--- a/forms/esdc_accessibility_fund_FOR-DEMO.json
+++ b/forms/esdc_accessibility_fund_FOR-DEMO.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "Grant Application for Funding – Enabling Accessibility Fund (EAF) - Small Projects Component",
   "internalTitleFr": "Demande de financement de subvention - Initiative pour appuyer les communautés noires du Canada (ACNC)",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "steven.talbot@cds-snc.ca"

--- a/forms/intake.json
+++ b/forms/intake.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "CDS Intake Form",
   "internalTitleFr": "SNC Formulaire d'admission",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "fitore.jaha.price@cds-snc.ca"

--- a/forms/lostfishgear.json
+++ b/forms/lostfishgear.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "Atlantic lost fishing gear form: Fixed gear, including crab and lobster traps",
   "internalTitleFr": "Formulaire de déclaration de perte d'engin de pêche : Fixe, incluant les casiers à homard et à crabe (Atlantique)",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "mario.garneau@cds-snc.ca"

--- a/forms/securityclearanceform.json
+++ b/forms/securityclearanceform.json
@@ -1,7 +1,7 @@
 {
   "internalTitleEn": "Security Clearance Form",
   "internalTitleFr": "Liste de vérification des exigences relatives à la sécurité",
-  "publishingStatus": true,
+  "publishingStatus": false,
   "submission": {
     "templateID": "",
     "email": "mario.garneau@cds-snc.ca"

--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -19,11 +19,13 @@ function _getFormByID(formID: string): Record<string, unknown> {
 // Returns -> Array of form IDs.
 function _getFormByStatus(status: boolean): Array<number> {
   return Object.values(Forms)
-    .map((form) => {
-      if (form.publishingStatus === status) {
-        return form.form.id;
-      }
-    })
+    .map(
+      logger((form) => {
+        if (form.publishingStatus === status) {
+          return form.form.id;
+        }
+      })
+    )
     .filter((val) => typeof val !== "undefined" && val !== null);
 }
 

--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -15,6 +15,18 @@ function _getFormByID(formID: string): Record<string, unknown> {
   return formToReturn;
 }
 
+// Get an array of form IDs based on the publishing status
+// Returns -> Array of form IDs.
+function _getFormByStatus(status: boolean): Array<number> {
+  return Object.values(Forms)
+    .map((form) => {
+      if (form.publishingStatus === status) {
+        return form.form.id;
+      }
+    })
+    .filter((val) => typeof val !== "undefined" && val !== null);
+}
+
 // Get the submission format by using the form ID
 // Returns => json object of the submission details.
 function _getSubmissionByID(formID: string): Record<string, unknown> {
@@ -30,3 +42,4 @@ function _getSubmissionByID(formID: string): Record<string, unknown> {
 
 export const getFormByID = logger(_getFormByID);
 export const getSubmissionByID = logger(_getSubmissionByID);
+export const getFormByStatus = logger(_getFormByStatus);

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,74 +1,63 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link, withTranslation } from "../i18n";
+import { getFormByStatus, getFormByID } from "../lib/dataLayer.tsx";
+import { getProperty } from "../lib/formBuilder";
 
-const Home = ({ t }) => (
-  <>
-    <h1 className="gc-h1">{t("title")}</h1>
+const Home = ({ t, i18n }) => {
+  const formIDs = getFormByStatus(true);
 
-    <div className="">
-      <div className="mb-20">
-        <h2 className="text-3xl mb-5">{t("product.title")}</h2>
-        <p>{t("product.text")}</p>
-        <h2 className="text-3xl mb-5">{t("formList.title")}</h2>
-        <p>
-          <Link href="/14">{t("formList.accessibility")}</Link>
-        </p>
-        <p>
-          <Link href="/8">{t("formList.esdc")}</Link>
-        </p>
-        <p>
-          <Link href="/9">{t("formList.clearance")}</Link>
-        </p>
-        <p>
-          <Link href="/18">{t("formList.callback")}</Link>
-        </p>
-        <p>
-          <Link href="/1">{t("formList.intake")}</Link>
-        </p>
-        <p>
-          <Link href="/12">{t("formList.notifycontact")}</Link>
-        </p>
-        <p>
-          <Link href="/3">{t("formList.award")}</Link>
-        </p>
-        <p>
-          <Link href="/4">{t("formList.baggage")}</Link>
-        </p>
-        <p>
-          <Link href="/5">{t("formList.lostfishgear")}</Link>
-        </p>
+  return (
+    <>
+      <h1 className="gc-h1">{t("title")}</h1>
+
+      <div className="">
+        <div className="mb-20">
+          <h2 className="text-3xl mb-5">{t("product.title")}</h2>
+          <p>{t("product.text")}</p>
+          <h2 className="text-3xl mb-5">{t("formList.title")}</h2>
+          {formIDs.map((formID) => {
+            const form = getFormByID(formID);
+            return (
+              <p key={`link-${form.id}`}>
+                <Link href={`/${form.id}`}>
+                  {form[getProperty("title", i18n.language)].toString()}
+                </Link>
+              </p>
+            );
+          })}
+        </div>
+
+        <div className="mb-20">
+          <h2 className="text-3xl mb-5">{t("design.title")}</h2>
+          <p>{t("design.text")}</p>
+          <p>
+            <a href="https://platform-storybook.herokuapp.com/">
+              {t("design.system.title")}
+            </a>
+          </p>
+        </div>
+
+        <div className="mb-20">
+          <h2 className="text-3xl mb-5">{t("technology.title")}</h2>
+          <p>{t("technology.text")}</p>
+          <p>
+            <a href="https://github.com/cds-snc/platform-forms-node/">
+              {t("technology.git.title")}
+            </a>
+          </p>
+        </div>
       </div>
-
-      <div className="mb-20">
-        <h2 className="text-3xl mb-5">{t("design.title")}</h2>
-        <p>{t("design.text")}</p>
-        <p>
-          <a href="https://platform-storybook.herokuapp.com/">
-            {t("design.system.title")}
-          </a>
-        </p>
-      </div>
-
-      <div className="mb-20">
-        <h2 className="text-3xl mb-5">{t("technology.title")}</h2>
-        <p>{t("technology.text")}</p>
-        <p>
-          <a href="https://github.com/cds-snc/platform-forms-node/">
-            {t("technology.git.title")}
-          </a>
-        </p>
-      </div>
-    </div>
-  </>
-);
-
+    </>
+  );
+};
 Home.getInitialProps = async () => ({
   namespacesRequired: ["welcome"],
 });
 
 Home.propTypes = {
   t: PropTypes.func.isRequired,
+  i18n: PropTypes.object.isRequired,
 };
 
 export default withTranslation("welcome")(Home);

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,19 @@ import { getFormByStatus, getFormByID } from "../lib/dataLayer.tsx";
 import { getProperty } from "../lib/formBuilder";
 
 const Home = ({ t, i18n }) => {
-  const formIDs = getFormByStatus(true);
+  const LinksList = () => {
+    const formIDs = getFormByStatus(false);
+    return formIDs.map((formID) => {
+      const form = getFormByID(formID);
+      return (
+        <p key={`link-${form.id}`}>
+          <Link href={`/${form.id}`}>
+            {form[getProperty("title", i18n.language)].toString()}
+          </Link>
+        </p>
+      );
+    });
+  };
 
   return (
     <>
@@ -16,16 +28,7 @@ const Home = ({ t, i18n }) => {
           <h2 className="text-3xl mb-5">{t("product.title")}</h2>
           <p>{t("product.text")}</p>
           <h2 className="text-3xl mb-5">{t("formList.title")}</h2>
-          {formIDs.map((formID) => {
-            const form = getFormByID(formID);
-            return (
-              <p key={`link-${form.id}`}>
-                <Link href={`/${form.id}`}>
-                  {form[getProperty("title", i18n.language)].toString()}
-                </Link>
-              </p>
-            );
-          })}
+          <LinksList />
         </div>
 
         <div className="mb-20">

--- a/pages/sandbox.js
+++ b/pages/sandbox.js
@@ -5,7 +5,19 @@ import { getFormByStatus, getFormByID } from "../lib/dataLayer.tsx";
 import { getProperty } from "../lib/formBuilder";
 
 const Sandbox = ({ t, i18n }) => {
-  const formIDs = getFormByStatus(false);
+  const LinksList = () => {
+    const formIDs = getFormByStatus(false);
+    return formIDs.map((formID) => {
+      const form = getFormByID(formID);
+      return (
+        <p key={`link-${form.id}`}>
+          <Link href={`/${form.id}`}>
+            {form[getProperty("title", i18n.language)].toString()}
+          </Link>
+        </p>
+      );
+    });
+  };
 
   return (
     <>
@@ -16,16 +28,7 @@ const Sandbox = ({ t, i18n }) => {
           <h2 className="text-3xl mb-5">{t("product.title")}</h2>
           <p>{t("product.text")}</p>
           <h2 className="text-3xl mb-5">{t("formList.title")}</h2>
-          {formIDs.map((formID) => {
-            const form = getFormByID(formID);
-            return (
-              <p key={`link-${form.id}`}>
-                <Link href={`/${form.id}`}>
-                  {form[getProperty("title", i18n.language)].toString()}
-                </Link>
-              </p>
-            );
-          })}
+          <LinksList />
         </div>
 
         <div className="mb-20">

--- a/pages/sandbox.js
+++ b/pages/sandbox.js
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Link, withTranslation } from "../i18n";
+import { getFormByStatus, getFormByID } from "../lib/dataLayer.tsx";
+import { getProperty } from "../lib/formBuilder";
+
+const Sandbox = ({ t, i18n }) => {
+  const formIDs = getFormByStatus(false);
+
+  return (
+    <>
+      <h1 className="gc-h1">{t("title")}</h1>
+
+      <div className="">
+        <div className="mb-20">
+          <h2 className="text-3xl mb-5">{t("product.title")}</h2>
+          <p>{t("product.text")}</p>
+          <h2 className="text-3xl mb-5">{t("formList.title")}</h2>
+          {formIDs.map((formID) => {
+            const form = getFormByID(formID);
+            return (
+              <p key={`link-${form.id}`}>
+                <Link href={`/${form.id}`}>
+                  {form[getProperty("title", i18n.language)].toString()}
+                </Link>
+              </p>
+            );
+          })}
+        </div>
+
+        <div className="mb-20">
+          <h2 className="text-3xl mb-5">{t("design.title")}</h2>
+          <p>{t("design.text")}</p>
+          <p>
+            <a href="https://platform-storybook.herokuapp.com/">
+              {t("design.system.title")}
+            </a>
+          </p>
+        </div>
+
+        <div className="mb-20">
+          <h2 className="text-3xl mb-5">{t("technology.title")}</h2>
+          <p>{t("technology.text")}</p>
+          <p>
+            <a href="https://github.com/cds-snc/platform-forms-node/">
+              {t("technology.git.title")}
+            </a>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+Sandbox.getInitialProps = async () => ({
+  namespacesRequired: ["welcome"],
+});
+
+Sandbox.propTypes = {
+  t: PropTypes.func.isRequired,
+  i18n: PropTypes.object.isRequired,
+};
+
+export default withTranslation("welcome")(Sandbox);

--- a/public/static/locales/en/welcome.json
+++ b/public/static/locales/en/welcome.json
@@ -5,19 +5,6 @@
     "title": "Product Vision",
     "text": "Help government-users quickly and easily publish simple, accessible, online forms that the public can use to apply for or access the services or benefits they need."
   },
-  "formList": {
-    "title": "Forms List",
-    "a11yfunding": "Grant Application for Funding – Enabling Accessibility Fund (EAF) - Small Projects Component",
-    "esdc": "Grant Application for Funding – Supporting Black Canadian Communities (SBCC) Initiative",
-    "clearance": "Security Clearance Form",
-    "notifycontact": "Notify Contact Us",
-    "intake": "CDS Intake Form",
-    "award": "Public Service Award of Excellence 2020 Nominations",
-    "callback": "Service Canada Callback form",
-    "lostfishgear": "Atlantic lost fishing gear form: Fixed gear, including crab and lobster traps",
-    "baggage": "Delayed Baggage Report",
-    "accessibility": "Enabling Accessibility Fund (EAF) - Small Projects Component"
-  },
   "design": {
     "title": "Design",
     "text": "Learn more about our design, research and accessibility efforts.",

--- a/public/static/locales/en/welcome.json
+++ b/public/static/locales/en/welcome.json
@@ -5,6 +5,9 @@
     "title": "Product Vision",
     "text": "Help government-users quickly and easily publish simple, accessible, online forms that the public can use to apply for or access the services or benefits they need."
   },
+  "formList": {
+    "title": "Forms List"
+  },
   "design": {
     "title": "Design",
     "text": "Learn more about our design, research and accessibility efforts.",

--- a/public/static/locales/fr/welcome.json
+++ b/public/static/locales/fr/welcome.json
@@ -5,19 +5,7 @@
     "title": "La vision du produit",
     "text": "Aider les utilisateurs du gouvernement à publier rapidement et facilement des formulaires en ligne simples et accessibles que le public peut utiliser pour demander ou accéder aux services ou prestations dont il a besoin."
   },
-  "formList": {
-    "title": "Liste de formulaires",
-    "a11yfunding": "Demande de financement de subvention - Initiative pour appuyer les communautés noires du Canada (ACNC)",
-    "esdc": "Demande de financement de subvention - Initiative pour appuyer les communautés noires du Canada (ACNC)",
-    "clearance": "Liste de vérification des exigences relatives à la sécurité",
-    "notifycontact": "Nous joindre - Notification",
-    "intake": "Demo formulaire d'admission",
-    "award": "Prix d’excellence de la fonction publique 2020 - Formulaire de mise en candidature",
-    "callback": "SC Demandes des Services",
-    "lostfishgear": "Formulaire de déclaration de perte d'engin de pêche : Fixe, incluant les casiers à homard et à crabe (Atlantique)",
-    "baggage": "Rapport de bagages retardés",
-    "accessibility": "Fonds pour l'accessibilité (FA) - Projets de petite envergure"
-  },
+
   "design": {
     "title": "Design",
     "text": "En savoir plus sur nos efforts en matière de conception, de recherche et d'accessibilité.",

--- a/public/static/locales/fr/welcome.json
+++ b/public/static/locales/fr/welcome.json
@@ -5,7 +5,9 @@
     "title": "La vision du produit",
     "text": "Aider les utilisateurs du gouvernement à publier rapidement et facilement des formulaires en ligne simples et accessibles que le public peut utiliser pour demander ou accéder aux services ou prestations dont il a besoin."
   },
-
+  "formList": {
+    "title": "Liste de formulaires"
+  },
   "design": {
     "title": "Design",
     "text": "En savoir plus sur nos efforts en matière de conception, de recherche et d'accessibilité.",


### PR DESCRIPTION
# Summary | Résumé

This PR introduces a new page `sandbox` that will display the links to all forms that have their `publishingStatus` set to `false`.  The form titles are no longer using static i18n json but instead the internationalization is using the bilingual forms titles as set on the form json object.

The `welcome` page will only display the forms that have their `publishingStatus` set to `true` and implements the same i18n changes.

It is no longer required to manually add links to either page when a new form is uploaded as both pages are now dynamically driven by all forms under the `forms` folder at the root of the project.