### PR TITLE
Group radio and checkboxes correctly for screen reader support

### DIFF
--- a/components/forms/FormGroup/FormGroup.tsx
+++ b/components/forms/FormGroup/FormGroup.tsx
@@ -12,7 +12,12 @@ interface FormGroupProps {
 export const FormGroup = (props: FormGroupProps): React.ReactElement => {
   const { children, name, className, ariaDescribedBy, error } = props;
 
-  const classes = classnames("gc-form-group", { "gc-form-group--error": error }, className);
+  const classes = classnames(
+    "gc-form-group",
+    "focus-group",
+    { "gc-form-group--error": error },
+    className
+  );
 
   return (
     <fieldset

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -4,17 +4,18 @@ import { useTranslation } from "next-i18next";
 
 interface LabelProps {
   children: React.ReactNode;
-  htmlFor: string;
+  htmlFor?: string;
   id?: string;
   className?: string;
   error?: boolean;
   hint?: React.ReactNode;
   srOnly?: boolean;
   required?: boolean;
+  group?: boolean;
 }
 
 export const Label = (props: LabelProps): React.ReactElement => {
-  const { children, htmlFor, className, error, hint, srOnly, required, id } = props;
+  const { children, htmlFor, className, error, hint, srOnly, required, id, group } = props;
 
   const classes = classnames(
     {
@@ -27,8 +28,8 @@ export const Label = (props: LabelProps): React.ReactElement => {
 
   const { t } = useTranslation("common");
 
-  return (
-    <label data-testid="label" className={classes} htmlFor={htmlFor} id={id}>
+  const childrenElements = (
+    <>
       {children}{" "}
       {required ? (
         <span data-testid="asterisk" aria-hidden>
@@ -37,6 +38,16 @@ export const Label = (props: LabelProps): React.ReactElement => {
       ) : null}
       {required ? <i className="visually-hidden">{t("required-field")}</i> : null}
       {hint && <span className="gc-hint">{hint}</span>}
+    </>
+  );
+
+  return group ? (
+    <legend data-testid="label" className={classes} id={id}>
+      {childrenElements}
+    </legend>
+  ) : (
+    <label data-testid="label" className={classes} htmlFor={htmlFor} id={id}>
+      {childrenElements}
     </label>
   );
 };

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -69,6 +69,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
       htmlFor={id}
       className={isRequired ? "required" : ""}
       required={isRequired}
+      group={["radio", "checkbox"].indexOf(element.type) !== -1}
     >
       {labelText}
     </Label>
@@ -146,15 +147,13 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
 
       return (
         <FormGroup name={id} ariaDescribedBy={description ? `desc-${id}` : undefined}>
-          <div className="focus-group">
-            {labelComponent}
-            {description ? <Description id={id}>{description}</Description> : null}
-            <MultipleChoiceGroup
-              type="checkbox"
-              name={id}
-              choicesProps={checkboxItems}
-            ></MultipleChoiceGroup>
-          </div>
+          {labelComponent}
+          {description ? <Description id={id}>{description}</Description> : null}
+          <MultipleChoiceGroup
+            type="checkbox"
+            name={id}
+            choicesProps={checkboxItems}
+          ></MultipleChoiceGroup>
         </FormGroup>
       );
     }
@@ -171,15 +170,13 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
 
       return (
         <FormGroup name={id} ariaDescribedBy={description ? `desc-${id}` : undefined}>
-          <div className="focus-group">
-            {labelComponent}
-            {description ? <Description id={id}>{description}</Description> : null}
-            <MultipleChoiceGroup
-              type="radio"
-              name={id}
-              choicesProps={radioItems}
-            ></MultipleChoiceGroup>
-          </div>
+          {labelComponent}
+          {description ? <Description id={id}>{description}</Description> : null}
+          <MultipleChoiceGroup
+            type="radio"
+            name={id}
+            choicesProps={radioItems}
+          ></MultipleChoiceGroup>
         </FormGroup>
       );
     }


### PR DESCRIPTION
# Summary | Résumé
Fix for #306 .

This PR slightly adjusts the markup in radio and checkbox groups in order to better support Screen readers.

Previously, screen readers would not identify checkbox and radio groups as "groups" for navigation purposes, but would rather just read out the label and inputs separately. This is not the correct behaviour and caused confusion in user testing.

VoiceOver now correctly identifies the fieldset element around these elements as a group. It seems like the key was using a legend instead of a label in these groups, and eliminating extraneous divs.