### PR TITLE
Layout Fix

### DIFF
--- a/components/globals/Fip.js
+++ b/components/globals/Fip.js
@@ -4,18 +4,16 @@ import { withTranslation } from "../../i18n";
 import LanguageToggle from "./LanguageToggle";
 
 const Fip = ({ t, i18n }) => (
-  <div className="page--container">
-    <div className="fip-container">
-      <div className="canada-flag">
-        <a href={t("fip.link")} aria-label={t("fip.text")}>
-          <img
-            src={"/img/sig-blk-" + i18n.language + ".svg"}
-            alt={t("fip.text")}
-          />
-        </a>
-      </div>
-      <LanguageToggle />
+  <div data-testid="fip" className="gc-fip">
+    <div className="canada-flag">
+      <a href={t("fip.link")} aria-label={t("fip.text")}>
+        <img
+          src={"/img/sig-blk-" + i18n.language + ".svg"}
+          alt={t("fip.text")}
+        />
+      </a>
     </div>
+    <LanguageToggle />
   </div>
 );
 

--- a/components/globals/Footer.js
+++ b/components/globals/Footer.js
@@ -3,34 +3,20 @@ import PropTypes from "prop-types";
 import { withTranslation } from "../../i18n";
 
 const Footer = ({ t }) => (
-  <footer className="border-0 bg-gray-100 mt-20">
-    <div className="page--container flex flex-row justify-between md:items-baseline pt-4 md:pt-10 pb-6 md:pb-10">
-      <div className="footer-links md:w-4/5">
-        <ul className="p-0 text-base list-inside">
-          <li className="md:inline-block pr-4">
-            <a
-              href={t("footer.privacy.link")}
-              className="no-underline hover:underline"
-            >
-              {t("footer.privacy.desc")}
-            </a>
+  <footer className="gc-footer" data-testid="footer">
+    <div className="gc-footer-container">
+      <div>
+        <ul>
+          <li>
+            <a href={t("footer.privacy.link")}>{t("footer.privacy.desc")}</a>
           </li>
-          <li className="md:inline-block">
-            <a
-              href={t("footer.terms.link")}
-              className="no-underline hover:underline"
-            >
-              {t("footer.terms.desc")}
-            </a>
+          <li>
+            <a href={t("footer.terms.link")}>{t("footer.terms.desc")}</a>
           </li>
         </ul>
       </div>
-      <div className="md:w-1/5 md:relative">
-        <img
-          alt={t("fip.text")}
-          src="/img/wmms-blk.svg"
-          className="h-12 pt-2 md:absolute md:bottom-0 md:right-0"
-        />
+      <div>
+        <img alt={t("fip.text")} src="/img/wmms-blk.svg" />
       </div>
     </div>
   </footer>

--- a/components/globals/LanguageToggle.js
+++ b/components/globals/LanguageToggle.js
@@ -14,7 +14,7 @@ const LanguageToggle = ({ t, i18n }) => {
   return (
     <>
       <h2 className="sr-only">{t("lang-toggle")}</h2>
-      <div className="language-link">
+      <div className="gc-language-toggle">
         {locale == "en" ? (
           <button
             onClick={() => {

--- a/components/globals/LanguageToggle.js
+++ b/components/globals/LanguageToggle.js
@@ -13,7 +13,7 @@ const LanguageToggle = ({ t, i18n }) => {
 
   return (
     <>
-      <h2 className="sr-only">{t("lang-toggle")}</h2>
+      <h2 className="sr-only visually-hidden">{t("lang-toggle")}</h2>
       <div className="gc-language-toggle">
         {locale == "en" ? (
           <button

--- a/components/globals/PhaseBanner.js
+++ b/components/globals/PhaseBanner.js
@@ -3,12 +3,9 @@ import PropTypes from "prop-types";
 import { withTranslation } from "../../i18n";
 
 const PhaseBanner = ({ t }) => (
-  <div className="phase-banner">
+  <div data-testid="PhaseBanner" className="gc-phase-banner">
     <div>
-      <span>
-        <strong className="font-normal">ALPHA</strong>
-        <span className="visually-hidden"></span>
-      </span>
+      <span>ALPHA</span>
       <span>{t("phase.desc")}</span>
     </div>
   </div>

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -18,32 +18,33 @@
   @apply mb-12;
 }
 
+// FOOTER STYLES
+
 .gc-footer {
   @apply border-0 bg-gray-100 mt-20;
-}
 
-.gc-footer .gc-footer-container {
-  @apply flex py-10 px-40 mt-10 flex-row items-center justify-between;
-}
+  div img {
+    @apply h-10;
+  }
 
-.gc-footer .gc-footer-container ul {
-  @apply p-0 flex text-base list-inside;
-}
+  .gc-footer-container {
+    @apply flex py-10 px-40 mt-10 flex-row items-center justify-between;
 
-.gc-footer .gc-footer-container ul li {
-  @apply pr-4;
-}
+    ul {
+      @apply p-0 mb-0 flex text-base list-none;
 
-.gc-footer .gc-footer-container ul li:last-of-type {
-  @apply pr-0;
-}
+      li {
+        @apply pr-8;
 
-.gc-footer .gc-footer-container ul li a {
-  @apply no-underline hover:underline text-blue-dark;
-}
-
-.gc-footer div img {
-  @apply h-10;
+        a {
+          @apply no-underline hover:underline text-blue-dark;
+        }
+      }
+      li:last-of-type {
+        @apply pr-0;
+      }
+    }
+  }
 }
 
 /* Adjustments for tailwind defaults that conflict with the node-starter-app defaults */
@@ -130,19 +131,12 @@ h6 {
 }
 
 %page-container {
-  max-width: 960px;
-  margin: 0 auto;
-  padding-left: $space-md;
-  padding-right: $space-md;
-
-  @include xl {
-    max-width: 1024px;
-  }
+  @apply mx-40;
 }
 
 main {
   @extend %page-container;
-  padding: 0 $space-md;
+  padding: 0;
 }
 
 li:not(:last-of-type) {

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -118,3 +118,5 @@
 .validation-message {
   @apply text-red-500;
 }
+
+

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -1,37 +1,44 @@
+// PHASE BANNER STYLES
+
 .gc-phase-banner {
   @apply bg-gray-background flex items-center py-6 px-40;
+
+  span {
+    @apply text-sm;
+  }
+
+  span:first-of-type {
+    @apply border-2 border-black-default py-0 px-0 mr-4;
+    padding: 2px 8px !important;
+  }
+
+  span:last-of-type {
+    @apply mt-3;
+  }
+
+  span span {
+    @apply border-0 py-0 px-0 mr-0;
+  }
 }
 
-.gc-phase-banner span {
-  @apply text-sm;
-}
-
-.gc-phase-banner span:first-of-type {
-  @apply border-2 border-black-default py-1 px-4 mr-4;
-}
-
-.gc-phase-banner span:last-of-type {
-  @apply mt-3;
-}
-
-.gc-phase-banner span span {
-  @apply border-0 py-0 px-0 mr-0;
-}
+// FIP STYLES
 
 .gc-fip {
   @apply flex flex-row justify-between items-center mx-40 my-20;
+
+  div {
+    @apply h-auto max-h-10 w-72;
+  }
 }
 
-.gc-fip div {
-  @apply h-auto max-h-10 w-72;
-}
+// LANGUAGE TOGGLE
 
 .gc-language-toggle {
   @apply text-right text-sm;
-}
 
-.gc-language-toggle button {
-  @apply shadow-none bg-none text-blue-900 underline border-0 text-base;
+  button {
+    @apply shadow-none bg-none text-blue-900 underline border-0 text-base;
+  }
 }
 
 header {


### PR DESCRIPTION
## This PR consists of the following

### Modifying some of the components in `globals/Base.js` to match the storybook components
> Phasebanner.js
> Fip.js
> LanguageToggle.js
> Footer.js

In doing so, I deleted some of the queries that were breaking due to some of the new classes etc. (I'll fix this when I start working on some of the smaller screen styles)

|  Before |  After  |
|---|---|
|  <img width="1552" alt="Screen Shot 2021-02-04 at 19 03 51" src="https://user-images.githubusercontent.com/30609058/106970989-fceb7780-671b-11eb-8c0f-16678060b7c8.png"> <img width="1552" alt="Screen Shot 2021-02-04 at 19 03 48" src="https://user-images.githubusercontent.com/30609058/106970992-fe1ca480-671b-11eb-9eaa-cf713e280223.png">  |  <img width="1552" alt="Screen Shot 2021-02-04 at 19 04 01" src="https://user-images.githubusercontent.com/30609058/106971024-0f65b100-671c-11eb-9eef-c7012c3d853e.png"> <img width="1552" alt="Screen Shot 2021-02-04 at 19 03 55" src="https://user-images.githubusercontent.com/30609058/106971025-0ffe4780-671c-11eb-9ea7-2d132e81a1c7.png"> |