### PR TITLE
feat: Add a Return to form link to the confirmation page preview

### DIFF
--- a/components/form-builder/icons/BackArrowIcon.tsx
+++ b/components/form-builder/icons/BackArrowIcon.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+export const BackArrowIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
+    <path d="m12 20-8-8 8-8 1.425 1.4-5.6 5.6H20v2H7.825l5.6 5.6Z" />
+  </svg>
+);

--- a/components/form-builder/icons/index.ts
+++ b/components/form-builder/icons/index.ts
@@ -13,3 +13,4 @@ export { ShortAnswerIcon } from "./ShortAnswerIcon";
 export { ThreeDotsIcon } from "./ThreeDotsIcon";
 export { NumberedListIcon } from "./NumberedListIcon";
 export { BulletedListIcon } from "./BulletedListIcon";
+export { BackArrowIcon } from "./BackArrowIcon";

--- a/components/form-builder/layout/Preview.tsx
+++ b/components/form-builder/layout/Preview.tsx
@@ -21,7 +21,6 @@ export const Preview = () => {
 
   return (
     <>
-      <h2 className="gc-h2">Preview</h2>
       <Form formRecord={formRecord} language={language} router={router} t={t} isPreview={true}>
         {currentForm}
       </Form>

--- a/components/form-builder/preview/Form.tsx
+++ b/components/form-builder/preview/Form.tsx
@@ -13,8 +13,26 @@ import classNames from "classnames";
 import { Responses, PublicFormRecord } from "@lib/types";
 import { NextRouter } from "next/router";
 import Markdown from "markdown-to-jsx";
+import styled from "styled-components";
+import { BackArrowIcon } from "../icons";
 
 type InnerFormProps = FormProps & FormikProps<Responses>;
+
+const Link = styled.div`
+  text-decoration: underline;
+  cursor: pointer;
+  margin: 15px 0;
+
+  & svg {
+    display: inline-block;
+  }
+`;
+
+const SubmitButtonLabel = styled.div`
+  background-color: #cbc4f5;
+  display: inline-block;
+  padding: 2px 6px;
+`;
 
 /**
  * This is the "inner" form component that isn't connected to Formik and just renders a simple form
@@ -154,6 +172,14 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
       )}
       {formStatusSubmitted && props.isPreview && (
         <>
+          <Link
+            onClick={() => {
+              props.setStatus("None");
+            }}
+          >
+            <BackArrowIcon />
+            Back to form preview
+          </Link>
           <Markdown options={{ forceBlock: true }}>
             {form.endPage ? form.endPage.descriptionEn : ""}
           </Markdown>
@@ -226,6 +252,11 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               ))}
             <div className="buttons">
               <Button type="submit">{t("submitButton")}</Button>
+              {props.isPreview && (
+                <SubmitButtonLabel>
+                  To preview your confirmation message, click submit
+                </SubmitButtonLabel>
+              )}
             </div>
           </div>
         </form>


### PR DESCRIPTION
# Summary | Résumé

When you submit a previewed form, the confirmation page is displayed. This adds a link to return to the Form preview.

Also adds some instructional text next to the Submit button on the form "To preview your confirmation message, click submit"

| Submit label                                        | Return link                                      |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="797" alt="image" src="https://user-images.githubusercontent.com/1187115/190684275-aca5deb1-7e7a-453b-bade-090e05063f3f.png"> | <img width="676" alt="image" src="https://user-images.githubusercontent.com/1187115/190684325-d26b341d-0152-4ca1-97d1-15c384382c9a.png"> |

# Test instructions | Instructions pour tester la modification

- Create a form with elements
- Preview the form
- Notice the new label beside the submit button
- Click submit
- Notice the "Return to form preview" link

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
