### PR TITLE
feat: insert at index when duplicating

### DIFF
--- a/components/form-builder/__tests__/useTemplateStore.test.ts
+++ b/components/form-builder/__tests__/useTemplateStore.test.ts
@@ -1,7 +1,6 @@
 import useTemplateStore from "../store/useTemplateStore";
 import { renderHook } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
-import { logMessage } from "@lib/logger";
 
 const createStore = () => {
   const { result } = renderHook(() => useTemplateStore());

--- a/components/form-builder/__tests__/useTemplateStore.test.ts
+++ b/components/form-builder/__tests__/useTemplateStore.test.ts
@@ -1,6 +1,7 @@
 import useTemplateStore from "../store/useTemplateStore";
 import { renderHook } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
+import { logMessage } from "@lib/logger";
 
 const createStore = () => {
   const { result } = renderHook(() => useTemplateStore());
@@ -129,6 +130,32 @@ describe("TemplateStore", () => {
     });
 
     expect(result.current.form.elements[0].properties.choices).toHaveLength(2);
+  });
+
+  it("Duplicates an element and inserts after index of copied item", () => {
+    const result = createStore();
+    expect(result.current.form.titleEn).toBe("My Form");
+
+    // Create an element with three choices
+    act(() => {
+      result.current.add(0);
+      result.current.add(1);
+      result.current.add(2);
+
+      result.current.updateField(`form.elements[0].properties.titleEn`, "Element one");
+      result.current.updateField(`form.elements[1].properties.titleEn`, "Element two");
+      result.current.updateField(`form.elements[2].properties.titleEn`, "Element three");
+    });
+
+    expect(result.current.form.elements).toHaveLength(3);
+
+    act(() => {
+      result.current.duplicateElement(1);
+    });
+
+    expect(result.current.form.elements).toHaveLength(4);
+    expect(result.current.form.elements[2].properties.titleEn).toBe("Element two copy");
+    expect(result.current.form.elements[3].properties.titleEn).toBe("Element three");
   });
 
   it("Moves an element up", () => {

--- a/components/form-builder/store/useTemplateStore.ts
+++ b/components/form-builder/store/useTemplateStore.ts
@@ -89,7 +89,7 @@ const useTemplateStore = create<ElementStore>()(
         const element = JSON.parse(JSON.stringify(state.form.elements[index]));
         element.id = incrementElementId(state.form.elements);
         element.properties.titleEn = `${element.properties.titleEn} copy`;
-        state.form.elements.push(element);
+        state.form.elements.splice(index + 1, 0, element);
       });
     },
     bulkAddChoices: (index, bulkChoices) => {


### PR DESCRIPTION
# Summary | Résumé

Previously, duplicated elements were just pushed to the end of the array of elements. This PR changes that behaviour to insert the duplicated element after the element being duplicated.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![Screen Recording 2022-09-16 at 10 53 12 AM](https://user-images.githubusercontent.com/1187115/190668692-901ec36b-a1c4-4679-b8cb-407d60b98441.gif) | ![Screen Recording 2022-09-16 at 10 54 15 AM](https://user-images.githubusercontent.com/1187115/190668854-cba18acd-5da7-4f6d-97ef-a19db523f07d.gif) |

# Test instructions | Instructions pour tester la modification

- Add multiple elements
- Duplicate one
- Note where the new item gets inserted

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
