### PR TITLE
fix: a11y in Login UI

### DIFF
--- a/components/login/SignInKey.tsx
+++ b/components/login/SignInKey.tsx
@@ -131,6 +131,7 @@ const SignInKey = (props: LoginStageProps): React.ReactElement => {
           name="signInKey"
           className="gc-textarea full-height font-mono"
           data-testid="signInKey"
+          aria-describedby="desc-form-sign-in-key"
           onChange={handleChange}
         />
         <br />

--- a/components/login/TemporaryToken.tsx
+++ b/components/login/TemporaryToken.tsx
@@ -85,6 +85,7 @@ const TemporaryToken = (props: LoginStageProps): React.ReactElement => {
           name="temporaryToken"
           className="gc-textarea full-height font-mono"
           data-testid="temporaryToken"
+          aria-describedby="desc-instructions"
           onChange={handleChange}
         />
         <br />


### PR DESCRIPTION
closes #971 

- Added two `aria-describedby` flags in order to get more context on what is expected when specific input is selected