### PR TITLE
fix: hydration errors due to react tree and dom being out of sync

### DIFF
--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -26,29 +26,31 @@ const Base = ({ children }) => {
   const { t } = useTranslation("common");
 
   return (
-    mounted && (
-      <>
-        <Head>
-          <title>{t("title")}</title>
-          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-          <meta charSet="utf-8" />
-          <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />
-        </Head>
+    <>
+      {!mounted ? null : (
+        <>
+          <Head>
+            <title>{t("title")}</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+            <meta charSet="utf-8" />
+            <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />
+          </Head>
 
-        <SkipLink />
-        <div className={classes}>
-          {!isEmbeddable && (
-            <header>
-              {shouldDisplayAlphaBanner && <PhaseBanner />}
-              <Fip formRecord={formRecord} />
-              {isAdmin && <AdminNav user={children.props.user} />}
-            </header>
-          )}
-          <main id="content">{children}</main>
-          {!isEmbeddable && <Footer />}
-        </div>
-      </>
-    )
+          <SkipLink />
+          <div className={classes}>
+            {!isEmbeddable && (
+              <header>
+                {shouldDisplayAlphaBanner && <PhaseBanner />}
+                <Fip formRecord={formRecord} />
+                {isAdmin && <AdminNav user={children.props.user} />}
+              </header>
+            )}
+            <main id="content">{children}</main>
+            {!isEmbeddable && <Footer />}
+          </div>
+        </>
+      )}
+    </>
   );
 };
 

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import Footer from "./Footer";
 import Head from "next/head";
@@ -10,6 +10,11 @@ import { useTranslation } from "next-i18next";
 import { getPageClassNames } from "@lib/routeUtils";
 
 const Base = ({ children }) => {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const formRecord =
     children && children.props && children.props.formRecord ? children.props.formRecord : null;
   const classes = getPageClassNames(formRecord);
@@ -21,27 +26,29 @@ const Base = ({ children }) => {
   const { t } = useTranslation("common");
 
   return (
-    <>
-      <Head>
-        <title>{t("title")}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta charSet="utf-8" />
-        <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />
-      </Head>
+    mounted && (
+      <>
+        <Head>
+          <title>{t("title")}</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+          <meta charSet="utf-8" />
+          <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" sizes="32x32" />
+        </Head>
 
-      <SkipLink />
-      <div className={classes}>
-        {!isEmbeddable && (
-          <header>
-            {shouldDisplayAlphaBanner && <PhaseBanner />}
-            <Fip formRecord={formRecord} />
-            {isAdmin && <AdminNav user={children.props.user} />}
-          </header>
-        )}
-        <main id="content">{children}</main>
-        {!isEmbeddable && <Footer />}
-      </div>
-    </>
+        <SkipLink />
+        <div className={classes}>
+          {!isEmbeddable && (
+            <header>
+              {shouldDisplayAlphaBanner && <PhaseBanner />}
+              <Fip formRecord={formRecord} />
+              {isAdmin && <AdminNav user={children.props.user} />}
+            </header>
+          )}
+          <main id="content">{children}</main>
+          {!isEmbeddable && <Footer />}
+        </div>
+      </>
+    )
   );
 };
 

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -27,7 +27,7 @@ const Base = ({ children }) => {
 
   return (
     <>
-      {!mounted ? null : (
+      {mounted && (
         <>
           <Head>
             <title>{t("title")}</title>

--- a/components/globals/SkipLink.js
+++ b/components/globals/SkipLink.js
@@ -1,16 +1,22 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "next-i18next";
 
 const SkipLink = () => {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   const { t } = useTranslation("common");
   return (
-    <nav aria-label={t("skip-link")}>
-      <div id="skip-link-container">
-        <a href="#content" id="skip-link">
-          {t("skip-link")}
-        </a>
-      </div>
-    </nav>
+    mounted && (
+      <nav aria-label={t("skip-link")}>
+        <div id="skip-link-container">
+          <a href="#content" id="skip-link">
+            {t("skip-link")}
+          </a>
+        </div>
+      </nav>
+    )
   );
 };
 

--- a/components/globals/SkipLink.js
+++ b/components/globals/SkipLink.js
@@ -8,15 +8,19 @@ const SkipLink = () => {
   }, []);
   const { t } = useTranslation("common");
   return (
-    mounted && (
-      <nav aria-label={t("skip-link")}>
-        <div id="skip-link-container">
-          <a href="#content" id="skip-link">
-            {t("skip-link")}
-          </a>
-        </div>
-      </nav>
-    )
+    <>
+      {!mounted ? null : (
+        <>
+          <nav aria-label={t("skip-link")}>
+            <div id="skip-link-container">
+              <a href="#content" id="skip-link">
+                {t("skip-link")}
+              </a>
+            </div>
+          </nav>
+        </>
+      )}
+    </>
   );
 };
 

--- a/components/globals/SkipLink.js
+++ b/components/globals/SkipLink.js
@@ -9,7 +9,7 @@ const SkipLink = () => {
   const { t } = useTranslation("common");
   return (
     <>
-      {!mounted ? null : (
+      {mounted && (
         <>
           <nav aria-label={t("skip-link")}>
             <div id="skip-link-container">


### PR DESCRIPTION
Tracked down two react tree and DOM sync errors that was visible in [staging](https://reactjs.org/docs/error-decoder.html/?invariant=418) and the local environment. Not happening in prod which i suspect is related to using a pre-built version of the code.

According to [Nextjs](https://nextjs.org/docs/messages/react-hydration-error) in order to prevent the first render from being different you can use `useEffect` which is only executed in the browser and is executed during hydration.

I tested locally and the hydration errors are no longer visible after applying the changes to the two components with the error.

![image](https://user-images.githubusercontent.com/85885638/172417643-c906cfd7-210a-4549-9363-cb8af31490d2.png)

*Note*: I think the eslint rules came into effect after these files were created so i had to make some formatting changes so that these files comply with the new lint rules.
