### PR TITLE
Add click handler that will show/hide the JSON output in the Forms builder

### DIFF
--- a/components/form-builder/layout/Layout.tsx
+++ b/components/form-builder/layout/Layout.tsx
@@ -31,9 +31,7 @@ export const Layout = () => {
       </div>
       <ElementPanel />
       <Import />
-      <div className="hidden">
-        <Output />
-      </div>
+      <Output />
     </>
   );
 };

--- a/components/form-builder/layout/Output.tsx
+++ b/components/form-builder/layout/Output.tsx
@@ -10,20 +10,29 @@ const JSONOutput = styled.pre`
   overflow: "scroll";
 `;
 
-const Separator = styled.div`
-  border-top: 1px solid rgba(0, 0, 0, 0.12);
-  margin: 20px 0;
+const Separator = styled.hr`
+  display: block;
+  margin-top: 20px;
+  padding-bottom: 20px;
+  cursor: pointer;
 `;
 
 export const Output = () => {
   const { stringified } = useGetTemplate();
 
+  const [showJSON, setShowJSON] = React.useState(false);
+  const handleClick = () => setShowJSON(!showJSON);
+
   return (
     <>
-      <Separator />
-      <h2 className="gc-h2">JSON Output</h2>
-      <CopyToClipboard />
-      <JSONOutput>{stringified}</JSONOutput>
+      <Separator onClick={handleClick} />
+      {showJSON && (
+        <>
+          <h2 className="gc-h2">JSON Output</h2>
+          <CopyToClipboard />
+          <JSONOutput>{stringified}</JSONOutput>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
# Summary | Résumé

There's a way to see the JSON output, but we hid it initially because right now we just want to be showing the form builder. 
However, we _do_ want to be able to see the JSON output for the form, for those in the know. 

This PR removes the "hidden" div and adds a click handler to the bottom separator. It's not intuitive at all, but that's also kind of the point.

## gif

![Screen Recording 2022-09-07 at 10 16 29](https://user-images.githubusercontent.com/2454380/188901939-3e1b2e27-6c91-4026-929f-1feb91c12feb.gif)

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

We can make this permanent later, or maybe we find another place to put this. For now, this is just for devs and for anyone who wants to see what the generated output is.

