### PR TITLE
fix: logout session end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix stuck "Loading..." animation after uploading a new JSON config. [#898](https://github.com/cds-snc/platform-forms-client/pull/898)
 - Fix ReCaptcha feature being broken because of missing API Key.
+- Fix logout session end date [#945](https://github.com/cds-snc/platform-forms-client/issues/945)
 
 ## [1.3.0] 2022-07-15
 

--- a/cypress/integration/logout.spec.js
+++ b/cypress/integration/logout.spec.js
@@ -6,14 +6,14 @@ describe("Logout Page test", () => {
   it("Display french page version", () => {
     cy.get("button[lang='fr']").click();
     cy.get("h2").should("contain", "Vous êtes déconnecté.");
-    cy.get(".gc-last-login-time").should("contain", "Votre dernière session de connexion");
+    cy.get(".gc-last-logout-time").should("contain", "Votre dernière session de connexion");
     cy.get(".gc-login-menu").find("a").should("contain", "Connexion");
     cy.get(".gc-go-to-login-btn").should("be.visible");
   });
 
   it("Toggle page language to en", () => {
     cy.get("h2").should("contain", "You are signed out");
-    cy.get(".gc-last-login-time").should("contain", "Your last session ended at");
+    cy.get(".gc-last-logout-time").should("contain", "Your last session ended at");
     cy.get(".gc-go-to-login-btn").find("a").should("contain", "Go to login");
   });
 

--- a/pages/auth/logout.tsx
+++ b/pages/auth/logout.tsx
@@ -1,22 +1,27 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { GetServerSideProps } from "next";
-import { useSession } from "next-auth/react";
 
 const Logout = () => {
   const { i18n, t } = useTranslation("logout");
-  const { data: session } = useSession();
+  const [logoutDate, setLogoutDate] = useState("");
+
+  useEffect(() => {
+    setLogoutDate(
+      new Date().toLocaleString(`${i18n.language + "-CA"}`, {
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      })
+    );
+  }, []);
 
   return (
     <>
       <div>
         <h2>{t("messageContent")}</h2>
-        <div className="gc-last-login-time">
-          <>
-            {t("lastLoginTime")} : {session?.user?.lastLoginTime}
-          </>
+        <div className="gc-last-logout-time">
+          {t("logoutDate")} : {logoutDate}
         </div>
         <div className="gc-go-to-login-btn">
           <Link href={`/${i18n.language}/auth/login`}>{t("goToLoginLabel")}</Link>

--- a/public/static/locales/en/logout.json
+++ b/public/static/locales/en/logout.json
@@ -1,6 +1,6 @@
 {
-    "messageContent": "You are signed out",
-    "goToLoginLabel": "Go to login",
-    "lastLoginTime": "Your last session ended at",
-    "title": "Sign out"
-} 
+  "messageContent": "You are signed out",
+  "goToLoginLabel": "Go to login",
+  "logoutDate": "Your last session ended at",
+  "title": "Sign out"
+}

--- a/public/static/locales/fr/logout.json
+++ b/public/static/locales/fr/logout.json
@@ -1,6 +1,6 @@
 {
-    "messageContent": "Vous êtes déconnecté.",
-    "goToLoginLabel": "Connectez-vous",
-    "lastLoginTime": "Votre dernière session de connexion",
-    "title": "Déconnexion"
-} 
+  "messageContent": "Vous êtes déconnecté.",
+  "goToLoginLabel": "Connectez-vous",
+  "logoutDate": "Votre dernière session de connexion",
+  "title": "Déconnexion"
+}

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -411,17 +411,15 @@
   }
 }
 
-.gc-last-login-time{ 
+.gc-last-logout-time {
   @apply text-sm not-italic font-sans items-center font-normal pb-10 pt-3;
   line-height: 125%;
 }
-
 
 .gc-go-to-login-btn {
   a {
     @apply bg-blue-500 hover:bg-blue-700 text-white-default font-bold py-2 px-4 rounded;
     text-decoration: none !important;
-    background-color: #26374A;
-    ;
+    background-color: #26374a;
   }
 }


### PR DESCRIPTION
# Summary | Résumé

closes #945 

- Fixed session end date being displayed on logout page

<img width="495" alt="Screen Shot 2022-08-25 at 11 48 37 AM" src="https://user-images.githubusercontent.com/1763961/186711945-1c05ad28-b446-4ed9-967d-044dd7054f49.png">

# Test instructions | Instructions pour tester la modification

- Run code contained in fix/logout-last-session-end-date branch
- Navigate to http://localhost:3000/auth/logout

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
