### PR TITLE
Add ability to provide a custom logo for a form

### DIFF
--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -18,6 +18,8 @@ const getPageClassNames = () => {
 const Base = ({ children }) => {
   const isProduction = process.env.GA_ACTIVE ? true : false;
   const classes = getPageClassNames();
+  const formMetadata =
+    children && children.props && children.props.formMetadata ? children.props.formMetadata : null;
 
   return (
     <>
@@ -51,7 +53,7 @@ const Base = ({ children }) => {
       <div className={classes}>
         <header>
           <PhaseBanner />
-          <Fip />
+          <Fip formMetadata={formMetadata} />
         </header>
         <main id="content">{children}</main>
         <Footer />

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -8,18 +8,19 @@ import Fip from "./Fip";
 import classnames from "classnames";
 import { useRouter } from "next/router";
 
-const getPageClassNames = () => {
+const getPageClassNames = (formMetadata) => {
   const router = useRouter();
   const pageName = router && router.asPath ? router.asPath.split("?")[0] : "";
-  const classes = classnames("outer-container", `page${pageName.replace(/\//g, "-")}`);
+  const brandName = formMetadata && formMetadata.brand ? formMetadata.brand.title : "";
+  const classes = classnames("outer-container", `page${pageName.replace(/\//g, "-")}`, brandName);
   return classes;
 };
 
 const Base = ({ children }) => {
   const isProduction = process.env.GA_ACTIVE ? true : false;
-  const classes = getPageClassNames();
   const formMetadata =
     children && children.props && children.props.formMetadata ? children.props.formMetadata : null;
+  const classes = getPageClassNames(formMetadata);
 
   return (
     <>

--- a/components/globals/Fip.js
+++ b/components/globals/Fip.js
@@ -1,11 +1,12 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
 import LanguageToggle from "./LanguageToggle";
 import { getProperty } from "../../lib/formBuilder";
 
 const Fip = (props) => {
   const { t, i18n } = useTranslation("common");
-  const formTheme = props.formMetadata ? props.formMetadata.theme : null;
+  const formTheme = props.formMetadata ? props.formMetadata.brand : null;
 
   const customLogo =
     formTheme && formTheme[getProperty("logo", i18n.language)]
@@ -13,17 +14,25 @@ const Fip = (props) => {
       : null;
 
   const logo = customLogo ? customLogo : "/img/sig-blk-" + i18n.language + ".svg";
+  const linkUrl =
+    formTheme && formTheme[getProperty("url", i18n.language)]
+      ? formTheme[getProperty("url", i18n.language)]
+      : t("fip.link");
 
   return (
     <div data-testid="fip" className="gc-fip">
       <div className="canada-flag">
-        <a href={t("fip.link")} aria-label={t("fip.text")}>
+        <a href={linkUrl} aria-label={t("fip.text")}>
           <img src={logo} alt={t("fip.text")} />
         </a>
       </div>
       <LanguageToggle />
     </div>
   );
+};
+
+Fip.propTypes = {
+  formMetadata: PropTypes.object,
 };
 
 export default Fip;

--- a/components/globals/Fip.js
+++ b/components/globals/Fip.js
@@ -1,14 +1,24 @@
 import React from "react";
 import { useTranslation } from "next-i18next";
 import LanguageToggle from "./LanguageToggle";
+import { getProperty } from "../../lib/formBuilder";
 
-const Fip = () => {
+const Fip = (props) => {
   const { t, i18n } = useTranslation("common");
+  const formTheme = props.formMetadata ? props.formMetadata.theme : null;
+
+  const customLogo =
+    formTheme && formTheme[getProperty("logo", i18n.language)]
+      ? formTheme[getProperty("logo", i18n.language)]
+      : null;
+
+  const logo = customLogo ? customLogo : "/img/sig-blk-" + i18n.language + ".svg";
+
   return (
     <div data-testid="fip" className="gc-fip">
       <div className="canada-flag">
         <a href={t("fip.link")} aria-label={t("fip.text")}>
-          <img src={"/img/sig-blk-" + i18n.language + ".svg"} alt={t("fip.text")} />
+          <img src={logo} alt={t("fip.text")} />
         </a>
       </div>
       <LanguageToggle />

--- a/documentation/Forms/FormViewer.stories.mdx
+++ b/documentation/Forms/FormViewer.stories.mdx
@@ -22,6 +22,7 @@ The form viewer expects a JSON with the following structure.
     "titleEn": "",
     "titleFr": "",
     "layout": [ ... ],
+    "brand": {},
     "elements": [ ... ],
     "startPage": {},
     "endPage": {}
@@ -40,6 +41,8 @@ There are 2 main parts to the structure:
    `titleEn/Fr`: The displayed title of the form to the user (`string`)
 
    `layout`: The order of the questions and/or page elements identified by id (`array`)
+
+   `brand`: Certain departments might have legal obligations to display a different brand, in terms of logo
 
    `elements`: An array of question and page display objects (`array`)
 
@@ -78,6 +81,13 @@ Example:
   "titleEn": "CDS Intake Form",
   "titleFr": "SNC Formulaire d'admission",
   "layout": ["1", "5", "6", "7"],
+  "brand": {
+    "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
+    "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
+    "urlEn": "https://digital.canada.ca/",
+    "urlFr": "https://numerique.canada.ca/",
+    "title": "cds-snc"
+  },
   "endPage": {
     "referrerUrlEn": "https://digital.canada.ca/",
     "referrerUrlFr": "https://numerique.canada.ca/"

--- a/forms/intake.json
+++ b/forms/intake.json
@@ -12,9 +12,12 @@
     "titleEn": "CDS Intake Form",
     "titleFr": "SNC Formulaire d'admission",
     "layout": [1, 2, 3, 4, 5, 6, 7],
-    "theme": {
+    "brand": {
       "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
-      "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg"
+      "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
+      "urlEn": "https://digital.canada.ca/",
+      "urlFr": "https://numerique.canada.ca/",
+      "title": "cds-snc"
     },
     "startPage": {},
     "endPage": {

--- a/forms/intake.json
+++ b/forms/intake.json
@@ -12,6 +12,10 @@
     "titleEn": "CDS Intake Form",
     "titleFr": "SNC Formulaire d'admission",
     "layout": [1, 2, 3, 4, 5, 6, 7],
+    "theme": {
+      "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
+      "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg"
+    },
     "startPage": {},
     "endPage": {
       "descriptionEn": "",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -14,7 +14,7 @@
   },
   "skip-link": "Skip to main content",
   "fip": {
-    "link": "",
+    "link": "/",
     "text": "Government of Canada"
   },
   "preview": {

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -14,7 +14,7 @@
   },
   "skip-link": "Passer au contenu principal",
   "fip": {
-    "link": "",
+    "link": "/",
     "text": "Gouvernement du Canada"
   },
   "preview": {


### PR DESCRIPTION
# Summary | Résumé

This PR adds the ability to provide custom brand information to the Form, via its JSON config, for example the logo, url and title:

```
    "brand": {
      "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
      "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
      "urlEn": "https://digital.canada.ca/",
      "urlFr": "https://numerique.canada.ca/",
      "title": "cds-snc"
    }
```

The `brand.title` for now is used only as a classname, but potentially can be shown in the URL as well.