### PR TITLE
Get vault submission to nextJS page

### DIFF
--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -16,7 +16,7 @@ import {
 
 // Get the form json object by using the form ID
 // Returns => json object of form
-function _getFormByID(formID: string): Record<string, unknown> {
+function _getFormByID(formID: string): FormMetadataProperties {
   // Need to get these forms from a DB or API in the future
   let formToReturn = null;
   for (const form of Object.values(Forms)) {

--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -233,7 +233,7 @@ function _handleFormDataText(key: string, value: string, formData: FormData) {
 function _handleFormDataArray(key: string, value: Array<string>, formData: FormData) {
   formData.append(key, JSON.stringify({ value: value }));
 }
-async function _submitToApI(
+async function _submitToAPI(
   values: Responses,
   formikBag: FormikBag<DynamicFormProps, FormValues>,
   isProduction: boolean
@@ -308,6 +308,6 @@ async function _submitToApI(
 export const getFormByID = logger(_getFormByID);
 export const getSubmissionByID = logger(_getSubmissionByID);
 export const getFormByStatus = logger(_getFormByStatus);
-export const submitToAPI = logger(_submitToApI);
+export const submitToAPI = logger(_submitToAPI);
 export const rehydrateFormResponses = logger(_rehydrateFormResponses);
 export const buildFormDataObject = logger(_buildFormDataObject);

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { signOut } from "next-auth/client";
+import Link from "next/link";
 import { AuthenticatedUser } from "../../lib/types";
 import { requireAuthentication } from "../../lib/auth";
 import { Button } from "../../components/forms";
@@ -48,6 +49,13 @@ const AdminWelcome: React.FC<AdminWelcomeProps> = (props: AdminWelcomeProps) => 
             <Link href="/admin/vault">View Form Submissions</Link>
           </p>
         </div>
+      </div>
+      <div className="pt-10">
+        <li>
+          <Link href={"/admin/vault"} locale={i18n.language}>
+            {t("formResponses")}
+          </Link>
+        </li>
       </div>
     </>
   );

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { signOut } from "next-auth/client";
-import Link from "next/link";
 import { AuthenticatedUser } from "../../lib/types";
 import { requireAuthentication } from "../../lib/auth";
 import { Button } from "../../components/forms";
@@ -49,13 +48,6 @@ const AdminWelcome: React.FC<AdminWelcomeProps> = (props: AdminWelcomeProps) => 
             <Link href="/admin/vault">View Form Submissions</Link>
           </p>
         </div>
-      </div>
-      <div className="pt-10">
-        <li>
-          <Link href={"/admin/vault"} locale={i18n.language}>
-            {t("formResponses")}
-          </Link>
-        </li>
       </div>
     </>
   );

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -2,8 +2,6 @@ import React, { useState } from "react";
 import { useTranslation } from "next-i18next";
 import axios from "axios";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { signOut } from "next-auth/client";
-import { Responses, FormMetadataProperties } from "../../lib/types";
 import { requireAuthentication } from "../../lib/auth";
 import { getFormByID } from "../../lib/dataLayer";
 import convertMessage from "../../lib/markdown";
@@ -91,7 +89,6 @@ const AdminVault: React.FC = () => {
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    console.log(formID);
     fetchResponses(formID);
   };
 
@@ -113,7 +110,7 @@ const AdminVault: React.FC = () => {
           setResponses(response.data);
         })
         .catch((err) => {
-          console.log(err);
+          console.error(err);
           setResponses({ Items: [], Count: 0 });
         });
     } else {

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { useTranslation } from "next-i18next";
+import axios from "axios";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { signOut } from "next-auth/client";
+import { AuthenticatedUser, FormMetadataProperties } from "../../lib/types";
+import { requireAuthentication } from "../../lib/auth";
+import { Button } from "../../components/forms";
+
+const AdminVault: React.FC = () => {
+  const { t } = useTranslation("admin-vault");
+
+  const [formID, setFormID] = useState("");
+  const [responses, setResponses] = useState<ResponseListInterface>({ Items: [], Count: 0 });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    console.log(formID);
+    fetchResponses(formID);
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFormID(event.target.value);
+  };
+
+  const fetchResponses = async (formID: string) => {
+    await axios({
+      url: "/api/retrieval",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json ",
+      },
+      data: { formID, action: "GET" },
+    }).then((response) => {
+      setResponses(response.data);
+    });
+  };
+
+  interface ResponseListInterface {
+    Items: {
+      FormSubmission: {
+        S: string;
+      };
+      SubmissionID: {
+        S: string;
+      };
+      FormID: {
+        S: string;
+      };
+    }[];
+    Count: number;
+  }
+
+  return (
+    <>
+      <h1 className="gc-h1">{t("title")}</h1>
+      <div>
+        <h2 className="gc-h2">{t("subTitle")}:</h2>
+      </div>
+      <div>
+        <form id="form" onSubmit={handleSubmit}>
+          <label className={"gc-label"} htmlFor={"formTextInput"} id={"1"}>
+            {t("formInput")}
+          </label>
+          <input
+            className={"gc-input-text"}
+            id={"formTextInput"}
+            name="formTextInput"
+            onChange={handleChange}
+          />
+          <div className="buttons">
+            <Button className="gc-button" type="submit">
+              {t("submitButton")}
+            </Button>
+          </div>
+        </form>
+        {responses.Count
+          ? responses.Items.map((response) => {
+              const submission = response.FormSubmission.S;
+              const submissionID = response.SubmissionID.S;
+              const formID = response.FormID.S;
+              return (
+                <div key={submissionID}>
+                  <p>Submission: {submission}</p>
+                  <p>SubmissionID: {submissionID}</p>
+                  <p>For Form: {formID}</p>
+                </div>
+              );
+            })
+          : null}
+      </div>
+    </>
+  );
+};
+
+export const getServerSideProps = requireAuthentication(async (context) => {
+  if (context.locale) {
+    return {
+      props: {
+        ...(await serverSideTranslations(context.locale, ["common", "admin-vault"])),
+      },
+    };
+  }
+  return { props: {} };
+});
+
+export default AdminVault;

--- a/pages/api/retrieval.js
+++ b/pages/api/retrieval.js
@@ -1,0 +1,50 @@
+const { LambdaClient, InvokeCommand } = require("@aws-sdk/client-lambda");
+import { getSession } from "next-auth/client";
+import { logMessage } from "../../lib/logger";
+
+const retrieval = async (req, res) => {
+  const session = await getSession({ req });
+
+  if (session) {
+    const formID = req.body.formID ? req.body.formID : null;
+    const action = req.body.action ? req.body.action : null;
+    if (!formID) {
+      throw new Error("No form ID specified");
+    }
+
+    const lambdaClient = new LambdaClient({ region: "ca-central-1" });
+
+    const command = new InvokeCommand({
+      FunctionName: process.env.RETRIEVAL_API ?? "Retrieval",
+      Payload: JSON.stringify({
+        formID,
+        action,
+      }),
+    });
+    return await lambdaClient
+      .send(command)
+      .then((response) => {
+        if (response.FunctionError) {
+          throw Error("Submission API could not process form response");
+        } else {
+          logMessage.info("Lambda Client successfully triggered");
+        }
+
+        let decoder = new TextDecoder();
+        const payload = JSON.parse(decoder.decode(response.Payload));
+
+        const { Items, Count } = payload;
+
+        res.status(200).json({ Items, Count });
+      })
+      .catch((err) => {
+        logMessage.error(err);
+        throw new Error("Could not process request with Lambda Retrieval function");
+      });
+  } else {
+    // Not Signed in
+    res.status(403).json({ error: "Need to be authenticate" });
+  }
+};
+
+export default retrieval;

--- a/pages/api/submit.js
+++ b/pages/api/submit.js
@@ -41,11 +41,12 @@ const callLambda = async (form, fields) => {
   const lambdaClient = new LambdaClient({ region: "ca-central-1" });
 
   const command = new InvokeCommand({
-    FunctionName: process.env.SUBMISSION_API ?? "",
+    FunctionName: process.env.SUBMISSION_API ?? "Submission",
     Payload: JSON.stringify({
       form,
       responses: fields,
       submission,
+      vault: true,
     }),
   });
   return await lambdaClient

--- a/public/static/locales/en/admin-login.json
+++ b/public/static/locales/en/admin-login.json
@@ -5,5 +5,6 @@
   "button": {
     "login": "Login",
     "logout": "Logout"
-  }
+  },
+  "formResponses": "Stored Responses from forms"
 }

--- a/public/static/locales/en/admin-vault.json
+++ b/public/static/locales/en/admin-vault.json
@@ -1,0 +1,6 @@
+{
+  "title": "Forms Vault",
+  "subTitle": "Your form responses",
+  "formInput": "Form to get responses for",
+  "submitButton": "Look up responses"
+}


### PR DESCRIPTION
# Summary | Résumé

This PR creates a new page `/admin/vault` and a new api endpoint `/api/retrieval` that request through a lambda function submissions that have been stored in the vault for a specific form.  Both the `/admin/vault` page and `/api/retrieval` api are protected through auth.  Designs are obviously to be iterated upon.

| Search for Form 45 | Response 1 | Response 2 |
|:-----:|:----:|:----:|
|![Screen Shot 2021-05-19 at 1 39 39 PM](https://user-images.githubusercontent.com/25329319/118859366-246be780-b8a8-11eb-9961-01a10fe153c4.png)| ![Screen Shot 2021-05-19 at 1 40 14 PM](https://user-images.githubusercontent.com/25329319/118859386-2b92f580-b8a8-11eb-9c42-2642e5fb1cdd.png) | ![Screen Shot 2021-05-19 at 1 40 24 PM](https://user-images.githubusercontent.com/25329319/118859410-3188d680-b8a8-11eb-8d80-b53fe36455fc.png)


