### PR TITLE
feat: resend confirmation api

### DIFF
--- a/__tests__/api/signup/confirm.test.ts
+++ b/__tests__/api/signup/confirm.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import { createMocks, RequestMethod } from "node-mocks-http";
+import { getCsrfToken } from "next-auth/react";
+import { mocked } from "jest-mock";
+import {
+  CognitoIdentityProviderClient,
+  ConfirmSignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import confirm from "@pages/api/signup/confirm";
+
+const mockGetCSRFToken = mocked(getCsrfToken, true);
+
+jest.mock("next-auth/react");
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn(),
+  ConfirmSignUpCommand: jest.fn(),
+}));
+
+describe("/signup/confirm", () => {
+  afterEach(() => {
+    mockGetCSRFToken.mockReset();
+  });
+  beforeAll(() => {
+    process.env.COGNITO_REGION = "ca-central-1";
+    process.env.COGNITO_APP_CLIENT_ID = "somemockvalue";
+  });
+  afterAll(() => {
+    process.env.COGNITO_REGION = undefined;
+    process.env.COGNITO_APP_CLIENT_ID = undefined;
+  });
+  describe("Access Control", () => {
+    test.each(["GET", "PUT", "DELETE"])(
+      "Should not allow an unaccepted method",
+      async (httpVerb) => {
+        const { req, res } = createMocks({
+          method: httpVerb as RequestMethod,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        await confirm(req, res);
+        expect(res.statusCode).toBe(403);
+        expect(JSON.parse(res._getData())).toMatchObject({ error: "HTTP Method Forbidden" });
+      }
+    );
+
+    it("does not allow a non valid CSRF token", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "invalid_csrf",
+        },
+      });
+
+      await confirm(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Access Denied",
+      });
+    });
+  });
+  describe("Sign Up Confirmation", () => {
+    const mockedCognitoIdentityProviderClient: any = mocked(CognitoIdentityProviderClient, true);
+    const mockedConfirmSignUpCommand: any = mocked(ConfirmSignUpCommand, true);
+    const sendFunctionMock = jest.fn();
+    afterEach(() => {
+      mockedCognitoIdentityProviderClient.mockReset();
+      mockedConfirmSignUpCommand.mockReset();
+      sendFunctionMock.mockReset();
+    });
+    it("handler returns 400 status code if username or confirmation code not provided", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+      });
+
+      await confirm(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "username and confirmation code needs to be provided in the body of the request",
+      });
+    });
+    it("handler returns empty body and cognito status code when command succeeds", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      sendFunctionMock.mockImplementation(async () => {
+        return {
+          $metadata: {
+            httpStatusCode: 200,
+          },
+        };
+      });
+      mockedCognitoIdentityProviderClient.mockImplementationOnce(() => ({
+        send: sendFunctionMock,
+      }));
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test",
+          confirmationCode: "1921231",
+        },
+      });
+
+      await confirm(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(mockedCognitoIdentityProviderClient).toBeCalledTimes(1);
+      expect(mockedConfirmSignUpCommand.mock.calls[0][0]).toEqual({
+        ClientId: "somemockvalue",
+        Username: "test",
+        ConfirmationCode: "1921231",
+      });
+      expect(res._getData()).toEqual("");
+    });
+    it("handles error when the cognito send function fails", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      sendFunctionMock.mockRejectedValue({
+        toString: () => "There is an error",
+        $metadata: {
+          httpStatusCode: 400,
+        },
+      });
+      mockedCognitoIdentityProviderClient.mockImplementationOnce(() => ({
+        send: sendFunctionMock,
+      }));
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test",
+          confirmationCode: "1921231",
+        },
+      });
+
+      await confirm(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "There is an error",
+      });
+    });
+  });
+});

