### PR TITLE
Add block style to logo so that focus state appears when the logo has focus

### DIFF
--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -27,6 +27,10 @@
   @apply xs:px-4 md:px-8 lg:px-16 lg:flex-col-reverse lg:items-start lg:my-10 xl:px-32 xxl:px-48 flex flex-row justify-between items-center my-20 px-64;
 }
 
+.gc-fip a {
+  @apply block;
+}
+
 // LANGUAGE TOGGLE
 
 .gc-language-toggle {


### PR DESCRIPTION
I tried inline-block but that made our default SVG disappear. Block seems to work with both .pngs and .svgs