### PR TITLE
Added missing line ending.

### DIFF
--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build Form Viewer
         run: |
           docker build -t base \
-          --build-arg PRODUCTION_ENV=true
+          --build-arg PRODUCTION_ENV=true \
           --build-arg GITHUB_SHA_ARG=$GITHUB_SHA .
 
       - name: Configure Production AWS credentials


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

Fixing a line in the production build script, that was missing a `\` at the end of a line, which caused the command to be truncated.
