### PR TITLE
Set list position to be inside (inline with text start)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Aligned HTTP methods on API requests to decommission request body `method` property.
+- Changed CSS on ordered and unordered lists to align with beginning of page text.
 
 ## [1.1.0] 2022-03-04
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsonschema": "^1.4.0",
     "jsonwebtoken": "^8.5.1",
     "lint-staged": "^12.1.2",
-    "markdown-to-jsx": "^7.1.1",
+    "markdown-to-jsx": "^7.1.7",
     "mmmagic": "^0.5.3",
     "next": "^11.1.4",
     "next-auth": "^3.28.0",

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -119,7 +119,7 @@
 
   ul,
   ol {
-    @apply mb-10;
+    @apply mb-10 list-inside;
   }
 
   a:visited {
@@ -372,7 +372,7 @@
     outline: solid 2px #303fc3;
     outline-offset: 2px;
     @apply bg-blue-focus;
-    @apply text-gray-50;    
+    @apply text-gray-50;
   }
 
   &:active {

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -119,7 +119,11 @@
 
   ul,
   ol {
-    @apply mb-10 list-inside;
+    @apply mb-10;
+  }
+
+  ol {
+    @apply list-inside;
   }
 
   a:visited {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11756,10 +11756,15 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-markdown-to-jsx@^7.1.1, markdown-to-jsx@^7.1.3:
+markdown-to-jsx@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz#f00bae66c0abe7dd2d274123f84cb6bd2a2c7c6a"
   integrity sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==
+
+markdown-to-jsx@^7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz#a5f22102fb12241c8cea1ca6a4050bb76b23a25d"
+  integrity sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
# Summary | Résumé

Sets the list position style explicitly to 'inside' so the decimal or bullet markers are inline with the beginning of the text.


| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
|![Screen Shot 2022-03-09 at 3 29 58 PM](https://user-images.githubusercontent.com/25329319/157531401-072e4e91-5506-46d1-9a12-f9dd4a0d9b51.png)|![Screen Shot 2022-03-09 at 3 29 14 PM](https://user-images.githubusercontent.com/25329319/157531350-8776b019-d24b-439f-a37b-248a3c3061a5.png)|


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
