### PR TITLE
Make screen reader announce heading on confirmation page

### DIFF
--- a/components/forms/RichText/RichText.tsx
+++ b/components/forms/RichText/RichText.tsx
@@ -8,6 +8,16 @@ interface RichTextProps {
   className?: string;
 }
 
+// override the default h1 element such that to place a tabindex value of -1 to make it
+// able to be programmatically focusable
+const H1 = ({ children, ...props }: { children: React.ReactElement }) => {
+  return (
+    <h1 {...props} tabIndex={-1}>
+      {children}
+    </h1>
+  );
+};
+
 export const RichText = (props: RichTextProps): React.ReactElement | null => {
   const { children, className, id } = props;
   if (!children) {
@@ -17,7 +27,9 @@ export const RichText = (props: RichTextProps): React.ReactElement | null => {
   const classes = classnames("gc-richText", className);
   return (
     <div data-testid="richText" className={classes} id={id}>
-      <Markdown options={{ forceBlock: true }}>{children}</Markdown>
+      <Markdown options={{ forceBlock: true, overrides: { h1: { component: H1 } } }}>
+        {children}
+      </Markdown>
     </div>
   );
 };

--- a/components/forms/TextPage/TextPage.tsx
+++ b/components/forms/TextPage/TextPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import parse from "html-react-parser";
 import { useTranslation } from "next-i18next";
 import { RichText } from "../../../components/forms";
@@ -27,7 +27,9 @@ const getPageContent = (t: TFunction, pageText: string, urlQuery: string | undef
   const backToLink = urlQuery ? <a href={urlQuery}>{t("backLink")}</a> : null;
   return (
     <>
-      <h1 className="gc-h1">{t("title")}</h1>
+      <h1 className="gc-h1" tabIndex={-1}>
+        {t("title")}
+      </h1>
       <div>
         <p>{t("body")}</p>
       </div>
@@ -45,6 +47,11 @@ export const TextPage = (props: TextPageProps): React.ReactElement => {
     formConfig && formConfig.endPage
       ? formConfig.endPage[getProperty("description", language)]
       : "";
+
+  // autoFocus h1 element of page to ensure its read out
+  useEffect(() => {
+    document.getElementsByTagName("h1").item(0)?.focus();
+  });
 
   return (
     <>

--- a/cypress/integration/cds_intake.spec.js
+++ b/cypress/integration/cds_intake.spec.js
@@ -42,5 +42,6 @@ describe("CDS Intake Form functionality", { baseUrl: "http://localhost:3000" }, 
   it("Submit the Form", () => {
     cy.get("button").contains("Submit").click();
     cy.url().should("include", "/confirmation");
+    cy.get("h1").should("have.focus");
   });
 });


### PR DESCRIPTION
# Summary | Résumé

closes #319 

Special shout out to @craigzour  detective work!

- Used useEffect and tabIndex to make h1 heading be focused on page load for the confirmation page. 
- Added an override to the markdown-to-jsx library to add tabIndex -1 to h1 elements in RichText component
- Added cypress test to test that h1 is focusable when page is loaded 

# Test instructions | Instructions pour tester la modification

1. Pull down changes
2. Turn voice over on 
3. Complete form and press submit ( whichever form you please )
4. Observe screen reader reading the h1 element on the confirmation page

# Help requested | Aide requise

N/A

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

N/A

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [x] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [x] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [x] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [x] Have you tested it? | L’avez-vous testé?
- [x] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
