### PR TITLE
refactor: minor security improvement

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,11 @@
 # Security
 
-**Do not post security issues to our public repositories.** Security issues must be reported by email to [john.obrien@tbs-sct.gc.ca](mailto:john.obrien@tbs-sct.gc.ca).
+**Do not post security issues to our public repositories.** Security issues must
+be reported by email to <security@cds-snc.ca>.
 
----
+______________________
 
 # Sécurité
 
-**Ne publiez pas de problèmes de sécurité dans nos dépôts publics.** Les problèmes de sécurité doivent être signalés par courriel à [john.obrien@tbs-sct.gc.ca](mailto:john.obrien@tbs-sct.gc.ca).
+**Ne publiez pas de problèmes de sécurité dans nos dépôts publics.** Les
+problèmes de sécurité doivent être signalés par courriel à <securite@cds-snc.ca>.

--- a/pages/api/submit.tsx
+++ b/pages/api/submit.tsx
@@ -22,8 +22,7 @@ const lambdaClient = new LambdaClient({
 
 const submit = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
-    const incomingForm = new formidable.IncomingForm();
-    incomingForm.maxFileSize = 8000000; // Set to 8 MB and override default of 200 MB
+    const incomingForm = new formidable.IncomingForm({ maxFileSize: 8000000}); // Set to 8 MB and override default of 200 MB
     return incomingForm.parse(req, async (err, fields, files) => {
       if (err) {
         throw new Error(err);

--- a/pages/api/submit.tsx
+++ b/pages/api/submit.tsx
@@ -23,6 +23,7 @@ const lambdaClient = new LambdaClient({
 const submit = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
     const incomingForm = new formidable.IncomingForm();
+    incomingForm.maxFileSize = 8000000; // Set to 8 MB and override default of 200 MB
     return incomingForm.parse(req, async (err, fields, files) => {
       if (err) {
         throw new Error(err);

--- a/pages/api/submit.tsx
+++ b/pages/api/submit.tsx
@@ -22,7 +22,7 @@ const lambdaClient = new LambdaClient({
 
 const submit = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
-    const incomingForm = new formidable.IncomingForm({ maxFileSize: 8000000}); // Set to 8 MB and override default of 200 MB
+    const incomingForm = new formidable.IncomingForm({ maxFileSize: 8000000 }); // Set to 8 MB and override default of 200 MB
     return incomingForm.parse(req, async (err, fields, files) => {
       if (err) {
         throw new Error(err);


### PR DESCRIPTION
This PR is to update the security readme and to set an upper limit to the amount of data received by the formidable form. If this form requires more than 8 MB please add a review comment and i'll update my PR.

#### Why these changes are being suggested 
Rejecting requests with significant content length is a good practice to control the network traffic intensity and thus resource consumption in order to prevents Denial of Service attacks. By default the formidable form accepts up to 200 MB of data and is typically never exceeded by the majority of applications by a significant margin.

For most of the features of an application, it is recommended to limit the size of requests to:

- lower or equal to 8mb for file uploads.
- lower or equal to 2mb for other requests.

##### Risk mitigated
- Service disruptions due to a malicious user submitting forms of 200 MB in quick succession would may lead to service degradations.

##### References
[Owasp Cheat Sheet ](https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html)- Owasp Denial of Service Cheat Sheet
[CWE-770](https://cwe.mitre.org/data/definitions/770.html) - Allocation of Resources Without Limits or Throttling
[CWE-400](https://cwe.mitre.org/data/definitions/400.html) - Uncontrolled Resource Consumption