### PR TITLE
Don't replace the entire "form", just reset the elements

### DIFF
--- a/components/form-builder/store/useTemplateStore.ts
+++ b/components/form-builder/store/useTemplateStore.ts
@@ -51,9 +51,14 @@ const useTemplateStore = create<ElementStore>()(
     },
     publishingStatus: true,
     updateField: (path, value) => set((state) => update(state, path, value)),
-    moveUp: (index) => set((state) => ({ form: { elements: moveUp(state.form.elements, index) } })),
+    moveUp: (index) =>
+      set((state) => {
+        state.form.elements = moveUp(state.form.elements, index);
+      }),
     moveDown: (index) =>
-      set((state) => ({ form: { elements: moveDown(state.form.elements, index) } })),
+      set((state) => {
+        state.form.elements = moveDown(state.form.elements, index);
+      }),
     add: () =>
       set((state) => {
         state.form.elements.push({
@@ -63,7 +68,9 @@ const useTemplateStore = create<ElementStore>()(
         });
       }),
     remove: (elementId) =>
-      set((state) => ({ form: { elements: removeElementById(state.form.elements, elementId) } })),
+      set((state) => {
+        state.form.elements = removeElementById(state.form.elements, elementId);
+      }),
     addChoice: (index) =>
       set((state) => {
         state.form.elements[index].properties.choices.push({ en: "", fr: "" });


### PR DESCRIPTION
# Summary | Résumé

Fixes some console errors we were seeing when removing elements or moving them around.

## Notes

There was a bug I was seeing when either moving form fields or removing a field, which was that a bunch of the fields in the "form" object were being removed. The way that the new "elements" was being updated was correct, but it was resetting the "form" object such that all the other keys were being deleted.

Updated so that the "elements" key is getting replaced without any side effects.

## gif 

This is an example of the console error being thrown when removing a field.

![Screen Recording 2022-09-09 at 15 16 45](https://user-images.githubusercontent.com/2454380/189428389-614c3e35-dc86-4b74-ae05-b00e91569784.gif)

