### PR TITLE
Add accessibility report docs and fix storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,6 +13,11 @@ module.exports = {
       ],
     });
 
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "next-i18next": "react-i18next",
+    };
+
     return config;
   },
 };

--- a/documentation/Forms/AccessibilityReport.stories.mdx
+++ b/documentation/Forms/AccessibilityReport.stories.mdx
@@ -1,0 +1,95 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Forms/Docs: Accessibility Report for Forms (Alpha)" />
+
+# Accessibility Report for Forms (Alpha)
+
+_Canadian Digital Service_
+
+This report describes the conformance of the Forms (Alpha) website with the [W3C’s Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/). This review process is based on the evaluation process described in [Accessibility Evaluation Resources](https://www.w3.org/WAI/eval/).
+
+Based on this evaluation, the Forms (Alpha) website is close to meeting WCAG 2.1, Conformance Level AA. Detailed review results will be available shortly. Feedback on this evaluation is welcome.
+
+Conformance evaluation of this website’s accessibility incorporated a combination of semi-automated evaluation tools and manual evaluation by an experienced team of accessibility testers. Inclusive design reviews were conducted with the product team to ensure best practices were being followed, and that insights from research were iterated on and presented within the app. This document will be updated frequently to reflect the current status of the website.
+
+Read our [Accessibility Statement](https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert/accessibility-statement.html) for the current accessibility status and known issues of Forms (Alpha), as well as our approach to accessibility.
+
+## WCAG 2.1 AA Evaluation
+
+Forms (Alpha) is 95% compliant with WCAG 2.1 AA. Some screens of the website do not yet meet the following success criteria:
+
+- 1.4.11 Non-Text Contrast (AA)
+- 1.4.3 Contrast (Minimum) (Level AA)
+
+### Disability Considerations
+
+We considered the following kinds of disabilities in ensuring the accessibility of Forms (Alpha):
+
+- **Vision:** Complete or partial blindness, color blindness, or other issues related to vision.
+- **Hearing disabilities:** Auditory problems that lead to complete or partial deafness or other hearing impairments.
+- **Physical:** Difficulty using a keyboard, mouse, or other physical tools commonly used to use a computer or mobile.
+- **Cognitive:** Learning or memory difficulties
+- **Literacy:** Reading or comprehension difficulties
+
+### Testing process and tools
+
+We used the following testing processes to improve the accessibility of Forms (Alpha):
+
+- **Manual testing:** Using screen-readers and web accessibility services.
+- **Testing with analysis tools:** To discover opportunities to improve your app's accessibility.
+- **Automated testing:** [https://a11y-tools-query.herokuapp.com/revisions/cds-snc%2Fforms](Accessibility Tracker) and [axe-core via cypress](https://github.com/cds-snc/platform-forms-client/actions/workflows/cypress.yml).
+- **Testing with users:** Soon.
+
+## Tell us how we’re doing
+
+We’re grateful for your feedback and insights. To tell us about accessibility issues in Forms (Alpha), please do one of the following:
+
+- [Create an issue on our public GitHub repository](https://github.com/cds-snc/platform-forms-client/issues).
+- Email us at [a11y@cds-snc.ca](mailto:a11y@cds-snc.ca).
+
+---
+
+# Rapport sur l’accessibilité de l’application Formulaires
+
+_Service numérique canadien_
+
+Le présent rapport décrit le niveau de conformité de Formulaires aux [Règles pour l’accessibilité des contenus Web (WCAG) de W3C](https://www.w3.org/Translations/WCAG20-fr/). Le processus d’examen utilisé est fondé sur le processus d’évaluation décrit dans les [ressources d’évaluation de la l’accessibilité](https://www.w3.org/WAI/eval/).
+
+D’après l’évaluation, Formulaires est près de respecter la conformité de niveau AA des WCAG 2.1. Les résultats détaillés de l’évaluation seront disponibles sous peu. Vos commentaires sur l’évaluation sont les bienvenus.
+
+L’évaluation de la conformité à l’accessibilité de comprenait une combinaison d’outils d’évaluation semi-automatisés et d’évaluations manuelles menées par une équipe expérimentée de testeurs d’accessibilité. L’évaluation a également été éclairée par les commentaires de personnes handicapées concernant l’accessibilité, obtenus par des méthodes à la fois informelles et formelles. Des examens de la conception inclusive ont été menés avec l’équipe de produit pour veiller à ce que les pratiques exemplaires ont été suivies et que les résultats de la recherche ont servi à apporter des itérations qui ont été intégrées dans l’application. Les résultats de l’évaluation décrits dans le présent rapport sont fondés sur une évaluation effectuée avant le lancement de l’application. Des modifications ont pu être apportées à l’application depuis. Le présent document sera fréquemment mis à jour afin de refléter l’état actuel de l’application.
+
+Prenez connaissance de notre [Déclaration sur l’accessibilité](https://www.canada.ca/fr/sante-publique/services/maladies/maladie-coronavirus-covid-19/alerte-covid/declaration-accessibilite.html) pour connaître l’état actuel de l’accessibilité et les problèmes connus concernant l’application Formulaires, ainsi que notre approche en matière d’accessibilité.
+
+## Évaluation de la conformité de niveau AA des WCAG 2.1
+
+Formulaires respecte 95 % des critères de conformité de niveau AA des WCAG 2.1. Certains écrans de l’application ne satisfont pas encore aux critères de réussite suivants :
+
+- 1.4.11 Contraste des éléments non textuels (AA)
+- 1.4.3 Contraste (minimum) (niveau AA)
+
+### Considérations relatives aux handicaps
+
+Nous avons tenu compte des types de handicaps suivants pour assurer l’accessibilité d’Formulaires :
+
+- **Troubles de la vue :** Cécité totale ou partielle, daltonisme ou autres problèmes liés à la vision.
+- **Déficience auditive :** Troubles auditifs qui entraînent une surdité totale ou partielle ou autres déficiences auditives.
+- **Handicaps physiques :** Difficulté à utiliser un clavier, une souris ou d’autres outils matériels couramment utilisés par l’utilisateur d’un ordinateur ou d’un appareil mobile.
+- **Troubles cognitifs :** Troubles d’apprentissage ou de mémoire
+- **Alphabétisme :** Troubles de lecture ou de compréhension
+
+### Processus et outils d’évaluation
+
+Nous avons utilisé les processus d’évaluation suivants pour améliorer l’accessibilité de Formulaires :
+
+- **Tests manuels :** Utilisation des services d’accessibilité.
+- **Tests à l’aide d’outils d’analyse :** Pour cerner les possibilités d’amélioration de l’accessibilité de l’application.
+- **Tests automatisés :** [https://a11y-tools-query.herokuapp.com/revisions/cds-snc%2Fforms](Accessibility Tracker) et [axe-core via cypress](https://github.com/cds-snc/platform-forms-client/actions/workflows/cypress.yml).
+- **Tests menés auprès des utilisateurs :** Prochainement.
+
+## Vos commentaires S.V.P.
+
+Nous serions heureux de recevoir vos commentaires et vos idées. Pour nous faire part de problèmes d’accessibilité dans Formulaires, veuillez procéder de l’une des manières suivantes:
+
+- [Créez un problème (« issue ») dans notre dépôt public GitHub](https://github.com/cds-snc/platform-forms-client/issues).
+- Faites parvenir un courriel à [a11y@cds-snc.ca](mailto:a11y@cds-snc.ca).

--- a/documentation/Forms/FormViewer.stories.mdx
+++ b/documentation/Forms/FormViewer.stories.mdx
@@ -48,7 +48,7 @@ There are 2 main parts to the structure:
 
    `startPage`: Defines what appears on the first, intro page
 
-   `endPage`: Defines what appears on the confirmation page, after the form was submitted
+   `endPage`: Defines what appears on the confirmation page, after the form was submitted. Can write markdown within the description.
 
    `publishingStatus`: If set to false, the link to the form will not appear on the main page, rather under "sandbox"
 
@@ -89,8 +89,8 @@ Example:
     "title": "cds-snc"
   },
   "endPage": {
-    "referrerUrlEn": "https://digital.canada.ca/",
-    "referrerUrlFr": "https://numerique.canada.ca/"
+    "descriptionEn": "# Thank you for your enquiry  \n\r Canadian Digital Services will respond to your email within one week.",
+    "descriptionFr": "# Merci pour votre demande  \n\r Le Service numérique canadien répondra à votre demande d’ici une semaine."
   },
   "elements": [
     {


### PR DESCRIPTION
# Summary | Résumé

- Similarly to how EN (covid alert) has their "[Accessibility Report]( https://github.com/cds-snc/covid-alert-documentation/blob/main/AccessibilityReport.md)" in their repo, I've added our version by slightly modifying their text
- Also, storybook was broken (components like Label uses translations) as it couldn't resolve i18n but found [a fix to resolve via alias](https://github.com/isaachinman/next-i18next/issues/935#issuecomment-802001105)

Note: I'll update Storybook via `gh-pages` after merging this PR. 