### PR TITLE
Increase axios timeout of submit function to 60 seconds

### DIFF
--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -267,7 +267,7 @@ async function _submitToAPI(values: Responses, formikBag: FormikBag<DynamicFormP
     },
     data: formDataObject,
     // If development mode disable timeout
-    timeout: process.env.NODE_ENV === "production" ? 5000 : 0,
+    timeout: process.env.NODE_ENV === "production" ? 15000 : 0,
   })
     .then((serverResponse) => {
       if (serverResponse.data.received === true) {

--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -267,7 +267,7 @@ async function _submitToAPI(values: Responses, formikBag: FormikBag<DynamicFormP
     },
     data: formDataObject,
     // If development mode disable timeout
-    timeout: process.env.NODE_ENV === "production" ? 15000 : 0,
+    timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
   })
     .then((serverResponse) => {
       if (serverResponse.data.received === true) {


### PR DESCRIPTION
# Summary | Résumé
This PR increases the submit timeout from 5 to 60 seconds.  The increase is due to file uploads taking additional upload time vs just sending json data.

