### PR TITLE
fix: uninitialized variable in token creation

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -74,6 +74,7 @@ export const authOptions: NextAuthOptions = {
 
           token.admin = user.admin;
           token.userId = user.id;
+          token.authorizedForm = null;
           token.lastLoginTime = new Date();
           token.role = "admin";
           token.acceptableUse = false;


### PR DESCRIPTION
# Summary | Résumé

- Token variable is not properly initialized when logging in with Google credential provider.