### PR TITLE
Fix TSB email validation bug

### DIFF
--- a/forms/TSB-contact.json
+++ b/forms/TSB-contact.json
@@ -122,7 +122,7 @@
           "charLimit": 100,
           "validation": {
             "required": false,
-            "type": "email"
+            "type": "text"
           }
         }
       },


### PR DESCRIPTION
A non email field was set to type: email, causing validation issues