### PR TITLE
Form builder bugfix: Don't pass in the key as props

### DIFF
--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -332,7 +332,7 @@ const ElementWrapperDiv = styled.div`
   margin-top: -1px;
 `;
 
-export const ElementWrapper = ({ item, key }: { item: ElementTypeWithIndex; key: number }) => {
+export const ElementWrapper = ({ item }: { item: ElementTypeWithIndex }) => {
   const { t } = useTranslation("form-builder");
   const {
     form: { elements },
@@ -355,7 +355,7 @@ export const ElementWrapper = ({ item, key }: { item: ElementTypeWithIndex; key:
   };
 
   return (
-    <ElementWrapperDiv className={`element-${item.index}`} key={key}>
+    <ElementWrapperDiv className={`element-${item.index}`}>
       <FormWrapper>
         <Form item={item} />
       </FormWrapper>

--- a/components/form-builder/panel/PanelActions.tsx
+++ b/components/form-builder/panel/PanelActions.tsx
@@ -138,5 +138,5 @@ export const PanelActions = ({
 PanelActions.propTypes = {
   item: PropTypes.object,
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-  renderSaveButton: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  renderSaveButton: PropTypes.func,
 };


### PR DESCRIPTION
Very small PR, fixes two problems that were causing console errors:

1. Passing in the `key` as a property.

React is not chill with this, so adding a question was causing console errors. No longer passing in the key solves this.

2. Using the wrong prop type for one of the properties on `PanelActions`

In this one, we're passing in a function that renders an element, not the actual element itself.  The prop type said to expect a string or an element, but that's now out of date. Fixed it to say to expect an element.
