### PR TITLE
fix: remove react-i18next references

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,7 +21,8 @@ module.exports = {
     config.resolve.alias = {...config.resolve.alias, "@components": path.resolve(__dirname, "../components")}
 
     config.resolve.alias = {
-      ...config.resolve.alias
+      ...config.resolve.alias,
+      "next-i18next": "react-i18next",
     };
 
     config.resolve.fallback = {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,8 +21,7 @@ module.exports = {
     config.resolve.alias = {...config.resolve.alias, "@components": path.resolve(__dirname, "../components")}
 
     config.resolve.alias = {
-      ...config.resolve.alias,
-      "next-i18next": "react-i18next",
+      ...config.resolve.alias
     };
 
     config.resolve.fallback = {

--- a/__utils__/setupTests.ts
+++ b/__utils__/setupTests.ts
@@ -7,16 +7,6 @@ jest.mock("next/config", () => () => ({
   },
 }));
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => {
-    return {
-      t: (str: string) => str,
-      i18n: {
-        changeLanguage: () => Promise.resolve(),
-      },
-    };
-  },
-}));
 jest.mock("next-i18next", () => ({
   useTranslation: () => {
     return {

--- a/components/forms/Button/DeleteButton.tsx
+++ b/components/forms/Button/DeleteButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@components/forms";
 import { useRouter } from "next/router";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { logMessage } from "@lib/logger";
 
 interface DeleteButtonProps {

--- a/components/login/SignInKey.test.js
+++ b/components/login/SignInKey.test.js
@@ -6,10 +6,6 @@ import SignInKey from "./SignInKey";
 
 jest.mock("axios");
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key) => key }),
-}));
-
 describe("Login Component with Sign-In Key", () => {
   it("Renders properly.", async () => {
     render(<SignInKey setParentStage={jest.fn()} />);

--- a/components/login/TemporaryToken.test.js
+++ b/components/login/TemporaryToken.test.js
@@ -4,10 +4,6 @@ import TemporaryToken from "./TemporaryToken";
 
 jest.mock("axios");
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key) => key }),
-}));
-
 describe("Temporary Token Component", () => {
   it("Renders properly.", async () => {
     await act(async () => {


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

Since `next-i18next` is being used, there were some references to `react-i18next` that needed to be removed since they were no longer being used.

# Test instructions | Instructions pour tester la modification

- All tests should pass successfully
- The `<DeleteButton>` on the settings page of a form should continue to display the correct message in the selected language

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
