### PR TITLE
test: adjust mockResolvedValue and mockRejectedValue based on status code

### DIFF
--- a/__tests__/Settings.test.js
+++ b/__tests__/Settings.test.js
@@ -69,7 +69,7 @@ describe("Form Settings Page", () => {
   });
   test("Logs errors on failure", async () => {
     const user = userEvent.setup();
-    mockedAxios.mockResolvedValue({
+    mockedAxios.mockRejectedValue({
       status: 400,
     });
     // I wanted to spy console.error but it didn't want to work

--- a/components/admin/FormAccess/FormAccess.test.js
+++ b/components/admin/FormAccess/FormAccess.test.js
@@ -114,7 +114,7 @@ describe("Form Access Component", () => {
           },
         ],
       })
-      .mockResolvedValueOnce({
+      .mockRejectedValueOnce({
         status: 400,
         data: { error: "The email is not a valid GC email" },
       });

--- a/components/auth/AcceptableUse.test.js
+++ b/components/auth/AcceptableUse.test.js
@@ -39,7 +39,7 @@ describe("Acceptable use terms", () => {
   });
 
   it("Agree on the terms of use", async () => {
-    mockedAxios.mockRejectedValue({
+    mockedAxios.mockResolvedValue({
       status: 200,
     });
 

--- a/lib/tests/helpers.test.js
+++ b/lib/tests/helpers.test.js
@@ -198,7 +198,7 @@ describe("Submit and Template helpers", () => {
     expect(mockedConsoleError.mock.calls[0][0]).toEqual(new Error("some error"));
   });
   test("Get form by ID returns null when no records returned", async () => {
-    mockedAxios.mockResolvedValue({
+    mockedAxios.mockRejectedValue({
       status: 400,
       data: {
         data: {
@@ -215,7 +215,7 @@ describe("Submit and Template helpers", () => {
   });
 
   test("API Error", async () => {
-    mockedAxios.mockResolvedValue({
+    mockedAxios.mockRejectedValue({
       status: 502,
       data: { received: false },
     });


### PR DESCRIPTION
# Summary | Résumé

Just tightening up some of our tests.  Any responses that return a status of 200 should be a resolved response, and conversely, any response that is 3xx, 4xx, or 5xx, should be a rejected response.

# Test instructions | Instructions pour tester la modification

- All tests should continue to pass

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

- I am not convinced that our tests are checking for what we want them to be checking for. That being said, I am certain that we should be changing the `mockedResolvedValue` and `mockedRejectedValue` to match the expected status responses.

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
