### PR TITLE
Hide header/footer if embedding a form within an iframe

### DIFF
--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -17,6 +17,7 @@ const Base = ({ children }) => {
   } = getConfig();
   const formMetadata =
     children && children.props && children.props.formMetadata ? children.props.formMetadata : null;
+  const isEmbeddable = formMetadata && children && children.props && children.props.isEmbeddable;
   const classes = getPageClassNames(formMetadata);
 
   return (
@@ -51,12 +52,14 @@ const Base = ({ children }) => {
       </Head>
       <SkipLink />
       <div className={classes}>
-        <header>
-          <PhaseBanner />
-          <Fip formMetadata={formMetadata} />
-        </header>
+        {!isEmbeddable && (
+          <header>
+            <PhaseBanner />
+            <Fip formMetadata={formMetadata} />
+          </header>
+        )}
         <main id="content">{children}</main>
-        <Footer />
+        {!isEmbeddable && <Footer />}
       </div>
     </>
   );

--- a/documentation/Introduction.stories.mdx
+++ b/documentation/Introduction.stories.mdx
@@ -12,6 +12,14 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - Tech stack: [Next.js](https://nextjs.org/), TypeScript, React components, using Formik for form processing
 - [Data Models](https://cds-snc.github.io/platform-forms-client/?path=/story/forms-docs-form-viewer-json--page)
 
+### Embed a form
+
+- To embed a form via iframes, simply append the `?embed=true` parameter to the URL of the form, e.g.
+
+```HTML
+<iframe src="https://forms-formulaires.alpha.canada.ca/id/20?embed=true" title="Form description title"></iframe>
+```
+
 ### Forms Design System
 
 - The UI inventory is a single source of truth for both Design and Development when it comes to best practices in UI.

--- a/pages/id/[form]/[[...step]].js
+++ b/pages/id/[form]/[[...step]].js
@@ -6,6 +6,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 export async function getServerSideProps(context) {
   let form = null;
   const formId = context.params.form;
+  const isEmbeddable = (context.query.embed && context.query.embed == "true") || null;
   const {
     publicRuntimeConfig: { isProduction: isProduction },
   } = getConfig();
@@ -34,6 +35,7 @@ export async function getServerSideProps(context) {
   return {
     props: {
       formMetadata: form,
+      isEmbeddable: isEmbeddable,
       ...(await serverSideTranslations(context.locale, ["common", "welcome", "confirmation"])),
     }, // will be passed to the page component as props
   };


### PR DESCRIPTION
# Summary | Résumé

- If we pass the `?embed=true` parameter to a form url, the header and the footer won't be shown
- Updated docs to indicate how to embed in an iframe

```
<iframe src="https://forms-formulaires.alpha.canada.ca/id/20?embed=true" title="Form description title"></iframe>
```
