### PR TITLE
Round out component validation tests

### DIFF
--- a/components/forms/Checkbox/Checkbox.test.js
+++ b/components/forms/Checkbox/Checkbox.test.js
@@ -101,4 +101,14 @@ describe("Checkbox component", () => {
       expect(input.value).toEqual(resultsArray[index]);
     });
   });
+  test("required elements display correctly", () => {
+    checkboxData.properties.validation.required = true;
+    render(
+      <Form formMetadata={formMetadata} t={(key) => key} language="fr">
+        <GenerateElement element={checkboxData} language="fr" />
+      </Form>
+    );
+
+    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+  });
 });

--- a/components/forms/Dropdown/Dropdown.test.js
+++ b/components/forms/Dropdown/Dropdown.test.js
@@ -137,4 +137,13 @@ describe("Dropdown component", () => {
       dropdownData.properties.choices[newValue].fr
     );
   });
+  test("required elements display properly", () => {
+    dropdownData.properties.validation.required = true;
+    render(
+      <Form t={(key) => key}>
+        <GenerateElement element={dropdownData} language="fr" />
+      </Form>
+    );
+    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+  });
 });

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -29,7 +29,12 @@ export const Label = (props: LabelProps): React.ReactElement => {
 
   return (
     <label data-testid="label" className={classes} htmlFor={htmlFor} id={id}>
-      {children} {required ? <span aria-hidden>*</span> : null}
+      {children}{" "}
+      {required ? (
+        <span data-testid="asterisk" aria-hidden>
+          *
+        </span>
+      ) : null}
       {required ? <i className="visually-hidden">{t("required-field")}</i> : null}
       {hint && <span className="gc-hint">{hint}</span>}
     </label>

--- a/components/forms/Radio/Radio.test.js
+++ b/components/forms/Radio/Radio.test.js
@@ -42,6 +42,7 @@ describe("Generate a radio button", () => {
     expect(screen.getByText(radioButtonData.properties.choices[0].en)).toBeInTheDocument();
     expect(screen.getByText(radioButtonData.properties.choices[1].en)).toBeInTheDocument();
     // Field is required
+    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     screen.getAllByRole("radio").forEach((input) => {
       expect(input).toBeRequired();
     });
@@ -61,10 +62,23 @@ describe("Generate a radio button", () => {
     expect(screen.getByText(radioButtonData.properties.choices[0].fr)).toBeInTheDocument();
     expect(screen.getByText(radioButtonData.properties.choices[1].fr)).toBeInTheDocument();
     // Field is required
+    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     screen.getAllByRole("radio").forEach((input) => {
       expect(input).toBeRequired();
     });
     // Proper linked description to element
     expect(screen.getByRole("group")).toHaveDescription(radioButtonData.properties.descriptionFr);
+  });
+  test("not required displays properly", () => {
+    radioButtonData.properties.validation.required = false;
+    render(
+      <Form t={(key) => key}>
+        <GenerateElement element={radioButtonData} language="en" />
+      </Form>
+    );
+    expect(screen.queryByTestId("asterisk")).not.toBeInTheDocument();
+    screen.getAllByRole("radio").forEach((input) => {
+      expect(input).not.toBeRequired();
+    });
   });
 });

--- a/components/forms/TextArea/TextArea.test.js
+++ b/components/forms/TextArea/TextArea.test.js
@@ -41,6 +41,7 @@ describe("Generate a text area", () => {
     expect(screen.getByRole("textbox"))
       .toBeRequired()
       .toHaveDescription(textAreaData.properties.descriptionEn);
+    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(textAreaData.properties.placeholderEn)).toBeInTheDocument();
   });

--- a/components/forms/TextInput/TextInput.test.js
+++ b/components/forms/TextInput/TextInput.test.js
@@ -40,6 +40,7 @@ describe("Generate a text input", () => {
     expect(screen.getByRole("textbox"))
       .toBeRequired()
       .toHaveDescription(textInputData.properties.descriptionEn);
+    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(textInputData.properties.placeholderEn)).toBeInTheDocument();
   });

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -1,15 +1,16 @@
 import { validateOnSubmit, getErrorList } from "../validation";
 import { cleanup, render, screen } from "@testing-library/react";
 
