### PR TITLE
Remote File Inclusion - AWS Firewall blocking form submissions

### DIFF
--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -61,24 +61,19 @@ function _getSubmissionByID(formID: string): Record<string, unknown> {
 function _rehydrateFormResponses(payload: Submission) {
   const { form, responses } = payload;
   const rehydratedResponses: Responses = {};
-  form.layout.forEach((qID: string) => {
-    const question = form.elements.find((element: FormElement) => element.id === qID);
-    if (question) {
-      const response = responses[question.id];
-      switch (question.type) {
-        case "checkbox":
-        case "dynamicRow":
-          if (response) {
-            rehydratedResponses[question.id] = JSON.parse(response as string).value;
-          } else rehydratedResponses[question.id] = [];
-          break;
-        case "richText":
-          break;
-        default:
-          rehydratedResponses[question.id] = response;
-      }
-    } else {
-      logMessage.warn(`Failed component ID look up ${qID} on form ID ${form.id}`);
+  form.elements.forEach((question: FormElement) => {
+    const response = responses[question.id];
+    switch (question.type) {
+      case "checkbox":
+      case "dynamicRow":
+        if (response) {
+          rehydratedResponses[question.id] = JSON.parse(response as string).value;
+        } else rehydratedResponses[question.id] = [];
+        break;
+      case "richText":
+        break;
+      default:
+        rehydratedResponses[question.id] = response;
     }
   });
   return rehydratedResponses;
@@ -190,17 +185,13 @@ function handleTextResponse(title: string, response: string, collector: Array<st
 
 function _buildFormDataObject(form: FormMetadataProperties, values: Responses) {
   const formData = new FormData();
-  const formElementList = form.layout;
+  const formElementList = form.elements;
 
-  formElementList.map((elementID) => {
-    const element = form.elements.find((formElement: FormElement) => formElement.id === elementID);
-
-    if (element) {
+  formElementList
+    .filter((element) => !["richText"].includes(element.type))
+    .map((element) => {
       _handleFormDataType(element, values[element.id], formData);
-    } else {
-      logMessage.warn(`Failed component ID look up ${elementID} on form ID ${form.id}`);
-    }
-  });
+    });
   formData.append("formInfo", JSON.stringify(form));
   return formData;
 }
@@ -226,8 +217,6 @@ function _handleFormDataType(element: FormElement, value: Response, formData: Fo
       Array.isArray(value)
         ? _handleFormDataArray(element.id, value as Array<string>, formData)
         : _handleFormDataText(element.id, "", formData);
-
-      break;
 
       break;
     case "fileInput":

--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -89,8 +89,6 @@ export function extractFormData(submission: Submission): Array<string> {
     const question = formOrigin.elements.find((element: FormElement) => element.id === qID);
     if (question) {
       handleType(question, formResponses[question.id], dataCollector);
-    } else {
-      logMessage.warn(`Failed component ID look up ${qID} on form ID ${formOrigin.id}`);
     }
   });
   return dataCollector;
@@ -185,13 +183,11 @@ function handleTextResponse(title: string, response: string, collector: Array<st
 
 function _buildFormDataObject(form: FormMetadataProperties, values: Responses) {
   const formData = new FormData();
-  const formElementList = form.elements;
+  form.elements = form.elements.filter((element) => !["richText"].includes(element.type));
 
-  formElementList
-    .filter((element) => !["richText"].includes(element.type))
-    .map((element) => {
-      _handleFormDataType(element, values[element.id], formData);
-    });
+  form.elements.map((element) => {
+    _handleFormDataType(element, values[element.id], formData);
+  });
   formData.append("formInfo", JSON.stringify(form));
   return formData;
 }

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -280,11 +280,11 @@ const _getFormInitialValues = (formMetadata: FormMetadataProperties, language: s
 
   const initialValues: Record<string, unknown> = {};
 
-  formMetadata.elements.map((element: FormElement) => {
-    if (element.type !== "richText") {
+  formMetadata.elements
+    .filter((element) => !["richText"].includes(element.type))
+    .map((element: FormElement) => {
       initialValues[element.id] = _getElementInitialValue(element, language);
-    }
-  });
+    });
 
   return initialValues;
 };

--- a/lib/tests/dataLayer.test.js
+++ b/lib/tests/dataLayer.test.js
@@ -110,17 +110,7 @@ describe("Extract Form data", () => {
       }
     }
   });
-  test("Logs error when Layout includes non-existant element ID", () => {
-    const badForm = {
-      id: 1,
-      layout: [1, 2],
-      elements: [],
-    };
-    const mockedLogger = jest.spyOn(logMessage, "warn");
-    const formResponses = extractFormData({ form: badForm, responses: mockResponses });
-    expect(formResponses.length).toBe(0);
-    expect(mockedLogger).toBeCalledTimes(2);
-  });
+
   test("Build form data object", () => {
     const formData = buildFormDataObject(testForm, mockResponses);
     for (const [key, response] of Object.entries(mockResponses)) {

--- a/pages/api/submit.js
+++ b/pages/api/submit.js
@@ -17,6 +17,9 @@ const submit = async (req, res) => {
   try {
     const incomingForm = new formidable.IncomingForm();
     await incomingForm.parse(req, (err, fields, files) => {
+      if (err) {
+        throw new Error(err);
+      }
       const form = { ...JSON.parse(fields.formInfo) };
       delete fields.formInfo;
       processFormData(form, fields, files, res, req).finally(() => {


### PR DESCRIPTION
# Summary | Résumé

This PR has a few small changes:
- Aligns logic around form values and form data to center on the `form.elements` array as the source of truth and leaves `form.layout` only the source of truth for form rendering
- Filters out any `richText` elements from the `formMetaData` passed to the submit API to ensure that any urls in richText do not block the form submission at the  AWS firewall. This is only needed until we can host the form templates in their own DB or API.
- Removes check for element ID's in the `layout` property that do no exist in elements.  This is likely to occur now that we are filtering out the richText elements from the array however their ID still appears in the `layout` property.  The associated test for this check is also removed.   
