### PR TITLE
Wait for i18n to initialize

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -5,4 +5,8 @@ module.exports = {
     locales: ["en", "fr"],
   },
   localePath: path.resolve("./public/static/locales"),
+  react: {
+    useSuspense: false,
+    wait: true,
+  },
 };


### PR DESCRIPTION
# Summary | Résumé

This PR implements a fix that is caused by the next-i18next package that leverages react-i18next under the hood.  It tries to use `Suspense` however given that some of the pages are rendered server side the `Suspense` function doesn't exist.

Solution posted here on  [NextJS github repo](https://github.com/vercel/next.js/issues/22508)
