### PR TITLE
Remove annotations and commenting from GitHub actions for now

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -12,5 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Jest Tests
-        if: github.event_name == 'push'
         run: yarn test --coverage

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,5 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: "Install dependencies"
+        run: yarn install
       - name: Jest Tests
         run: yarn test --coverage

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,14 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: "Install dependencies"
-        run: yarn install
-      - name: Jest Annotations & Coverage
-        if: github.event_name == 'pull_request'
-        uses: dkershner6/jest-coverage-commenter-action@v1
-        with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          test_command: "yarn test --coverage"
       - name: Jest Tests
         if: github.event_name == 'push'
-        run: yarn test
+        run: yarn test --coverage

--- a/lib/tests/dataLayer.test.js
+++ b/lib/tests/dataLayer.test.js
@@ -55,9 +55,6 @@ const mockResponses = {
 };
 
 describe("Get form functions", () => {
-  test("Fail on purpose", () => {
-    expect(true).toBe(false);
-  });
   test("Get Form by ID", () => {
     const form = getFormByID("1");
     expect(form).toMatchObject({

--- a/lib/tests/dataLayer.test.js
+++ b/lib/tests/dataLayer.test.js
@@ -55,6 +55,9 @@ const mockResponses = {
 };
 
 describe("Get form functions", () => {
+  test("Fail on purpose", () => {
+    expect(true).toBe(false);
+  });
   test("Get Form by ID", () => {
     const form = getFormByID("1");
     expect(form).toMatchObject({


### PR DESCRIPTION
# Summary | Résumé

Remove annotations from GitHub actions so that external collaborators can not have github actions fail on PR's due to lack of write access.

Will improve by implementing pull_request_target in separate action that handles artifacts and writes to the PR in the future.