### PR TITLE
feat: log error when we failed to generate temporary token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A tab on the Form Settings page that allows the user to see and refresh the bearer token.
 - A tab on the Form Settings page that allows form access to be enabled / disabled for users.
 - Replace the retrieval Api lambda implementation by an App backEnd API. [#481](https://github.com/cds-snc/platform-forms-client/issues/481)
+- Log error when we failed to generate a temporary token (will be used to trigger an alarm in AWS CloudWatch)
 
 ### Changed
 
@@ -157,4 +158,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Forms:
   - CDS Intake Form
-

--- a/pages/api/token/temporary.ts
+++ b/pages/api/token/temporary.ts
@@ -65,6 +65,8 @@ const handler = async (
     logMessage.info(`Temporary Token Requested: Form ID: ${formID} Email: ${email}`);
     res.status(200).json({ message: "success" });
   } catch (error) {
+    logMessage.error("Failed to generate temporary token.");
+
     let errorMessage = "Malformed API Request";
 
     if ((error as Error).message.includes("Could not send temporary token by email")) {


### PR DESCRIPTION
# Summary | Résumé

closes #616
linked to https://github.com/cds-snc/forms-terraform/pull/176

- Log error when we detect that we failed to generate a temporary token. It will get into our ECS Log group in CloudWatch. We can then pattern match it in order to trigger an alarm.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
