### PR TITLE
Remove Heroku Specific Configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,0 @@
-{
-  "name": "GCForms review app template",
-  "description": "This file is to help build the Heroku Review App",
-  "addons": ["heroku-redis"],
-  "success_url": "/en/welcome-bienvenue"
-}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "cypress:headless": "cypress run --browser chrome --headless",
     "build-storybook": "build-storybook -s public --no-dll",
     "storybook": "start-storybook -s public -p 6006",
-    "heroku-postbuild": "cd ./migrations && yarn install && cd ../flag_initialization && yarn install && cd .. &&  yarn build",
     "postinstall": "[ \"$NODE_ENV\" = production ] && exit 0; husky install"
   },
   "dependencies": {


### PR DESCRIPTION
# Summary | Résumé
This PR removes the Heroku specific configuration that was used for the preview app.
Seeing as we're no longer used the preview app feature this configuration can be safely removed.