### PR TITLE
fix: update devcontainer to not use root user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:16
+ARG VARIANT=16
 
-ARG USERNAME=vscode
+FROM node:${VARIANT}
+
+ARG USERNAME=node
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
@@ -8,10 +10,10 @@ COPY migrations /src
 WORKDIR /src
 RUN yarn install 
 
-FROM node:16
+FROM node:${VARIANT}
 
 
-ARG USERNAME=vscode
+ARG USERNAME=node
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
@@ -19,9 +21,9 @@ COPY flag_initialization /src
 WORKDIR /src
 RUN yarn install
 
-FROM node:16
+FROM node:${VARIANT}
 
-ARG USERNAME=vscode
+ARG USERNAME=node
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
@@ -30,13 +32,24 @@ WORKDIR /src
 
 RUN yarn install 
 
-FROM node:16
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 LABEL maintainer="-"
 
-ARG USERNAME=vscode
+ARG USERNAME=node
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# Install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+        apt-utils \
+        postgresql-client \
+        2>&1 \
+    && apt-get -y install \
+        zsh \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
 
@@ -45,5 +58,7 @@ COPY --from=1 /src/node_modules ./flag_initialization/node_modules
 COPY --from=2 /src/node_modules ./node_modules
 
 ENV PORT 3000
+
+ENV SHELL /bin/zsh
 
 EXPOSE 3000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,23 @@
 {
-    "name": "Node 14 Container",
-    "dockerComposeFile": "docker-compose.yml",
-    "service": "dev",
-    "workspaceFolder": "/src",
-    "shutdownAction": "stopCompose",
-    "settings": {
-        "prettier.configPath": ".prettierrc.json",
-        "prettier.useEditorConfig": false,
+  "name": "Forms Node Development Container",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "dev",
+  "workspaceFolder": "/src",
+  "shutdownAction": "stopCompose",
+  "settings": {
+    "prettier.configPath": ".prettierrc.json",
+    "prettier.useEditorConfig": false
+  },
+  "features": {
+    "aws-cli": {
+      "version": "2.5.6"
     }
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "mtxr.sqltools",
+    "mtxr.sqltools-driver-pg",
+    "GitHub.copilot"
+  ],
+  "remoteUser": "node"
 }

--- a/.devcontainer/scripts/forms-dev-entrypoint.sh
+++ b/.devcontainer/scripts/forms-dev-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ex 
+
+###################################################################
+# This script will get executed *once* the Docker container has 
+# been built. Commands that need to be executed with all available
+# tools and the filesystem mount enabled should be located here. 
+###################################################################
+
+# Define aliases
+echo -e "\n\n# User's Aliases" >> ~/.zshrc
+echo -e "alias fd=fdfind" >> ~/.zshrc
+echo -e "alias l='ls -al --color'" >> ~/.zshrc
+echo -e "alias ls='exa'" >> ~/.zshrc
+echo -e "alias l='exa -alh'" >> ~/.zshrc
+echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
+echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
+
+cd /src 
+yarn install --production=false
+
+cd /src/migrations
+
+FILE=.env
+
+if [ ! -f "$FILE" ]; then
+cat <<EOF >> .env
+DB_NAME=formsDB
+DB_USERNAME=postgres
+DB_PASSWORD=chummy
+DB_HOST=db
+EOF
+fi
+
+yarn install
+node index.js

--- a/.devcontainer/scripts/forms-dev-entrypoint.sh
+++ b/.devcontainer/scripts/forms-dev-entrypoint.sh
@@ -7,15 +7,6 @@ set -ex
 # tools and the filesystem mount enabled should be located here. 
 ###################################################################
 
-# Define aliases
-echo -e "\n\n# User's Aliases" >> ~/.zshrc
-echo -e "alias fd=fdfind" >> ~/.zshrc
-echo -e "alias l='ls -al --color'" >> ~/.zshrc
-echo -e "alias ls='exa'" >> ~/.zshrc
-echo -e "alias l='exa -alh'" >> ~/.zshrc
-echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
-echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
-
 cd /src 
 yarn install --production=false
 


### PR DESCRIPTION
Currently the devcontainer is using the incorrect user, so the shell is defaulting to the root user. This PR fixes that, as well as introducing a devcontainer helper post create script to setup the basics.