### PR TITLE
feat: Double-click headers to switch language

### DIFF
--- a/components/form-builder/layout/Layout.tsx
+++ b/components/form-builder/layout/Layout.tsx
@@ -8,6 +8,11 @@ import { Save } from "./Save";
 import { Start } from "./Start";
 import { Preview } from "./Preview";
 
+const StyledHeader = styled.h1`
+  border-bottom: none;
+  margin-bottom: 2rem;
+`;
+
 const Input = styled.input`
   padding: 22px 10px;
   width: 800px;
@@ -36,7 +41,7 @@ const Tab = styled.span`
 `;
 
 export const Layout = () => {
-  const { lang, updateField, toggleLang, localizeField, form } = useTemplateStore();
+  const { updateField, toggleLang, localizeField, form } = useTemplateStore();
   const { t } = useTranslation("form-builder");
 
   const [showTab, setShowTab] = React.useState("start");
@@ -45,6 +50,13 @@ export const Layout = () => {
     setShowTab(tab);
   };
 
+  const handleHeaderClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (e.detail === 2) {
+      // double click
+      toggleLang();
+    }
+  };
+  /* eslint-disable */
   return (
     <>
       <Navigation className={showTab}>
@@ -55,7 +67,7 @@ export const Layout = () => {
         <Tab className="create" onClick={() => handleClick("create")}>
           {t("create")}
         </Tab>{" "}
-        / <Tab onClick={toggleLang}>{lang === "en" ? "Français" : "English"}</Tab> /{" "}
+        /{" "}
         <Tab className="preview" onClick={() => handleClick("preview")}>
           {t("preview")}
         </Tab>{" "}
@@ -65,11 +77,16 @@ export const Layout = () => {
         </Tab>
       </Navigation>
 
-      {showTab === "start" && <Start createForm={handleClick} />}
+      {showTab === "start" && (
+        <>
+          <h1 onClick={handleHeaderClick}>{t("start")}</h1>
+          <Start changeTab={handleClick} />
+        </>
+      )}
       {showTab === "create" && (
         <>
           <div>
-            <h1>{t("title")}</h1>
+            <h1 onClick={handleHeaderClick}>{t("title")}</h1>
             <Input
               placeholder={t("placeHolderFormTitle")}
               value={form[localizeField(LocalizedFormProperties.TITLE)]}
@@ -81,10 +98,21 @@ export const Layout = () => {
           <ElementPanel />
         </>
       )}
-      {showTab === "save" && <Save />}
-      {showTab === "preview" && <Preview />}
+      {showTab === "preview" && (
+        <>
+          <h1 onClick={handleHeaderClick}>{form[localizeField(LocalizedFormProperties.TITLE)]}</h1>
+          <Preview />
+        </>
+      )}
+      {showTab === "save" && (
+        <>
+          <StyledHeader onClick={handleHeaderClick}>{t("saveH1")}</StyledHeader>
+          <Save />
+        </>
+      )}
     </>
   );
+  /* eslint-enable */
 };
 
 export default Layout;

--- a/components/form-builder/layout/Preview.tsx
+++ b/components/form-builder/layout/Preview.tsx
@@ -4,10 +4,9 @@ import { Form } from "../preview/Form";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { getRenderedForm } from "@lib/formBuilder";
-import { LocalizedFormProperties } from "../types";
 
 export const Preview = () => {
-  const { getSchema, form, localizeField } = useTemplateStore();
+  const { getSchema } = useTemplateStore();
   const stringified = getSchema();
 
   const formRecord = {
@@ -21,11 +20,8 @@ export const Preview = () => {
   const currentForm = getRenderedForm(formRecord, language, t);
 
   return (
-    <>
-      <h1>{form[localizeField(LocalizedFormProperties.TITLE)]}</h1>
-      <Form formRecord={formRecord} language={language} router={router} t={t} isPreview={true}>
-        {currentForm}
-      </Form>
-    </>
+    <Form formRecord={formRecord} language={language} router={router} t={t} isPreview={true}>
+      {currentForm}
+    </Form>
   );
 };

--- a/components/form-builder/layout/Save.tsx
+++ b/components/form-builder/layout/Save.tsx
@@ -5,11 +5,6 @@ import { DownloadFileButton } from "./DownloadFileButton";
 import { CopyToClipboard } from "./CopyToClipboard";
 import { Output } from "./Output";
 
-const StyledHeader = styled.h1`
-  border-bottom: none;
-  margin-bottom: 2rem;
-`;
-
 const BottomMargin = styled.div`
   margin-bottom: 1.5rem;
 `;
@@ -42,7 +37,6 @@ export const Save = () => {
 
   return (
     <>
-      <StyledHeader>{t("saveH1")}</StyledHeader>
       <BottomMargin>
         <p>{t("saveP1")}</p>
       </BottomMargin>

--- a/components/form-builder/layout/Start.tsx
+++ b/components/form-builder/layout/Start.tsx
@@ -55,7 +55,7 @@ const StyledContainer = styled.div`
   }
 `;
 
-export const Start = ({ createForm }: { createForm: (tab: string) => void }) => {
+export const Start = ({ changeTab }: { changeTab: (tab: string) => void }) => {
   const { t } = useTranslation("form-builder");
 
   const { importTemplate } = useTemplateStore();
@@ -89,7 +89,7 @@ export const Start = ({ createForm }: { createForm: (tab: string) => void }) => 
         // ensure elements follow layout array order
         data.form.elements = sortByLayout(data.form);
         importTemplate(data);
-        createForm("create");
+        changeTab("create");
       };
     } catch (e) {
       if (e instanceof Error) {
@@ -100,14 +100,13 @@ export const Start = ({ createForm }: { createForm: (tab: string) => void }) => 
 
   return (
     <>
-      <h1>{t("start")}</h1>
       {errors && <div className="pt-2 pb-2 mt-4 mb-4 text-lg text-red-700">{errors}</div>}
       <StyledContainer>
         <button
           className="box"
           onClick={(e) => {
             e.preventDefault();
-            createForm("create");
+            changeTab("create");
           }}
         >
           <DesignIcon />


### PR DESCRIPTION
# Summary | Résumé

We need to get the French/English language toggle out of the top nav but we also want it to be available to us.

The compromise here is using the Headings as the toggle, even though it is not something we want to do long-term.

Still easy to click and very unlikely someone will activate it by accident.

## gif 

![Screen Recording 2022-09-29 at 16 05 55](https://user-images.githubusercontent.com/2454380/193132079-3d1ab5e8-f914-4591-9522-b157ebdfb33d.gif)
