### PR TITLE
Enable local template lambda

### DIFF
--- a/lib/dataLayer.tsx
+++ b/lib/dataLayer.tsx
@@ -116,7 +116,10 @@ async function _crudTemplates(payload: CrudTemplateInput): Promise<CrudTemplateR
     });
   }
 
-  const lambdaClient = new LambdaClient({ region: "ca-central-1" });
+  const lambdaClient = new LambdaClient({
+    region: "ca-central-1",
+    endpoint: process.env.LOCAL_LAMBDA_ENDPOINT,
+  });
   const encoder = new TextEncoder();
   const command = new InvokeCommand({
     FunctionName: process.env.TEMPLATES_API ?? "Templates",


### PR DESCRIPTION
# Summary | Résumé

Once you have the local infrastructure setup running, simply add the following line to your .env to enable hitting your local template lambda:
`LOCAL_LAMBDA_ENDPOINT=http://127.0.0.1:3001`