### PR TITLE
fix: Add accessible labels to our Remove buttons

### DIFF
--- a/components/form-builder/elements/Option.tsx
+++ b/components/form-builder/elements/Option.tsx
@@ -97,7 +97,7 @@ export const Option = ({
       />
       <RemoveButton
         icon={<Close />}
-        aria-label={`${t("remove")} ${val}`}
+        aria-label={`${t("removeOption")} ${val}`}
         onClick={() => {
           removeChoice(parentIndex, index);
         }}

--- a/components/form-builder/elements/RichTextLocked.tsx
+++ b/components/form-builder/elements/RichTextLocked.tsx
@@ -21,9 +21,12 @@ const ContentWrapper = styled.div`
   display: flex;
   margin: 0px 20px;
 
-  & h3 {
+  & h2 {
+    font-size: 26px;
+    line-height: 32px;
     margin-top: 15px;
     margin-bottom: 0;
+    padding-bottom: 0;
   }
 `;
 

--- a/components/form-builder/elements/RichTextLocked.tsx
+++ b/components/form-builder/elements/RichTextLocked.tsx
@@ -41,12 +41,14 @@ export const RichTextLocked = ({
   children,
   initialValue,
   schemaProperty,
+  "aria-label": ariaLabel = undefined,
 }: {
   id: string;
   addElement: boolean;
   children?: React.ReactElement;
   initialValue: string;
   schemaProperty: string;
+  "aria-label"?: string;
 }) => {
   const input = useRef<HTMLInputElement>(null);
   const { localizeField, updateField } = useTemplateStore();
@@ -82,7 +84,7 @@ export const RichTextLocked = ({
     <ElementWrapperDiv>
       <ContentWrapper>{children}</ContentWrapper>
       <OptionWrapper>
-        <RichTextEditor id={editorId} value={value} onChange={onChange} />
+        <RichTextEditor id={editorId} value={value} onChange={onChange} aria-label={ariaLabel} />
       </OptionWrapper>
       <PanelActionsLocked addElement={addElement} />
     </ElementWrapperDiv>

--- a/components/form-builder/elements/ShortAnswer.tsx
+++ b/components/form-builder/elements/ShortAnswer.tsx
@@ -3,8 +3,8 @@ import styled from "styled-components";
 
 const TextHint = styled.div`
   margin: 20px 5px;
-  color: rgba(0, 0, 0, 0.38);
-  border-bottom: 1px dotted rgba(0, 0, 0, 0.38);
+  color: rgba(0, 0, 0, 0.55);
+  border-bottom: 1px dotted rgba(0, 0, 0, 0.45);
 `;
 
 export const ShortAnswer = ({ children }: { children: string }) => {

--- a/components/form-builder/hooks/useElementOptions.tsx
+++ b/components/form-builder/hooks/useElementOptions.tsx
@@ -22,7 +22,6 @@ export const useElementOptions = () => {
   const { t } = useTranslation("form-builder");
   const elementOptions = [
     { id: "richText", value: t("richText"), icon: <ParagraphIcon />, append: <Separator /> },
-    { id: "text", value: t("richText"), icon: <ParagraphIcon />, append: <Separator /> },
     { id: "radio", value: t("singleChoice"), icon: <RadioIcon /> },
     { id: "checkbox", value: t("checkboxes"), icon: <CheckIcon /> },
     { id: "dropdown", value: t("dropdown"), icon: <SelectMenuIcon />, append: <Separator /> },

--- a/components/form-builder/panel/Button.tsx
+++ b/components/form-builder/panel/Button.tsx
@@ -44,15 +44,22 @@ export const Button = ({
   onClick,
   className,
   disabled = false,
+  "aria-label": ariaLabel = undefined,
 }: {
   children?: JSX.Element | string;
   icon?: ReactElement;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
   className?: string;
   disabled?: boolean;
+  "aria-label"?: string;
 }) => {
   return (
-    <StyledButton onClick={onClick} className={className} disabled={disabled}>
+    <StyledButton
+      onClick={onClick}
+      className={className}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
       {icon}
       {children}
     </StyledButton>

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -583,6 +583,7 @@ const ElementPanelDiv = styled.div`
 `;
 
 export const ElementPanel = () => {
+  const { t } = useTranslation("form-builder");
   const { form, localizeField } = useTemplateStore();
 
   const introTextPlaceholder =
@@ -601,6 +602,7 @@ export const ElementPanel = () => {
         addElement={true}
         initialValue={introTextPlaceholder}
         schemaProperty="introduction"
+        aria-label={t("richTextIntroTitle")}
       />
       {form.elements.map((element, index) => {
         const item = { ...element, index };
@@ -613,16 +615,18 @@ export const ElementPanel = () => {
             addElement={false}
             initialValue={confirmTextPlaceholder}
             schemaProperty="endPage"
+            aria-label={t("richTextConfirmationTitle")}
           >
-            <h2>Confirmation page and message</h2>
+            <h2>{t("richTextConfirmationTitle")}</h2>
           </RichTextLocked>
           <RichTextLocked
             id="policyPage"
             addElement={false}
             initialValue={policyTextPlaceholder}
             schemaProperty="privacyPolicy"
+            aria-label={t("richTextPrivacyTitle")}
           >
-            <h2>Privacy statement</h2>
+            <h2>{t("richTextPrivacyTitle")}</h2>
           </RichTextLocked>
         </>
       )}

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -264,6 +264,8 @@ const Form = ({ item }: { item: ElementTypeWithIndex }) => {
     [setSelectedItem]
   );
 
+  const hasDescription = item.properties[localizeField(LocalizedElementProperties.DESCRIPTION)];
+
   return (
     <>
       <Row isRichText={isRichText}>
@@ -275,9 +277,11 @@ const Form = ({ item }: { item: ElementTypeWithIndex }) => {
               <TitleInput
                 ref={input}
                 type="text"
+                id={`item${item.index}`}
                 name={`item${item.index}`}
                 placeholder={t("Question")}
                 value={item.properties[localizeField(LocalizedElementProperties.TITLE)]}
+                aria-describedby={hasDescription ? `item${item.index}-describedby` : undefined}
                 onChange={(e) => {
                   updateField(
                     `form.elements[${item.index}].properties.${localizeField(
@@ -289,12 +293,11 @@ const Form = ({ item }: { item: ElementTypeWithIndex }) => {
               />
             </>
           )}
-          {item.properties[localizeField(LocalizedElementProperties.DESCRIPTION)] &&
-            item.type !== "richText" && (
-              <DivDisabled aria-label={t("Description")}>
-                {item.properties[localizeField(LocalizedElementProperties.DESCRIPTION)]}
-              </DivDisabled>
-            )}
+          {hasDescription && item.type !== "richText" && (
+            <DivDisabled id={`item${item.index}-describedby`}>
+              {item.properties[localizeField(LocalizedElementProperties.DESCRIPTION)]}
+            </DivDisabled>
+          )}
           <SelectedElement item={item} selected={selectedItem} />
           {item.properties.validation.maxLength && (
             <DivDisabled>
@@ -611,7 +614,7 @@ export const ElementPanel = () => {
             initialValue={confirmTextPlaceholder}
             schemaProperty="endPage"
           >
-            <h3>Confirmation page and message</h3>
+            <h2>Confirmation page and message</h2>
           </RichTextLocked>
           <RichTextLocked
             id="policyPage"
@@ -619,7 +622,7 @@ export const ElementPanel = () => {
             initialValue={policyTextPlaceholder}
             schemaProperty="privacyPolicy"
           >
-            <h3>Privacy statement</h3>
+            <h2>Privacy statement</h2>
           </RichTextLocked>
         </>
       )}

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -81,13 +81,15 @@ const getSelectedOption = (item: ElementTypeWithIndex): ElementOption => {
   if (!type) {
     return elementOptions[2];
   } else if (type === "textField") {
+    const validationType = elements[item.index].properties.validation.type;
     /**
      * Email, phone, and date fields are specialized text field types.
      * That is to say, their "type" is "textField" but they have specalized validation "type"s.
      * So if we have a "textField", we want to first check properties.validation.type to see if
      * it is a true Short Answer, or one of the other types.
+     * The one exception to this is validationType === "text" types, for which we want to return "textField"
      */
-    type = elements[item.index].properties.validation.type || type;
+    type = validationType && validationType !== "text" ? validationType : type;
   }
 
   const selected = elementOptions.filter((item) => item.id === type);

--- a/components/form-builder/plate-editor/RichTextEditor.tsx
+++ b/components/form-builder/plate-editor/RichTextEditor.tsx
@@ -48,6 +48,11 @@ const RichTextWrapper = styled.div`
     z-index: 1000;
     padding-bottom: 0;
   }
+
+  span[data-slate-placeholder="true"] {
+    color: #71767e;
+    opacity: 1 !important;
+  }
 `;
 
 const plugins = createMyPlugins(
@@ -70,10 +75,12 @@ export const RichTextEditor = ({
   id,
   value,
   onChange,
+  "aria-label": ariaLabel = undefined,
 }: {
   id: string;
   value: MyRootBlock[];
   onChange: (value: Value) => void;
+  "aria-label"?: string;
 }) => {
   return (
     <RichTextWrapper style={{ width: "100%" }}>
@@ -86,7 +93,9 @@ export const RichTextEditor = ({
         </HeadingToolbar>
         <Plate<MyValue>
           id={id}
-          editableProps={editableProps}
+          editableProps={
+            ariaLabel ? { ...editableProps, ...{ "aria-label": ariaLabel } } : editableProps
+          }
           plugins={plugins}
           initialValue={value}
           onChange={onChange}

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -39,5 +39,8 @@
   "startH3": "Open a form file",
   "startP2": "Revisit and edit an existing form file you saved from your last session",
   "startErrorValidation": "Template validation failed",
-  "startErrorParse": "Failed to parse file, not valid JSON"
+  "startErrorParse": "Failed to parse file, not valid JSON",
+  "richTextIntroTitle": "Form introduction",
+  "richTextConfirmationTitle": "Confirmation page and message",
+  "richTextPrivacyTitle": "Privacy statement"
 }

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -15,7 +15,7 @@
   "date": "Date",
   "numericField": "Numeric field",
   "option": "Option",
-  "remove": "Remove",
+  "removeOption": "Remove option:",
   "design": "Design",
   "json": "JSON",
   "preview": "Preview",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -15,7 +15,7 @@
   "date": "[FR] Date",
   "numericField": "[FR] Numeric field",
   "option": "[FR] Option",
-  "remove": "[FR] Remove",
+  "removeOption": "[FR] Remove option :",
   "design": "[FR] Design",
   "json": "[FR] JSON",
   "preview": "[FR] Preview",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -39,5 +39,8 @@
   "startH3": "[FR] Open a form file",
   "startP2": "[FR] Revisit and edit an existing form file you saved from your last session",
   "startErrorValidation": "[FR] Template validation failed",
-  "startErrorParse": "[FR] Failed to parse file, not valid JSON"
+  "startErrorParse": "[FR] Failed to parse file, not valid JSON",
+  "richTextIntroTitle": "[FR] Form introduction",
+  "richTextConfirmationTitle": "[FR] Confirmation page and message",
+  "richTextPrivacyTitle": "[FR] Privacy statement"
 }


### PR DESCRIPTION
# Summary | Résumé

This PR addresses some of the a11y violations flagged by aXe.

In particular:
- adds aria-labels to the "Remove" buttons. There was an aria-label attribute being added to the buttons but they weren't doing anything with it previously.
- use the "description" as an aria-describedby fields for question titles
- added a missing "id" to question titles
- use heading level 2s in our RichTextLocked fields
- add `aria-label`s to our RichTextLocked fields 

There are still some left over related to the RichText field, so I will explain them in the notes.


| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| 29 aXe violations, uh oh | just 5 now 👍 |
|  <img width="1449" alt="Screen Shot 2022-10-11 at 12 26 05" src="https://user-images.githubusercontent.com/2454380/195147605-b1a2a2de-e242-4e23-b4f2-edf4db62fdf6.png"> | <img width="1449" alt="Screen Shot 2022-10-11 at 12 26 08" src="https://user-images.githubusercontent.com/2454380/195147608-6f0d1477-f6e7-40c0-9572-3c9edf0fe1a3.png"> |

### Adding aria-labels to the "remove" buttons

This one accounted for about 10 of the flagged issues. The Remove buttons did actually contain an `aria-label` prop, but our custom button component didn't know to look for it. I rewrote the label to be more descriptive and made sure it was being passed through.

| Screenshot                                          | 
| ----------------------------------------------- | 
| Descriptive labels are now added to each button |
|  <img width="600" alt="Screen Shot 2022-10-07 at 10 47 40" src="https://user-images.githubusercontent.com/2454380/194584497-494c7f97-19a9-4f97-8941-46b7622f8284.png">  |


### Adding aria-describedby to the Question heading labels

This one happens only when a description is added. The "description" was previously using `aria-label: Description` which means a screen reader would not read the description itself, but would just read out "Description". Not really that helpful.

Instead, I added an "aria-describedby" field to the question input pointing at the description if it exists, which matches the `id` of our "description" div.

| Screenshot                                          | 
| ----------------------------------------------- | 
| Question input is now labelled using `aria-describedby` if a description exists |
|  <img width="600" alt="Screen Shot 2022-10-07 at 10 48 05" src="https://user-images.githubusercontent.com/2454380/194584502-0453b892-9069-4980-ab4d-ed74c46bf545.png">  |


### RichTextFields

So there are 2 issues that are being flagged by the RichTextFields:
1. No labels on them 
2. The placeholder text doesn't pass contrast

#### RichTextFields: labels

Input fields must have an accessible name: basically, we are supposed to put a `<label>` (or `aria-label`) on every text field we have. There are 2 kinds of RichTextFields: those added to the form by users and those that are "Locked" (intro, privacy, conformation page).
- The ones added to the form by users don't have labels that we can add, really, since they are not really "sections" or a specific "question", they are just random text someone wants to add. 
- The ones that are "locked" are for specific sections, so on these ones we can label them. 

I added an extra prop on the locked fields that allow us to pass in an `aria-label` that will be associated with the input element here, so that somewhat addresses this issue. (The dynamic rich text fields still don't have labels though.)

#### RichTextFields: placeholder contrast

The placeholder text for the rich text fields is getting flagged by axe for being too low contrast. We can change the colour of them with CSS, so I started trying it out. 

The issue here is that normally placeholders are not identified by aXe scans, because they are not really a separate “element” on the page. The plate placeholder is its own HTML element, a `<span>`, not just an attribute of an `<input>`. The problem here is that all of our default placeholder colours wouldn’t pass accessibility either but that's the browser's default colour it uses. Eg, here’s 2 pictures:

| How it looks now                                          |  With higher contrast | 
| ----------------------------------------------- | ---|
| Regular placeholder text colour for "Type..." | Higher contrast placeholder text colour for "Type..." | 
|  <img width="826" alt="Screen Shot 2022-10-08 at 14 27 50" src="https://user-images.githubusercontent.com/2454380/195149007-9c76afb9-b13f-4406-acdd-f61be9c5d806.png"> |  <img width="826" alt="Screen Shot 2022-10-08 at 14 27 37" src="https://user-images.githubusercontent.com/2454380/195149005-7dc6b561-9aa3-4c2b-b478-eba3b5ed71b2.png">   |

In the first one, aXe says it’s a problem but all the placeholder text is the same colour. In the second one, the placeholder text in the rich text field (“Type…“) is darker than the question/option placeholders, but aXe is happy now.

For now, I am not going to do anything else about this. It doesn't really make sense to change just the placeholder text for these elements and not the others, so we will wait and see if this comes up again later.



