### PR TITLE
Update git ignore to exclude storybook static directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ credentials
 
 terraform/azure/secrets.auto.tfvars
 package-lock.json
+
+# storybook
+storybook-static/


### PR DESCRIPTION
I was running Storybook locally and noticed it added close to 50 files under this directory. We probably want to ignore this directory so nothing gets accidentally committed?