### PR TITLE
fix: change isAdmin logic

### DIFF
--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -8,13 +8,14 @@ import Fip from "./Fip";
 import AdminNav from "./AdminNav";
 import { useTranslation } from "next-i18next";
 import { getPageClassNames } from "@lib/routeUtils";
+import { UserRole } from "@prisma/client";
 
 const Base = ({ children }) => {
   const formRecord =
     children && children.props && children.props.formRecord ? children.props.formRecord : null;
   const classes = getPageClassNames(formRecord);
 
-  const isAdmin = children && children.props && children.props.user;
+  const isAdmin = children?.props?.user?.role === UserRole.ADMINISTRATOR;
   const isEmbeddable = formRecord && children && children.props && children.props.isEmbeddable;
 
   const shouldDisplayAlphaBanner = formRecord ? formRecord.formConfig.displayAlphaBanner : true;


### PR DESCRIPTION
# Summary | Résumé

Closes #989 

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| 
![image](https://user-images.githubusercontent.com/77435/190197903-d372ca19-3b94-4a2d-a082-c23a52e209eb.png)
 |  
![Screen Shot 2022-09-14 at 11 29 21 AM](https://user-images.githubusercontent.com/77435/190197949-a4e56295-1de4-4798-875a-e06f3c37151e.png)
|

# Test instructions | Instructions pour tester la modification

- login as a Program Administrator (~/auth/login). Observe that the adminNav menu no longer appears on the "policy" or "retrieval" pages.
- login as an admin (~/admin). Observe that the adminNav menu still appears under the `~/settings` page.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
