### PR TITLE
fix: add `'limit` and `offset` the the crudTemplates call, retrieving the templates in batches

### DIFF
--- a/lib/integration/crud.ts
+++ b/lib/integration/crud.ts
@@ -250,11 +250,19 @@ async function _getFormByStatus(
  * Recursively calls lambda function to retrieve the forms (templates) from the database
  * @param templates the array which the records will be added to, then recursively passed to the next `getForms()` call
  * @param limit the number of records to fetch from the database
- * @param offest the record to start from
+ * @param offset the record to start from
  * @returns an array of all the forms (templates) from the database
  */
 
-const _getForms = async (templates: unknown[] = [], limit = 50, offset = 0): Promise<unknown[]> => {
+const _getForms = async (
+  templates: CrudTemplateResponse = {
+    data: {
+      records: [],
+    },
+  },
+  limit = 50,
+  offset = 0
+): Promise<CrudTemplateResponse> => {
   try {
     const lambdaResult = await crudTemplates({ method: "GET", limit: limit, offset: offset });
 
@@ -262,7 +270,15 @@ const _getForms = async (templates: unknown[] = [], limit = 50, offset = 0): Pro
       return templates;
     }
 
-    templates = templates.concat(lambdaResult.data.records);
+    if (templates.data.records) {
+      templates.data.records = templates.data.records.concat(lambdaResult.data.records);
+    } else {
+      templates = {
+        data: {
+          records: [...lambdaResult.data.records],
+        },
+      };
+    }
 
     if (lambdaResult.data.records.length === limit) {
       // There could be more records in the database, so get the next batch
@@ -272,7 +288,7 @@ const _getForms = async (templates: unknown[] = [], limit = 50, offset = 0): Pro
     }
   } catch (e) {
     logMessage.error(e as Error);
-    return [];
+    return templates;
   }
 };
 

--- a/lib/integration/crud.ts
+++ b/lib/integration/crud.ts
@@ -262,7 +262,7 @@ const _getForms = async (templates: unknown[] = [], limit = 50, offset = 0): Pro
       return templates;
     }
 
