### PR TITLE
fix: Use formik state as opposed to child state to fix submission glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Form configuration upload now correctly displays the updated configuration instead of displaying old values. [#579](https://github.com/cds-snc/platform-forms-client/pull/597)
 - Clicking a link clears the form. [#498](https://github.com/cds-snc/platform-forms-client/issues/498)
 - AWS WAF blocking image uploads. [#434](https://github.com/cds-snc/platform-forms-client/issues/434)
+- Form scrolling up on submit after fixing errors from first submit. [#160](https://github.com/cds-snc/platform-forms-client/issues/160)
 
 ## [1.0.4] 2021-12-3
 

--- a/components/forms/Form/Form.test.js
+++ b/components/forms/Form/Form.test.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { cleanup, render, screen, act } from "@testing-library/react";
 import Form from "./Form";
 import mockedDataLayer from "../../../lib/integration/helpers";
 
@@ -30,18 +29,25 @@ describe("Generate a form component", () => {
       .toContainElement(screen.getByTestId("test-child"));
   });
   describe("Form Functionality", () => {
+    let mockedSubmitFunction;
+    beforeEach(() => {
+      mockedSubmitFunction = jest.spyOn(mockedDataLayer, "submitToAPI");
+    });
+    afterEach(() => {
+      mockedSubmitFunction.mockRestore();
+    });
     afterAll(() => {
-      cleanup;
+      cleanup();
     });
 
-    test("Form is submitted", () => {
-      render(<Form formConfig={formConfig} language="en" t={(key) => key}></Form>);
-
-      userEvent.click(screen.getByRole("button", { type: "submit" }));
-      const mockedSubmitFunction = jest.spyOn(mockedDataLayer, "submitToAPI");
-      waitFor(() => {
-        expect(mockedSubmitFunction).toBeCalledTimes(1);
+    it("Form is submitted", async () => {
+      await act(async () => {
+        await render(<Form formConfig={formConfig} language="en" t={(key) => key}></Form>);
       });
+      await act(async () => {
+        await screen.getByRole("button", { type: "submit" }).click();
+      });
+      expect(mockedSubmitFunction).toBeCalledTimes(1);
     });
   });
 });

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -47,7 +47,7 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
 
   return (
     <>
-      {isSubmitting || (props.submitCount > 0 && props.isValid) ? (
+      {isSubmitting || (props.submitCount > 0 && props.isValid && !formStatusError) ? (
         <Loader loading={isSubmitting} message={t("loading")} />
       ) : (
         <>

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -19,8 +19,7 @@ declare global {
  * @param props
  */
 const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
-  const { children, handleSubmit, t } = props;
-  const [submitting, setSubmitting] = useState(false);
+  const { children, handleSubmit, t, isSubmitting } = props;
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(0);
 
@@ -33,7 +32,6 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
   useEffect(() => {
     if (formStatusError) {
       setFocusOnErrorMessage(props, serverErrorId);
-      setSubmitting(false);
     }
 
     if (!props.isValid && !canFocusOnError) {
@@ -41,18 +39,16 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
         setCanFocusOnError(true);
         setLastSubmitCount(props.submitCount);
       }
-      setSubmitting(false);
     } else if (!props.isValid) {
       setFocusOnErrorMessage(props, errorId);
       setCanFocusOnError(false);
-      setSubmitting(false);
     }
   }, [formStatusError, errorList, lastSubmitCount, canFocusOnError]);
 
   return (
     <>
-      {submitting ? (
-        <Loader loading={submitting} message={t("loading")} />
+      {isSubmitting ? (
+        <Loader loading={isSubmitting} message={t("loading")} />
       ) : (
         <>
           {formStatusError ? (
@@ -74,11 +70,8 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
             id="form"
             data-testid="form"
             onSubmit={(e) => {
-              setSubmitting(true);
               handleSubmit(e);
             }}
-            method="POST"
-            encType="multipart/form-data"
             noValidate
           >
             {children}
@@ -111,6 +104,7 @@ export const Form = withFormik<DynamicFormProps, FormValues>({
 
   handleSubmit: async (values, formikBag) => {
     try {
+      formikBag.setSubmitting(true);
       await submitToAPI(values as Responses, formikBag);
     } catch (err) {
       logMessage.error(err as Error);

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -104,7 +104,6 @@ export const Form = withFormik<DynamicFormProps, FormValues>({
 
   handleSubmit: async (values, formikBag) => {
     try {
-      formikBag.setSubmitting(true);
       await submitToAPI(values as Responses, formikBag);
     } catch (err) {
       logMessage.error(err as Error);

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -47,7 +47,7 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
 
   return (
     <>
-      {isSubmitting ? (
+      {isSubmitting || (props.submitCount > 0 && props.isValid) ? (
         <Loader loading={isSubmitting} message={t("loading")} />
       ) : (
         <>


### PR DESCRIPTION
# Summary | Résumé

closes #160 

The problem stemmed from component refreshes when setting state. `setSubmit` was called in the onSubmit handler for the form element. This resulted in the component refreshing and the useEffect hook being executed. What this meant was when submitting a form after an initial submit was done with errors, the `isValid` prop was still false and when `setSubmit(true)` was executed, the component was refreshed and `setFocusOnErrorMessage` was called. This resulted in scrolling to the top of the page even when no errors were present.

The fix was simply to use the state provided by the HOC `withFormik` isSubmitting as opposed to any internal state for the lower component. This means that validation will be done before any refreshes happen and isValidate will be correctly set. 
 


https://user-images.githubusercontent.com/26819992/155180202-61645776-329f-45e0-a16e-19a85b3d67ac.mov



# Test instructions | Instructions pour tester la modification

1. Open any Form with validation 
2. Submit such that there are errors
3. Fix the errors
4. Submit again and observe loading spinner being rendered

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

N/A

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
