### PR TITLE
fix welcome page url for storybook

### DIFF
--- a/pages/welcome-bienvenue.js
+++ b/pages/welcome-bienvenue.js
@@ -19,7 +19,7 @@ const Home = () => {
           <p>{t("design.text")}</p>
           <ul className="link-list custom">
             <li>
-              <a href="https://cds-snc.github.io/platform-forms-client/">
+              <a href="https://cds-snc.github.io/platform-forms-client/main">
                 {t("design.system.title")}
               </a>
             </li>


### PR DESCRIPTION
# Summary | Résumé
This PR fixes the Storybook Design System link for GCForms on our welcome page.
When the storybook versions started being built for every PR the root path changed and was not modified in the application.