### PR TITLE
fix: Analytics Iframe only on prod url page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Google Tag manager iframe will no longer appear in other environment other then staging. [#563](https://github.com/cds-snc/platform-forms-client/pull/563)
+
 ## [1.0.4] 2021-12-3
 
 ### Added

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -28,15 +28,6 @@ const Base = ({ children }) => {
         <meta charSet="utf-8" />
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />
       </Head>
-      <noscript>
-        <iframe
-          src="https://www.googletagmanager.com/ns.html?id=GTM-W3ZVVX5"
-          title="Google Tag Manager Iframe Window"
-          height="0"
-          width="0"
-          style={{ display: "none", visibility: "hidden" }}
-        ></iframe>
-      </noscript>
 
       <SkipLink />
       <div className={classes}>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -170,6 +170,17 @@ class MyDocument extends Document {
           {this.props.currentUrl === "forms-formulaires.alpha.canada.ca" ? GoogleTagScript : null}
         </CustomHead>
         <body>
+          {this.props.currentUrl === "forms-formulaires.alpha.canada.ca" ? (
+            <noscript>
+              <iframe
+                src="https://www.googletagmanager.com/ns.html?id=GTM-W3ZVVX5"
+                title="Google Tag Manager Iframe Window"
+                height="0"
+                width="0"
+                style={{ display: "none", visibility: "hidden" }}
+              ></iframe>
+            </noscript>
+          ) : null}
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
# Summary | Résumé

This PR ensures that the Google Tag Manager Iframe only appears in Production.  It appears some of the Google Analytics from Staging and Local are finding their way in.  Hoping this will solve the issue.

# Test instructions | Instructions pour tester la modification

In _document.js change the logic to not check for the forms-formulaires.alpha.canada.ca domain.  In the elements in Dev Tools you should see the script appear. 


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
