### PR TITLE
copy prisma folder to final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY public ./public
 COPY next.config.js .
 COPY next-i18next.config.js .
 COPY migrations ./migrations
+COPY prisma ./prisma
 COPY flag_initialization ./flag_initialization
 COPY --from=1 /src/node_modules ./migrations/node_modules
 COPY --from=2 /src/node_modules ./flag_initialization/node_modules


### PR DESCRIPTION
Fixes that prisma folder was not copied to final image in docker creation file.