### PR TITLE
A11y iterations for LanguageToggle and required fields

### DIFF
--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classnames from "classnames";
+import { useTranslation } from "next-i18next";
 
 interface LabelProps {
   children: React.ReactNode;
@@ -23,9 +24,12 @@ export const Label = (props: LabelProps): React.ReactElement => {
     className
   );
 
+  const { t } = useTranslation("common");
+
   return (
     <label data-testid="label" className={classes} htmlFor={htmlFor}>
-      {children} {required ? <span aria-label="required">*</span> : null}
+      {children} {required ? <span aria-hidden>*</span> : null}
+      {required ? <i className="visually-hidden">{t("required-field")}</i> : null}
       {hint && <span className="gc-hint">{hint}</span>}
     </label>
   );

--- a/components/globals/LanguageToggle.js
+++ b/components/globals/LanguageToggle.js
@@ -19,14 +19,17 @@ const LanguageToggle = () => {
 
   return (
     <>
-      <h2 className="sr-only visually-hidden">{t("lang-toggle")}</h2>
       <div className="gc-language-toggle">
+        <label htmlFor="lang-switcher-button">
+          {t("lang-toggle")}: {locale == "en" ? "Français" : "English"}
+        </label>
         {locale == "en" ? (
           <button
             onClick={() => {
               changeLang("fr");
             }}
             lang="fr"
+            id="lang-switcher-button"
           >
             Français
           </button>
@@ -36,6 +39,7 @@ const LanguageToggle = () => {
               changeLang("en");
             }}
             lang="en"
+            id="lang-switcher-button"
           >
             English
           </button>

--- a/lib/tests/setupTests.ts
+++ b/lib/tests/setupTests.ts
@@ -6,3 +6,10 @@ jest.mock("next/config", () => () => ({
     isProduction: false,
   },
 }));
+jest.mock("react-i18next", () => ({
+  useTranslation: () => {
+    return {
+      t: (str: string) => str,
+    };
+  },
+}));

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -34,6 +34,7 @@
     "phone": "Please enter a valid telephone number",
     "regex": "Please enter the correct format"
   },
+  "required-field": "Required",
   "server-error": "Oops, looks like there was a problem submitting your form.  Please try again later.",
   "title": "GC Forms - Formulaires GC"
 }

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -34,6 +34,7 @@
     "phone": "Veuillez entrer numéro de téléphone valide",
     "regex": "Veuillez utiliser le bon format"
   },
+  "required-field": "Nécessaire",
   "server-error": "Oups, il semble qu'un problème est survenu lors de l'envoi de votre formulaire. Veuillez réessayer plus tard.",
   "title": "GC Forms - Formulaires GC"
 }

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -36,24 +36,16 @@
 .gc-language-toggle {
   @apply md:text-small_base text-base text-right;
 
+  label {
+    @include visuallyHidden();
+  }
+
   button {
     @apply shadow-none bg-none text-blue-900 underline border-0;
   }
 }
 
 header {
-  .language-link {
-    h2 {
-      @include visuallyHidden();
-    }
-
-    button {
-      &:focus {
-        @include focus(3px, 3px);
-      }
-    }
-  }
-
   .canada-flag {
     @apply xxs:w-flag-fold xs:w-flag-5s md:w-flag-6s lg:mt-10 w-flag-desktop mt-0;
   }


### PR DESCRIPTION
# Summary | Résumé
Updated the accessibility of the LanguageToggle component, by removing the `<h2>` and replacing with a label.
My biggest outstanding complaint with the language toggle is that when you change the page while using a screenreader, the screenreader does not give any indication that the page or content has changed. Ideally it would read out the new title of the page or somehow otherwise indicate that the content has changed. It looks like this is an area of active work for next.js so we should keep an eye on their updates.

Also iterated on the required field (*) readout - as Screenreader was still reading out the asterisk.
Now it reads out 
`label name ->  "required" -> input description` in successive tabs. Still not perfect but I'm happier with it.

This iteration also required translating the "required" word so that it reads out correctly en français. Let me know if you'd rather I did the importing differently, as this necessitated me mocking out the library for tests.
Also @mcman12 if you could check the translation I used for "required" to make sure you're happy with it!