### PR TITLE
Add api route to view app version

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,12 @@ module.exports = {
       use: "raw-loader",
     });
 
+    // Load version file
+    config.module.rules.push({
+      test: /VERSION/,
+      use: "raw-loader",
+    });
+
     // The pino logger module is transpiled for IE11 via babel.config.js
     config.module.rules.push({
       test: /\.js$/,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcforms",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/pages/api/version.js
+++ b/pages/api/version.js
@@ -1,0 +1,12 @@
+const version = async (req, res) => {
+  const privacyContent = await require(`../../VERSION`);
+  const changeLog = await require(`../../CHANGELOG.md`);
+
+  const versionInfo = {
+    version: privacyContent.default,
+    changeLog: changeLog.default,
+  };
+  res.json(versionInfo);
+};
+
+export default version;


### PR DESCRIPTION
# Summary | Résumé
Adds `/api/version` which shows the current app version from the VERSION file, and also the current contents of the changelog file.

Also syncs the version in package.json with the new VERSION file. We'll need to note that we need to keep these values in sync (not that anything bad will happen if we don't, it's just good practice)