### PR TITLE
Update Next Auth to 4.10

### DIFF
--- a/__tests__/api/flags.test.ts
+++ b/__tests__/api/flags.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import { createMocks } from "node-mocks-http";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import enable from "@pages/api/flags/[key]/enable";
 import disable from "@pages/api/flags/[key]/disable";
 import check from "@pages/api/flags/[key]/check";
@@ -13,7 +13,7 @@ import { UserRole } from "@prisma/client";
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, true);
 
 jest.mock("@lib/flags");
 

--- a/__tests__/api/id/form/bearer.test.ts
+++ b/__tests__/api/id/form/bearer.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { createMocks, RequestMethod } from "node-mocks-http";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import retrieve from "@pages/api/id/[form]/bearer";
 import jwt from "jsonwebtoken";
 import { logMessage } from "@lib/logger";
@@ -14,7 +14,7 @@ import { Prisma, UserRole } from "@prisma/client";
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, true);
 const mockLogMessage = jest.mocked(logMessage, true);
 
 jest.mock("@lib/logger");

--- a/__tests__/api/id/form/owners.test.ts
+++ b/__tests__/api/id/form/owners.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { createMocks, RequestMethod } from "node-mocks-http";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import owners from "@pages/api/id/[form]/owners";
 import * as logAdmin from "@lib/adminLogs";
 import { prismaMock } from "@jestUtils";
