### PR TITLE
Add google tag manager

### DIFF
--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -8,6 +8,11 @@ import { logMessage } from "../../../lib/logger";
 import { FormValues, InnerFormProps, DynamicFormProps, Responses } from "../../../lib/types";
 import Loader from "../../globals/Loader";
 
+declare global {
+  interface Window {
+    dataLayer: Array<unknown>;
+  }
+}
 /**
  * This is the "inner" form component that isn't connected to Formik and just renders a simple form
  * @param props
@@ -105,6 +110,14 @@ export const Form = withFormik<DynamicFormProps, FormValues>({
     } catch (err) {
       logMessage.error(err);
     } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "form_submission_trigger",
+        formID: formikBag.props.formConfig.formID,
+        formTitle: formikBag.props.formConfig.titleEn,
+      });
+
       formikBag.setSubmitting(false);
     }
   },

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -26,15 +26,16 @@ const Base = ({ children }) => {
       <Head>
         {googleTag && (
           <React.Fragment>
-            <script async src="https://www.googletagmanager.com/gtag/js?id=G-8PNSS76E3B"></script>
             <script
               dangerouslySetInnerHTML={{
                 __html: `
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
-                
-                  gtag('config', 'G-8PNSS76E3B');
+                <!-- Google Tag Manager -->
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-W3ZVVX5');
+                <!-- End Google Tag Manager -->
               `,
               }}
             />
@@ -51,6 +52,17 @@ const Base = ({ children }) => {
         />
         <title>{t("title")}</title>
       </Head>
+
+      <noscript>
+        <iframe
+          src="https://www.googletagmanager.com/ns.html?id=GTM-W3ZVVX5"
+          title="Google Tag Manager Iframe Window"
+          height="0"
+          width="0"
+          style={{ display: "none", visibility: "hidden" }}
+        ></iframe>
+      </noscript>
+
       <SkipLink />
       <div className={classes}>
         {!isEmbeddable && (


### PR DESCRIPTION
# Summary | Résumé

Adds google tag manager with a custom data event on form submission.  Included in the event are custom Data Layer variables including the `formID` and `formTitle` for form identification.

No additional user information is sent as part of this form submission event.
closes #237 