### PR TITLE
bug fix - dynamic row initial value

### DIFF
--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -266,7 +266,9 @@ const _getElementInitialValue = (
       const dynamicRowInitialValue: Record<string, unknown> =
         element.properties.subElements?.reduce((accumulator, currentValue, currentIndex) => {
           const subElementID = `${currentIndex}`;
-          accumulator[subElementID] = _getElementInitialValue(currentValue, language);
+          if (!["richText"].includes(currentValue.type)) {
+            accumulator[subElementID] = _getElementInitialValue(currentValue, language);
+          }
           return accumulator;
         }, {} as Record<string, unknown>) ?? {};
       return [dynamicRowInitialValue];

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -293,7 +293,7 @@ const _getFormInitialValues = (formConfig: PublicFormSchemaProperties, language:
 
   formConfig.elements
     .filter((element) => !["richText"].includes(element.type))
-    .map((element: FormElement) => {
+    .forEach((element: FormElement) => {
       initialValues[element.id] = _getElementInitialValue(element, language);
     });
 


### PR DESCRIPTION
# Summary | Résumé
This PR fixes a bug where a form will not render if a dynamic row contains a `richText` form element.