### PR TITLE
Upload the CDS platform intake form JSON

### DIFF
--- a/forms/platform_intake.json
+++ b/forms/platform_intake.json
@@ -9,8 +9,10 @@
   "form": {
     "id": 20,
     "version": 1,
-    "titleEn": "Register to learn more about CDS Platform products",
-    "titleFr": "Inscrivez-vous pour en savoir plus sur nos produits de plate-forme CDS",
+    "titleEn": "",
+    "titleFr": "",
+    "descriptionEn": "Register to learn more about CDS Platform products",
+    "descriptionFr": "Inscrivez-vous pour en savoir plus sur nos produits de plate-forme CDS",
     "layout": [1, 2, 3, 4, 5, 6, 7, 8],
     "startPage": {},
     "endPage": {

--- a/forms/platform_intake.json
+++ b/forms/platform_intake.json
@@ -11,7 +11,7 @@
     "version": 1,
     "titleEn": "Register to learn more about CDS Platform products",
     "titleFr": "Inscrivez-vous pour en savoir plus sur nos produits de plate-forme CDS",
-    "layout": [1, 2, 3, 4, 5, 6, 7],
+    "layout": [1, 2, 3, 4, 5, 6, 7, 8],
     "startPage": {},
     "endPage": {
       "descriptionEn": "",
@@ -86,7 +86,7 @@
       },
 
       {
-        "id": 5,
+        "id": 7,
         "type": "checkbocx",
         "properties": {
           "titleEn": "How can we work together?",
@@ -116,7 +116,7 @@
         }
       },
       {
-        "id": 7,
+        "id": 8,
         "type": "textArea",
         "properties": {
           "titleEn": "Email(s) of other people in your team we should reach out to",

--- a/forms/platform_intake.json
+++ b/forms/platform_intake.json
@@ -93,24 +93,24 @@
           "titleFr": "Comment pouvons-nous collaborer?",
           "descriptionEN": "Select all that apply",
           "descriptionFr": "Cocher tous les choix qui s’appliquent",
-          "choices":[
-		      {
-		        "en":"I have a form I would like to publish in the next month",
-		        "fr":"J’ai un formulaire à faire publier d’ici le mois prochain."
-		      },
-		      {
-		        "en":"I have feedback on why this product will (or won't) work for my team",
-		        "fr":"J’ai des commentaires qui expliquent pourquoi ce produit est bien (ou n’est pas bien) adapté à mon équipe."
-		      },
-		      {
-		        "en":"I'm interested in learning more please contact me to set up a demo",
-		        "fr":"Je suis intéressé d’en apprendre plus. Veuillez me contacter pour mettre en place un démo."
-		      },
-		      {
-		        "en":"Please keep me in the loop by adding me to your mailing list",
-		        "fr":"Tenez-moi au courant de vos projets en m’ajoutant à votre liste de distribution."
-		      },
-		    ],
+          "choices": [
+            {
+              "en": "I have a form I would like to publish in the next month",
+              "fr": "J’ai un formulaire à faire publier d’ici le mois prochain."
+            },
+            {
+              "en": "I have feedback on why this product will (or won't) work for my team",
+              "fr": "J’ai des commentaires qui expliquent pourquoi ce produit est bien (ou n’est pas bien) adapté à mon équipe."
+            },
+            {
+              "en": "I'm interested in learning more please contact me to set up a demo",
+              "fr": "Je suis intéressé d’en apprendre plus. Veuillez me contacter pour mettre en place un démo."
+            },
+            {
+              "en": "Please keep me in the loop by adding me to your mailing list",
+              "fr": "Tenez-moi au courant de vos projets en m’ajoutant à votre liste de distribution."
+            }
+          ],
           "charLimit": 100,
           "required": true
         }

--- a/forms/platform_intake.json
+++ b/forms/platform_intake.json
@@ -4,7 +4,7 @@
   "publishingStatus": true,
   "submission": {
     "templateID": "",
-    "email": "TBD@cds-snc.ca"
+    "email": "forms-formulaires@cds-snc.ca"
   },
   "form": {
     "id": 20,

--- a/forms/platform_intake.json
+++ b/forms/platform_intake.json
@@ -1,0 +1,132 @@
+{
+  "internalTitleEn": "CDS Platform Intake Form",
+  "internalTitleFr": "SNC Formulaire d'admission du Plateforme",
+  "publishingStatus": true,
+  "submission": {
+    "templateID": "",
+    "email": "TBD@cds-snc.ca"
+  },
+  "form": {
+    "id": 20,
+    "version": 1,
+    "titleEn": "Register to learn more about CDS Platform products",
+    "titleFr": "Inscrivez-vous pour en savoir plus sur nos produits de plate-forme CDS",
+    "layout": [1, 2, 3, 4, 5, 6, 7],
+    "startPage": {},
+    "endPage": {
+      "descriptionEn": "",
+      "descriptionFr": "",
+      "referrerUrlEn": "https://digital.canada.ca/",
+      "referrerUrlFr": "https://numerique.canada.ca/"
+    },
+
+    "elements": [
+      {
+        "id": 1,
+        "type": "plainText",
+        "properties": {
+          "titleEn": "Thank you so much for your interest in the Canadian Digital Service’s Platform products.",
+          "titleFr": "Merci beaucoup de l’intérêt que vous portez aux produits de la plateforme du Service Numérique Canadien.",
+          "charLimit": 200,
+          "required": false
+        }
+      },
+      {
+        "id": 2,
+        "type": "plainText",
+        "properties": {
+          "titleEn": "Please fill out the form below so that we can reach out to chat further to help with your specific needs.",
+          "titleFr": "Veuillez remplir le formulaire ci-dessous afin que nous puissions vous contacter pour discuter davantage pour répondre à vos besoins spécifiques.",
+          "charLimit": 200,
+          "required": false
+        }
+      },
+      {
+        "id": 3,
+        "type": "textField",
+        "properties": {
+          "titleEn": "Name",
+          "titleFr": "Nom",
+          "charLimit": 100,
+          "required": true
+        }
+      },
+      {
+        "id": 4,
+        "type": "textField",
+        "properties": {
+          "titleEn": "Work email",
+          "titleFr": "Courriel professionnel",
+          "charLimit": 100,
+          "required": true
+        }
+      },
+      {
+        "id": 5,
+        "type": "textField",
+        "properties": {
+          "titleEn": "What department do you work for?",
+          "titleFr": "Pour quel service travaillez-vous?",
+          "placeholderEn": "",
+          "placeholderFr": "",
+          "description": "",
+          "charLimit": 100,
+          "required": false
+        }
+      },
+      {
+        "id": 6,
+        "type": "textField",
+        "properties": {
+          "titleEn": "Work phone number",
+          "titleFr": "Numéro de téléphone professionnel",
+          "charLimit": 100,
+          "required": false
+        }
+      },
+
+      {
+        "id": 5,
+        "type": "checkbocx",
+        "properties": {
+          "titleEn": "How can we work together?",
+          "titleFr": "Comment pouvons-nous collaborer?",
+          "descriptionEN": "Select all that apply",
+          "descriptionFr": "Cocher tous les choix qui s’appliquent",
+          "choices":[
+		      {
+		        "en":"I have a form I would like to publish in the next month",
+		        "fr":"J’ai un formulaire à faire publier d’ici le mois prochain."
+		      },
+		      {
+		        "en":"I have feedback on why this product will (or won't) work for my team",
+		        "fr":"J’ai des commentaires qui expliquent pourquoi ce produit est bien (ou n’est pas bien) adapté à mon équipe."
+		      },
+		      {
+		        "en":"I'm interested in learning more please contact me to set up a demo",
+		        "fr":"Je suis intéressé d’en apprendre plus. Veuillez me contacter pour mettre en place un démo."
+		      },
+		      {
+		        "en":"Please keep me in the loop by adding me to your mailing list",
+		        "fr":"Tenez-moi au courant de vos projets en m’ajoutant à votre liste de distribution."
+		      },
+		    ],
+          "charLimit": 100,
+          "required": true
+        }
+      },
+      {
+        "id": 7,
+        "type": "textArea",
+        "properties": {
+          "titleEn": "Email(s) of other people in your team we should reach out to",
+          "titleFr": "Courriel(s) d'autres personnes de votre équipe que nous devrions contacter.",
+          "descriptionEn": "Separate each email address with a comma.",
+          "descriptionFr": "Veuillez ajouter des courriels séparés par des virgules ci-dessus.",
+          "charLimit": 500,
+          "required": false
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First draft of the CDS platform intake form (WITH copy and design changes, see below)

**JSON TO-DOs BEFORE GOING LIVE:**
- add the recipient email address (currently set to `tbd@cds-snc.ca`) ✅
- clear design and copy changes with ... Elodie? Who owns this form @srtalbot ?
- update French copy for the following line: `Veuillez ajouter des courriels séparés par des virgules ci-dessus.` to match the new English copy `Separate each email address with a comma.` cc @mcman12 if you have a moment? This is the only translation change needed

**Design & copy changes:**
- Removed the “Platform CDS” header from the page. Rationale: it sits outside the page hierarchy and isn’t needed when the form title is clear. We also don't have a component that renders such an element right now, nor is it necessary.
- Add “CDS”/“SNC” to the form title (to address the previously mentioned change ^)
- Replace “First Name” and “Last Name” fields with a single Name field. Rationale: this conforms to CDS design community’s best practices for capturing name information on forms. As this doesn’t hook into any major backend databases or APIs, this is also a fix that’s easily made and demonstrates we are making choices informed by user-centric design.
- Sentence-casing the copy of the form throughout. Rationale: More readable, no need for jargon-ifdying things with capital letters. Conforms to user-centric design standards and CDS style.
- Move “Select all that apply” to the description of the checkbox field, not the label element. Reason: this choice is a content standard to be implemented by the Forms team. Questions are not directions, meta-directions should be in description fields. 
- Changed the copy to make adding comma-separated emails more clear (EN - **requires FR update**)
