### PR TITLE
Render and read the asterisk on required fields more accessibly

### DIFF
--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -8,10 +8,11 @@ interface LabelProps {
   error?: boolean;
   hint?: React.ReactNode;
   srOnly?: boolean;
+  required?: boolean;
 }
 
 export const Label = (props: LabelProps): React.ReactElement => {
-  const { children, htmlFor, className, error, hint, srOnly } = props;
+  const { children, htmlFor, className, error, hint, srOnly, required } = props;
 
   const classes = classnames(
     {
@@ -24,7 +25,7 @@ export const Label = (props: LabelProps): React.ReactElement => {
 
   return (
     <label data-testid="label" className={classes} htmlFor={htmlFor}>
-      {children} {classes.includes("required") ? <span aria-label="required">*</span> : null}
+      {children} {required ? <span aria-label="required">*</span> : null}
       {hint && <span className="gc-hint">{hint}</span>}
     </label>
   );

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -24,7 +24,7 @@ export const Label = (props: LabelProps): React.ReactElement => {
 
   return (
     <label data-testid="label" className={classes} htmlFor={htmlFor}>
-      {children}
+      {children} {classes.includes("required") ? <span aria-label="required">*</span> : null}
       {hint && <span className="gc-hint">{hint}</span>}
     </label>
   );

--- a/components/forms/TextArea/TextArea.test.js
+++ b/components/forms/TextArea/TextArea.test.js
@@ -34,7 +34,7 @@ describe("Generate a text area", () => {
       </Form>
     );
     // Label properly renders
-    expect(screen.getByLabelText(textAreaData.properties.titleEn)).toBeInTheDocument();
+    expect(screen.getByTestId("label")).toContainHTML(textAreaData.properties.titleEn);
     // Description properly render
     expect(screen.getByText(textAreaData.properties.descriptionEn)).toBeInTheDocument();
     // Field marked as required and have aria described by
@@ -51,7 +51,7 @@ describe("Generate a text area", () => {
       </Form>
     );
     // Label properly renders
-    expect(screen.getByLabelText(textAreaData.properties.titleFr)).toBeInTheDocument();
+    expect(screen.getByTestId("label")).toContainHTML(textAreaData.properties.titleFr);
     // Description properly render
     expect(screen.getByText(textAreaData.properties.descriptionFr)).toBeInTheDocument();
     // Placeholder properly renders

--- a/components/forms/TextInput/TextInput.test.js
+++ b/components/forms/TextInput/TextInput.test.js
@@ -33,7 +33,7 @@ describe("Generate a text input", () => {
       </Form>
     );
     // Label properly renders
-    expect(screen.getByLabelText(textInputData.properties.titleEn)).toBeInTheDocument();
+    expect(screen.getByTestId("label")).toContainHTML(textInputData.properties.titleEn);
     // Description properly renders
     expect(screen.getByText(textInputData.properties.descriptionEn)).toBeInTheDocument();
     // Field marked as required
@@ -50,7 +50,7 @@ describe("Generate a text input", () => {
       </Form>
     );
     // Label properly renders
-    expect(screen.getByLabelText(textInputData.properties.titleFr)).toBeInTheDocument();
+    expect(screen.getByTestId("label")).toContainHTML(textInputData.properties.titleFr);
     // Description properly render
     expect(screen.getByText(textInputData.properties.descriptionFr)).toBeInTheDocument();
     // Placeholder properly renders

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -64,7 +64,12 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
 
   const labelText = element.properties[getProperty("title", lang)]?.toString();
   const labelComponent = labelText ? (
-    <Label key={`label-${id}`} htmlFor={id} className={isRequired ? "required" : ""}>
+    <Label
+      key={`label-${id}`}
+      htmlFor={id}
+      className={isRequired ? "required" : ""}
+      required={isRequired}
+    >
       {labelText}
     </Label>
   ) : null;

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -145,7 +145,7 @@
 
 .gc-label {
   @apply md:text-small_base block mb-2 text-base font-bold w-full;
-  &.required::after {
+  &.required > span {
     @apply text-red-500;
     content: " *";
   }


### PR DESCRIPTION
As per WCAG, meaningful content should not be inserted using CSS pseudo elements. This PR moves the asterisk indicated a required field into a <span> within the label element. I've also added an aria label to it so that screenreaders will read "required" instead of "star" or "asterisk" when reading it out.

I'm making this as a draft because currently the new asterisk is a separate readout from the label, requiring an extra tab to navigate through, and i'd like to improve that.
UPDATE: upon further research this is how screen readers are expected to work, and so I'm marking this as ready for review.