### PR TITLE
fix: escape markdown characters

### DIFF
--- a/pages/api/token/temporary.ts
+++ b/pages/api/token/temporary.ts
@@ -105,7 +105,7 @@ const sendTemporaryTokenByEmail = async (email: string, temporaryToken: string) 
   return await notifyClient
     .sendEmail(sendTempTokenTemplateID, email, {
       personalisation: {
-        temporaryToken: temporaryToken,
+        temporaryToken: `\`${temporaryToken}\``,
       },
       reference: null,
     })


### PR DESCRIPTION
# Summary | Résumé

Closes #839.

The problem was solved by escaping the double underscore that is interpreted by Markdown as bold. While other characters used for Markdown syntax could be improperly rendered by a Notify template, only the underscore can be used in a token.

# Test instructions | Instructions pour tester la modification

- modify `temporary.ts` to have a hardcoded temporary token that contains a double underscore
- modify `temporary.ts` to send email to `forms-formulaires@cds-snc.ca`.
- use the api to request a temporary token for a valid form / email on your local install
- check the email for `forms-formulaires@cds-snc.ca` to see an email with the hardcoded temporary token that contains a double underscore.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
