### PR TITLE
fix: dropdown default selected value is now displayed with text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed CSS on ordered and unordered lists to align with beginning of page text.
 - Open links from richText component in new Tab.
 - Improved/fixed accessibility for file input component
+- Fixed dropdown initial value not being displayed the same way across browsers
 
 ## [1.1.0] 2022-03-04
 

--- a/components/forms/Dropdown/Dropdown.test.js
+++ b/components/forms/Dropdown/Dropdown.test.js
@@ -97,7 +97,7 @@ describe.each([["en"], ["fr"]])("Dropdown component", (lang) => {
       .toBeInTheDocument()
       .toHaveAccessibleDescription(description)
       .toHaveClass("gc-dropdown")
-      .toHaveDisplayValue("");
+      .toHaveDisplayValue("dropdown-initial-option-text");
     expect(
       screen.getByRole("combobox", {
         name: title,

--- a/components/forms/Dropdown/Dropdown.tsx
+++ b/components/forms/Dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import { useField } from "formik";
+import { useTranslation } from "next-i18next";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 
 interface DropdownProps {
@@ -17,8 +18,6 @@ interface DropdownOptionProps {
   value: string;
 }
 
-const InitialDropdownOption = <option hidden value=""></option>;
-
 const DropdownOption = (props: DropdownOptionProps): React.ReactElement => {
   return <option value={props.value}>{props.name}</option>;
 };
@@ -26,9 +25,13 @@ const DropdownOption = (props: DropdownOptionProps): React.ReactElement => {
 export const Dropdown = (props: DropdownProps): React.ReactElement => {
   const { id, className, choices, required, ariaDescribedBy } = props;
 
+  const { t } = useTranslation("common");
+
   const classes = classnames("gc-dropdown", className);
 
   const [field, meta] = useField(props);
+
+  const initialDropdownOption = <option value="">{t("dropdown-initial-option-text")}</option>;
 
   const options = choices.map((choice, i) => {
     const innerId = `${id}-${i}`;
@@ -48,7 +51,7 @@ export const Dropdown = (props: DropdownProps): React.ReactElement => {
         aria-describedby={ariaDescribedBy}
         {...field}
       >
-        {InitialDropdownOption}
+        {initialDropdownOption}
         {options}
       </select>
     </>

--- a/lib/tests/formBuilder.test.js
+++ b/lib/tests/formBuilder.test.js
@@ -62,7 +62,7 @@ describe("Get rendered form", () => {
     expect(screen.queryAllByRole("checkbox").length).toBe(6);
     expect(screen.queryAllByRole("radio").length).toBe(5);
     expect(screen.queryAllByRole("combobox").length).toBe(1);
-    expect(screen.queryAllByRole("option").length).toBe(14);
+    expect(screen.queryAllByRole("option").length).toBe(15);
     expect(screen.queryAllByRole("group").length).toBe(4);
   });
   test("Renders form for all elements - French", () => {
@@ -76,7 +76,7 @@ describe("Get rendered form", () => {
     expect(screen.queryAllByRole("checkbox").length).toBe(6);
     expect(screen.queryAllByRole("radio").length).toBe(5);
     expect(screen.queryAllByRole("combobox").length).toBe(1);
-    expect(screen.queryAllByRole("option").length).toBe(14);
+    expect(screen.queryAllByRole("option").length).toBe(15);
     expect(screen.queryAllByRole("group").length).toBe(4);
     expect(screen.queryAllByRole("button").length).toBe(2);
   });

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -42,6 +42,7 @@
   "file-upload-button-text": "Upload a file",
   "file-upload-sr-only-file-selected": "Currently selected file is",
   "file-upload-no-file-selected": "No file currently selected",
+  "dropdown-initial-option-text": "No selection",
   "server-error": "Oops, looks like there was a problem submitting your form.  Please try again later.",
   "title": "GC Forms - Formulaires GC",
   "loading": "We are processing your form submission.  Please wait.",

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -42,6 +42,7 @@
   "file-upload-button-text": "Téléverser un fichier",
   "file-upload-sr-only-file-selected": "Le fichier actuellement sélectionné est",
   "file-upload-no-file-selected": "Aucun fichier actuellement sélectionné",
+  "dropdown-initial-option-text": "Pas de sélection",
   "server-error": "Oups, il semble qu'un problème est survenu lors de l'envoi de votre formulaire. Veuillez réessayer plus tard.",
   "title": "GC Forms - Formulaires GC",
   "loading": "Nous traitons votre soumission de formulaire. Veuillez patienter.",


### PR DESCRIPTION
# Summary | Résumé

closes #623

- Modified default selected value so that it is now displayed with a text instead of being an hidden option (which did not work properly on all browsers)

Following Before/After is based on Safari:

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
|<img width="1198" alt="68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3565346439396532623837383165373739306237653863632f39613565383064622d366166302d346366362d613732632d626139366136336431333164" src="https://user-images.githubusercontent.com/1763961/157903507-29160895-d70e-49ac-86a4-ec61727044a9.png">|<img width="537" alt="Screen Shot 2022-03-11 at 11 04 06 AM" src="https://user-images.githubusercontent.com/1763961/157903751-de32e188-1b72-479e-afb8-6824de60d78b.png">|

# Test instructions | Instructions pour tester la modification

- Open a form with a dropdown component in either Google Chrome or Safari and test it

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
