### PR TITLE
Do not run deploy workflow when app doesn't change

### DIFF
--- a/.github/workflows/build-and-deploy-storybooks.yml
+++ b/.github/workflows/build-and-deploy-storybooks.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [main]
+    paths-ignore:
+      # Ignore all files and folders that start with '.'
+      - ".**"
+      # Ignore all files and folder in fixtures, tests, utils, etc.
+      - "__*/**"
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -3,6 +3,11 @@ name: Production — Push container to ECR
 on:
   push:
     branches: [main]
+    paths-ignore:
+      # Ignore all files and folders that start with '.'
+      - ".**"
+      # Ignore all files and folder in fixtures, tests, utils, etc.
+      - "__*/**"
 
 env:
   ECR_REPOSITORY: form_viewer_production

--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -3,6 +3,11 @@ name: "Staging — Push container to ECR"
 on:
   push:
     branches: [develop]
+    paths-ignore:
+      # Ignore all files and folders that start with '.'
+      - ".**"
+      # Ignore all files and folder in fixtures, tests, utils, etc.
+      - "__*/**"
 
 env:
   ECR_REPOSITORY: form_viewer_staging

--- a/.github/workflows/test-container-build-production.yml
+++ b/.github/workflows/test-container-build-production.yml
@@ -23,4 +23,3 @@ jobs:
             --build-arg GITHUB_SHA_ARG=$GITHUB_SHA \
             --build-arg GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
             --build-arg GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID .
-

--- a/.github/workflows/test-container-build-staging.yml
+++ b/.github/workflows/test-container-build-staging.yml
@@ -22,4 +22,3 @@ jobs:
             --build-arg GITHUB_SHA_ARG=$GITHUB_SHA \
             --build-arg GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
             --build-arg GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID .
-

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,11 +25,7 @@ const customJestConfig = {
   ],
   testEnvironment: "jsdom",
   collectCoverage: true,
-  collectCoverageFrom: [
-    "{pages,lib,components}/**/*.{ts,tsx}",
-    "!**/*.d.ts",
-    "!**/node_modules/**",
-  ],
+  collectCoverageFrom: ["{pages,lib,components}/**/{!(*.stories),}.{ts,tsx}"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,11 @@ const customJestConfig = {
   ],
   testEnvironment: "jsdom",
   collectCoverage: true,
-  collectCoverageFrom: ["**/*.{ts,tsx}", "!**/*.d.ts", "!**/node_modules/**"],
+  collectCoverageFrom: [
+    "{pages,lib,components}/**/*.{ts,tsx}",
+    "!**/*.d.ts",
+    "!**/node_modules/**",
+  ],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
# Summary | Résumé
This PR modifies various Github workflow actions to not run when application files do not change.
Ignored files and paths include paths that begin with '.' as well as paths that begin with '__'.  These files and paths are only used for development and are not part of the core application.
A change to a `.github` workflow or a `.vscode` development setting should not trigger an application build and deployment.

Also this PR modifies the jest test coverage to only focus on application files and ignore all other files, including storybook files embedded in the application directory.