--- a/__tests__/api/signup/register.test.ts
+++ b/__tests__/api/signup/register.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import { createMocks, RequestMethod } from "node-mocks-http";
+import { getCsrfToken } from "next-auth/react";
+import { mocked } from "jest-mock";
+import {
+  CognitoIdentityProviderClient,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import register from "@pages/api/signup/register";
+
+const mockGetCSRFToken = mocked(getCsrfToken, true);
+
+jest.mock("next-auth/react");
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn(),
+  SignUpCommand: jest.fn(),
+}));
+
+describe("/signup/register", () => {
+  afterEach(() => {
+    mockGetCSRFToken.mockReset();
+  });
+  beforeAll(() => {
+    process.env.COGNITO_REGION = "ca-central-1";
+    process.env.COGNITO_APP_CLIENT_ID = "somemockvalue";
+  });
+  afterAll(() => {
+    process.env.COGNITO_REGION = undefined;
+    process.env.COGNITO_APP_CLIENT_ID = undefined;
+  });
+  describe("Access Control", () => {
+    test.each(["GET", "PUT", "DELETE"])(
+      "Should not allow an unaccepted method",
+      async (httpVerb) => {
+        const { req, res } = createMocks({
+          method: httpVerb as RequestMethod,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        await register(req, res);
+        expect(res.statusCode).toBe(403);
+        expect(JSON.parse(res._getData())).toMatchObject({ error: "HTTP Method Forbidden" });
+      }
+    );
+
+    it("does not allow a non valid CSRF token", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "invalid_csrf",
+        },
+      });
+
+      await register(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Access Denied",
+      });
+    });
+  });
+  describe("Sign Up Registration", () => {
+    const mockedCognitoIdentityProviderClient: any = mocked(CognitoIdentityProviderClient, true);
+    const mockedSignUpCommand: any = mocked(SignUpCommand, true);
+    const sendFunctionMock = jest.fn();
+    afterEach(() => {
+      mockedCognitoIdentityProviderClient.mockReset();
+      mockedSignUpCommand.mockReset();
+      sendFunctionMock.mockReset();
+    });
+    it("handler returns 400 status code when username or password is not included", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+      });
+      await register(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "username and password need to be provided in the body of the request",
+      });
+    });
+    it("handler returns empty body and cognito status code when command succeeds", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      sendFunctionMock.mockImplementation(async () => {
+        return {
+          $metadata: {
+            httpStatusCode: 200,
+          },
+        };
+      });
+      mockedCognitoIdentityProviderClient.mockImplementationOnce(() => ({
+        send: sendFunctionMock,
+      }));
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test",
+          password: "test",
+        },
+      });
+
+      await register(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(mockedCognitoIdentityProviderClient).toBeCalledTimes(1);
+      expect(mockedSignUpCommand.mock.calls[0][0]).toEqual({
+        ClientId: "somemockvalue",
+        Username: "test",
+        Password: "test",
+      });
+      expect(res._getData()).toEqual("");
+    });
+    it("handles error when the cognito send function fails", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      sendFunctionMock.mockRejectedValue({
+        toString: () => "There is an error",
+        $metadata: {
+          httpStatusCode: 400,
+        },
+      });
+      mockedCognitoIdentityProviderClient.mockImplementationOnce(() => ({
+        send: sendFunctionMock,
+      }));
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test",
+          password: "test",
+        },
+      });
+
+      await register(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "There is an error",
+      });
+    });
+  });
+});

