### PR TITLE
fix: add ON DELETE cascade to form_users template_id FK and render date field as type=text

### DIFF
--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -82,9 +82,13 @@ function _buildForm(element: FormElement, lang: string, t: TFunction): ReactElem
     </Label>
   ) : null;
 
-  const textType = element.properties?.validation?.type
-    ? element.properties.validation.type
-    : "text";
+  const textType =
+    element.properties?.validation?.type &&
+    ["email", "name", "number", "password", "search", "tel", "url"].includes(
+      element.properties.validation.type
+    )
+      ? element.properties.validation.type
+      : "text";
 
   const placeHolderPerLocale = element.properties[getProperty("placeholder", lang)];
   const placeHolder = placeHolderPerLocale ? placeHolderPerLocale.toString() : "";

--- a/migrations/migrations/010-delete-cascade-form-users.js
+++ b/migrations/migrations/010-delete-cascade-form-users.js
@@ -1,0 +1,12 @@
+const query = `
+  ALTER TABLE form_users
+  DROP CONSTRAINT form_users_template_id_fkey;
+
+  ALTER TABLE form_users
+    ADD CONSTRAINT form_users_template_id_fkey
+    FOREIGN KEY (template_id)
+    REFERENCES templates (id)
+    ON DELETE CASCADE;
+`;
+
+module.exports.generateSql = () => `${query}`;


### PR DESCRIPTION
# Summary | Résumé
No Issue exists

* Created a migration to add an ON DELETE cascade to the template_id FK constraint
* Render date text fields as type=text for now to remove native date picker

# Test instructions | Instructions pour tester la modification

1. Run migrations on local database.
2. Add user to a form
3. Confirm you can still delete the form
4. Confirm date field renders as a plain text field

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

N/A

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
