### PR TITLE
Add white text to active state for mobile

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -90,7 +90,7 @@ ul.custom {
 
         a:active {
           box-shadow: 4px 0 0 0 #1B2736, -4px 0 0 0 #1B2736;
-          @apply underline bg-blue-active;
+          @apply underline bg-blue-active text-white-default;
         }
       }
       li:last-of-type {
@@ -126,7 +126,7 @@ a:focus {
 
 a:active {
   box-shadow: 4px 0 0 0 #1B2736, -4px 0 0 0 #1B2736;
-  @apply underline bg-blue-active;
+  @apply underline bg-blue-active text-white-default;
 }
 
 .link-list {

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -69,7 +69,7 @@
 
     &:active {
       box-shadow: 4px 0 0 0 #1b2736, -4px 0 0 0 #1b2736;
-      @apply underline bg-blue-active;
+      @apply underline bg-blue-active text-white-default;
     }
   }
 }
@@ -137,7 +137,7 @@
 
   a:active {
     box-shadow: 4px 0 0 0 #1b2736, -4px 0 0 0 #1b2736;
-    @apply underline bg-blue-active;
+    @apply underline bg-blue-active text-white-default;
   }
 }
 

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -52,7 +52,7 @@
 
   button:active {
     box-shadow: 4px 0 0 0 #1b2736, -4px 0 0 0 #1b2736;
-    @apply underline bg-blue-active;
+    @apply underline bg-blue-active text-white-default;
   }
 }
 


### PR DESCRIPTION
## Context

With the way `hover` works on mobile it was triggering the hover state and the active state at the same time. The result was blue text on a dark background (gross!). 

The active styles have been updated to have white text so they will overwrite the hover state as the button is touched.
