### PR TITLE
fix: test-container-build-production workflow checkout action not pinned

### DIFF
--- a/.github/workflows/test-container-build-production.yml
+++ b/.github/workflows/test-container-build-production.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout
+        uses: actions/checkout@v2
 
       - name: Build Container
         run: |


### PR DESCRIPTION
# Summary | Résumé

Pinning actions/checkout to v2
