### PR TITLE
feat: autoComplete attribute on textField

### DIFF
--- a/components/forms/TextInput/TextInput.test.js
+++ b/components/forms/TextInput/TextInput.test.js
@@ -18,6 +18,7 @@ const textInputData = {
     placeholderFr: "Je ne sais pas",
     descriptionEn: "This is a description",
     descriptionFr: "Voice une description",
+    autoComplete: "name",
     validation: {
       required: true,
     },
@@ -52,5 +53,16 @@ describe.each([["en"], ["fr"]])("Generate a text input", (lang) => {
     expect(screen.queryByTestId("asterisk")).toBeInTheDocument();
     // Placeholder properly renders
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
+  });
+});
+
+describe("Check attributes on rendered text input", () => {
+  it("has the correct autoComplete value", () => {
+    render(
+      <Form t={(key) => key}>
+        <GenerateElement element={textInputData} language={"en"} />
+      </Form>
+    );
+    expect(screen.getByRole("textbox").hasAttribute("autoComplete").valueOf("name"));
   });
 });

--- a/components/forms/TextInput/TextInput.tsx
+++ b/components/forms/TextInput/TextInput.tsx
@@ -21,7 +21,7 @@ export type OptionalTextInputProps = CustomTextInputProps & JSX.IntrinsicElement
 export type TextInputProps = RequiredTextInputProps & OptionalTextInputProps;
 
 export const TextInput = (props: TextInputProps): React.ReactElement => {
-  const { id, type, className, required, ariaDescribedBy, placeholder } = props;
+  const { id, type, className, required, ariaDescribedBy, placeholder, autoComplete } = props;
   const [field, meta] = useField(props);
   const classes = classnames("gc-input-text", className);
 
@@ -34,7 +34,7 @@ export const TextInput = (props: TextInputProps): React.ReactElement => {
         id={id}
         type={type}
         required={required}
-        autoComplete={type == "text" ? "off" : type}
+        autoComplete={autoComplete}
         aria-describedby={ariaDescribedBy}
         placeholder={placeholder}
         {...field}

--- a/components/forms/TextInput/TextInput.tsx
+++ b/components/forms/TextInput/TextInput.tsx
@@ -34,7 +34,7 @@ export const TextInput = (props: TextInputProps): React.ReactElement => {
         id={id}
         type={type}
         required={required}
-        autoComplete={autoComplete}
+        autoComplete={autoComplete ? autoComplete : "off"}
         aria-describedby={ariaDescribedBy}
         placeholder={placeholder}
         {...field}

--- a/documentation/Forms/FormViewer.stories.mdx
+++ b/documentation/Forms/FormViewer.stories.mdx
@@ -108,6 +108,7 @@ Example:
         "placeholderFr": "",
         "description": "",
         "charLimit": 100,
+        "autoComplete": "name",
         "validation": {
           "required": true
         }
@@ -202,6 +203,8 @@ A simple text input where the `title` property is used as the input's label.
 `descriptionEn / descriptionFr`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
 
 `charLimit`: The maximum number of characters that can be submitted through the input
+
+`autoComplete`: When appropropriate, a string for the autoComplete token to identify the field. A list of acceptable tokens can be found here: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens
 
 `required`: A boolean flag identifying if the question element is a mandatory for submission (`bool`)
 

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -118,7 +118,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
             required={isRequired}
             ariaDescribedBy={description ? `desc-${id}` : undefined}
             placeholder={placeHolder.toString()}
-            autoComplete={element.properties.autoComplete}
+            autoComplete={element.properties.autoComplete?.toString()}
           />
         </div>
       );

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -118,6 +118,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
             required={isRequired}
             ariaDescribedBy={description ? `desc-${id}` : undefined}
             placeholder={placeHolder.toString()}
+            autoComplete={element.properties.autoComplete}
           />
         </div>
       );


### PR DESCRIPTION
# Summary | Résumé

Closes #626 

# Test instructions | Instructions pour tester la modification

- Update a config for a form to include the `autoComplete` attribute. For example:
`      {
        "id": 4,
        "type": "textField",
        "properties": {
          "titleEn": "Address",
          "titleFr": "Adresse",
          "autoComplete": "street-address",
          "validation": {
            "required": false
          },
        }
      }`

- Load a form, and inspect that the code includes `autocomplete="street-address"` for the modified textField.
- Please note that there is a specific list of allowed values for `autoComplete`: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
