### PR TITLE
Fixed use of deprecated Jest toHaveDescription function

### DIFF
--- a/components/forms/Checkbox/Checkbox.test.js
+++ b/components/forms/Checkbox/Checkbox.test.js
@@ -61,7 +61,7 @@ describe.each([["en"], ["fr"]])("Checkbox component", (lang) => {
       expect(input).toHaveClass("gc-input-checkbox__input").not.toBeChecked();
     });
     // Proper linked description to element
-    expect(screen.getByRole("group")).toHaveDescription(description);
+    expect(screen.getByRole("group")).toHaveAccessibleDescription(description);
 
     // Check the boxes
     screen.getAllByRole("checkbox").forEach((input) => {

--- a/components/forms/Dropdown/Dropdown.test.js
+++ b/components/forms/Dropdown/Dropdown.test.js
@@ -95,7 +95,7 @@ describe.each([["en"], ["fr"]])("Dropdown component", (lang) => {
           : dropdownData.properties.descriptionFr;
     expect(screen.queryByTestId("dropdown"))
       .toBeInTheDocument()
-      .toHaveDescription(description)
+      .toHaveAccessibleDescription(description)
       .toHaveClass("gc-dropdown")
       .toHaveDisplayValue("");
     expect(

--- a/components/forms/FormGroup/FormGroup.test.js
+++ b/components/forms/FormGroup/FormGroup.test.js
@@ -47,7 +47,7 @@ describe.each([["en"], ["fr"]])("Generate a form group", (lang) => {
     expect(screen.getByText(title)).toHaveClass("gc-label");
     // description properly renders
     expect(screen.getByText(description)).toBeInTheDocument().toHaveClass("gc-description");
-    expect(screen.getByRole("group")).toHaveDescription(description);
+    expect(screen.getByRole("group")).toHaveAccessibleDescription(description);
     // Children render
     expect(screen.getByRole("group"))
       .toContainElement(screen.getByText(title))

--- a/components/forms/Radio/Radio.test.js
+++ b/components/forms/Radio/Radio.test.js
@@ -53,7 +53,7 @@ describe.each([["en"], ["fr"]])("Generate a radio button", (lang) => {
       expect(input).toBeRequired();
     });
     // Proper linked description to element
-    expect(screen.getByRole("group")).toHaveDescription(description);
+    expect(screen.getByRole("group")).toHaveAccessibleDescription(description);
   });
   test("not required displays properly", () => {
     radioButtonData.properties.validation.required = false;

--- a/components/forms/TextArea/TextArea.test.js
+++ b/components/forms/TextArea/TextArea.test.js
@@ -48,7 +48,7 @@ describe("Generate a text area", () => {
     // Description properly render
     expect(screen.getByText(description)).toBeInTheDocument();
     // Field marked as required and have aria described by
-    expect(screen.getByRole("textbox")).toBeRequired().toHaveDescription(description);
+    expect(screen.getByRole("textbox")).toBeRequired().toHaveAccessibleDescription(description);
     expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();

--- a/components/forms/TextInput/TextInput.test.js
+++ b/components/forms/TextInput/TextInput.test.js
@@ -48,7 +48,7 @@ describe.each([["en"], ["fr"]])("Generate a text input", (lang) => {
     // Description properly renders
     expect(screen.getByText(description)).toBeInTheDocument();
     // Field marked as required
-    expect(screen.getByRole("textbox")).toBeRequired().toHaveDescription(description);
+    expect(screen.getByRole("textbox")).toBeRequired().toHaveAccessibleDescription(description);
     expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();


### PR DESCRIPTION
# Summary | Résumé

Fix for #291 .

Now using the official replacement for `toHaveDescription` https://github.com/testing-library/jest-dom#tohavedescription