### PR TITLE
test: remove redundant baseurl

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -5,7 +5,7 @@ const A11Y_OPTIONS = {
   },
 };
 
-describe("Accessibility (A11Y) Check", { baseUrl: "http://localhost:3000" }, () => {
+describe("Accessibility (A11Y) Check", () => {
   it("Welcome Page Passes accessibility tests", () => {
     cy.visit("/en/welcome-bienvenue");
     cy.injectAxe();
@@ -17,7 +17,7 @@ describe("Accessibility (A11Y) Check", { baseUrl: "http://localhost:3000" }, () 
     const body = {
       method: "GET",
     };
-    cy.request("http://localhost:3000/api/templates", JSON.stringify(body))
+    cy.request("/api/templates", JSON.stringify(body))
       .then((response) => {
         response.body.data.records.forEach((rec) => {
           if (rec.formConfig.publishingStatus) {

--- a/cypress/integration/cds_intake.spec.js
+++ b/cypress/integration/cds_intake.spec.js
@@ -1,4 +1,4 @@
-describe("CDS Intake Form functionality", { baseUrl: "http://localhost:3000" }, () => {
+describe("CDS Intake Form functionality", () => {
   let formConfig = null,
     formID = null;
   before(() => {
@@ -6,7 +6,7 @@ describe("CDS Intake Form functionality", { baseUrl: "http://localhost:3000" }, 
     const body = {
       method: "GET",
     };
-    cy.request("http://localhost:3000/api/templates", JSON.stringify(body)).then((response) => {
+    cy.request("/api/templates", JSON.stringify(body)).then((response) => {
       const record = response.body.data.records.find(
         (rec) => rec.formConfig.internalTitleEn === "CDS Intake Form"
       );

--- a/cypress/integration/dynamic_rows.spec.js
+++ b/cypress/integration/dynamic_rows.spec.js
@@ -1,4 +1,4 @@
-describe("Dynamic Row Functionality", { baseUrl: "http://localhost:3000" }, () => {
+describe("Dynamic Row Functionality", () => {
   const formID = 76; // Form: Copyright Board of Canada - Proposed Tariff Filing Form
 
   beforeEach(() => {

--- a/cypress/integration/forms_functionality.spec.js
+++ b/cypress/integration/forms_functionality.spec.js
@@ -5,8 +5,8 @@ const A11Y_OPTIONS = {
   },
 };
 
-describe("Forms Functionality", { baseUrl: "http://localhost:3000" }, () => {
-  describe("text field tests", { baseUrl: "http://localhost:3000" }, () => {
+describe("Forms Functionality", () => {
+  describe("text field tests", () => {
     it("renders the form", () => {
       cy.visit(`/en/id/1?mockedFormFile=textFieldTestForm`);
       cy.get("h1").contains("Text Field Test Form");

--- a/cypress/integration/platform_intake_spec.js
+++ b/cypress/integration/platform_intake_spec.js
@@ -1,4 +1,4 @@
-describe("CDS Platform Intake Form functionality", { baseUrl: "http://localhost:3000" }, () => {
+describe("CDS Platform Intake Form functionality", () => {
   let formConfig = null,
     formID = null;
   before(() => {
@@ -6,7 +6,7 @@ describe("CDS Platform Intake Form functionality", { baseUrl: "http://localhost:
     const body = {
       method: "GET",
     };
-    cy.request("http://localhost:3000/api/templates", JSON.stringify(body)).then((response) => {
+    cy.request("/api/templates", JSON.stringify(body)).then((response) => {
       const record = response.body.data.records.find(
         (rec) => rec.formConfig.internalTitleEn === "Work with CDS on a Digital Form"
       );

--- a/cypress/integration/tsb_contact.spec.js
+++ b/cypress/integration/tsb_contact.spec.js
@@ -1,4 +1,4 @@
-describe("TSB Contact Form functionality", { baseUrl: "http://localhost:3000" }, () => {
+describe("TSB Contact Form functionality", () => {
   let formConfig = null,
     formID = null;
 
@@ -7,7 +7,7 @@ describe("TSB Contact Form functionality", { baseUrl: "http://localhost:3000" },
     const body = {
       method: "GET",
     };
-    cy.request("http://localhost:3000/api/templates", JSON.stringify(body)).then((response) => {
+    cy.request("/api/templates", JSON.stringify(body)).then((response) => {
       const record = response.body.data.records.find(
         (rec) => rec.formConfig.internalTitleEn === "Contact Us - TSB"
       );

--- a/cypress/integration/welcome_page.spec.js
+++ b/cypress/integration/welcome_page.spec.js
@@ -1,4 +1,4 @@
-describe("Welcome Page", { baseUrl: "http://localhost:3000/" }, () => {
+describe("Welcome Page", () => {
   it("En page renders", () => {
     cy.visit("/en/welcome-bienvenue");
     cy.get("h1").should("contain", "Welcome to Forms");


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

The baseUrl, or any explicit reference to http://localhost:3000 in the Cypress test is redundant, since the baseUrl is configured in the cypress.json config file.

# Test instructions | Instructions pour tester la modification

Run the cypress tests. The tests should pass, connecting to http://localhost:3000 as defined in the config file.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
