### PR TITLE
Need to include next-i18next config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=0 /src/node_modules ./node_modules
 COPY --from=0 /src/.next ./.next
 COPY public ./public
 COPY next.config.js .
+COPY next-i18next.config.js .
 
 ENV PORT 3000
 


### PR DESCRIPTION
# Summary | Résumé

This PR fixes an issue with the Docker Image.  The new i18n package requires the config file to also be available after the NextJS package is built.