### PR TITLE
fix: Fix typo in template schema

### DIFF
--- a/lib/middleware/schemas/templates.schema.json
+++ b/lib/middleware/schemas/templates.schema.json
@@ -222,7 +222,6 @@
   },
   "required": ["form", "submission", "publishingStatus"],
   "additionalProperties": true,
-
   "definitions": {
     "element": {
       "type": "object",
@@ -305,7 +304,7 @@
                 "regex": {
                   "type": "string"
                 },
-                "maxLegth": {
+                "maxLength": {
                   "description": "The maximum number of characters that can be entered in a textinput or textarea.",
                   "type": "integer",
                   "minimum": 1


### PR DESCRIPTION
# Summary | Résumé

Very simple PR here that fixes a typo in the form schema. 
The `maxLegth` key is actually supposed to be `maxLength`, with an `n`.

## Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
