### PR TITLE
fix: URGENT fix. Only allow POST method in the submit API

### DIFF
--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -372,6 +372,6 @@ const processFormData = async (
 };
 
 export default middleware(
-  [cors({ allowedMethods: ["GET", "POST", "PUT", "DELETE"] }), csrfProtected(protectedMethods)],
+  [cors({ allowedMethods: ["POST"] }), csrfProtected(protectedMethods)],
   submit
 );


### PR DESCRIPTION
# Summary | Résumé

The submit API allowed GET, POST, PUT and DELETE API requests which were not CSRF protected. The submit API should have only allowed the POST method and this method should be protected with a CSRF token. This is the same fix that was merged in main


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
