### PR TITLE
Add emailSubject field to JSON config to allow customizing it per form

### DIFF
--- a/documentation/Forms/FormViewer.stories.mdx
+++ b/documentation/Forms/FormViewer.stories.mdx
@@ -21,6 +21,8 @@ The form viewer expects a JSON with the following structure.
     "version": 1,
     "titleEn": "",
     "titleFr": "",
+    "emailSubjectEn": "",
+    "emailSubjectFr": "",
     "layout": [ ... ],
     "brand": {},
     "elements": [ ... ],
@@ -39,6 +41,8 @@ There are 2 main parts to the structure:
    `version`: Defines the static version of the form (`int`)
 
    `titleEn/Fr`: The displayed title of the form to the user (`string`)
+
+   `emailSubjectEn/Fr`: Optional value to customize the subject line, if different from the `titleEn/Fr`,
 
    `layout`: The order of the questions and/or page elements identified by id (`array`)
 

--- a/forms/TSB-contact.json
+++ b/forms/TSB-contact.json
@@ -11,8 +11,8 @@
     "version": 1,
     "titleEn": "Transportation Safety Board of Canada general enquiries",
     "titleFr": "Renseignements généraux Bureau de la sécurité des transports du Canada",
-    "emailSubjectEn": "TSB email subject",
-    "emailSubjectFr": "BST couriel sujet",
+    "emailSubjectEn": "TSB general enquiries",
+    "emailSubjectFr": "Renseignements généraux BST",
     "layout": [1, 2, 3, 4, 5, 6, 7],
     "brand": {
       "name": "tsb-bst",

--- a/forms/TSB-contact.json
+++ b/forms/TSB-contact.json
@@ -11,6 +11,8 @@
     "version": 1,
     "titleEn": "Transportation Safety Board of Canada general enquiries",
     "titleFr": "Renseignements généraux Bureau de la sécurité des transports du Canada",
+    "emailSubjectEn": "TSB email subject",
+    "emailSubjectFr": "BST couriel sujet",
     "layout": [1, 2, 3, 4, 5, 6, 7],
     "brand": {
       "name": "tsb-bst",

--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -246,6 +246,8 @@ async function _submitToApI(
       id: formMetadata.id,
       titleEn: formMetadata.titleEn,
       titleFr: formMetadata.titleFr,
+      emailSubjectEn: formMetadata.emailSubjectEn,
+      emailSubjectFr: formMetadata.emailSubjectFr,
       elements: formMetadata.elements,
       layout: formMetadata.layout,
     },

--- a/lib/markdown.tsx
+++ b/lib/markdown.tsx
@@ -4,7 +4,15 @@ import { Submission } from "./types";
 import { extractFormData } from "./dataLayer";
 
 export default logger((formResponse: Submission): string => {
-  const title = `${formResponse.form.titleEn} / ${formResponse.form.titleFr}`;
+  const subjectEn = formResponse.form.emailSubjectEn
+    ? formResponse.form.emailSubjectEn
+    : formResponse.form.titleEn;
+  const subjectFr = formResponse.form.emailSubjectFr
+    ? formResponse.form.emailSubjectFr
+    : formResponse.form.titleFr;
+
+  const title = `${subjectEn} / ${subjectFr}`;
+
   const stringifiedData = extractFormData(formResponse);
   const mdBody = stringifiedData.map((item) => {
     return { p: item };

--- a/lib/tests/markdown.test.js
+++ b/lib/tests/markdown.test.js
@@ -22,3 +22,25 @@ describe("JSON to markdown", () => {
       .toEqual(expect.stringContaining("three"));
   });
 });
+
+describe("Custom email subject - JSON to markdown", () => {
+  const mockForm = {
+    form: {
+      titleEn: "I'm a title",
+      titleFr: "Je suis une titre",
+      emailSubjectEn: "I'm an email subject title",
+      emailSubjectFr: "Je suis une couriel sujet titre",
+    },
+    responses: {},
+  };
+  test("Renders email subject", () => {
+    const response = markdown(mockForm);
+    expect(response)
+      .toEqual(
+        expect.stringContaining("# I'm an email subject title / Je suis une couriel sujet titre")
+      )
+      .toEqual(expect.stringContaining("one"))
+      .toEqual(expect.stringContaining("two"))
+      .toEqual(expect.stringContaining("three"));
+  });
+});

--- a/lib/types.tsx
+++ b/lib/types.tsx
@@ -7,6 +7,8 @@ export interface FormMetadataProperties {
   version?: string | undefined;
   titleEn: string;
   titleFr: string;
+  emailSubjectEn?: string;
+  emailSubjectFr?: string;
   layout: Array<string>;
   brand?: BrandProperties;
   elements: Array<FormElement>;

--- a/pages/api/submit.js
+++ b/pages/api/submit.js
@@ -73,7 +73,7 @@ const previewNotify = async (form, fields) => {
   );
 
   const emailBody = await convertMessage({ form, responses: fields });
-  const messageSubject = form.titleEn + " Submission";
+  const messageSubject = `${form.emailSubjectEn ? form.emailSubjectEn : form.titleEn} Submission`;
   return await notify
     .previewTemplateById(templateID, {
       subject: messageSubject,


### PR DESCRIPTION
# Summary | Résumé

- This PR adds a new field in EN/FR to allow customizing the email subject line for the form
- Tests/Docs updated

TODO: update the terraform repos as well ([staging PR](https://github.com/cds-snc/forms-staging-terraform/pull/14) and [prod](https://github.com/cds-snc/forms-production-terraform/blob/main/forms/aws/lambda/reliability/reliability.js#L38))