### PR TITLE
Update cypress tests to check for brand/logo and confirmation text

### DIFF
--- a/cypress/integration/platform_intake_spec.js
+++ b/cypress/integration/platform_intake_spec.js
@@ -1,7 +1,15 @@
 describe("CDS Platform Intake Form functionality", { baseUrl: "http://localhost:3000" }, () => {
+  let formMetaData = null;
+  before(() => {
+    //Get form JSON configuration
+    cy.readFile("forms/platform_intake.json").then((response) => {
+      formMetaData = response;
+    });
+  });
+
   it("CDS Platform Intake Form renders", () => {
-    cy.visit("/en/id/20");
-    cy.get("h1").contains("Work with CDS on a Digital Form");
+    cy.visit(`/en/id/${formMetaData.form.id}`);
+    cy.get("h1").contains(formMetaData.form.titleEn);
   });
   it("Fill out the form", () => {
     cy.get("input[id='2']").type("Santa Claus").should("have.value", "Santa Claus");
@@ -17,6 +25,11 @@ describe("CDS Platform Intake Form functionality", { baseUrl: "http://localhost:
   });
   it("Submit the Form", () => {
     cy.get("button").contains("Submit").click();
-    cy.url().should("include", "/confirmation");
+    cy.url().should("include", `/en/id/${formMetaData.form.id}/confirmation`);
+    cy.get("h1").contains("Your submission has been received");
+    cy.get("[data-testid='fip']").find("img").should("have.attr", "src", "/img/sig-blk-en.svg");
+    cy.get("#content").contains(
+      "Thank you, your request has been submitted. A team member will email you shortly."
+    );
   });
 });

--- a/cypress/integration/tsb_contact.spec.js
+++ b/cypress/integration/tsb_contact.spec.js
@@ -1,0 +1,37 @@
+describe("TSB Contact Form functionality", { baseUrl: "http://localhost:3000" }, () => {
+  let formMetaData = null;
+
+  before(() => {
+    //Get form JSON configuration
+    cy.readFile("forms/TSB-contact.json").then((response) => {
+      formMetaData = response;
+    });
+  });
+
+  it("TSB Contact Form renders", () => {
+    cy.visit(`/en/id/${formMetaData.form.id}`);
+    cy.get("h1").contains(formMetaData.form.titleEn);
+  });
+  it("Fill out the form", () => {
+    cy.get("input[id='2']").type("Santa").should("have.value", "Santa");
+    cy.get("input[id='3']")
+      .type("santa@northpole.global")
+      .should("have.value", "santa@northpole.global");
+    cy.get(".gc-checkbox-label").click({ multiple: true });
+    cy.get("input[id='5']")
+      .type("Specifying what 'other' means")
+      .should("have.value", "Specifying what 'other' means");
+    cy.get("textarea[id='6']")
+      .type("Contacting the Transportion Safety Board for a personal inquiry")
+      .should("have.value", "Contacting the Transportion Safety Board for a personal inquiry");
+  });
+  it("Submit the Form", () => {
+    cy.get("button").contains("Submit").click();
+    cy.url().should("include", `/en/id/${formMetaData.form.id}/confirmation`);
+    cy.get("h1").contains("Thank you for your enquiry");
+    cy.get("[data-testid='fip']").find("img").should("have.attr", "src", "/img/tsb-en.png");
+    cy.get("#content").contains(
+      "The Transportation Safety Board of Canada will respond to your email within one week."
+    );
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

This PR adds a test for the TSB form and updates the platform intake one:
- Reads the form config file, for formMetadata
- Checks the brand/logo, if applicable
- Checks for text on the confirmation page

Note: I descoped the work, but plan to continue and add fixtures that allow us to dynamically test both EN and FR versions of the forms, all fields, etc
