### PR TITLE
feature: Add the submission object.

### DIFF
--- a/lib/middleware/schemas/templates.schema.json
+++ b/lib/middleware/schemas/templates.schema.json
@@ -34,6 +34,19 @@
         }
       },
       "required": ["elements"]
+    },
+    "submission": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "The email address to which the form submission should be sent.",
+          "type": "string"
+        },
+        "vault": {
+          "description": "If set to true, the form submission will be saved in the vault.",
+          "type": "boolean"
+        }
+      }
     }
   },
   "required": ["form", "submission", "internalTitleEn", "internalTitleFr", "publishingStatus"],


### PR DESCRIPTION
# Summary | Résumé

There is no PR for this issue.

It was noticed that the definition for `submission` was not included in the schema. Added the definition, with the 2 possible properties: `email` and `vault`.