### PR TITLE
Add validation types to TSB form

### DIFF
--- a/forms/TSB-contact.json
+++ b/forms/TSB-contact.json
@@ -24,7 +24,8 @@
           "description": "",
           "charLimit": 100,
           "validation": {
-            "required": true
+            "required": true,
+            "type": "text"
           }
         }
       },
@@ -40,7 +41,8 @@
           "descriptionFr": "",
           "charLimit": 100,
           "validation": {
-            "required": true
+            "required": true,
+            "type": "email"
           }
         }
       },


### PR DESCRIPTION
# Summary | Résumé
- Validate email and text fields via `type` in the TSB form