### PR TITLE
feat: Preview outline and preview after upload

### DIFF
--- a/components/form-builder/layout/Layout.tsx
+++ b/components/form-builder/layout/Layout.tsx
@@ -40,6 +40,11 @@ const Tab = styled.span`
   cursor: pointer;
 `;
 
+const StyledPreviewWrapper = styled.div`
+  border: 2px dashed blue;
+  padding: 20px;
+`;
+
 export const Layout = () => {
   const { updateField, toggleLang, localizeField, form } = useTemplateStore();
   const { t } = useTranslation("form-builder");
@@ -100,8 +105,10 @@ export const Layout = () => {
       )}
       {showTab === "preview" && (
         <>
-          <h1 onClick={handleHeaderClick}>{form[localizeField(LocalizedFormProperties.TITLE)]}</h1>
-          <Preview />
+          <StyledPreviewWrapper>
+            <h1 onClick={handleHeaderClick}>{form[localizeField(LocalizedFormProperties.TITLE)]}</h1>
+            <Preview />
+          </StyledPreviewWrapper>
         </>
       )}
       {showTab === "save" && (

--- a/components/form-builder/layout/Layout.tsx
+++ b/components/form-builder/layout/Layout.tsx
@@ -41,7 +41,7 @@ const Tab = styled.span`
 `;
 
 const StyledPreviewWrapper = styled.div`
-  border: 2px dashed blue;
+  border: 3px dashed blue;
   padding: 20px;
 `;
 

--- a/components/form-builder/layout/Start.tsx
+++ b/components/form-builder/layout/Start.tsx
@@ -89,7 +89,7 @@ export const Start = ({ changeTab }: { changeTab: (tab: string) => void }) => {
         // ensure elements follow layout array order
         data.form.elements = sortByLayout(data.form);
         importTemplate(data);
-        changeTab("create");
+        changeTab("preview");
       };
     } catch (e) {
       if (e instanceof Error) {


### PR DESCRIPTION
# Summary | Résumé

Adds a blue dashed border around the Preview, and redirect to Preview after opening a form file. Also, when you "open a form" on the start screen, redirect to Preview (previously went to Design).

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="1315" alt="image" src="https://user-images.githubusercontent.com/1187115/194409512-5886e9b2-503e-4881-b971-4054f0579e90.png"> | <img width="1309" alt="image" src="https://user-images.githubusercontent.com/1187115/194409446-2844986a-f574-40c0-b1e0-27ffa99262df.png"> |


