### PR TITLE
fix: remove redundant `required` copy.

### DIFF
--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -37,7 +37,6 @@ export const Label = (props: LabelProps): React.ReactElement => {
           ({t("required")})
         </span>
       )}
-      {required && <i className="visually-hidden">{t("required-field")}</i>}
       {hint && <span className="gc-hint">{hint}</span>}
     </>
   );

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -37,6 +37,7 @@ export const Label = (props: LabelProps): React.ReactElement => {
           ({t("required")})
         </span>
       )}
+      {group && required && <i className="visually-hidden">{t("required-field")}</i>}
       {hint && <span className="gc-hint">{hint}</span>}
     </>
   );

--- a/pages/api/templates.ts
+++ b/pages/api/templates.ts
@@ -4,7 +4,6 @@ import { middleware, jsonValidator, cors, sessionExists } from "@lib/middleware"
 import templatesSchema from "@lib/middleware/schemas/templates.schema.json";
 import { NextApiRequest, NextApiResponse } from "next";
 import { isAdmin } from "@lib/auth";
-import { CrudTemplateResponse, PublicFormSchemaProperties } from "@lib/types";
 
 const allowedMethods = ["GET", "POST", "PUT", "DELETE"];
 const authenticatedMethods = ["POST", "PUT", "DELETE"];


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

The removed code is redundant for non-group form elements. If a element is already marked as `required`, then the screen reader will read out: "Full name required required", since it is reading out the visually-hidden copy of `required`, as well as the `required` attribute for the form elements (ie: `input`, `textarea`, etc..).

# Test instructions | Instructions pour tester la modification

- load a form with required elements
- tabbing through the form elements should only read out `required` only once per element, regardless if it is a group element or not

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
