### PR TITLE
Quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Remove unused debugging `console.logs()`
+
+### Fixed
+
+- When Feature 'Submit to Reliability Queue' is off do not treat the submission as an Error.
+
 ### Removed
 
 - Temporary routing for existing form Ids to newly assigned Ids.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove unused debugging `console.logs()`
+- Remove info level logging from production builds
 
 ### Fixed
 

--- a/lib/logger.tsx
+++ b/lib/logger.tsx
@@ -1,7 +1,7 @@
 import pino from "pino";
 // create pino loggger
 export const logMessage = pino({
-  level: process.env.DEBUG ? "debug" : "info",
+  level: process.env.DEBUG ? "debug" : process.env.NODE_ENV === "development" ? "info" : "warn",
   browser: {
     asObject: true,
     transmit: {

--- a/lib/tests/logger.test.js
+++ b/lib/tests/logger.test.js
@@ -41,7 +41,7 @@ describe("logMessage function", () => {
     });
     test("During normal operation", () => {
       const testLogger = require("../logger").logMessage;
-      expect(testLogger.level).toEqual("info");
+      expect(testLogger.level).toEqual("warn");
     });
   });
 });

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -197,7 +197,7 @@ const AdminVault: React.FC = () => {
           },
           data: { formID, action: "DELETE" },
         })
-          .then((response) => {
+          .then(() => {
             setResponses({ Items: [] });
           })
           .catch((err) => {
@@ -218,7 +218,7 @@ const AdminVault: React.FC = () => {
       <Button
         onClick={async () => {
           try {
-            const resp = await removeAllSubmissions();
+            await removeAllSubmissions();
           } catch (e) {
             console.error(e);
           }

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -198,7 +198,6 @@ const AdminVault: React.FC = () => {
           data: { formID, action: "DELETE" },
         })
           .then((response) => {
-            console.log(response);
             setResponses({ Items: [] });
           })
           .catch((err) => {
@@ -220,7 +219,6 @@ const AdminVault: React.FC = () => {
         onClick={async () => {
           try {
             const resp = await removeAllSubmissions();
-            console.log(resp);
           } catch (e) {
             console.error(e);
           }

--- a/pages/api/submit.tsx
+++ b/pages/api/submit.tsx
@@ -169,8 +169,8 @@ const processFormData = async (
         return res.status(201).json({ received: true, htmlEmail: response });
       });
     }
-
-    return res.status(400).json({ received: false });
+    // Set this to a 200 response as it's valid if the send to reliability queue option is off.
+    return res.status(200).json({ received: true });
   } catch (err) {
     logMessage.error(err);
     return res.status(500).json({ received: false });

--- a/pages/api/templates.js
+++ b/pages/api/templates.js
@@ -20,7 +20,6 @@ const templates = async (req, res) => {
     const session = await getSession({ req });
 
     const requestBody = JSON.parse(req.body);
-    console.log(requestBody);
 
     if (isAllowed(session, requestBody.method)) {
       return crudTemplates({ ...requestBody, session })


### PR DESCRIPTION
# Summary | Résumé

This PR removes left over debugging `console.logs()`, reduces the production level logger level to `warn` from `info`, and fixes an issue when the Reliability Queue feature is turned off.  

When the 'Send to Reliability Queue' feature is turned off the Submit API was returning an error to the form client when it should have been returning a 200 success.