### PR TITLE
fix: json upload bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix stuck "Loading..." animation after uploading a new JSON config. [#898](https://github.com/cds-snc/platform-forms-client/pull/898)
+
 ## [1.3.0] 2022-07-15
 
 ### Added
@@ -20,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix retrieval API [#845](https://github.com/cds-snc/platform-forms-client/pull/845)
 - Fix loading of csp scripts to happen after Dom is loaded [#848](https://github.com/cds-snc/platform-forms-client/pull/848)
 - Fix remaining characters display issue
-- Fix stuck "Loading..." animation after uploading a new JSON config. [#898](https://github.com/cds-snc/platform-forms-client/pull/898)
 
 ## [No Release Version] 2022-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix retrieval API [#845](https://github.com/cds-snc/platform-forms-client/pull/845)
 - Fix loading of csp scripts to happen after Dom is loaded [#848](https://github.com/cds-snc/platform-forms-client/pull/848)
 - Fix remaining characters display issue
+- Fix stuck "Loading..." animation after uploading a new JSON config. [#898](https://github.com/cds-snc/platform-forms-client/pull/898)
 
 ## [No Release Version] 2022-06-14
 

--- a/components/admin/JsonUpload/JsonUpload.test.js
+++ b/components/admin/JsonUpload/JsonUpload.test.js
@@ -13,13 +13,14 @@ jest.mock("@lib/hooks/useRefresh", () => ({
 describe("JSON Upload Component", () => {
   afterEach(cleanup);
   const formConfig = { test: "test JSON" };
-  test("renders without errors", async () => {
+  it("renders without errors", async () => {
     await act(async () => {
       render(<JSONUpload></JSONUpload>);
     });
     expect(screen.queryByTestId("jsonInput")).toBeInTheDocument();
+    expect(screen.queryByTestId("submitStatus")).not.toBeInTheDocument();
   });
-  test("renders existing form JSON if passed in", async () => {
+  it("renders existing form JSON if passed in", async () => {
     const form = {
       formConfig: formConfig,
     };
@@ -28,8 +29,8 @@ describe("JSON Upload Component", () => {
     });
     expect(screen.queryByTestId("jsonInput").value).toBe(JSON.stringify(formConfig, null, 2));
   });
-  test("It shows an error message if invalid json is entered", async () => {
-    userEvent.setup();
+  it("Shows an error message if unparseable JSON is entered", async () => {
+    const user = userEvent.setup();
     const form = {
       formConfig: undefined,
     };
@@ -37,13 +38,13 @@ describe("JSON Upload Component", () => {
       render(<JSONUpload form={form}></JSONUpload>);
     });
     await act(async () => {
-      await userEvent.click(screen.queryByTestId("upload"));
+      await user.click(screen.queryByTestId("upload"));
     });
     expect(mockedAxios.mock.calls.length).toBe(0);
     expect(screen.queryByTestId("alert")).toBeInTheDocument();
   });
-  test("It shows a success message if valid json is entered", async () => {
-    userEvent.setup();
+  it("Shows a submit status message if successfully submitted to API", async () => {
+    const user = userEvent.setup();
     const form = {
       formConfig: formConfig,
     };
@@ -52,10 +53,10 @@ describe("JSON Upload Component", () => {
       render(<JSONUpload form={form}></JSONUpload>);
     });
     await act(async () => {
-      await userEvent.click(screen.queryByTestId("upload"));
+      await user.click(screen.queryByTestId("upload"));
     });
     expect(mockedAxios.mock.calls.length).toBe(1);
     expect(mockedAxios).toHaveBeenCalledWith(expect.objectContaining({ url: "/api/templates" }));
-    //expect(screen.queryByTestId("submitStatus")).toBeInTheDocument();
+    expect(screen.queryByTestId("submitStatus")).toBeInTheDocument();
   });
 });

--- a/components/admin/JsonUpload/JsonUpload.tsx
+++ b/components/admin/JsonUpload/JsonUpload.tsx
@@ -60,12 +60,14 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
     } catch (err) {
       logMessage.error(err);
       setSubmitting(false);
-      if (axios.isAxiosError(err) && err.response) {
-        if ((err.response.data.error as string).includes("JSON Validation Error: ")) {
-          setErrorState({ message: err.response.data.error });
-        }
+      if (
+        axios.isAxiosError(err) &&
+        (err.response?.data.error as string).includes("JSON Validation Error: ")
+      ) {
+        setErrorState({ message: err.response?.data.error });
+      } else {
+        setErrorState({ message: "Uploading Error" });
       }
-      setErrorState({ message: "Uploading Error" });
     }
   };
 

--- a/components/admin/JsonUpload/JsonUpload.tsx
+++ b/components/admin/JsonUpload/JsonUpload.tsx
@@ -69,11 +69,11 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
             }
 
             const resp = await handleSubmit(formID);
-
+            logMessage.info(resp);
             // If the server returned a record, this is a new record
             // Redirect to the appropriate page
 
-            if (resp && resp.data && resp.data.data && resp.data.data.records) {
+            if (resp?.data?.data?.records) {
               const formID = resp.data.data.records[0].formID;
               router.push({
                 pathname: `/${i18n.language}/id/${formID}/settings`,
@@ -81,6 +81,8 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
                   newForm: true,
                 },
               });
+              setSubmitStatus(t("upload.success"));
+              setSubmitting(false);
             } else if (resp) {
               // If not, but response was successful,
               // update the page text to show a success
@@ -117,9 +119,11 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
                 <button type="submit" className="gc-button" data-testid="upload">
                   {t("upload.submit")}
                 </button>
-                <span id="submitStatus" data-testid="submitStatus">
-                  {submitStatus}
-                </span>
+                {submitStatus && (
+                  <span id="submitStatus" data-testid="submitStatus">
+                    {submitStatus}
+                  </span>
+                )}
               </div>
             </>
           )}


### PR DESCRIPTION
# Summary | Résumé

Closes #897 

When uploading the JSON config for a new form, the page wasn't updating to the `~/settings` page. The data being returned from the API had changed along the way, and didn't match what was being looked for.

Also updated some Jest tests. `submitStatus` was always visible on the screen, even though it may have been empty.

Refactored some code while I was fixing this bug.

# Test instructions | Instructions pour tester la modification

Go to the "Template Upload" page, enter some new JSON to be uploaded. After submitting, it should redirect to the `~/settings` page.

All other functionality should remain the same. If uploading empty or corrupt JSON, it should present an error message.  Updating JSON from the `~/settings` page should present the message that the JSON was properly updated.


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

I noticed that when uploading some JSON, if there is any error returned from the server, the JSON will be removed from the form. It would be ideal if the JSON would remain, allowing the user to fix the JSON, rather than being presented with a blank form.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
