### PR TITLE
fix: remove service links from devcontainer docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,9 +12,7 @@ services:
       - 3000:3000
     expose: 
       - 3000
-    links: 
-      - db
-      - redis
+
   db:
     image: postgres:11.2
     environment:
@@ -29,6 +27,7 @@ services:
       - "-c"
       - "listen_addresses=*"
     restart: always
+
   redis:
     restart: always
     image: redis:latest
@@ -36,5 +35,3 @@ services:
       - "6379:6379"
     expose:
       - 6379
-
-


### PR DESCRIPTION
# Summary
Update the devcontainer docker-compose to no longer
explicitly link the services.  

This is because `links` are no longer required as all 
services implicitly share the same Docker network.