### PR TITLE
Make form templates page more readable

### DIFF
--- a/components/containers/Dashboard/DataView.tsx
+++ b/components/containers/Dashboard/DataView.tsx
@@ -46,10 +46,14 @@ const DataElement = (props: { template: FormDBConfigProperties }): React.ReactEl
 
   let title = "";
   if (template.formConfig) {
-    if (i18n.language === "en" && template.formConfig.internalTitleEn)
-      title = template.formConfig.internalTitleEn;
-    else if (i18n.language === "fr" && template.formConfig.internalTitleFr)
-      title = template.formConfig.internalTitleFr;
+    if (i18n.language === "en")
+      title = template.formConfig.internalTitleEn
+        ? template.formConfig.internalTitleEn
+        : template.formConfig.form.titleEn;
+    else if (i18n.language === "fr")
+      title = template.formConfig.internalTitleFr
+        ? template.formConfig.internalTitleFr
+        : template.formConfig.form.titleFr;
   }
   return (
     <li>

--- a/components/containers/Dashboard/DataView.tsx
+++ b/components/containers/Dashboard/DataView.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 //import classnames from "classnames";
 import { useTranslation } from "next-i18next";
 import Head from "next/head";

--- a/components/containers/Dashboard/DataView.tsx
+++ b/components/containers/Dashboard/DataView.tsx
@@ -34,14 +34,9 @@ export const DataView = (props: DataViewProps): React.ReactElement => {
 
 const DataElement = (props: { template: FormDBConfigProperties }): React.ReactElement => {
   const { t, i18n } = useTranslation("admin-templates");
-  const [isExpanded, setIsExpanded] = useState(false);
   const { template } = props;
   const formID = template.formID;
   const router = useRouter();
-
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
-  };
 
   const redirectToSettings = (formID: number) => {
     router.push({
@@ -49,17 +44,26 @@ const DataElement = (props: { template: FormDBConfigProperties }): React.ReactEl
     });
   };
 
+  let title = "";
+  if (template.formConfig) {
+    if (i18n.language === "en" && template.formConfig.internalTitleEn)
+      title = template.formConfig.internalTitleEn;
+    else if (i18n.language === "fr" && template.formConfig.internalTitleFr)
+      title = template.formConfig.internalTitleFr;
+  }
   return (
-    <li className={isExpanded ? "expanded" : ""}>
-      <button className="expand" onClick={() => toggleExpanded()}>
-        {isExpanded ? t("view.collapse") : t("view.expand")}
-      </button>
-      <div className="expandable pb-4 m-auto px-4">
-        <span>{JSON.stringify(template)}</span>
-        <div className="update-buttons">
+    <li>
+      <div className="pb-4 m-auto px-4">
+        <div className="update-buttons mr-4">
           <button onClick={() => redirectToSettings(formID)} className="gc-button">
             {t("view.update")}
           </button>
+        </div>
+        <div className="inline-block break-words form-title">
+          <p>
+            {t("view.formID")} {formID}
+          </p>
+          <p>{title}</p>
         </div>
       </div>
     </li>

--- a/lib/types.tsx
+++ b/lib/types.tsx
@@ -4,7 +4,7 @@ import { NextRouter } from "next/router";
 
 export interface FormDefinitionProperties {
   internalTitleEn?: string;
-  interalTitleFr?: string;
+  internalTitleFr?: string;
   publishingStatus: boolean;
   submission: {
     email?: string;

--- a/public/static/locales/en/admin-templates.json
+++ b/public/static/locales/en/admin-templates.json
@@ -6,10 +6,9 @@
     "success": "JSON successfully uploaded."
   },
   "view": {
-    "title": "View Form Template JSON",
-    "expand": "Expand",
-    "collapse": "Collapse",
-    "update": "Edit"
+    "title": "View Form Templates",
+    "update": "Edit",
+    "formID": "Form ID:"
   },
   "settings": {
     "title": "Form Settings",

--- a/public/static/locales/fr/admin-templates.json
+++ b/public/static/locales/fr/admin-templates.json
@@ -6,10 +6,9 @@
     "success": "JSON téléchargé avec succès."
   },
   "view": {
-    "title": "Voir le modèle de formulaire JSON",
-    "expand": "Élargir",
-    "collapse": "Collapse",
-    "update": "Modifier"
+    "title": "Voir le modèle des formulaires",
+    "update": "Modifier",
+    "formID": "ID de formulaire:"
   },
   "settings": {
     "title": "Paramètres du formulaire",

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -117,29 +117,18 @@ ul.custom {
 ul.json_templates {
   @apply list-none;
   li {
-    @apply border-2 border-solid border-gray-400 cursor-pointer;
-
-    button.expand {
-      left: 0;
-      @apply bg-green-default w-full text-white-default;
-    }
-  }
-  li div.expandable {
+    @apply border-2 border-solid border-gray-400 cursor-pointer inline-block overflow-hidden break-words;
     max-height: 100px;
     max-width: 100%;
+    width: 100%;
     font-family: monospace;
     margin: 0 1rem;
-    @apply inline-block overflow-hidden break-words;
 
     div.update-buttons {
-      display: none;
+      display: inline-block;
     }
-  }
-  li.expanded div.expandable {
-    max-height: 100%;
-
-    div.update-buttons {
-      display: block;
+    div.form-title {
+      max-width: 70%;
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

A quick sandbox update to the 'view form templates' admin page.

Since we now have a form settings page, and we have quite a lot of forms, printing out the form JSON on this page was not very useful, and not very readable.
I've streamlined the page to just show the id and internal name of the form, and the full JSON can be viewed on the settings page by clicking the Edit button

<img width="1007" alt="Screen Shot 2021-06-15 at 12 19 10 PM" src="https://user-images.githubusercontent.com/5032149/122103825-43409980-cdd4-11eb-844e-674dcb01c1d3.png">
