### PR TITLE
add csrf  protection (with  next-auth's getCsrfToken func)

### DIFF
--- a/components/containers/DynamicForm/DynamicForm.tsx
+++ b/components/containers/DynamicForm/DynamicForm.tsx
@@ -7,13 +7,14 @@ import { getProperty, getRenderedForm } from "@lib/formBuilder";
 import { DynamicFormProps } from "@lib/types";
 import { useRouter } from "next/router";
 import { useFlag } from "@lib/hooks/useFlag";
+import { csrfToken } from "next-auth/client";
 
 /* The Dynamic form component is the outer stateful component which renders either a form step or a
     form text page based on the step
 */
 
 export const DynamicForm = (props: DynamicFormProps): React.ReactElement => {
-  const { formConfig } = props;
+  const { formConfig, csrfToken } = props;
   const { t, i18n } = useTranslation();
   const language = i18n.language as string;
   const classes = classnames("gc-form-wrapper");
@@ -42,6 +43,7 @@ export const DynamicForm = (props: DynamicFormProps): React.ReactElement => {
         router={router}
         t={t}
         notifyPreviewFlag={notifyPreviewFlag}
+        csrfToken={csrfToken}
       >
         {currentForm}
       </Form>

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -31,7 +31,7 @@ declare global {
 const InnerForm: React.FC<InnerFormProps & FormikProps<FormValues> & DynamicFormProps> = (
   props: InnerFormProps & FormikProps<FormValues> & DynamicFormProps
 ) => {
-  const { children, handleSubmit, isSubmitting, formConfig } = props;
+  const { children, handleSubmit, isSubmitting, formConfig, csrfToken } = props;
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(-1);
 
@@ -219,6 +219,7 @@ const InnerForm: React.FC<InnerFormProps & FormikProps<FormValues> & DynamicForm
           <div className="buttons">
             <Button type="submit">{t("submitButton")}</Button>
           </div>
+          <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
         </div>
       </form>
     </>

--- a/lib/integration/helpers.ts
+++ b/lib/integration/helpers.ts
@@ -251,7 +251,7 @@ function _handleFormDataArray(key: string, value: Array<string>): [string, strin
 }
 
 async function _submitToAPI(values: Responses, formikBag: FormikBag<DynamicFormProps, FormValues>) {
-  const { language, router, formConfig, notifyPreviewFlag } = formikBag.props;
+  const { language, router, formConfig, notifyPreviewFlag, csrfToken } = formikBag.props;
   const { setStatus } = formikBag;
 
   const formDataObject = _buildFormDataObject(formConfig, values);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -146,6 +146,7 @@ export interface DynamicFormProps {
   isReCaptchaEnableOnSite?: boolean;
   children?: (JSX.Element | undefined)[] | null;
   t: TFunction;
+  csrfToken: string;
 }
 
 export interface InnerFormProps {

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { getSession } from "next-auth/client";
 import Login from "@components/containers/Auth/Login";
+import { getCsrfToken } from "next-auth/client";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context);
@@ -26,11 +27,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (context.locale) {
     return {
-      props: { ...(await serverSideTranslations(context.locale, ["common", "admin-login"])) },
+      props: {
+        ...(await serverSideTranslations(context.locale, ["common", "admin-login"])),
+        csrfToken: await getCsrfToken(context),
+      },
     };
   }
 
-  return { props: {} };
+  return { props: { csrfToken: await getCsrfToken(context) } };
 };
 
 export default Login;

--- a/pages/id/[form]/[[...step]].js
+++ b/pages/id/[form]/[[...step]].js
@@ -2,6 +2,7 @@ import { getFormByID } from "@lib/integration/crud";
 import DynamicForm from "@components/containers/DynamicForm/DynamicForm";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { checkOne } from "@lib/flags";
+import { getCsrfToken } from "next-auth/client";
 
 export async function getServerSideProps(context) {
   const unpublishedForms = await checkOne("unpublishedForms");
@@ -35,6 +36,7 @@ export async function getServerSideProps(context) {
     props: {
       formConfig: form,
       isEmbeddable: isEmbeddable,
+      csrfToken: await getCsrfToken(context),
       ...(await serverSideTranslations(context.locale, ["common", "welcome", "confirmation"])),
     }, // will be passed to the page component as props
   };


### PR DESCRIPTION
Add Cross-Site Request Forgery (CSRF) to pages that include forms
closed #716