-    Array.prototype.push.apply(templates, lambdaResult.data.records);
+    templates = templates.concat(lambdaResult.data.records);
 
     if (lambdaResult.data.records.length === limit) {
       // There could be more records in the database, so get the next batch

--- a/lib/integration/crud.ts
+++ b/lib/integration/crud.ts
@@ -246,6 +246,28 @@ async function _getFormByStatus(
   return [];
 }
 
+const _getForms = async (templates: unknown[] = [], limit = 50, offset = 0): Promise<unknown[]> => {
+  try {
+    const lambdaResult = await crudTemplates({ method: "GET", limit: limit, offset: offset });
+
+    if (!lambdaResult?.data?.records) {
+      return templates;
+    }
+
+    Array.prototype.push.apply(templates, lambdaResult.data.records);
+
+    if (lambdaResult.data.records.length === limit) {
+      // There could be more records in the database, so get the next batch
+      return await _getForms(templates, limit, offset + limit);
+    } else {
+      return templates;
+    }
+  } catch (e) {
+    logMessage.error(e as Error);
+    return [];
+  }
+};
+
 async function _getFormByID(formID: string): Promise<PublicFormSchemaProperties | null> {
   try {
     const response = await crudTemplates({ method: "GET", formID: formID });
@@ -281,6 +303,7 @@ const _onlyIncludePublicProperties = async ({
 
 export const crudOrganizations = logger(_crudOrganizationsWithCache);
 export const crudTemplates = logger(_crudTemplatesWithCache);
+export const getForms = logger(_getForms);
 export const getFormByID = logger(_getFormByID);
 export const getFormByStatus = logger(_getFormByStatus);
 export const getSubmissionByID = logger(_getSubmissionByID);

--- a/lib/integration/crud.ts
+++ b/lib/integration/crud.ts
@@ -51,13 +51,15 @@ async function _crudTemplatesWithCache(payload: CrudTemplateInput): Promise<Crud
 
 async function _crudTemplates(payload: CrudTemplateInput): Promise<CrudTemplateResponse> {
   const getConfig = (payload: CrudTemplateInput) => {
-    const { method, formID, formConfig } = payload;
+    const { method, formID, formConfig, limit, offset } = payload;
 
     switch (method) {
       case "GET":
         return {
           method: "GET",
           formID,
+          limit,
+          offset,
         };
       case "POST":
         return {

--- a/lib/integration/crud.ts
+++ b/lib/integration/crud.ts
@@ -246,6 +246,14 @@ async function _getFormByStatus(
   return [];
 }
 
+/**
+ * Recursively calls lambda function to retrieve the forms (templates) from the database
+ * @param templates the array which the records will be added to, then recursively passed to the next `getForms()` call
+ * @param limit the number of records to fetch from the database
+ * @param offest the record to start from
+ * @returns an array of all the forms (templates) from the database
+ */
+
 const _getForms = async (templates: unknown[] = [], limit = 50, offset = 0): Promise<unknown[]> => {
   try {
     const lambdaResult = await crudTemplates({ method: "GET", limit: limit, offset: offset });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -175,6 +175,8 @@ export interface CrudTemplateInput {
   method: string;
   formID?: string;
   formConfig?: FormDefinitionProperties;
+  limit?: number;
+  offset?: number;
 }
 
 export interface CrudTemplateResponse {

--- a/pages/admin/view-templates.tsx
+++ b/pages/admin/view-templates.tsx
@@ -1,31 +1,14 @@
-//import getConfig from "next/config";
 import DataView from "../../components/containers/Admin/Dashboard/DataView";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { crudTemplates } from "../../lib/integration/crud";
-import { requireAuthentication } from "../../lib/auth";
+import { getForms } from "@lib/integration/crud";
+import { requireAuthentication } from "@lib/auth";
 
 export const getServerSideProps = requireAuthentication(async (context) => {
   {
     // getStaticProps is serverside, and therefore instead of doing a request,
     // we import the invoke Lambda function directly
 
-    const templatesJSON: unknown[] = [];
-
-    const getTemplatesFromLambda = async (limit = 13, offset = 0) => {
-      const lambdaResult = await crudTemplates({ method: "GET", limit: limit, offset: offset });
-
-      if (!lambdaResult || !lambdaResult.data || !lambdaResult.data.records) {
-        return;
-      }
-
-      Array.prototype.push.apply(templatesJSON, lambdaResult.data.records);
-
-      if (!(lambdaResult.data.records.length < limit)) {
-        await getTemplatesFromLambda(limit, offset + limit);
-      }
-    };
-
-    await getTemplatesFromLambda();
+    const templatesJSON: unknown[] = await getForms();
 
     if (context.locale) {
       return {

--- a/pages/admin/view-templates.tsx
+++ b/pages/admin/view-templates.tsx
@@ -8,12 +8,12 @@ export const getServerSideProps = requireAuthentication(async (context) => {
     // getStaticProps is serverside, and therefore instead of doing a request,
     // we import the invoke Lambda function directly
 
-    const templatesJSON: unknown[] = await getForms();
+    const templatesJSON = await getForms();
 
     if (context.locale) {
       return {
         props: {
-          templatesJSON: templatesJSON,
+          templatesJSON: templatesJSON.data.records,
           ...(await serverSideTranslations(context.locale, ["common", "admin-templates"])),
         }, // will be passed to the page component as props
       };

--- a/pages/api/templates.ts
+++ b/pages/api/templates.ts
@@ -1,4 +1,4 @@
-import { crudTemplates, onlyIncludePublicProperties } from "@lib/integration/crud";
+import { crudTemplates, onlyIncludePublicProperties, getForms } from "@lib/integration/crud";
 
 import { middleware, jsonValidator, cors, sessionExists } from "@lib/middleware";
 import templatesSchema from "@lib/middleware/schemas/templates.schema.json";
@@ -13,7 +13,10 @@ const authenticatedMethods = ["POST", "PUT", "DELETE"];
 const templates = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const session = await isAdmin({ req });
-    const response = await crudTemplates({ ...req.body, method: req.method, session });
+    const response =
+      req.method === "GET"
+        ? await getForms()
+        : await crudTemplates({ ...req.body, method: req.method, session });
     if (response) {
       if (session && session.user.id && ["POST", "PUT", "DELETE"].includes(req.method as string)) {
         const formId = response.data.records ? response.data.records[0].formID : req.body.formID;


### PR DESCRIPTION
# Summary | Résumé

Closes #786 

Created a recursive function to retrieve the form templates in batches. This adds parameters for `limit` and `offset`, to request only some form templates in each call to the lambda function, ensuring that each batch is below the 1MB limit. It will merge all the batches together, and return all templates back to the calling function.

# Test instructions | Instructions pour tester la modification

- PR 211 on the `forms-terraform` repo will need to be merged in first in order to test.
- The database will need to have more than 50 forms in the `templates` table in order to test this.
- Visit the `/admin/view-templates` page, and observe that all templates are returned.
- All jest and cypress tests should pass too.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

What should the default `limit` be? Currently set at 50, but I suspect it could be quite a bit higher than that, and still be under the 1MB limit.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
