### PR TITLE
Add redirects and confirmations for uploads and deletes

### DIFF
--- a/components/containers/DynamicForm/Settings.test.js
+++ b/components/containers/DynamicForm/Settings.test.js
@@ -17,6 +17,9 @@ describe("Form Settings Page", () => {
     formConfig: { test: "test JSON" },
   };
   test("renders without errors", () => {
+    useRouter.mockImplementation(() => ({
+      query: {},
+    }));
     render(<FormSettings form={form}></FormSettings>);
     expect(screen.queryByText("Form ID: 15")).toBeInTheDocument();
   });
@@ -33,6 +36,9 @@ describe("Form Settings Page", () => {
     render(<FormSettings form={form}></FormSettings>);
 
     await fireEvent.click(screen.queryByTestId("delete"));
+    expect(screen.queryByTestId("confirmDelete")).toBeInTheDocument();
+
+    await fireEvent.click(screen.queryByTestId("confirmDelete"));
     expect(push).toHaveBeenCalled();
   });
 });

--- a/components/containers/DynamicForm/Settings.tsx
+++ b/components/containers/DynamicForm/Settings.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import JSONUpload from "../../forms/JsonUpload/JsonUpload";
 import { useTranslation } from "next-i18next";
 import Button from "../../forms/Button/Button";
@@ -40,13 +40,14 @@ export const FormSettings = (props: FormSettingsProps): React.ReactElement => {
   const { form } = props;
   const router = useRouter();
   const { t } = useTranslation("admin-templates");
-  return (
+
+  const newText = router.query && router.query.newForm ? t("settings.new") : "";
+
+  const [deleteVisible, setDeleteVisible] = useState(false);
+
+  const deleteButton = deleteVisible ? (
     <>
-      <h1 className="gc-h1">{t("settings.title")}</h1>
-      <div data-testid="formID">Form ID: {form.formID}</div>
-      <h2>Edit Form Config File:</h2>
-      <JSONUpload form={form}></JSONUpload>
-      <br />
+      <p>{t("settings.delete-check")}</p>
       <Button
         onClick={async () => {
           try {
@@ -62,11 +63,38 @@ export const FormSettings = (props: FormSettingsProps): React.ReactElement => {
             console.error(e);
           }
         }}
-        testid="delete"
+        testid="confirmDelete"
         type="button"
       >
-        {t("settings.delete")}
+        {t("settings.confirm-delete")}
       </Button>
+    </>
+  ) : (
+    ""
+  );
+
+  return (
+    <>
+      <h1 className="gc-h1">{t("settings.title")}</h1>
+      <div>
+        <p>{newText}</p>
+      </div>
+      <div data-testid="formID">Form ID: {form.formID}</div>
+      <h2>Edit Form Config File:</h2>
+      <JSONUpload form={form}></JSONUpload>
+      <br />
+      <div>
+        <Button
+          type="button"
+          testid="delete"
+          onClick={() => {
+            setDeleteVisible(!deleteVisible);
+          }}
+        >
+          {t("settings.delete")}
+        </Button>
+        <div>{deleteButton}</div>
+      </div>
     </>
   );
 };

--- a/components/forms/JsonUpload/JsonUpload.tsx
+++ b/components/forms/JsonUpload/JsonUpload.tsx
@@ -10,9 +10,10 @@ interface JSONUploadProps {
 
 export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
   const { t, i18n } = useTranslation("admin-templates");
-  const [jsonConfig, setJsonConfig] = useState("");
-  const [submitStatus, setSubmitStatus] = useState("");
   const { form } = props;
+
+  const [jsonConfig, setJsonConfig] = useState(form ? JSON.stringify(form.formConfig) : "");
+  const [submitStatus, setSubmitStatus] = useState("");
 
   const formID = form ? form.formID : null;
   const router = useRouter();

--- a/components/forms/JsonUpload/JsonUpload.tsx
+++ b/components/forms/JsonUpload/JsonUpload.tsx
@@ -2,25 +2,44 @@ import React, { useState } from "react";
 import axios from "axios";
 import { useTranslation } from "next-i18next";
 import { FormDBConfigProperties } from "../../../lib/types";
+import { useRouter } from "next/router";
 
 interface JSONUploadProps {
   form?: FormDBConfigProperties;
 }
 
 export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
-  const { t } = useTranslation("admin-templates");
+  const { t, i18n } = useTranslation("admin-templates");
   const [jsonConfig, setJsonConfig] = useState("");
+  const [submitStatus, setSubmitStatus] = useState("");
   const { form } = props;
 
   const formID = form ? form.formID : null;
+  const router = useRouter();
 
   return (
     <>
       <div>
         <form
-          onSubmit={(e) => {
+          onSubmit={async (e) => {
             e.preventDefault();
-            handleSubmit(jsonConfig, formID);
+            const resp = await handleSubmit(jsonConfig, formID);
+            console.log(resp);
+            // If the server returned a record, this is a new record
+            // Redirect to the appropriate page
+            if (resp && resp.data && resp.data.data && resp.data.data.records) {
+              const formID = resp.data.data.records[0].formID;
+              router.push({
+                pathname: `/${i18n.language}/id/${formID}/settings`,
+                query: {
+                  newForm: true,
+                },
+              });
+            } else if (resp) {
+              // If not, but response was successful,
+              // update the page text to show a success
+              setSubmitStatus(t("upload.success"));
+            }
           }}
           method="POST"
           encType="multipart/form-data"
@@ -40,6 +59,7 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
             <button type="submit" className="gc-button">
               {t("upload.submit")}
             </button>
+            <span id="submitStatus">{submitStatus}</span>
           </div>
         </form>
       </div>
@@ -62,9 +82,7 @@ const handleSubmit = async (jsonInput: string, formID: number | null) => {
     timeout: 0,
   })
     .then((serverResponse) => {
-      // TODO - indicate success
       jsonInput = "";
-      console.log(serverResponse);
       return serverResponse;
     })
     .catch((err) => {

--- a/public/static/locales/en/admin-templates.json
+++ b/public/static/locales/en/admin-templates.json
@@ -2,7 +2,8 @@
   "upload": {
     "title": "Upload a form Configuration file",
     "edit-title": "Edit a form Configuration file",
-    "submit": "Upload"
+    "submit": "Upload",
+    "success": "JSON successfully uploaded."
   },
   "view": {
     "title": "View Form Template JSON",
@@ -12,6 +13,9 @@
   },
   "settings": {
     "title": "Form Settings",
-    "delete": "Delete"
+    "delete": "Delete",
+    "delete-check": "Are you sure you want to delete this form?",
+    "confirm-delete": "Confirm Delete",
+    "new": "The Form was successfully created"
   }
 }


### PR DESCRIPTION
# Summary | Résumé
This PR adds several small UI updates to help give feedback on user actions.

- When creating a form, the page redirects to the settings page for the newly create form on success.
- When updating the JSON of an existing form on the settings page, a small success message appears beside the upload button once the request is successful
- When deleting a form, the user is first asked to confirm the deletion before it goes through - to make deleting a little less easy to accidentally do