### PR TITLE
feat: mirror a11y tracker and run dynamic security scans weekly

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -75,6 +75,12 @@ jobs:
           json='{"product": "cds-snc/forms", "revision": "${{github.sha}}", "urls":["https://forms-staging.cdssandbox.xyz", "https://forms-staging.cdssandbox.xyz/fr"], "spider": 1}'
           curl -X POST -H 'X-API-KEY: ${{ secrets.A11Y_TRACKER_KEY }}' --data "$json" https://api.a11y.cdssandbox.xyz/v1
 
+      - name: Run scan websites
+        run: |
+          curl -s https://scan-websites.alpha.canada.ca > /dev/null
+          sleep 60
+          curl -X GET -H 'X-API-KEY: ${{ secrets.SCAN_WEBSITES_KEY }}' -H 'X-TEMPLATE-TOKEN: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}' https://scan-websites.alpha.canada.ca/scans/start
+
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/weekly-dynamic-security-scan.yml
+++ b/.github/workflows/weekly-dynamic-security-scan.yml
@@ -1,0 +1,15 @@
+name: Scan for security vulnerabilities (Weekly on Sunday)
+
+on:
+  schedule:
+  - cron: "0 12 * * 0"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run scan websites
+        run: |
+          curl -s https://scan-websites.alpha.canada.ca > /dev/null
+          sleep 60
+          curl -X GET -H 'X-API-KEY: ${{ secrets.SCAN_WEBSITES_KEY }}' -H 'X-TEMPLATE-TOKEN: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}' 'https://scan-websites.alpha.canada.ca/scans/start?dynamic=true'


### PR DESCRIPTION
This PR adds a call to the Scan websites tool into the CI pipeline. After the client component has been deployed it will make an API call to the static (read-only traffic) tracking tools API that request a spidering of the public facing pages of both the english and french domains.

This also adds a weekly call to the Scan websites tool to run dynamic security testing every Sunday.