@@ -13,7 +13,7 @@ import { Prisma, UserRole } from "@prisma/client";
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, true);
 
 describe("/id/[forms]/owners", () => {
   describe("Access Control", () => {

--- a/__tests__/api/templates.test.ts
+++ b/__tests__/api/templates.test.ts
@@ -3,7 +3,7 @@
  */
 import { createMocks } from "node-mocks-http";
 import templates from "@pages/api/templates";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import validFormTemplate from "../../__fixtures__/validFormTemplate.json";
 import brokenFormTemplate from "../../__fixtures__/brokenFormTemplate.json";
 import * as logAdmin from "@lib/adminLogs";
@@ -11,7 +11,7 @@ import { prismaMock } from "@jestUtils";
 import { UserRole } from "@prisma/client";
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, true);
 
 jest.mock("next-auth/next");
 

--- a/__tests__/api/users.test.ts
+++ b/__tests__/api/users.test.ts
@@ -3,7 +3,7 @@
  */
 import { createMocks } from "node-mocks-http";
 
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import users from "@pages/api/users";
 import { prismaMock } from "@jestUtils";
 import { Prisma, UserRole } from "@prisma/client";
@@ -12,7 +12,7 @@ import * as logAdmin from "@lib/adminLogs";
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, true);
 
 describe("Users API endpoint", () => {
   describe("Access Control", () => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,4 @@
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import { Session } from "next-auth";
 import {
   GetServerSidePropsResult,
@@ -40,7 +40,7 @@ export function requireAuthentication(
   return async (
     context: GetServerSidePropsAuthContext
   ): Promise<GetServerSidePropsResult<Record<string, unknown>>> => {
-    const session = await getServerSession(context, authOptions);
+    const session = await unstable_getServerSession(context, authOptions);
 
     if (!session) {
       // If no user, redirect to login
@@ -85,7 +85,7 @@ export const isAdmin = async ({
   req: NextApiRequest;
   res: NextApiResponse;
 }): Promise<Session | null> => {
-  const session = await getServerSession({ req, res }, authOptions);
+  const session = await unstable_getServerSession({ req, res }, authOptions);
   return session?.user.role === UserRole.ADMINISTRATOR ? session : null;
 };
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -40,7 +40,7 @@ export function requireAuthentication(
   return async (
     context: GetServerSidePropsAuthContext
   ): Promise<GetServerSidePropsResult<Record<string, unknown>>> => {
-    const session = await unstable_getServerSession(context, authOptions);
+    const session = await unstable_getServerSession(context.req, context.res, authOptions);
 
     if (!session) {
       // If no user, redirect to login
@@ -85,7 +85,7 @@ export const isAdmin = async ({
   req: NextApiRequest;
   res: NextApiResponse;
 }): Promise<Session | null> => {
-  const session = await unstable_getServerSession({ req, res }, authOptions);
+  const session = await unstable_getServerSession(req, res, authOptions);
   return session?.user.role === UserRole.ADMINISTRATOR ? session : null;
 };
 

--- a/lib/tests/auth.test.ts
+++ b/lib/tests/auth.test.ts
@@ -1,6 +1,6 @@
 import { isAdmin, validateTemporaryToken } from "@lib/auth";
 import { createMocks } from "node-mocks-http";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import jwt, { Secret } from "jsonwebtoken";
 import { prismaMock } from "@jestUtils";
 import { UserRole } from "@prisma/client";
@@ -8,7 +8,7 @@ import { UserRole } from "@prisma/client";
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, true);
 
 describe("Test Auth lib", () => {
   describe("isAdmin", () => {

--- a/lib/tests/sessionExists.test.js
+++ b/lib/tests/sessionExists.test.js
@@ -1,5 +1,5 @@
 import { createMocks } from "node-mocks-http";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import { sessionExists } from "@lib/middleware";
 import { UserRole } from "@prisma/client";
 
@@ -33,7 +33,7 @@ describe("Test a session middleware", () => {
         role: UserRole.PROGRAM_ADMINISTRATOR,
       },
     };
-    getServerSession.mockReturnValueOnce(mockSession);
+    unstable_getServerSession.mockReturnValueOnce(mockSession);
     const { req, res } = createMocks({
       method: "GET",
       headers: {
@@ -55,7 +55,7 @@ describe("Test a session middleware", () => {
         role: UserRole.ADMINISTRATOR,
       },
     };
-    getServerSession.mockReturnValueOnce(mockSession);
+    unstable_getServerSession.mockReturnValueOnce(mockSession);
     const { req, res } = createMocks({
       method: "GET",
       headers: {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "markdown-to-jsx": "^7.1.7",
     "mmmagic": "^0.5.3",
     "next": "^12.1.4",
-    "next-auth": "^4.3.3",
+    "next-auth": "^4.10.3",
     "next-i18next": "^11.0.0",
     "notifications-node-client": "^5.1.1",
     "pino": "^7.9.2",

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -27,7 +27,7 @@ const Login = (): JSX.Element => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await unstable_getServerSession(context, authOptions);
+  const session = await unstable_getServerSession(context.req, context.res, authOptions);
 
   if (session?.user.role === UserRole.ADMINISTRATOR)
     return {

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 
 import React from "react";
 import { useTranslation } from "next-i18next";
@@ -27,7 +27,7 @@ const Login = (): JSX.Element => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getServerSession(context, authOptions);
+  const session = await unstable_getServerSession(context, authOptions);
 
   if (session?.user.role === UserRole.ADMINISTRATOR)
     return {

--- a/pages/admin/unauthorized.tsx
+++ b/pages/admin/unauthorized.tsx
@@ -17,7 +17,7 @@ const Unauthorized: React.FC = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await unstable_getServerSession(context, authOptions);
+  const session = await unstable_getServerSession(context.req, context.res, authOptions);
 
   if (session?.user.role === UserRole.ADMINISTRATOR)
     return {

--- a/pages/admin/unauthorized.tsx
+++ b/pages/admin/unauthorized.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { getServerSession } from "next-auth/next";
+import { unstable_getServerSession } from "next-auth/next";
 import { useTranslation } from "next-i18next";
 import { authOptions } from "@pages/api/auth/[...nextauth]";
 import { UserRole } from "@prisma/client";
@@ -17,7 +17,7 @@ const Unauthorized: React.FC = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getServerSession(context, authOptions);
+  const session = await unstable_getServerSession(context, authOptions);
 
   if (session?.user.role === UserRole.ADMINISTRATOR)
     return {

--- a/types/next_auth/index.d.ts
+++ b/types/next_auth/index.d.ts
@@ -3,7 +3,7 @@ import { DefaultJWT } from "next-auth/jwt";
 
 declare module "next-auth" {
   /**
-   * Returned by `useSession`, `getSession`, `getServerSession` and received as a prop on the `SessionProvider` React Context
+   * Returned by `useSession`, `getSession`, `unstable_getServerSession` and received as a prop on the `SessionProvider` React Context
    */
   interface Session extends DefaultSession {
     user: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11240,10 +11240,10 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
   integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
 
-next-auth@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.3.3.tgz#5ff892e73648a0f33c2af0e9d7cafda729f63ae7"
-  integrity sha512-bUs+oOOPT18Pq/+4v9q4PA/DGoVoAX6jwY7RTfE/akFXwlny+y/mNS6lPSUwpqcHjljqBaq34PQA3+01SdOOPw==
+next-auth@^4.10.3:
+  version "4.10.3"
+  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.10.3.tgz#0a952dd5004fd2ac2ba414c990922cf9b33951a3"
+  integrity sha512-7zc4aXYc/EEln7Pkcsn21V1IevaTZsMLJwapfbnKA4+JY0+jFzWbt5p/ljugesGIrN4VOZhpZIw50EaFZyghJQ==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@panva/hkdf" "^1.0.1"


### PR DESCRIPTION
# Summary | Résumé
This PR updates NextAuth to v4.10 and renames `getServerSession` to `unstable_getServerSession`.