### PR TITLE
Fix accessibility issues with error messages 

### DIFF
--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -20,23 +20,24 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
 
   const errorList = props.errors ? getErrorList(props) : null;
   const errorId = "gc-form-errors";
-  const formStatus = props.status === "Error" ? t("server-error") : null;
-  if (formStatus) {
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  }
+  const serverErrorId = `${errorId}-server`;
+  const formStatusError = props.status === "Error" ? t("server-error") : null;
 
   //  If there are errors on the page, set focus the first error field
   useEffect(() => {
+    if (formStatusError) {
+      setFocusOnErrorMessage(props, serverErrorId);
+    }
     if (!props.isValid && props.submitCount > 0) {
-      if (typeof window !== "undefined") {
-        setFocusOnErrorMessage(props, errorId);
-      }
+      setFocusOnErrorMessage(props, errorId);
     }
   }, [props.submitCount, props.isValid, props.errors]);
 
   return (
     <>
-      {formStatus ? <Alert type="error" heading={formStatus} /> : null}
+      {formStatusError ? (
+        <Alert type="error" heading={formStatusError} tabIndex={0} id={serverErrorId} />
+      ) : null}
       {errorList ? (
         <Alert
           type="error"

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { withFormik, FormikProps } from "formik";
 import getConfig from "next/config";
 import { getFormInitialValues } from "../../../lib/formBuilder";
-import { validateOnSubmit, getErrorList, setFocusOnErrors } from "../../../lib/validation";
+import { validateOnSubmit, getErrorList, setFocusOnErrorMessage } from "../../../lib/validation";
 import { submitToAPI } from "../../../lib/dataLayer";
 import { Button, Alert } from "../index";
 import { logMessage } from "../../../lib/logger";
@@ -25,11 +25,11 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
-  //  If there are errors on the page, scroll into view and set focus the first error field
+  //  If there are errors on the page, set focus the first error field
   useEffect(() => {
     if (!props.isValid && props.submitCount > 0) {
       if (typeof window !== "undefined") {
-        setFocusOnErrors(props, errorId);
+        setFocusOnErrorMessage(props, errorId);
       }
     }
   }, [props.submitCount, props.isValid, props.errors]);

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 interface LabelProps {
   children: React.ReactNode;
   htmlFor: string;
+  id?: string;
   className?: string;
   error?: boolean;
   hint?: React.ReactNode;
@@ -12,7 +13,7 @@ interface LabelProps {
 }
 
 export const Label = (props: LabelProps): React.ReactElement => {
-  const { children, htmlFor, className, error, hint, srOnly, required } = props;
+  const { children, htmlFor, className, error, hint, srOnly, required, id } = props;
 
   const classes = classnames(
     {
@@ -24,7 +25,7 @@ export const Label = (props: LabelProps): React.ReactElement => {
   );
 
   return (
-    <label data-testid="label" className={classes} htmlFor={htmlFor}>
+    <label data-testid="label" className={classes} htmlFor={htmlFor} id={id}>
       {children} {required ? <span aria-label="required">*</span> : null}
       {hint && <span className="gc-hint">{hint}</span>}
     </label>

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -66,6 +66,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
   const labelComponent = labelText ? (
     <Label
       key={`label-${id}`}
+      id={`label-${id}`}
       htmlFor={id}
       className={isRequired ? "required" : ""}
       required={isRequired}

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -149,7 +149,7 @@ export const setFocusOnErrorMessage = (
   props: InnerFormProps & FormikProps<FormValues>,
   errorId: string
 ): void => {
-  if (props && props.errors && props.touched && errorId) {
+  if (typeof window !== "undefined" && props && props.errors && props.touched && errorId) {
     const errorAlert = document.getElementById(errorId);
     if (errorAlert && typeof errorAlert !== "undefined") {
       errorAlert.focus();

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -11,6 +11,71 @@ import { FormikProps } from "formik";
 import { TFunction } from "next-i18next";
 
 /**
+ * getRegexByType [private] defines a mapping between the types of fields that need to be validated
+ * Also, defines the regex for validation, with a matching bilingual error message
+ */
+const getRegexByType = (type: string | undefined, t: TFunction, value?: string) => {
+  interface RegexProps {
+    [key: string]: {
+      regex: RegExp | null;
+      error: string;
+    };
+  }
+
+  const REGEX_CONFIG: RegexProps = {
+    email: {
+      regex: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.([a-zA-Z0-9-]{2,}))+$/,
+      error: t("input-validation.email"),
+    },
+    alphanumeric: {
+      regex: /^( )*[A-Za-z0-9\s]+( )*$/,
+      error: t("input-validation.alphanumeric") /* message needs a translation */,
+    },
+    text: {
+      regex: /^.*[^\n]+.*$/,
+      error: t("input-validation.regex") /* TODO update */,
+    },
+    name: {
+      regex: null,
+      error: t("input-validation.regex"), // No error message needed for regex
+    },
+    number: {
+      regex: /^[\d|.|,| ]+/,
+      error: t("input-validation.number"),
+    },
+    date: {
+      regex: /^(0[1-9]|1[0-2])\/(0[1-9]|1\d|2\d|3[01])\/(19|20)\d{2}$/, //mm/dd/yyyy
+      error: t("input-validation.date"),
+    },
+    phone: {
+      regex: /\+?(\d)?[-. ]?(\(?\d{3}\)?)[-. ]?(\d{3})[-. ]?(\d{4})/,
+      error: t("input-validation.phone"),
+    },
+    custom: {
+      regex: value ? new RegExp(value) : null,
+      error: t("input-validation.regex"),
+    },
+  };
+
+  return type ? REGEX_CONFIG[type] : null;
+};
+
+/**
+ * scrollErrorInView [private] is called when you click on an error link at the top of the form
+ * @param e The click event of the error link
+ * @param id The id of the input field that has the error and we need to focus
+ */
+const scrollErrorInView = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, id: string) => {
+  e.preventDefault();
+  const labelElement = document.getElementById(`label-${id}`);
+  const inputElement = document.getElementById(id);
+  if (labelElement && inputElement) {
+    inputElement.focus();
+    labelElement.scrollIntoView();
+  }
+};
+
+/**
  * validateOnSubmit is called during Formik's submission event to validate the fields
  * @param values
  * @param props
@@ -60,7 +125,14 @@ export const getErrorList = (
     errorList = errorEntries.map(([key, value], index) => {
       return (
         <li key={`error-${index}`}>
-          <a href={`#${key}`} className="gc-error-link" key={index}>
+          <a
+            href={`#${key}`}
+            className="gc-error-link"
+            key={index}
+            onClick={(e) => {
+              scrollErrorInView(e, key);
+            }}
+          >
             {value}
           </a>
         </li>
@@ -74,60 +146,17 @@ export const getErrorList = (
   ) : null;
 };
 
-export const setFocusOnErrors = (
+/**
+ * setFocusOnErrorMessage is called if form validation fails and ensures the users can see the messages
+ */
+export const setFocusOnErrorMessage = (
   props: InnerFormProps & FormikProps<FormValues>,
   errorId: string
-) => {
+): void => {
   if (props && props.errors && props.touched && errorId) {
     const errorAlert = document.getElementById(errorId);
     if (errorAlert && typeof errorAlert !== "undefined") {
       errorAlert.focus();
     }
   }
-};
-
-const getRegexByType = (type: string | undefined, t: TFunction, value?: string) => {
-  interface RegexProps {
-    [key: string]: {
-      regex: RegExp | null;
-      error: string;
-    };
-  }
-
-  const REGEX_CONFIG: RegexProps = {
-    email: {
-      regex: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.([a-zA-Z0-9-]{2,}))+$/,
-      error: t("input-validation.email"),
-    },
-    alphanumeric: {
-      regex: /^( )*[A-Za-z0-9\s]+( )*$/,
-      error: t("input-validation.alphanumeric") /* message needs a translation */,
-    },
-    text: {
-      regex: /^.*[^\n]+.*$/,
-      error: t("input-validation.regex") /* TODO update */,
-    },
-    name: {
-      regex: null,
-      error: t("input-validation.regex"), // No error message needed for regex
-    },
-    number: {
-      regex: /^[\d|.|,| ]+/,
-      error: t("input-validation.number"),
-    },
-    date: {
-      regex: /^(0[1-9]|1[0-2])\/(0[1-9]|1\d|2\d|3[01])\/(19|20)\d{2}$/, //mm/dd/yyyy
-      error: t("input-validation.date"),
-    },
-    phone: {
-      regex: /\+?(\d)?[.-]?(\(?\d{3}\)?)[.-]?(\d{3})[.-]?(\d{4})/,
-      error: t("input-validation.phone"),
-    },
-    custom: {
-      regex: value ? new RegExp(value) : null,
-      error: t("input-validation.regex"),
-    },
-  };
-
-  return type ? REGEX_CONFIG[type] : null;
 };

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -67,7 +67,23 @@ export const getErrorList = (
       );
     });
   }
-  return errorList && errorList.length ? <ol className="gc-ordered-list">{errorList}</ol> : null;
+  return errorList && errorList.length ? (
+    <ol id="gc-form-errors" className="gc-ordered-list">
+      {errorList}
+    </ol>
+  ) : null;
+};
+
+export const setFocusOnErrors = (
+  props: InnerFormProps & FormikProps<FormValues>,
+  errorId: string
+) => {
+  if (props && props.errors && props.touched && errorId) {
+    const errorAlert = document.getElementById(errorId);
+    if (errorAlert && typeof errorAlert !== "undefined") {
+      errorAlert.focus();
+    }
+  }
 };
 
 const getRegexByType = (type: string | undefined, t: TFunction, value?: string) => {

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -139,11 +139,7 @@ export const getErrorList = (
       );
     });
   }
-  return errorList && errorList.length ? (
-    <ol id="gc-form-errors" className="gc-ordered-list">
-      {errorList}
-    </ol>
-  ) : null;
+  return errorList && errorList.length ? <ol className="gc-ordered-list">{errorList}</ol> : null;
 };
 
 /**


### PR DESCRIPTION
# Summary | Résumé

In this PR, there are two fixes for validation accessibility:
1. When errors appear at the top of the form, the focus will shift to that error container
2. When clicking on an error link in this container (error alert box), you’ll be “scrolledIntoView” of the label that sits above the input field and the field will have focus on it (previously it would scroll directly into the input field, so the label text couldn't be seen)

*Note: open to future improvements, if we find a way to not use JS 