### PR TITLE
fix: Remove extra className value on submit button

### DIFF
--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -76,9 +76,7 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
           >
             {children}
             <div className="buttons">
-              <Button className="gc-button" type="submit">
-                {t("submitButton")}
-              </Button>
+              <Button type="submit">{t("submitButton")}</Button>
             </div>
           </form>
         </>


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this fix. I noticed that the submit button had a duplicate `className` value: `className="gc-button gc-button"`. The <Button> component adds the `gc-button` class by default, so it is not required when initializing the component.

# Test instructions | Instructions pour tester la modification

The submit button should appear and function exactly as before. Upon inspecting the code, the extra `gc-button` class should no longer be there.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
