### PR TITLE
feat: Replace 'asterisk' with 'required'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log error when we detect that an expired bearer token has been used (will be used to trigger an alarm in AWS CloudWatch)
 - Log error when we failed to generate a temporary token (will be used to trigger an alarm in AWS CloudWatch)
 - Log user access to retrieval API
+- Replace the asterisk on required fields with copy: "(required)"
 
 ### Changed
 

--- a/components/forms/Checkbox/Checkbox.test.js
+++ b/components/forms/Checkbox/Checkbox.test.js
@@ -84,6 +84,6 @@ describe.each([["en"], ["fr"]])("Checkbox component", (lang) => {
       </Form>
     );
 
-    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+    expect(screen.queryByTestId("required")).toBeInTheDocument();
   });
 });

--- a/components/forms/Dropdown/Dropdown.test.js
+++ b/components/forms/Dropdown/Dropdown.test.js
@@ -121,7 +121,7 @@ describe.each([["en"], ["fr"]])("Dropdown component", (lang) => {
         <GenerateElement element={dropdownData} language={lang} />
       </Form>
     );
-    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+    expect(screen.queryByTestId("required")).toBeInTheDocument();
     dropdownData.properties.validation.required = false;
   });
 });

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -30,7 +30,16 @@ export const Label = (props: LabelProps): React.ReactElement => {
 
   const childrenElements = (
     <>
-      {children} {required && <span data-testid="required">({t("required-field")})</span>}
+      {children}
+      {required && (
+        <>
+          &nbsp;
+          <span data-testid="required" aria-hidden>
+            ({t("required")})
+          </span>
+          <i className="visually-hidden">{t("required-field")}</i>
+        </>
+      )}
       {hint && <span className="gc-hint">{hint}</span>}
     </>
   );

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -30,13 +30,7 @@ export const Label = (props: LabelProps): React.ReactElement => {
 
   const childrenElements = (
     <>
-      {children}{" "}
-      {required ? (
-        <span data-testid="asterisk" aria-hidden>
-          *
-        </span>
-      ) : null}
-      {required ? <i className="visually-hidden">{t("required-field")}</i> : null}
+      {children} {required && <span data-testid="required">({t("required-field")})</span>}
       {hint && <span className="gc-hint">{hint}</span>}
     </>
   );

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -32,14 +32,12 @@ export const Label = (props: LabelProps): React.ReactElement => {
     <>
       {children}
       {required && (
-        <>
-          &nbsp;
-          <span data-testid="required" aria-hidden>
-            ({t("required")})
-          </span>
-          <i className="visually-hidden">{t("required-field")}</i>
-        </>
+        <span data-testid="required" aria-hidden>
+          {" "}
+          ({t("required")})
+        </span>
       )}
+      {required && <i className="visually-hidden">{t("required-field")}</i>}
       {hint && <span className="gc-hint">{hint}</span>}
     </>
   );

--- a/components/forms/Radio/Radio.test.js
+++ b/components/forms/Radio/Radio.test.js
@@ -49,7 +49,7 @@ describe.each([["en"], ["fr"]])("Generate a radio button", (lang) => {
     expect(screen.getByText(radioButtonData.properties.choices[0][lang])).toBeInTheDocument();
     expect(screen.getByText(radioButtonData.properties.choices[1][lang])).toBeInTheDocument();
     // Field is required
-    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+    expect(screen.queryByTestId("required")).toBeInTheDocument();
     screen.getAllByRole("radio").forEach((input) => {
       expect(input).toBeRequired();
     });
@@ -63,7 +63,7 @@ describe.each([["en"], ["fr"]])("Generate a radio button", (lang) => {
         <GenerateElement element={radioButtonData} language={lang} />
       </Form>
     );
-    expect(screen.queryByTestId("asterisk")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("required")).not.toBeInTheDocument();
     screen.getAllByRole("radio").forEach((input) => {
       expect(input).not.toBeRequired();
     });

--- a/components/forms/TextArea/TextArea.test.js
+++ b/components/forms/TextArea/TextArea.test.js
@@ -49,7 +49,7 @@ describe("Generate a text area", () => {
     expect(screen.getByText(description)).toBeInTheDocument();
     // Field marked as required and have aria described by
     expect(screen.getByRole("textbox")).toBeRequired().toHaveAccessibleDescription(description);
-    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+    expect(screen.queryByTestId("required")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
   });

--- a/components/forms/TextInput/TextInput.test.js
+++ b/components/forms/TextInput/TextInput.test.js
@@ -49,7 +49,7 @@ describe.each([["en"], ["fr"]])("Generate a text input", (lang) => {
     expect(screen.getByText(description)).toBeInTheDocument();
     // Field marked as required
     expect(screen.getByRole("textbox")).toBeRequired().toHaveAccessibleDescription(description);
-    expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
+    expect(screen.queryByTestId("required")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
   });

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -37,7 +37,7 @@
     "file-size-too-large": "Please select a smaller file",
     "file-type-invalid": "Please select a different file type"
   },
-  "required-field": "Required Field",
+  "required-field": "required",
   "file-upload-button-text": "Upload a file",
   "file-upload-sr-only-file-selected": "Currently selected file is",
   "file-upload-no-file-selected": "No file currently selected",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -37,7 +37,8 @@
     "file-size-too-large": "Please select a smaller file",
     "file-type-invalid": "Please select a different file type"
   },
-  "required-field": "required",
+  "required": "required",
+  "required-field": "Required Field",
   "file-upload-button-text": "Upload a file",
   "file-upload-sr-only-file-selected": "Currently selected file is",
   "file-upload-no-file-selected": "No file currently selected",

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -37,7 +37,7 @@
     "file-size-too-large": "Veuillez sélectionner un fichier plus petit",
     "file-type-invalid": "Veuillez sélectionner un autre type de fichier"
   },
-  "required-field": "Champ obligatoire",
+  "required-field": "obligatoire",
   "file-upload-button-text": "Téléverser un fichier",
   "file-upload-sr-only-file-selected": "Le fichier actuellement sélectionné est",
   "file-upload-no-file-selected": "Aucun fichier actuellement sélectionné",

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -37,7 +37,8 @@
     "file-size-too-large": "Veuillez sélectionner un fichier plus petit",
     "file-type-invalid": "Veuillez sélectionner un autre type de fichier"
   },
-  "required-field": "obligatoire",
+  "required": "obligatoire",
+  "required-field": "Champ obligatoire",
   "file-upload-button-text": "Téléverser un fichier",
   "file-upload-sr-only-file-selected": "Le fichier actuellement sélectionné est",
   "file-upload-no-file-selected": "Aucun fichier actuellement sélectionné",


### PR DESCRIPTION
# Summary | Résumé

Closes #625 - Replace the asterisk on required fields with copy:  "(required)" / "(obligatoire)"

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| 
![Screen Shot 2022-02-28 at 12 32 28 PM](https://user-images.githubusercontent.com/77435/156030756-b773c2d8-5898-4f63-b755-77ab615ca463.png)
 | 
![Screen Shot 2022-02-28 at 12 34 10 PM](https://user-images.githubusercontent.com/77435/156030790-ddd9b145-b857-4a25-b93b-1f27fa5cd65d.png)
 |

# Test instructions | Instructions pour tester la modification

- Load a form with required form elements.
- The asterisk should not appear, and the copy "(required)" / "(obligatoire)" should appear.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
