### PR TITLE
fix: path mapping for `@lib` and `@components`

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 module.exports = {
   core: {
     builder: "webpack5",
@@ -15,6 +17,8 @@ module.exports = {
         "sass-loader",
       ],
     });
+    config.resolve.alias = {...config.resolve.alias, "@lib": path.resolve(__dirname, "../lib")}
+    config.resolve.alias = {...config.resolve.alias, "@components": path.resolve(__dirname, "../components")}
 
     config.resolve.alias = {
       ...config.resolve.alias,


### PR DESCRIPTION
# Summary | Résumé

This change fixes a configuration issue with Storyboard. This allows it to find the folders `./lib` and `./components` when referenced as `@lib` and `@components`. The change is limited in scope to only when executed for **Storyboard**, it will have no impact on any other build or tests.

# Test instructions | Instructions pour tester la modification

Run Storyboard. It should compile and execute properly. If any of the stories are for components, check to see the import paths in the component itself (not the `*.stories.*` file. The import paths should be able to include `@lib`.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
