### PR TITLE
Expose GET method in api/templates, and don't crash the app if the lambda times out

### DIFF
--- a/pages/admin/upload.js
+++ b/pages/admin/upload.js
@@ -41,7 +41,10 @@ const handleSubmit = async (e) => {
     headers: {
       "Content-Type": "multipart/form-data",
     },
-    data: jsonInput.value,
+    data: {
+      json_config: jsonInput.value,
+      method: "INSERT", // todo, not hard code based on whether formID present
+    },
     timeout: 0,
   })
     .then((serverResponse) => {


### PR DESCRIPTION
# Summary | Résumé
Restructuring the api/templates route to actually accept and handle post POST and GET requests, to hopefully unblock @bryan-robitaille 

Also added a quick fix to just return null if the lambda has timed out instead of bringing down the whole app. Will brainstorm methods to reduce lambda timeouts tomorrow!