### PR TITLE
Vault response delete

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,1 @@
-{ "baseUrl": "http://localhost:3000", "video": false }
+{ "baseUrl": "http://localhost:3000", "video": false, "defaultCommandTimeout": 10000 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "yarn migrate && next start -p ${PORT:-3000}",
     "migrate": "cd ./migrations && yarn migrate && cd ..",
-    "start:test": "NODE_ENV=test next start",
+    "start:test": "CYPRESS=true next start",
     "lint": "eslint . ",
     "lint:report": "eslint --output-file eslint_report.json --format json . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint --fix .",

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -29,6 +29,8 @@ const FormResponse = ({ Items, Count, formSchema }: ResponseListInterface) => {
   const [response, setResponse] = useState("");
   const [submissionID, setSubmissionID] = useState("");
 
+  const { t } = useTranslation("admin-vault");
+
   useEffect(() => {
     if (Items.length > 0) {
       const submission = Items[index];
@@ -39,6 +41,10 @@ const FormResponse = ({ Items, Count, formSchema }: ResponseListInterface) => {
       });
     }
   }, [index, Items]);
+
+  useEffect(() => {
+    setIndex(0);
+  }, [formSchema, Count]);
 
   if (Count > 0) {
     return (
@@ -61,7 +67,7 @@ const FormResponse = ({ Items, Count, formSchema }: ResponseListInterface) => {
                 setIndex(goTo >= 0 ? goTo : 0);
               }}
             >
-              Back
+              {t("backButton")}
             </Button>
           ) : null}
 
@@ -75,7 +81,7 @@ const FormResponse = ({ Items, Count, formSchema }: ResponseListInterface) => {
                 setIndex(goTo >= 0 ? goTo : 0);
               }}
             >
-              Next
+              {t("nextButton")}
             </Button>
           ) : null}
         </div>
@@ -84,7 +90,7 @@ const FormResponse = ({ Items, Count, formSchema }: ResponseListInterface) => {
   } else {
     return (
       <>
-        <h3>No Responses for selected form</h3>
+        <h3>{t("noResponse")}</h3>
       </>
     );
   }

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -20,97 +20,114 @@ interface ResponseListInterface {
       S: string;
     };
   }[];
-  Count: number;
   formSchema?: PublicFormSchemaProperties;
 }
 
-const FormResponse = ({ Items, Count, formSchema }: ResponseListInterface) => {
+const FormResponse = ({ Items, formSchema }: ResponseListInterface) => {
   const [index, setIndex] = useState(0);
+  const [submissionArray, setSubmissionArray] = useState(Items);
   const [response, setResponse] = useState("");
   const [submissionID, setSubmissionID] = useState("");
-
   const { t } = useTranslation("admin-vault");
 
+  const removeSubmission = async () => {
+    if (submissionID) {
+      await axios({
+        url: "/api/retrieval",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json ",
+        },
+        data: { responseID: submissionID, action: "DELETE" },
+      })
+        .then(() => {
+          setSubmissionArray((subArray) =>
+            subArray.filter((item) => item.SubmissionID.S !== submissionID)
+          );
+          setIndex((index) => (index === submissionArray.length - 1 ? index - 1 : index));
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
+  };
+
   useEffect(() => {
-    if (Items.length > 0 && formSchema) {
-      const submission = Items[index];
+    if (submissionArray.length > 0 && formSchema) {
+      const submission = submissionArray[index];
       const responseJson = JSON.parse(submission.FormSubmission.S);
       const message = convertMessage({ form: formSchema, responses: responseJson });
       setResponse(message);
       setSubmissionID(submission.SubmissionID.S);
     }
-  }, [index, Items, formSchema]);
+  }, [index, submissionArray, formSchema]);
 
   useEffect(() => {
     setIndex(0);
-  }, [formSchema]);
+    setSubmissionArray(Items);
+  }, [formSchema, Items]);
 
-  if (Count > 0) {
-    return (
-      <>
-        <div className="border-b-4">
-          <div className="flex items-center">
-            <div className="pl-4 flex-auto">
-              <p>{`Response ${index + 1} of ${Count}`}</p>
-            </div>
-            <div className="flex-auto">
-              <Button className="gc-button rounded-lg float-right" type="button" onClick={() => {}}>
-                {t("removeButton")}
-              </Button>
-            </div>
+  return (
+    <>
+      <div className="border-b-4">
+        <div className="flex items-center">
+          <div className="pl-4 flex-auto">
+            <p>{`Response ${index + 1} of ${submissionArray.length}`}</p>
           </div>
-          <p className="pl-4">{`Submission ID: ${submissionID}`}</p>{" "}
-        </div>
-
-        <div className="p-5">
-          <RichText className="email-preview">{response}</RichText>
-        </div>
-        <div className="inline-block justify-center flex space-x-20">
-          {index > 0 ? (
-            <Button
-              className="gc-button rounded-lg float-left"
-              type="button"
-              onClick={() => {
-                const goTo = index - 1;
-
-                setIndex(goTo >= 0 ? goTo : 0);
-              }}
-            >
-              {t("backButton")}
-            </Button>
-          ) : null}
-
-          {index < Count - 1 ? (
+          <div className="flex-auto">
             <Button
               className="gc-button rounded-lg float-right"
               type="button"
-              onClick={() => {
-                const goTo = index + 1;
-
-                setIndex(goTo >= 0 ? goTo : 0);
-              }}
+              onClick={removeSubmission}
             >
-              {t("nextButton")}
+              {t("removeButton")}
             </Button>
-          ) : null}
+          </div>
         </div>
-      </>
-    );
-  } else {
-    return (
-      <>
-        <h3>{t("noResponse")}</h3>
-      </>
-    );
-  }
-};
+        <p className="pl-4">{`Submission ID: ${submissionID}`}</p>{" "}
+      </div>
 
+      <div className="p-5">
+        <RichText className="email-preview">{response}</RichText>
+      </div>
+      <div className="inline-block justify-center flex space-x-20">
+        {index > 0 ? (
+          <Button
+            className="gc-button rounded-lg float-left"
+            type="button"
+            onClick={() => {
+              const goTo = index - 1;
+
+              setIndex(goTo >= 0 ? goTo : 0);
+            }}
+          >
+            {t("backButton")}
+          </Button>
+        ) : null}
+
+        {index < submissionArray.length - 1 ? (
+          <Button
+            className="gc-button rounded-lg float-right"
+            type="button"
+            onClick={() => {
+              const goTo = index + 1;
+
+              setIndex(goTo >= 0 ? goTo : 0);
+            }}
+          >
+            {t("nextButton")}
+          </Button>
+        ) : null}
+      </div>
+    </>
+  );
+};
 const AdminVault: React.FC = () => {
   const { t } = useTranslation("admin-vault");
 
   const [formID, setFormID] = useState("");
   const [formSchema, setFormSchema] = useState<PublicFormSchemaProperties | undefined>(undefined);
-  const [responses, setResponses] = useState<ResponseListInterface>({ Items: [], Count: 0 });
+  const [responses, setResponses] = useState<ResponseListInterface>({ Items: [] });
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -142,10 +159,10 @@ const AdminVault: React.FC = () => {
         })
         .catch((err) => {
           console.error(err);
-          setResponses({ Items: [], Count: 0 });
+          setResponses({ Items: [] });
         });
     } else {
-      setResponses({ Items: [], Count: 0 });
+      setResponses({ Items: [] });
     }
   };
 
