### PR TITLE
Run tests on push

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, sandbox]
 jobs:
   cypress-run:
+    name: Cypress
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,10 @@
 name: E2E Tests
-on: [pull_request]
+on:
+  push:
+    branches: [main, sandbox]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main, sandbox]
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,5 +1,10 @@
 name: Linting Code
-on: [pull_request]
+on:
+  push:
+    branches: [main, sandbox]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main, sandbox]
 
 jobs:
   eslint_flow:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -7,9 +7,10 @@ on:
     branches: [main, sandbox]
 
 jobs:
-  eslint_flow:
+  eslint_flow_merge:
+    name: eslint_merge
     runs-on: ubuntu-latest
-
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v1
       - name: Node.JS 12
@@ -20,7 +21,25 @@ jobs:
         run: yarn install
         env:
           CI: TRUE
-      - name: Test Code Linting
+      - name: Test Code Linting on Merge
+        if: github.event_name == 'push'
+        run: yarn lint
+        # If there is an error stop here and fail the test
+  eslint_flow_pr:
+    name: eslint_pr
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v1
+      - name: Node.JS 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - name: Install Node Dependencies
+        run: yarn install
+        env:
+          CI: TRUE
+      - name: Test Code Linting on Pull Request
         run: yarn lint
         continue-on-error: true
       - name: Save Code Linting Report JSON

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,5 +1,10 @@
 name: Jest Tests
-on: [pull_request]
+on:
+  push:
+    branches: [main, sandbox]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main, sandbox]
 jobs:
   jest-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -7,13 +7,18 @@ on:
     branches: [main, sandbox]
 jobs:
   jest-run:
+    name: Jest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: "Install dependencies"
         run: yarn install
       - name: Jest Annotations & Coverage
+        if: github.event_name == 'pull_request'
         uses: dkershner6/jest-coverage-commenter-action@v1
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           test_command: "yarn test --coverage"
+      - name: Jest Tests
+        if: github.event_name == 'push'
+        run: yarn test

--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -12,6 +12,27 @@ jobs:
   push-production:
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for Jest tests to pass
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-jest-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Jest
+          ref: ${{ github.sha }}
+      - name: Wait for Cypress tests to pass
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-cypress-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Cypress
+          ref: ${{ github.sha }}
+      - name: Wait for ESLint tests to pass
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-eslint-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: eslint_merge
+          ref: ${{ github.sha }}
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -12,6 +12,27 @@ jobs:
   push-staging:
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for Jest tests to pass
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-jest-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Jest
+          ref: ${{ github.sha }}
+      - name: Wait for Cypress tests to pass
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-cypress-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Cypress
+          ref: ${{ github.sha }}
+      - name: Wait for ESLint tests to pass
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-eslint-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: eslint_merge
+          ref: ${{ github.sha }}
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds dependencies on the GitHub actions that build and deploy the code to AWS.  This ensures that even on a merge if the automated tests fail for any reason the code will not be deployed.
