### PR TITLE
feat: add language of submission to submission data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+###NBSPAdded
+
+- Add language of form submission to the Next JS submission API and lambda through the `Content-Language` HTTP header
+
 ### Fixed
 
 - Top left corner logo is now more accessible as it tells the user that clicking on it will get him back to the home page
 - Harmonized RichText and Checkbox/Radio label max width depending on screen ratio.
+- Fixed mixed async/await and promise style in `processFormData` and `callLambda`
+- Fixed naming of `submit.tsx` to `submit.ts`
 
 ## [1.0.2] 2021-09-21
 

--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -356,6 +356,7 @@ async function _submitToAPI(values: Responses, formikBag: FormikBag<DynamicFormP
     method: "POST",
     headers: {
       "Content-Type": "multipart/form-data",
+      "Content-Language": language,
     },
     data: formDataObject,
     // If development mode disable timeout

--- a/lib/tests/helpers.test.js
+++ b/lib/tests/helpers.test.js
@@ -130,6 +130,8 @@ describe("Submit Form data", () => {
         router: mockedRouter,
       },
     });
+    expect(mockedAxios.mock.calls[0][0].headers["Content-Language"]).toBe("en");
+    expect(mockedAxios.mock.calls[0][0].data).toEqual(buildFormDataObject(TestForm, mockResponses));
     expect(mockedRouter.push)
       .toBeCalledTimes(1)
       .toBeCalledWith(

--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -53,7 +53,7 @@ const submit = async (
   }
 };
 
-const callLambda = async (formID: string, fields: Responses) => {
+const callLambda = async (formID: string, fields: Responses, language: string) => {
   const submission = await getSubmissionByID(formID);
 
   const encoder = new TextEncoder();
@@ -63,26 +63,26 @@ const callLambda = async (formID: string, fields: Responses) => {
     Payload: encoder.encode(
       JSON.stringify({
         formID,
+        language,
         responses: fields,
         submission,
       })
     ),
   });
-  return await lambdaClient
-    .send(command)
-    .then((response) => {
-      const decoder = new TextDecoder();
-      const payload = decoder.decode(response.Payload);
-      if (response.FunctionError || !JSON.parse(payload).status) {
-        throw Error("Submission API could not process form response");
-      } else {
-        logMessage.info("Submission Lambda Client successfully triggered");
-      }
-    })
-    .catch((err) => {
-      logMessage.error(err);
-      throw new Error("Could not process request with Lambda Submission function");
-    });
+
+  try {
+    const response = await lambdaClient.send(command);
+    const decoder = new TextDecoder();
+    const payload = decoder.decode(response.Payload);
+    if (response.FunctionError || !JSON.parse(payload).status) {
+      throw new Error("Submission API could not process form response");
+    } else {
+      logMessage.info("Submission Lambda Client successfully triggered");
+    }
+  } catch (err) {
+    logMessage.error(err);
+    throw new Error("Could not process request with Lambda Submission function");
+  }
 };
 
 const previewNotify = async (form: PublicFormSchemaProperties, fields: Responses) => {
@@ -184,20 +184,24 @@ const processFormData = async (
           });
         }
       }
-      return await callLambda(form.formID, fields)
-        .then(async () => {
-          if (notifyPreview) {
-            await previewNotify(form, fields).then((response) => {
-              return res.status(201).json({ received: true, htmlEmail: response });
-            });
-          } else {
-            return res.status(201).json({ received: true });
-          }
-        })
-        .catch((err) => {
-          logMessage.error(err);
-          return res.status(500).json({ received: false });
-        });
+      try {
+        await callLambda(
+          form.formID,
+          fields,
+          // pass in the language from the header content language... assume english as the default
+          req.headers?.["content-language"] ? req.headers["content-language"] : "en"
+        );
+
+        if (notifyPreview) {
+          const notifyPreviewResponse = await previewNotify(form, fields);
+          return res.status(201).json({ received: true, htmlEmail: notifyPreviewResponse });
+        } else {
+          return res.status(201).json({ received: true });
+        }
+      } catch (err) {
+        logMessage.error(err);
+        return res.status(500).json({ received: false });
+      }
     }
     // Local development and Heroku
     else if (notifyPreview) {


### PR DESCRIPTION
# Summary | Résumé

Part 1/2 to close #336 

- Send language of the submission to the Next JS submission API through the `Content-Language` header
- Add a language key/value with this value assuming english as the default to the payload sent to the Submission Lambda
- Fix mixed async/await and promise code styles in `processFormData` and `callLambda` functions 
- Renamed `submit.tsx` to `submit.ts`, this is because there are no TSX components. 

# Test instructions | Instructions pour tester la modification

You should be able to confirm it works through the modified unit tests. Otherwise you can console.log the req headers in the submit API handler to confirm the presence of the `Content-Language` header

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

N/A

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Have you removed unnecessary lines such as `console.log` statements?
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
