### PR TITLE
make footer GC branding configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `/changelog` page. [#246](https://github.com/cds-snc/platform-forms-client/issues/246)
 - New `maxNumberOfRows` property in JSON template for DynamicRow component configuration [#528](https://github.com/cds-snc/platform-forms-client/issues/528)
 - Create a second GC Notify service account. [#698](https://github.com/cds-snc/platform-forms-client/issues/696)
-
+- Make configurable GC branding in the footer. [#804](https://github.com/cds-snc/platform-forms-client/issues/804)
 ### Fixed
 
 - Aligned HTTP methods on API requests to decommission request body `method` property.

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -39,7 +39,13 @@ const Base = ({ children }) => {
           </header>
         )}
         <main id="content">{children}</main>
-        {!isEmbeddable && <Footer />}
+        {!isEmbeddable && (
+          <Footer
+            disableGcBranding={
+              children.props.formRecord?.formConfig?.form?.brand?.disableGcBranding
+            }
+          />
+        )}
       </div>
     </>
   );

--- a/components/globals/Footer.js
+++ b/components/globals/Footer.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { useTranslation } from "next-i18next";
+import PropTypes from "prop-types";
 import { isSplashPage } from "@lib/routeUtils";
 
-const Footer = () => {
+const Footer = ({ disableGcBranding }) => {
   const { t } = useTranslation("common");
 
   return (
@@ -18,12 +19,18 @@ const Footer = () => {
             </>
           )}
         </div>
-        <div>
-          <img alt={t("fip.text")} src="/img/wmms-blk.svg" />
-        </div>
+        {!disableGcBranding && (
+          <div>
+            <img alt={t("fip.text")} src="/img/wmms-blk.svg" />
+          </div>
+        )}
       </div>
     </footer>
   );
+};
+
+Footer.propTypes = {
+  disableGcBranding: PropTypes.bool,
 };
 
 export default Footer;

--- a/cypress/integration/tsb_contact_remove_footer_gc_word.spec.js
+++ b/cypress/integration/tsb_contact_remove_footer_gc_word.spec.js
@@ -1,0 +1,13 @@
+describe("TSB Contact Form functionality", () => {
+  beforeEach(() => {
+    cy.useFlag("formTimer", false);
+    cy.mockForm("../../tests/data/tsbDisableFooterGCBranding.json");
+  });
+
+  it("TSB Contact Form renders", () => {
+    cy.get("h1").contains("Transportation Safety Board of Canada general enquiries");
+  });
+  it("Form footer does not contain GC branding ", () => {
+    cy.get("[data-testid='footer']").find("img").should("not.exist");
+  });
+});

--- a/lib/middleware/schemas/templates.schema.json
+++ b/lib/middleware/schemas/templates.schema.json
@@ -41,10 +41,47 @@
           "items": {
             "$ref": "#/$defs/element"
           }
+        },
+        "brand":{
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The brand name.",
+              "type": "string"
+            },
+            "urlEn": {
+              "description": "Url for english version of the site.",
+              "type": "string"
+            },
+            "urlFr": {
+              "description": "url for a french version of the site.",
+              "type": "string"
+            },
+            "logoEn": {
+              "description": "English logo path.",
+              "type": "string"
+            },
+            "logoFr": {
+              "description": "French logo path.",
+              "type": "string"
+            },
+            "logoTitleEn": {
+              "description": "logo title.",
+              "type": "string"
+            },
+            "logoTitleFr": {
+              "description": "logo title.",
+              "type": "string"
+            },
+            "disableGCBranding": {
+              "description": "If set to true, GC branding will not be rendered in the footer.",
+              "type": "boolean"
+            }
+          }
         }
-      },
-      "required": ["elements"]
 
+      },
+      "required": ["elements"]       
     },
     "submission": {
       "type": "object",

--- a/lib/types/form-types.ts
+++ b/lib/types/form-types.ts
@@ -92,6 +92,8 @@ export interface BrandProperties {
   logoTitleFr: string;
   urlEn?: string;
   urlFr?: string;
+  // if set to true the GC branding will be removed from the footer
+  disableGcBranding?: boolean;
 }
 
 // defines the fields for the main form configuration object

--- a/tests/data/tsbDisableFooterGCBranding.json
+++ b/tests/data/tsbDisableFooterGCBranding.json
@@ -1,0 +1,49 @@
+{
+  "form": {
+    "brand": {
+      "name": "tsb-bst",
+      "urlEn": "https://bst-tsb.gc.ca/eng/index.html",
+      "urlFr": "https://bst-tsb.gc.ca/fra/index.html",
+      "logoEn": "/img/tsb-en.png",
+      "logoFr": "/img/tsb-fr.png",
+      "logoTitleEn": "Transportation Safety Board of Canada",
+      "logoTitleFr": "Bureau de la sécurité des transports du Canada",
+      "disableGcBranding": true
+    },
+    "layout": [
+      1
+
+    ],
+    "endPage": {
+      "descriptionEn": "#Thank you for your message \n\r The Transportation Safety Board of Canada will respond to you within a week. \n\r <a href='https://www.tsb.gc.ca/eng/index.html' rel='noreferrer' target='_blank'>Go back.</a>",
+      "descriptionFr": "#Merci pour votre message  \n\r Le Bureau de la sécurité des transports du Canada vous répondra d’ici une semaine. \n\r <a href='https://www.tsb.gc.ca/fra/index.html'>Retour.</a>"
+    },
+    "titleEn": "Transportation Safety Board of Canada general enquiries",
+    "titleFr": "Demandes de renseignements au Bureau de la sécurité des transports du Canada",
+    "version": 1,
+    "elements": [
+      {
+        "id": 1,
+        "type": "richText",
+        "properties": {
+          "titleEn": "",
+          "titleFr": "",
+          "charLimit": 200,
+          "validation": {
+            "required": false
+          },
+          "descriptionEn": "Thank you for your interest in the TSB. Send your question using the form below. \n\r Find out how <a href='https://www.tsb.gc.ca/eng/avis-notices/avis-notices.html#priv'>the TSB protects your privacy</a>.",
+          "descriptionFr": "Merci de vous intéresser au BST. Faites-nous parvenir vos questions en utilisant le formulaire suivant. \n\r Apprenez comment <a href='https://www.tsb.gc.ca/fra/avis-notices/avis-notices.html#priv'>le BST protége votre confidentialité</a>."
+        }
+      }
+    ],
+    "emailSubjectEn": "TSB general enquiries",
+    "emailSubjectFr": "Renseignements généraux BST"
+  },
+  "submission": {
+    "email": "forms-formulaires@cds-snc.ca"
+  },
+  "internalTitleEn": "Contact Us - TSB",
+  "internalTitleFr": "Nous joindre - BST",
+  "publishingStatus": true
+}


### PR DESCRIPTION
# Summary | Résumé
Make Gc branding in the footer configurable via formConfig object. 
closed #804 

# Test instructions | Instructions pour tester la modification

1. create or update an existing form like [TSB Form](https://forms-staging.cdssandbox.xyz/id/25)
2. add the new attribute `disableGCBranding = true`   to `brand`  element like so :  
`    "brand": {
      "disableGcBranding": true 
    },`
3.  It should remove the GC word from the footer.  

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet
As of today, It is not possible to remove the GC branding in the footer for all forms at once. 
The implementation works for forms that have a custom branding enable meaning the `brand` attribute is configured otherwise GC branding will be displayed.  

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