--- a/__tests__/api/signup/resendconfirmation.test.ts
+++ b/__tests__/api/signup/resendconfirmation.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import { createMocks, RequestMethod } from "node-mocks-http";
+import { getCsrfToken } from "next-auth/react";
+import { mocked } from "jest-mock";
+import {
+  CognitoIdentityProviderClient,
+  ResendConfirmationCodeCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import resendConfirmation from "@pages/api/signup/resendconfirmation";
+
+const mockGetCSRFToken = mocked(getCsrfToken, true);
+
+jest.mock("next-auth/react");
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn(),
+  ResendConfirmationCodeCommand: jest.fn(),
+}));
+
+describe("/signup/resendconfirmation", () => {
+  afterEach(() => {
+    mockGetCSRFToken.mockReset();
+  });
+  beforeAll(() => {
+    process.env.COGNITO_REGION = "ca-central-1";
+    process.env.COGNITO_APP_CLIENT_ID = "somemockvalue";
+  });
+  afterAll(() => {
+    process.env.COGNITO_REGION = undefined;
+    process.env.COGNITO_APP_CLIENT_ID = undefined;
+  });
+  describe("Access Control", () => {
+    test.each(["GET", "PUT", "DELETE"])(
+      "Should not allow an unaccepted method",
+      async (httpVerb) => {
+        const { req, res } = createMocks({
+          method: httpVerb as RequestMethod,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        await resendConfirmation(req, res);
+        expect(res.statusCode).toBe(403);
+        expect(JSON.parse(res._getData())).toMatchObject({ error: "HTTP Method Forbidden" });
+      }
+    );
+
+    it("does not allow a non valid CSRF token", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "invalid_csrf",
+        },
+      });
+
+      await resendConfirmation(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Access Denied",
+      });
+    });
+  });
+  describe("Resend Confirmation Code", () => {
+    const mockedCognitoIdentityProviderClient: any = mocked(CognitoIdentityProviderClient, true);
+    const mockedResendConfirmationCodeCommand: any = mocked(ResendConfirmationCodeCommand, true);
+    const sendFunctionMock = jest.fn();
+    afterEach(() => {
+      mockedCognitoIdentityProviderClient.mockReset();
+      mockedResendConfirmationCodeCommand.mockReset();
+      sendFunctionMock.mockReset();
+    });
+    it("handler returns 400 status code if username not provided", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+      });
+
+      await resendConfirmation(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "username needs to be provided in the body of the request",
+      });
+    });
+    it("handler returns empty body and cognito status code when command succeeds", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      sendFunctionMock.mockImplementationOnce(async () => ({
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      }));
+      mockedCognitoIdentityProviderClient.mockImplementationOnce(() => ({
+        send: sendFunctionMock,
+      }));
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test",
+        },
+      });
+
+      await resendConfirmation(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res._getData()).toBe("");
+      expect(mockedResendConfirmationCodeCommand.mock.calls[0][0]).toEqual({
+        ClientId: "somemockvalue",
+        Username: "test",
+      });
+      expect(mockedCognitoIdentityProviderClient).toBeCalledTimes(1);
+    });
+    it("handles error when the cognito send function fails", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+      sendFunctionMock.mockRejectedValue({
+        toString: () => "There is an error",
+        $metadata: {
+          httpStatusCode: 400,
+        },
+      });
+      mockedCognitoIdentityProviderClient.mockImplementationOnce(() => ({
+        send: sendFunctionMock,
+      }));
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test",
+        },
+      });
+
+      await resendConfirmation(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "There is an error",
+      });
+    });
+  });
+});

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -8,7 +8,7 @@ import {
 } from "@aws-sdk/client-cognito-identity-provider";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { logMessage } from "@lib/logger";
-import { getFormUser, getOrCreateUser, userLastLogin } from "@lib/users";
+import { getOrCreateUser } from "@lib/users";
 import { UserRole } from "@prisma/client";
 import { LoggingAction } from "@lib/auth";
 import { prisma, prismaErrors } from "@lib/integration/prismaConnector";

--- a/pages/api/signup/register.ts
+++ b/pages/api/signup/register.ts
@@ -7,10 +7,14 @@ import {
 import { NextApiRequest, NextApiResponse } from "next";
 import { middleware, cors, csrfProtected } from "@lib/middleware";
 
-const { COGNITO_REGION, COGNITO_APP_CLIENT_ID } = process.env;
-
 const register = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { COGNITO_REGION, COGNITO_APP_CLIENT_ID } = process.env;
   // craft registration params for the SignUpCommand
+  if (!req.body.username || !req.body.password) {
+    return res.status(400).json({
+      message: "username and password need to be provided in the body of the request",
+    });
+  }
   const params: SignUpCommandInput = {
     ClientId: COGNITO_APP_CLIENT_ID,
     Password: req.body.password,


### PR DESCRIPTION
# Summary | Résumé

* added new API route with path /api/signup/resendconfirmation to resend confirmation code
* added api tests

