### PR TITLE
Add id back to FormGroup

### DIFF
--- a/components/forms/FormGroup/FormGroup.tsx
+++ b/components/forms/FormGroup/FormGroup.tsx
@@ -21,6 +21,7 @@ export const FormGroup = (props: FormGroupProps): React.ReactElement => {
   return (
     <fieldset
       name={name}
+      id={name}
       data-testid="formGroup"
       className={classes}
       aria-describedby={ariaDescribedBy}


### PR DESCRIPTION
# Summary | Résumé

This PR fixes and A11y issue where the Form Group element did not have an ID (only a name) and the label therefore could not be correctly associated to it.