### PR TITLE
fix: return only public properties for form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix logout session end date [#945](https://github.com/cds-snc/platform-forms-client/issues/945)
 - Fix last login date format [#950](https://github.com/cds-snc/platform-forms-client/pull/950)
 - Cleared email input field after successfully adding an email to Form Access [#954](https://github.com/cds-snc/platform-forms-client/pull/954)
+- Returned only public properties for forms [#1038](https://github.com/cds-snc/platform-forms-client/pull/1038)
 
 ### Removed
 

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -203,7 +203,14 @@ async function _getTemplateByID(formID: string): Promise<FormRecord | null> {
     return prismaErrors(e, null);
   }
 }
-
+/*
+ * Extract only the public properties from a form record.
+ * The public properties are the ones that are needed to display the form
+ * to unauthenticated users. (e.g. when filling out a form)
+ * Also sets some of the default values for properties that are not set.
+ * @param template A Form Record, containing all the properties
+ * @returns a Public Form Record, with only the public properties
+ */
 const _onlyIncludePublicProperties = (template: FormRecord): PublicFormRecord => {
   return {
     formID: template.formID,

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -218,8 +218,10 @@ describe("Template CRUD functions", () => {
     };
 
     const publicFormRecord = onlyIncludePublicProperties(formRecord as FormRecord);
-    expect(publicFormRecord).not.toHaveProperty("submission");
-    expect(publicFormRecord).not.toHaveProperty("internalTitleEn");
-    expect(publicFormRecord).not.toHaveProperty("internalTitleFr");
+    expect(publicFormRecord.formConfig).not.toHaveProperty("submission");
+    expect(publicFormRecord.formConfig).not.toHaveProperty("internalTitleEn");
+    expect(publicFormRecord.formConfig).not.toHaveProperty("internalTitleFr");
+    expect(publicFormRecord.formConfig).toHaveProperty("displayAlphaBanner");
+    expect(publicFormRecord.formConfig).toHaveProperty("securityAttribute");
   });
 });

--- a/pages/id/[form]/[[...step]].tsx
+++ b/pages/id/[form]/[[...step]].tsx
@@ -73,9 +73,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     if (!formID || Array.isArray(formID)) return redirect(context.locale);
 
     form = await getTemplateByID(formID);
-    if (form) {
-      form = onlyIncludePublicProperties(form);
-    }
   }
 
   // Redirect if form doesn't exist and
@@ -89,7 +86,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
   return {
     props: {
-      formRecord: form,
+      formRecord: onlyIncludePublicProperties(form),
       isEmbeddable: isEmbeddable,
       ...(context.locale &&
         (await serverSideTranslations(context.locale, ["common", "welcome", "confirmation"]))),

--- a/pages/id/[form]/[[...step]].tsx
+++ b/pages/id/[form]/[[...step]].tsx
@@ -1,4 +1,4 @@
-import { getTemplateByID } from "@lib/templates";
+import { getTemplateByID, onlyIncludePublicProperties } from "@lib/templates";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { checkOne } from "@lib/flags";
 import React from "react";
@@ -73,6 +73,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     if (!formID || Array.isArray(formID)) return redirect(context.locale);
 
     form = await getTemplateByID(formID);
+    if (form) {
+      form = onlyIncludePublicProperties(form);
+    }
   }
 
   // Redirect if form doesn't exist and


### PR DESCRIPTION
# Summary | Résumé

There is no issue for this PR.

The `getTemplateByID` request being made for the forms page was returning non-public form config data. This change sanitizes the data by calling `onlyIncludePublicProperties()` on the form, returning only the properties that can safely be sent to the browser when being requested by an unauthorized user (ie: someone filling out the form).

![Screen Shot 2022-09-14 at 2 32 28 PM](https://user-images.githubusercontent.com/77435/190264301-5d021817-3b29-4f1d-b0d0-f4925a55c75b.png)

# Test instructions | Instructions pour tester la modification

- Load any form into the browser, as if you were going to fill it out.
- Observe in the browser Developer Tools / Network tab, that the data being sent from the server does not include non-public properties, such as `submission`, or `internalTitleEN`, among other such properties. 
- It should include default values for `displayAlphaBanner` and `securityAttribute`, even if they are not present in the formConfig saved in the database

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
