### PR TITLE
Enable input type and autocomplete for "name" type 

### DIFF
--- a/components/forms/TextInput/TextInput.tsx
+++ b/components/forms/TextInput/TextInput.tsx
@@ -6,7 +6,7 @@ import ErrorMessage from "../ErrorMessage/ErrorMessage";
 interface RequiredTextInputProps {
   id: string;
   name: string;
-  type: "text" | "email" | "number" | "password" | "search" | "tel" | "url";
+  type: "text" | "email" | "name" | "number" | "password" | "search" | "tel" | "url";
 }
 
 interface CustomTextInputProps {

--- a/documentation/Forms/FormViewer.stories.mdx
+++ b/documentation/Forms/FormViewer.stories.mdx
@@ -409,7 +409,7 @@ An option to add rich text to the form via [markdown](https://guides.github.com/
 
 ### Validation and error messages
 
-Every field has a key `validation` that can contain the values below. The type can be "email", "text", "number", "phone", "date" and if those aren't relevant, you can provide a custom regular expression within "regex".
+Every field has a key `validation` that can contain the values below. The type can be "email", "alphanumeric", "text", "name", "number", "phone", "date" and if those aren't relevant, you can provide a custom regular expression within "regex".
 
 ```json
 "validation": {

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -82,6 +82,8 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
           return "email";
         case "phone":
           return "tel";
+        case "name":
+          return "name";
       }
     }
     return "text";
@@ -89,6 +91,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
   const textType = getTextType(element) as
     | "text"
     | "email"
+    | "name"
     | "number"
     | "password"
     | "search"


### PR DESCRIPTION
We already supported the "name" type in the json for validation purposes. This PR just extrapolates this and allows input type="name" and autocomplete="name" to be possible now when this type is used.

Enabling these properties when possible is a best practice for accessibility: https://www.w3.org/TR/WCAG21/#input-purposes