### PR TITLE
Fix blank confirmation page due to stringify/parse

### DIFF
--- a/components/forms/TextPage/TextPage.tsx
+++ b/components/forms/TextPage/TextPage.tsx
@@ -20,7 +20,7 @@ interface TextPageProps {
 const getPageContent = (t: TFunction, pageText: string, urlQuery: string | undefined) => {
   // Check if there's a custom text for the end page specified in the form's JSON config
   if (pageText && pageText !== undefined) {
-    return <RichText className="confirmation">{JSON.parse(pageText)}</RichText>;
+    return <RichText className="confirmation">{pageText}</RichText>;
   }
 
   // Otherwise, display the default confirmation text
@@ -43,7 +43,7 @@ export const TextPage = (props: TextPageProps): React.ReactElement => {
 
   const pageText =
     formMetadata && formMetadata.endPage
-      ? JSON.stringify(formMetadata.endPage[getProperty("description", language)])
+      ? formMetadata.endPage[getProperty("description", language)]
       : "";
 
   return (

--- a/pages/id/[form]/[[...step]].js
+++ b/pages/id/[form]/[[...step]].js
@@ -34,7 +34,7 @@ export async function getServerSideProps(context) {
   return {
     props: {
       formMetadata: form,
-      ...(await serverSideTranslations(context.locale, ["common", "welcome"])),
+      ...(await serverSideTranslations(context.locale, ["common", "welcome", "confirmation"])),
     }, // will be passed to the page component as props
   };
 }


### PR DESCRIPTION
# Summary | Résumé

Considering that the confirmation page doesn't receive the `pageText` from the URL query anymore, rather via the `formMetadata` property, we don't need to strigify/parse the values.