### PR TITLE
Add GA code

### DIFF
--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -7,9 +7,29 @@ import SkipLink from "./SkipLink";
 import Fip from "./Fip";
 
 const Base = ({ children }) => {
+  const isProduction = process.env.NODE_ENV === "production";
   return (
     <>
       <Head>
+        {isProduction && (
+          <React.Fragment>
+            <script
+              async
+              src="https://www.googletagmanager.com/gtag/js?id=G-KY2EVJV33K"
+            ></script>
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
+                window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', 'G-KY2EVJV33K');
+              `,
+              }}
+            />
+          </React.Fragment>
+        )}
         <meta charSet="utf-8" />
         <meta
           name="viewport"


### PR DESCRIPTION
# Summary | Résumé

This PR adds the Google Analytics tracking code to the Base page.  The GA script will only render when NODE_ENV is set to production.  Once we have multiple deployment environments (staging and production) we can revisit this setup.