@@ -176,7 +193,11 @@ const AdminVault: React.FC = () => {
       </div>
       <div className="border-4 rounded-lg border-black border-solid ">
         <div>
-          <FormResponse {...responses} formSchema={formSchema} />
+          {responses.Items.length ? (
+            <FormResponse {...responses} formSchema={formSchema} />
+          ) : (
+            <h3>{t("noResponse")}</h3>
+          )}
         </div>
       </div>
     </>

--- a/pages/api/submit.tsx
+++ b/pages/api/submit.tsx
@@ -142,10 +142,8 @@ const processFormData = async (
       responses: reqFields,
     });
 
-    /// Pick up here on Monday morning!!
-
     // Staging or Production AWS environments
-    if (process.env.NODE_ENV === "test") {
+    if (process.env.CYPRESS) {
       logMessage.info("Not Sending Email - Test mode");
       return res.status(200).json({ received: true });
     } else if (process.env.SUBMISSION_API) {
@@ -169,6 +167,8 @@ const processFormData = async (
       return await previewNotify(form, fields).then((response) => {
         return res.status(201).json({ received: true, htmlEmail: response });
       });
+    } else {
+      return res.status(400).json({ received: false });
     }
   } catch (err) {
     logMessage.error(err);

--- a/public/static/locales/en/admin-vault.json
+++ b/public/static/locales/en/admin-vault.json
@@ -2,5 +2,9 @@
   "title": "Forms Vault",
   "subTitle": "Your form responses",
   "formInput": "Form to get responses for",
-  "submitButton": "Look up responses"
+  "submitButton": "Look up responses",
+  "noResponse": "No Responses for selected form",
+  "nextButton": "Next",
+  "backButton": "Previous",
+  "removeButton": "Processed"
 }

--- a/public/static/locales/fr/admin-vault.json
+++ b/public/static/locales/fr/admin-vault.json
@@ -1,0 +1,10 @@
+{
+  "title": "Coffre de formulaires",
+  "subTitle": "Vos submissions",
+  "formInput": "Formulaire pour recueillir les submissions",
+  "submitButton": "Recueillir les submissions",
+  "noResponse": "Aucune submission pour cette formualire",
+  "nextButton": "Prochain",
+  "backButton": "Précédent",
+  "removeButton": "Traité"
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds the functionality to mark a form submission as processed and removes it from the Vault storage.

| Reading form submission | Form submission processed|
|:----:|:----:|
|![Screen Shot 2021-05-26 at 3 45 56 PM](https://user-images.githubusercontent.com/25329319/119721812-93fa4d80-be39-11eb-9c5e-62d55ec4fef4.png)|![Screen Shot 2021-05-26 at 3 46 22 PM](https://user-images.githubusercontent.com/25329319/119721809-92308a00-be39-11eb-884e-73cddcf31c01.png)

It also adds a new env var called `CYPRESS` when started with `yarn start:test` that ensures cypress does not actually submit forms.
Also increased Cypress command timeout to 10s from 4s. 