### PR TITLE
Feature/permission migration

### DIFF
--- a/lib/users.ts
+++ b/lib/users.ts
@@ -80,7 +80,7 @@ export const getOrCreateUser = async (userToken: JWT) => {
     const { name, email, picture: image } = userToken;
     const basePrivileges = await prisma.privilege.findUnique({
       where: {
-        nameEn: "base",
+        nameEn: "Base",
       },
       select: {
         id: true,

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -73,10 +73,10 @@ export const getOrCreateUser = async (userToken: JWT) => {
       },
     });
 
-    // If a user already exists return the record
+    // If a user already exists and has privileges return the record
     if (user !== null && user.privileges.length) return user;
 
-    // User does not exist, create and return a record
+    // User does not exist, create and return a record or assign base privileges
     const { name, email, picture: image } = userToken;
     const basePrivileges = await prisma.privilege.findUnique({
       where: {

--- a/prisma/migrations/20221006181804_permissions/migration.sql
+++ b/prisma/migrations/20221006181804_permissions/migration.sql
@@ -45,3 +45,40 @@ ALTER TABLE "_PrivilegeToUser" ADD CONSTRAINT "_PrivilegeToUser_A_fkey" FOREIGN 
 
 -- AddForeignKey
 ALTER TABLE "_PrivilegeToUser" ADD CONSTRAINT "_PrivilegeToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Populate with Privileges
+
+INSERT INTO
+  "Privilege" ("id","nameEn", "nameFr", "descriptionEn", "descriptionFr", "permissions")
+VALUES
+  (gen_random_uuid(),'Base','Base','Base Permissions','Autorisations de Base','[
+    {"action":"create","subject":"FormRecord"},
+    {"action":["view","update","delete"],"subject":"FormRecord","conditions":{"users":{"$elemMatch":{"id":"${user.id}"}}}},
+    {"action":"update","subject":"FormRecord","fields":["publishingStatus"],"inverted":true},
+    {"action":"delete","subject":"FormRecord","conditions":{"publishingStatus":true},"inverted":true}
+  ]'::JSONB),
+    (gen_random_uuid(),'PublishFormRecord','PublierUnFormulaire','Permission to Publish a Form','Autorisation de publier un formulaire','[
+    {"action":["update"],"subject":"FormRecord","fields":["publishingStatus"],"conditions":{"users":{"$elemMatch":{"id":"${user.id}"}}}}
+  ]'::JSONB),
+    (gen_random_uuid(),'ManageFormRecords','GérerLesFormulaire','Permission to manage all Forms','Autorisation de gérer tous les formulaires','[
+    {"action":["create","view","update","delete"],"subject":"FormRecord"}
+  ]'::JSONB),
+  (gen_random_uuid(),'ViewUserPrivileges','VisionnerPrivilègesUtilisateur','Permission to view user privileges','Autorisation d''afficher les privilèges de l''utilisateur','[
+    {"action":"view","subject":["User","Privilege"]}
+  ]'::JSONB),
+  (gen_random_uuid(),'ManageUsers','GérerUtilisateurs','Permission to manage users','Autorisation de gérer les utilisateurs','[
+    {"action":"view","subject":["User","Privilege"]},
+    {"action":"update","subject":"User"}
+  ]'::JSONB),
+   (gen_random_uuid(),'ManagePrivileges','GérerPrivilèges','Permission to manage privileges','Autorisation de gérer les privilèges','[
+    {"action":["create","view","update","delete"],"subject":"Privilege"}
+  ]'::JSONB),
+  (gen_random_uuid(),'ViewApplicationSettings','VisionnerParamètresApplication','Permission to view application settings','Autorisation d''afficher les paramètres de l''application','[
+    {"action":"view","subject":"Flags"}
+  ]'::JSONB),
+  (gen_random_uuid(),'ManageApplicationSettings','GérerParamètresApplication','Permission to manage application settings','Autorisation de gérer les paramètres de l''application','[
+    {"action":"view","subject":"Flags"},
+    {"action":"update","subject":"Flags"}
+  ]'::JSONB);
+  
+    

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -357,49 +357,6 @@ async function main() {
       },
     },
   });
-
-  await prisma.privilege.createMany({
-    data: [
-      {
-        nameEn: "base",
-        nameFr: "base",
-        descriptionEn: "User can view templates",
-        descriptionFr: "Utilisature pour voir les templates",
-        permissions: [{ action: "view", subject: "FormRecord" }],
-      },
-      {
-        nameEn: "formBuilder",
-        nameFr: "constructeurDeFormulaires",
-        descriptionEn: "User can create and modify templates",
-        descriptionFr: "Utilisature pour creer et modifier les templates",
-        permissions: [{ action: ["view", "update"], subject: "FormRecord" }],
-      },
-      {
-        nameEn: "ViewUserPrivileges",
-        nameFr: "ViewUserPrivileges",
-        descriptionEn: "Can view all Users",
-        descriptionFr: "Pour voir tous les utilisateurs",
-        permissions: [{ action: "view", subject: ["User", "Privilege"] }],
-      },
-      {
-        nameEn: "userManager",
-        nameFr: "userManager",
-        descriptionEn: "Can manage User permissions",
-        descriptionFr: "Peut gere les permissions d'utilisateur",
-        permissions: [
-          { action: ["view", "manage"], subject: "User" },
-          { action: "view", subject: "Privilege" },
-        ],
-      },
-      {
-        nameEn: "privilegeManage",
-        nameFr: "privilegeManage",
-        descriptionEn: "Can manage Privileges",
-        descriptionFr: "Peut gerer les privileges",
-        permissions: [{ action: ["view", "manage"], subject: "Privilege" }],
-      },
-    ],
-  });
 }
 
 main()


### PR DESCRIPTION
# Summary | Résumé
Adds initial privileges that will be required for the application to function properly immediately after migration.

- Removes duplicate seeding from Prisma seed file.
- Moves seeding to Prisma migration (.sql) file.

Closes #1099