-function getFormMetaData(type, required = false) {
+function getFormMetaData(type, textType, required = false) {
   return {
     formMetadata: {
       elements: [
         {
           id: 1,
+          type: type,
           properties: {
             validation: {
-              type: type,
+              type: textType,
               required: required,
             },
           },
@@ -20,129 +21,127 @@ function getFormMetaData(type, required = false) {
   };
 }
 
-// Add array of what should pass and fail and then map
-const text_ToPass = [{ 1: "Joe Pine" }, { 1: "Joe-Pine" }];
-const text_ToFail = [{ 1: "Joe % Pine" }, { 1: "Joe&Pine" }];
-const email_ToPass = [{ 1: "joe.pine@cedar.com" }];
-const email_ToFail = [{ 1: "joe.pine.com" }];
-const number_ToFail = [{ 1: "two" }, { 1: "four" }];
-const number_ToPass = [{ 1: "1" }, { 1: "4" }];
-const date_ToPass = [{ 1: "06/05/1950" }];
-const date_ToFail = [{ 1: "25/05/1950" }];
-const phone_ToPass = [{ 1: "1-819-555-7777" }];
-const phone_ToFail = [{ 1: "888-8989" }];
+// Test cases
+/*
+{
+  fieldType: e.g. "textField"
+  subType: for components like textField that have a type property
+  passConditions: [],
+  failConditions: [].
+  expectedError: {1: "error string"}
+  required: bool (optional),
+}
+*/
+const testCases = [
+  // text field validation
+  {
+    fieldType: "textField",
+    subType: "",
+    passConditions: [],
+    failConditions: [{ 1: "" }],
+    expectedError: { 1: "input-validation.required" },
+    required: true,
+  },
+  {
+    fieldType: "textField",
+    subType: "alphanumeric",
+    passConditions: [{ 1: "Joe Pine" }, { 1: "JoePine" }],
+    failConditions: [{ 1: "Joe % Pine" }, { 1: "Joe&Pine" }],
+    expectedError: { 1: "input-validation.alphanumeric" },
+  },
+  {
+    fieldType: "textField",
+    subType: "email",
+    passConditions: [{ 1: "joe.pine@cedar.com" }],
+    failConditions: [{ 1: "joe.pine.com" }],
+    expectedError: { 1: "input-validation.email" },
+  },
+  {
+    fieldType: "textField",
+    subType: "number",
+    passConditions: [{ 1: "1" }, { 1: "4" }],
+    failConditions: [{ 1: "two" }, { 1: "four" }],
+    expectedError: { 1: "input-validation.number" },
+  },
+  {
+    fieldType: "textField",
+    subType: "date",
+    passConditions: [{ 1: "06/05/1950" }],
+    failConditions: [{ 1: "25/05/1950" }],
+    expectedError: { 1: "input-validation.date" },
+  },
+  {
+    fieldType: "textField",
+    subType: "phone",
+    passConditions: [{ 1: "1-819-555-7777" }],
+    failConditions: [{ 1: "888-8989" }],
+    expectedError: { 1: "input-validation.phone" },
+  },
+  // required validation for other components
+  {
+    fieldType: "textArea",
+    passConditions: [],
+    failConditions: [{ 1: "" }],
+    expectedError: { 1: "input-validation.required" },
+    required: true,
+  },
+  {
+    fieldType: "richText",
+    passConditions: [],
+    failConditions: [{ 1: "" }],
+    expectedError: { 1: "input-validation.required" },
+    required: true,
+  },
+  {
+    fieldType: "dropDown",
+    passConditions: [],
+    failConditions: [{ 1: {} }],
+    expectedError: { 1: "input-validation.required" },
+    required: true,
+  },
+  {
+    fieldType: "radio",
+    passConditions: [],
+    failConditions: [{ 1: {} }],
+    expectedError: { 1: "input-validation.required" },
+    required: true,
+  },
+  {
+    fieldType: "checkbox",
+    passConditions: [],
+    failConditions: [{ 1: {} }],
+    expectedError: { 1: "input-validation.required" },
+    required: true,
+  },
+];
 
 describe("Test input validation", () => {
-  test("Validation on required field", () => {
-    const props = getFormMetaData("", true);
-    const values = { 1: "" };
-    const errors = validateOnSubmit(values, props);
-    expect(errors).toMatchObject({ 1: "input-validation.required" });
-  });
-  describe("Alphanumeric validation", () => {
-    test("validation to fail", () => {
-      const props = getFormMetaData("alphanumeric");
-      text_ToFail.map((value) => {
+  test.each(testCases)(
+    "$fieldType, $subType",
+    ({ fieldType, subType, passConditions, failConditions, expectedError, required }) => {
+      const props = getFormMetaData(
+        fieldType,
+        subType ? subType : undefined,
+        required ? required : false
+      );
+      passConditions.map((value) => {
         const errors = validateOnSubmit(value, props);
-        expect(errors).toMatchObject({
-          1: "input-validation.alphanumeric",
-        });
+        expect(errors).not.toMatchObject(expectedError);
       });
-    });
-    test("validation to pass", () => {
-      const props = getFormMetaData("text");
-      text_ToPass.map((value) => {
+      failConditions.map((value) => {
         const errors = validateOnSubmit(value, props);
-        expect(errors).not.toMatchObject({
-          1: "input-validation.text",
-        });
+        expect(errors).toMatchObject(expectedError);
       });
-    });
-  });
-  describe("Email validation", () => {
-    test("validation to fail", () => {
-      const props = getFormMetaData("email");
-      email_ToFail.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).toMatchObject({ 1: "input-validation.email" });
-      });
-    });
-    test("validation to pass", () => {
-      const props = getFormMetaData("email");
-      email_ToPass.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).not.toMatchObject({
-          1: "input-validation.email",
-        });
-      });
-    });
-  });
-  describe("Number validation", () => {
-    test("validation to fail", () => {
-      const props = getFormMetaData("number");
-      number_ToFail.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).toMatchObject({
-          1: "input-validation.number",
-        });
-      });
-    });
-
-    test("validation to pass", () => {
-      const props = getFormMetaData("number");
-      number_ToPass.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).not.toMatchObject({
-          1: "input-validation.number",
-        });
-      });
-    });
-  });
-  describe("Date validation", () => {
-    test("validation to fail", () => {
-      const props = getFormMetaData("date");
-      date_ToFail.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).toMatchObject({ 1: "input-validation.date" });
-      });
-    });
-
-    test("validation to pass", () => {
-      const props = getFormMetaData("date");
-      date_ToPass.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).not.toMatchObject({
-          1: "input-validation.date",
-        });
-      });
-    });
-  });
-  describe("Phone validation", () => {
-    test("validation to fail", () => {
-      const props = getFormMetaData("phone");
-      phone_ToFail.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).toMatchObject({ 1: "input-validation.phone" });
-      });
-    });
-
-    test("validation to pass", () => {
-      const props = getFormMetaData("phone");
-      phone_ToPass.map((value) => {
-        const errors = validateOnSubmit(value, props);
-        expect(errors).not.toMatchObject({
-          1: "input-validation.phone",
-        });
-      });
-    });
-  });
+    }
+  );
   test("Value not in elements", () => {
-    const props = getFormMetaData("", true);
+    const props = getFormMetaData("textField", "", undefined, true);
     const values = { 4: "test value" };
     const errors = validateOnSubmit(values, props);
     expect(errors).not.toHaveProperty("4");
   });
 });
+
 describe("Test getErrorList function", () => {
   afterEach(cleanup);
   const props = {


### PR DESCRIPTION
# Summary | Résumé
Recently, #220 exposed that our validation was non functional for checkboxes and radios.

In this PR I have written more tests around validation for existing components, to ensure that both a) the asterisk and other associated 'required' elements render on a required field, and b) an error is thrown if the field is empty.

I heavily rewrote validation.test.js to leverage jest.each using test cases. I converted all the existing text validation cases to this format, and then added one for testing whether a required field was filled for each other type of input element we currently have.