### PR TITLE
Added a generic h1 to the main page for a11y

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -7,9 +7,9 @@ const Home = () => {
   const { t } = useTranslation("common");
   return (
     <>
-    <div>
-      <h1 className="gc-h1">{t("title")}</h1>
-    </div>
+      <div>
+        <h1 className="gc-h1">{t("title")}</h1>
+      </div>
       <div className="border-gray-400 p-10 grid grid-cols-2 gap-x-4 max-w-2xl  w-2/4 m-auto">
         <p>
           <Link href="/en/welcome-bienvenue">Forms in English</Link>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,15 @@
 import React from "react";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useTranslation } from "next-i18next";
 import Link from "next/link";
 
 const Home = () => {
+  const { t } = useTranslation("common");
   return (
     <>
+    <div>
+      <h1 className="gc-h1">{t("title")}</h1>
+    </div>
       <div className="border-gray-400 p-10 grid grid-cols-2 gap-x-4 max-w-2xl  w-2/4 m-auto">
         <p>
           <Link href="/en/welcome-bienvenue">Forms in English</Link>


### PR DESCRIPTION
The remaining violations in the a11y scanner have to do with the fact that we don't have a < h1 > on the homepage [(see scan here)](https://a11y-tools-query.herokuapp.com/reports/d1fd1c478b318f3c0683872bcf93f75d45e20e3af6811660948fea48b0749661). I've added a generic "GC Forms" "GC Formulaires" title here.

This is just a placeholder, and happy to adjust the title or styling! I am not sure if I should tag in any of the designers on the team here, or flag on slack?