### PR TITLE
fix: missing localized error title on temporary token auth page

### DIFF
--- a/components/login/TemporaryToken.tsx
+++ b/components/login/TemporaryToken.tsx
@@ -62,7 +62,7 @@ const TemporaryToken = (props: LoginStageProps): React.ReactElement => {
   return (
     <>
       {errorState.message && (
-        <Alert type="error" heading={t("loginErrorHeading")}>
+        <Alert type="error" heading={t("temporaryToken.errorTitle")}>
           <ul>
             <ErrorListItem value={errorState.message} errorKey="temporaryToken" />
           </ul>

--- a/public/static/locales/en/login.json
+++ b/public/static/locales/en/login.json
@@ -18,12 +18,13 @@
   "lockoutDurationErrorMessagePart2": "seconds.",
   "temporaryToken": {
     "title": "Check your email",
-    "instructions": "We've sent you a one-time-use, 6-digit verificartion code by email. It may take a a few minutes to arrive.",
+    "instructions": "We've sent you a one-time-use, 6-digit verification code by email. It may take a few minutes to arrive.",
     "temporaryTokenLabel": "Enter verification code",
     "submitButton": "Submit",
     "helpText": "Didn't get the verification code?",
     "retryPrompt": "Double-check your login key and email then",
     "retry": "try again.",
+    "errorTitle": "Problems on this page:",
     "errorMessage": "Incorrect verification code."
   }
 }

--- a/public/static/locales/fr/login.json
+++ b/public/static/locales/fr/login.json
@@ -24,6 +24,7 @@
     "helpText": "Vous n'avez pas obtenu de code d'authentification?",
     "retryPrompt": "Veuillez confirmer votre clé d'accès et votre adresse courriel,",
     "retry": "puis essayez à nouveau.",
+    "errorTitle": "Problèmes sur cette page:",
     "errorMessage": "Code d'authentification erroné"
   }
 }


### PR DESCRIPTION
(no ticket assigned)

- Fix broken localized error title on temporary token auth page