### PR TITLE
Added "Delete all responses" per form to the vault

### DIFF
--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -35,6 +35,13 @@ const FormResponse = ({
   const [submissionID, setSubmissionID] = useState("");
   const { t } = useTranslation("admin-vault");
 
+  useEffect(() => {
+    if (Items.length != submissionArray.length) {
+      // allow "Look up responses" button to get updated numbers without a hard refresh
+      setSubmissionArray(Items);
+    }
+  });
+
   const removeSubmission = async () => {
     if (submissionID) {
       await axios({
@@ -177,6 +184,57 @@ const AdminVault: React.FC = () => {
     }
   };
 
+  const removeAllSubmissions = async () => {
+    if (formID) {
+      if (formID) {
+        await axios({
+          url: "/api/retrieval",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json ",
+          },
+          data: { formID, action: "DELETE" },
+        })
+          .then((response) => {
+            console.log(response);
+            setResponses({ Items: [] });
+          })
+          .catch((err) => {
+            console.error(err);
+            setResponses({ Items: [] });
+          });
+      } else {
+        setResponses({ Items: [] });
+      }
+    }
+  };
+
+  const [deleteVisible, setDeleteVisible] = useState(false);
+
+  const deleteButton = deleteVisible ? (
+    <>
+      <p>{t("confirmRemoveAll")}</p>
+      <Button
+        onClick={async () => {
+          try {
+            const resp = await removeAllSubmissions();
+            console.log(resp);
+          } catch (e) {
+            console.error(e);
+          }
+        }}
+        testid="confirmDelete"
+        type="button"
+        destructive={true}
+        className="rounded-lg"
+      >
+        {t("confirmRemoveAllButton")}
+      </Button>
+    </>
+  ) : (
+    ""
+  );
+
   return (
     <>
       <h1 className="gc-h1">{t("title")}</h1>
@@ -211,6 +269,23 @@ const AdminVault: React.FC = () => {
           )}
         </div>
       </div>
+      {responses.Items.length ? (
+        <div className="mt-4 inline-block justify-left flex space-x-20">
+          <Button
+            className="gc-button rounded-lg"
+            type="button"
+            destructive={true}
+            onClick={() => {
+              setDeleteVisible(!deleteVisible);
+            }}
+          >
+            {t("removeAllButton")}
+          </Button>
+          <div>{deleteButton}</div>
+        </div>
+      ) : (
+        ""
+      )}
     </>
   );
 };

--- a/public/static/locales/en/admin-vault.json
+++ b/public/static/locales/en/admin-vault.json
@@ -6,5 +6,8 @@
   "noResponse": "No Responses for selected form",
   "nextButton": "Next",
   "backButton": "Previous",
-  "removeButton": "Processed"
+  "removeButton": "Processed",
+  "removeAllButton": "Delete all responses",
+  "confirmRemoveAll": "Are you sure you want to delete all responses for this form? This cannot be undone.",
+  "confirmRemoveAllButton": "Confirm and delete"
 }

--- a/public/static/locales/fr/admin-vault.json
+++ b/public/static/locales/fr/admin-vault.json
@@ -1,10 +1,13 @@
 {
-  "title": "Coffre de formulaires",
-  "subTitle": "Vos submissions",
-  "formInput": "Formulaire pour recueillir les submissions",
-  "submitButton": "Recueillir les submissions",
-  "noResponse": "Aucune submission pour cette formualire",
-  "nextButton": "Prochain",
-  "backButton": "Précédent",
-  "removeButton": "Traité"
+  "title": "Forms Vault",
+  "subTitle": "Your form responses",
+  "formInput": "Form to get responses for",
+  "submitButton": "Look up responses",
+  "noResponse": "No Responses for selected form",
+  "nextButton": "Next",
+  "backButton": "Previous",
+  "removeButton": "Processed",
+  "removeAllButton": "Delete all responses",
+  "confirmRemoveAll": "Are you sure you want to delete all responses for this form? This cannot be undone.",
+  "confirmRemoveAllButton": "Confirm and delete"
 }


### PR DESCRIPTION
# Summary | Résumé

After a form with at least one entry is looked up in the vault, a "Delete all Responses" button now appears below the form entries. This uses similar logic to the Delete Form button I implemented on the Settings page (in that there's a confirmation and second button before the request goes through).

I also added a small useEffect() hook to allow the "Look up Responses" button to display a different amount of entries if it has changed since the page was loaded. Example - if you have a vault tab open and a tab open and submit a form, the vault tab wouldn't pick up on the new submission without a hard refresh.

Feel free to use form 196 or a new form to test.

I added this function to the vault page instead of as an option when deleting a form on the Settings page to avoid outstanding policy questions that will be answered in the future. I felt this was the safest implementation to leverage the feature for now.