### PR TITLE
fix: Sort the error summary to match the displayed elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log error when we detect that an expired bearer token has been used (will be used to trigger an alarm in AWS CloudWatch)
 - Log error when we failed to generate a temporary token (will be used to trigger an alarm in AWS CloudWatch)
 - Log user access to retrieval API
+- Ensure display order of error list matches the display order of the form elements.
 
 ### Changed
 

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -18,7 +18,7 @@ declare global {
  * This is the "inner" form component that isn't connected to Formik and just renders a simple form
  * @param props
  */
-const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
+const InnerForm = (props: InnerFormProps & FormikProps<FormValues> & DynamicFormProps) => {
   const { children, handleSubmit, t, isSubmitting } = props;
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(0);
@@ -51,10 +51,10 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
         <Loader loading={isSubmitting} message={t("loading")} />
       ) : (
         <>
-          {formStatusError ? (
+          {formStatusError && (
             <Alert type="error" heading={formStatusError} tabIndex={0} id={serverErrorId} />
-          ) : null}
-          {errorList ? (
+          )}
+          {errorList && (
             <Alert
               type="error"
               heading={t("input-validation.heading")}
@@ -64,7 +64,7 @@ const InnerForm = (props: InnerFormProps & FormikProps<FormValues>) => {
             >
               {errorList}
             </Alert>
-          ) : null}
+          )}
           {/**
            * method attribute needs to stay here in case javascript does not load
            * otherwise GET request will be sent which will result in leaking all the user data

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -325,6 +325,7 @@ describe("Test getErrorList function", () => {
       1: "input-validation.required",
       2: "input-validation.phone",
     },
+    children: [{ key: "1" }, { key: "2" }],
   };
   test("Error list renders", () => {
     const errors = getErrorList(props);
@@ -348,7 +349,7 @@ describe("Test getErrorList function", () => {
     spy.mockRestore();
   });
   test("Error message gets focus", () => {
-    // mok error element
+    // mock error element
     const errorElement = document.createElement("div");
     errorElement.className = "gc-form-errors";
     document.body.appendChild(errorElement);

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -325,7 +325,7 @@ describe("Test getErrorList function", () => {
       1: "input-validation.required",
       2: "input-validation.phone",
     },
-    children: [{ key: "1" }, { key: "2" }],
+    formConfig: { layout: [1, 2] },
   };
   test("Error list renders", () => {
     const errors = getErrorList(props);
@@ -372,7 +372,7 @@ describe("Test getErrorList function when error order doesn't match display orde
       1: "input-validation.required",
       2: "input-validation.phone",
     },
-    children: [{ key: "2" }, { key: "1" }],
+    formConfig: { layout: [2, 1] },
   };
   it("Renders error list in order matching display order", () => {
     const errors = getErrorList(props);

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -364,6 +364,27 @@ describe("Test getErrorList function", () => {
   });
 });
 
+describe("Test getErrorList function when error order doesn't match display order", () => {
+  afterEach(cleanup);
+  const props = {
+    touched: true,
+    errors: {
+      1: "input-validation.required",
+      2: "input-validation.phone",
+    },
+    children: [{ key: "2" }, { key: "1" }],
+  };
+  it("Renders error list in order matching display order", () => {
+    const errors = getErrorList(props);
+    const { container } = render(errors);
+    const { childNodes } = container.firstChild;
+    const firstDisplayedError = childNodes[0].childNodes[0];
+    const secondDisplayedError = childNodes[1].childNodes[0];
+    expect(screen.getByText("input-validation.phone")).toStrictEqual(firstDisplayedError);
+    expect(screen.getByText("input-validation.required")).toStrictEqual(secondDisplayedError);
+  });
+});
+
 describe("Gov Email domain validator", () => {
   it("Should return false with an empty string passed as email", async () => {
     expect(isValidGovEmail("", "{}")).toBeFalsy();

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -204,24 +204,18 @@ export const validateOnSubmit = (values: FormValues, props: DynamicFormProps): R
 export const getErrorList = (
   props: InnerFormProps & FormikProps<FormValues> & DynamicFormProps
 ): JSX.Element | null => {
-  if (!props.formConfig) {
+  if (!props.formConfig || !props.errors) {
     return null;
   }
   let errorList;
-  const formElementErrors: [string, string | undefined][] = Object.entries(props.errors);
-  const layout: string[] = props.formConfig.layout;
-  if (formElementErrors.length === 0 || layout.length === 0) {
-    return null;
-  }
 
-  const sortedFormElementErrors: [string, string | undefined][] = [];
-  layout.map((element) => {
-    formElementErrors.filter((elementError) => {
-      if (elementError && elementError[0] == element) {
-        sortedFormElementErrors.push(elementError);
-      }
+  const sortedFormElementErrors = props.formConfig.layout
+    .filter((element) => {
+      return element in props.errors;
+    })
+    .map((element) => {
+      return [element, props.errors[element]];
     });
-  });
 
   if (props.touched && sortedFormElementErrors.length) {
     errorList = sortedFormElementErrors.map(([formElementKey, formElementErrorValue]) => {

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -206,10 +206,7 @@ export const getErrorList = (
 ): JSX.Element | null => {
   let errorList;
   const formElementErrors = Object.entries(props.errors);
-  if (formElementErrors.length === 0) {
-    return null;
-  }
-  if (props.children === undefined) {
+  if (formElementErrors.length === 0 || props.children === undefined) {
     return null;
   }
   const formElements = Object.entries(props.children as Array<unknown>);


### PR DESCRIPTION
# Summary | Résumé

Closes #521 

This will loop through the list of errors generated by Formik and match them up with the list of elements in the form itself.

The UI changes to this are imperceivable as a screenshot, since it's only the anchor for the link that changed.

# Test instructions | Instructions pour tester la modification

- Create a form config where the `layout` ids are not in sequential order. 
- Submit a blank form, generating lots of errors.
- Verify that the links in the error list match and go to the correct form elements.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
