### PR TITLE
Update checkbox styles to avoid visual bug when using a screenreader

### DIFF
--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -174,7 +174,7 @@
   @apply block;
 
   .gc-input-checkbox__input {
-    @apply absolute opacity-0;
+    @apply md:mr-4 mr-6 absolute w-10 h-10 bg-white-default border-2 border-transparent;
     & + .gc-checkbox-label {
       @apply relative cursor-pointer p-0;
     }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -120,6 +120,7 @@ module.exports = {
         default: "#000",
         form: "#0b0c0c",
       },
+      transparent: "transparent",
     },
     boxShadow: {
       default: "0 1px 3px rgba(0, 0, 0, 0.05);",


### PR DESCRIPTION
Title is pretty self explanatory. Basically just matches the :before style we're using a bit more but transparent so that it doesn't show up. In my local testing, it looks how I would expect it to look. (I compared to Notify and it looks and behaves the same as there from what I can tell).