### PR TITLE
Refactor FormRecord and PublicFormRecord

### DIFF
--- a/__fixtures__/testData.json
+++ b/__fixtures__/testData.json
@@ -1,311 +1,303 @@
 {
-  "formID": "test0form00000id000asdf11",
-  "formConfig": {
-    "form": {
-      "version": 1,
-      "titleEn": "Test Form",
-      "titleFr": "Formulaire de test",
-      "layout": [1, 2, 3, 4, 5, 6, 7, 8],
-      "brand": {
-        "name": "cds-snc",
-        "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
-        "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
-        "logoTitleEn": "Canadian Digital Service",
-        "logoTitleFr": "Service numérique canadien",
-        "urlEn": "https://digital.canada.ca/",
-        "urlFr": "https://numerique.canada.ca/"
-      },
-      "endPage": {
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "referrerUrlEn": "https://digital.canada.ca/",
-        "referrerUrlFr": "https://numerique.canada.ca/"
-      },
-      "elements": [
-        {
-          "id": 1,
-          "type": "textField",
-          "properties": {
-            "titleEn": "What is your full name?",
-            "titleFr": "Quel est votre nom complet?",
-            "placeholderEn": "I wish I knew",
-            "placeholderFr": "Je ne sais pas",
-            "descriptionEn": "This is a description",
-            "descriptionFr": "Voice une description",
-            "validation": {
-              "required": true
-            }
-          }
-        },
-        {
-          "id": 2,
-          "type": "textArea",
-          "properties": {
-            "titleEn": "What is the problem you are facing",
-            "titleFr": "Quel est le problème auquel vous êtes confronté?",
-            "placeholderEn": "Something difficult",
-            "placeholderFr": "Quelque chose difficile",
-            "descriptionEn": "Here be a description",
-            "descriptionFr": "Pour décrire, ou pas décire..",
-            "validation": {
-              "required": true
-            }
-          }
-        },
-        {
-          "id": 3,
-          "type": "richText",
-          "properties": {
-            "titleEn": "",
-            "titleFr": "",
-            "descriptionEn":
-              "Thank you so much for your interest in the Canadian Digital Service’s Forms product. <br/><br/> Please provide your information below so CDS can contact you about improving, updating, or digitizing a form.",
-            "descriptionFr":
-              "Merci beaucoup de l’intérêt que vous portez au produit de Formulaire du Service Numérique Canadien. <br/><br/> Veuillez fournir vos renseignements ci-dessous afin que le SNC puisse vous contacter pour discuter davantage l'amélioration, la mise à jour ou la numérisation d'un formulaire.",
-            "validation": {
-              "required": false
-            }
-          }
-        },
-        {
-          "id": 4,
-          "type": "dropdown",
-          "properties": {
-            "titleEn": "Province or territory",
-            "titleFr": "Province ou territoire",
-            "placeholderEn": "",
-            "placeholderFr": "",
-            "descriptionEn": "",
-            "descriptionFr": "",
-            "choices": [
-              {
-                "en": "",
-                "fr": ""
-              },
-              {
-                "en": "Alberta",
-                "fr": "Alberta"
-              },
-              {
-                "en": "British Columbia",
-                "fr": "Colombie-Britannique"
-              },
-              {
-                "en": "Manitoba",
-                "fr": "Manitoba"
-              },
-              {
-                "en": "New Brunswick",
-                "fr": "Nouveau-Brunswick"
-              },
-              {
-                "en": "Newfoundland and Labrador",
-                "fr": "Terre-Neuve-et-Labrador"
-              },
-              {
-                "en": "Northwest Territories",
-                "fr": "Territoires du Nord-Ouest"
-              },
-              {
-                "en": "Nova Scotia",
-                "fr": "Nouvelle-Écosse"
-              },
-              {
-                "en": "Nunavut",
-                "fr": "Nunavut"
-              },
-              {
-                "en": "Ontario",
-                "fr": "Ontario"
-              },
-              {
-                "en": "Prince Edward Island",
-                "fr": "Île-du-Prince-Édouard"
-              },
-              {
-                "en": "Quebec",
-                "fr": "Québec"
-              },
-              {
-                "en": "Saskatchewan",
-                "fr": "Saskatchewan"
-              },
-              {
-                "en": "Yukon",
-                "fr": "Yukon"
-              }
-            ],
-            "validation": {
-              "required": false
-            }
-          }
-        },
-        {
-          "id": 5,
-          "type": "radio",
-          "properties": {
-            "titleEn": "Status",
-            "titleFr": "Statut",
-            "description": "",
-            "validation": {
-              "required": false
-            },
-            "choices": [
-              {
-                "en": "Citizen",
-                "fr": "Cityoen"
-              },
-              {
-                "en": "Permanent Resident",
-                "fr": "Permanent Resident"
-              },
-              {
-                "en": "Student",
-                "fr": "Student"
-              },
-              {
-                "en": "Visitor",
-                "fr": "Visitor"
-              },
-              {
-                "en": "Other",
-                "fr": "Autre"
-              }
-            ]
-          }
-        },
-        {
-          "id": 6,
-          "type": "checkbox",
-          "properties": {
-            "titleEn":
-              "Will the project or any of its activities involve or benefit people in English or French linguistic minority communities in Canada, in some way?",
-            "titleFr":
-              " Le projet ou les activités connexes impliquent-ils ou s’adressent-ils d’une façon ou d’une autre aux minorités francophones et anglophones du Canada?",
-            "validation": {
-              "required": false
-            },
-            "choices": [
-              {
-                "en": "Yes",
-                "fr": "Oui"
-              },
-              {
-                "en": "No",
-                "fr": "Non"
-              },
-              {
-                "en": "Not Applicable",
-                "fr": "Non applicable"
-              }
-            ]
-          }
-        },
-        {
-          "id": 7,
-          "type": "dynamicRow",
-          "properties": {
-            "titleEn": "",
-            "titleFr": "",
-            "validation": {
-              "required": false
-            },
-            "subElements": [
-              {
-                "id": 22,
-                "type": "textField",
-                "properties": {
-                  "titleEn": "Family name",
-                  "titleFr": "Nom",
-                  "placeholderEn": "",
-                  "placeholderFr": "",
-                  "descriptionEn": "",
-                  "descriptionFr": "",
-
-                  "validation": {
-                    "required": false
-                  }
-                }
-              },
-              {
-                "id": 22,
-                "type": "textField",
-                "properties": {
-                  "titleEn": "Given name",
-                  "titleFr": "Prénom",
-                  "laceholderEn": "",
-                  "placeholderFr": "",
-                  "descriptionEn": "",
-                  "descriptionFr": "",
-                  "validation": {
-                    "required": false
-                  }
-                }
-              },
-              {
-                "id": 22,
-                "type": "textField",
-                "properties": {
-                  "titleEn": "Department or organization",
-                  "titleFr": "Ministère ou organisme",
-                  "placeholderEn": "",
-                  "placeholderFr": "",
-                  "descriptionEn": "",
-                  "descriptionFr": "",
-                  "validation": {
-                    "required": false
-                  }
-                }
-              },
-              {
-                "id": 22,
-                "type": "checkbox",
-                "properties": {
-                  "titleEn":
-                    "Will the project or any of its activities involve or benefit people in English or French linguistic minority communities in Canada, in some way?",
-                  "titleFr":
-                    " Le projet ou les activités connexes impliquent-ils ou s’adressent-ils d’une façon ou d’une autre aux minorités francophones et anglophones du Canada?",
-                  "validation": {
-                    "required": false
-                  },
-                  "choices": [
-                    {
-                      "en": "Yes",
-                      "fr": "Oui"
-                    },
-                    {
-                      "en": "No",
-                      "fr": "Non"
-                    },
-                    {
-                      "en": "Not Applicable",
-                      "fr": "Non applicable"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        {
-          "id": 8,
-          "type": "textField",
-          "properties": {
-            "titleEn": "This Answer is empty?",
-            "titleFr": "Ce reponse est vide?",
-            "placeholderEn": "yuppers",
-            "placeholderFr": "oui",
-            "descriptionEn": "This is a description",
-            "descriptionFr": "Voice une description",
-            "validation": {
-              "required": false
-            }
+  "id": "test0form00000id000asdf11",
+  "form": {
+    "version": 1,
+    "titleEn": "Test Form",
+    "titleFr": "Formulaire de test",
+    "layout": [1, 2, 3, 4, 5, 6, 7, 8],
+    "brand": {
+      "name": "cds-snc",
+      "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
+      "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
+      "logoTitleEn": "Canadian Digital Service",
+      "logoTitleFr": "Service numérique canadien",
+      "urlEn": "https://digital.canada.ca/",
+      "urlFr": "https://numerique.canada.ca/"
+    },
+    "endPage": {
+      "descriptionEn": "",
+      "descriptionFr": "",
+      "referrerUrlEn": "https://digital.canada.ca/",
+      "referrerUrlFr": "https://numerique.canada.ca/"
+    },
+    "elements": [
+      {
+        "id": 1,
+        "type": "textField",
+        "properties": {
+          "titleEn": "What is your full name?",
+          "titleFr": "Quel est votre nom complet?",
+          "placeholderEn": "I wish I knew",
+          "placeholderFr": "Je ne sais pas",
+          "descriptionEn": "This is a description",
+          "descriptionFr": "Voice une description",
+          "validation": {
+            "required": true
           }
         }
-      ]
-    },
-    "submission": {
-      "email": "no-reply@cds-snc.ca"
-    }
+      },
+      {
+        "id": 2,
+        "type": "textArea",
+        "properties": {
+          "titleEn": "What is the problem you are facing",
+          "titleFr": "Quel est le problème auquel vous êtes confronté?",
+          "placeholderEn": "Something difficult",
+          "placeholderFr": "Quelque chose difficile",
+          "descriptionEn": "Here be a description",
+          "descriptionFr": "Pour décrire, ou pas décire..",
+          "validation": {
+            "required": true
+          }
+        }
+      },
+      {
+        "id": 3,
+        "type": "richText",
+        "properties": {
+          "titleEn": "",
+          "titleFr": "",
+          "descriptionEn": "Thank you so much for your interest in the Canadian Digital Service’s Forms product. <br/><br/> Please provide your information below so CDS can contact you about improving, updating, or digitizing a form.",
+          "descriptionFr": "Merci beaucoup de l’intérêt que vous portez au produit de Formulaire du Service Numérique Canadien. <br/><br/> Veuillez fournir vos renseignements ci-dessous afin que le SNC puisse vous contacter pour discuter davantage l'amélioration, la mise à jour ou la numérisation d'un formulaire.",
+          "validation": {
+            "required": false
+          }
+        }
+      },
+      {
+        "id": 4,
+        "type": "dropdown",
+        "properties": {
+          "titleEn": "Province or territory",
+          "titleFr": "Province ou territoire",
+          "placeholderEn": "",
+          "placeholderFr": "",
+          "descriptionEn": "",
+          "descriptionFr": "",
+          "choices": [
+            {
+              "en": "",
+              "fr": ""
+            },
+            {
+              "en": "Alberta",
+              "fr": "Alberta"
+            },
+            {
+              "en": "British Columbia",
+              "fr": "Colombie-Britannique"
+            },
+            {
+              "en": "Manitoba",
+              "fr": "Manitoba"
+            },
+            {
+              "en": "New Brunswick",
+              "fr": "Nouveau-Brunswick"
+            },
+            {
+              "en": "Newfoundland and Labrador",
+              "fr": "Terre-Neuve-et-Labrador"
+            },
+            {
+              "en": "Northwest Territories",
+              "fr": "Territoires du Nord-Ouest"
+            },
+            {
+              "en": "Nova Scotia",
+              "fr": "Nouvelle-Écosse"
+            },
+            {
+              "en": "Nunavut",
+              "fr": "Nunavut"
+            },
+            {
+              "en": "Ontario",
+              "fr": "Ontario"
+            },
+            {
+              "en": "Prince Edward Island",
+              "fr": "Île-du-Prince-Édouard"
+            },
+            {
+              "en": "Quebec",
+              "fr": "Québec"
+            },
+            {
+              "en": "Saskatchewan",
+              "fr": "Saskatchewan"
+            },
+            {
+              "en": "Yukon",
+              "fr": "Yukon"
+            }
+          ],
+          "validation": {
+            "required": false
+          }
+        }
+      },
+      {
+        "id": 5,
+        "type": "radio",
+        "properties": {
+          "titleEn": "Status",
+          "titleFr": "Statut",
+          "description": "",
+          "validation": {
+            "required": false
+          },
+          "choices": [
+            {
+              "en": "Citizen",
+              "fr": "Cityoen"
+            },
+            {
+              "en": "Permanent Resident",
+              "fr": "Permanent Resident"
+            },
+            {
+              "en": "Student",
+              "fr": "Student"
+            },
+            {
+              "en": "Visitor",
+              "fr": "Visitor"
+            },
+            {
+              "en": "Other",
+              "fr": "Autre"
+            }
+          ]
+        }
+      },
+      {
+        "id": 6,
+        "type": "checkbox",
+        "properties": {
+          "titleEn": "Will the project or any of its activities involve or benefit people in English or French linguistic minority communities in Canada, in some way?",
+          "titleFr": " Le projet ou les activités connexes impliquent-ils ou s’adressent-ils d’une façon ou d’une autre aux minorités francophones et anglophones du Canada?",
+          "validation": {
+            "required": false
+          },
+          "choices": [
+            {
+              "en": "Yes",
+              "fr": "Oui"
+            },
+            {
+              "en": "No",
+              "fr": "Non"
+            },
+            {
+              "en": "Not Applicable",
+              "fr": "Non applicable"
+            }
+          ]
+        }
+      },
+      {
+        "id": 7,
+        "type": "dynamicRow",
+        "properties": {
+          "titleEn": "",
+          "titleFr": "",
+          "validation": {
+            "required": false
+          },
+          "subElements": [
+            {
+              "id": 22,
+              "type": "textField",
+              "properties": {
+                "titleEn": "Family name",
+                "titleFr": "Nom",
+                "placeholderEn": "",
+                "placeholderFr": "",
+                "descriptionEn": "",
+                "descriptionFr": "",
+
+                "validation": {
+                  "required": false
+                }
+              }
+            },
+            {
+              "id": 22,
+              "type": "textField",
+              "properties": {
+                "titleEn": "Given name",
+                "titleFr": "Prénom",
+                "laceholderEn": "",
+                "placeholderFr": "",
+                "descriptionEn": "",
+                "descriptionFr": "",
+                "validation": {
+                  "required": false
+                }
+              }
+            },
+            {
+              "id": 22,
+              "type": "textField",
+              "properties": {
+                "titleEn": "Department or organization",
+                "titleFr": "Ministère ou organisme",
+                "placeholderEn": "",
+                "placeholderFr": "",
+                "descriptionEn": "",
+                "descriptionFr": "",
+                "validation": {
+                  "required": false
+                }
+              }
+            },
+            {
+              "id": 22,
+              "type": "checkbox",
+              "properties": {
+                "titleEn": "Will the project or any of its activities involve or benefit people in English or French linguistic minority communities in Canada, in some way?",
+                "titleFr": " Le projet ou les activités connexes impliquent-ils ou s’adressent-ils d’une façon ou d’une autre aux minorités francophones et anglophones du Canada?",
+                "validation": {
+                  "required": false
+                },
+                "choices": [
+                  {
+                    "en": "Yes",
+                    "fr": "Oui"
+                  },
+                  {
+                    "en": "No",
+                    "fr": "Non"
+                  },
+                  {
+                    "en": "Not Applicable",
+                    "fr": "Non applicable"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": 8,
+        "type": "textField",
+        "properties": {
+          "titleEn": "This Answer is empty?",
+          "titleFr": "Ce reponse est vide?",
+          "placeholderEn": "yuppers",
+          "placeholderFr": "oui",
+          "descriptionEn": "This is a description",
+          "descriptionFr": "Voice une description",
+          "validation": {
+            "required": false
+          }
+        }
+      }
+    ]
+  },
+  "submission": {
+    "email": "no-reply@cds-snc.ca"
   }
 }

--- a/__tests__/id/[form]/settings.test.js
+++ b/__tests__/id/[form]/settings.test.js
@@ -40,8 +40,8 @@ jest.mock("next-i18next", () => ({
 describe("Form Settings Page", () => {
   afterEach(cleanup);
   const form = {
-    formID: "test0form00000id000asdf11",
-    formConfig: validFormTemplate,
+    id: "test0form00000id000asdf11",
+    ...validFormTemplate,
   };
   test("renders without errors", () => {
     useRouter.mockImplementation(() => ({

--- a/components/admin/FormAccess/FormAccess.test.js
+++ b/components/admin/FormAccess/FormAccess.test.js
@@ -8,7 +8,7 @@ import FormAccess from "./FormAccess";
 jest.mock("axios");
 
 describe("Form Access Component", () => {
-  const formConfig = { formID: "test0form00000id000asdf11" };
+  const formConfig = { id: "test0form00000id000asdf11" };
 
   afterEach(cleanup);
 
@@ -24,10 +24,10 @@ describe("Form Access Component", () => {
       ],
     });
 
-    render(<FormAccess formID={formConfig.formID}></FormAccess>);
+    render(<FormAccess formID={formConfig.id}></FormAccess>);
     expect(mockedAxios.mock.calls.length).toBe(1);
     expect(mockedAxios).toHaveBeenCalledWith(
-      expect.objectContaining({ url: `/api/id/${formConfig.formID}/owners`, method: "GET" })
+      expect.objectContaining({ url: `/api/id/${formConfig.id}/owners`, method: "GET" })
     );
     expect(await screen.findByTestId("add-email")).toBeInTheDocument();
   });
@@ -46,7 +46,7 @@ describe("Form Access Component", () => {
       ],
     });
 
-    render(<FormAccess formID={formConfig.formID}></FormAccess>);
+    render(<FormAccess formID={formConfig.id}></FormAccess>);
 
     const input = await screen.findByLabelText("settings.formAccess.addEmailAriaLabel");
 
@@ -89,7 +89,7 @@ describe("Form Access Component", () => {
         data: { error: "The formID does not exist" },
       });
 
-    render(<FormAccess formID={formConfig.formID}></FormAccess>);
+    render(<FormAccess formID={formConfig.id}></FormAccess>);
 
     const input = await screen.findByLabelText("settings.formAccess.addEmailAriaLabel");
     await user.type(input, testEmailAddress);
@@ -119,7 +119,7 @@ describe("Form Access Component", () => {
         data: { error: "The email is not a valid GC email" },
       });
 
-    render(<FormAccess formID={formConfig.formID}></FormAccess>);
+    render(<FormAccess formID={formConfig.id}></FormAccess>);
 
     const input = await screen.findByLabelText("settings.formAccess.addEmailAriaLabel");
     await user.type(input, testEmailAddress);

--- a/components/admin/JsonUpload/JsonUpload.stories.tsx
+++ b/components/admin/JsonUpload/JsonUpload.stories.tsx
@@ -10,29 +10,27 @@ export default {
 export const defaultJSONUpload = (): React.ReactElement => <JSONUpload></JSONUpload>;
 
 const testForm = {
-  formID: "test0form00000id000asdf11",
-  formConfig: {
-    publishingStatus: true,
-    securityAttribute: "Unclassified",
-    submission: {
-      email: "test@test.com",
-    },
-    form: {
-      version: "1",
-      titleEn: "Test JSON!",
-      titleFr: "Test JSON!",
-      layout: [1],
-      elements: [
-        {
-          id: 1,
-          type: FormElementTypes.textField,
-          properties: {
-            titleEn: "test Element!",
-            titleFr: "test Element!",
-          },
+  id: "test0form00000id000asdf11",
+  publishingStatus: true,
+  securityAttribute: "Unclassified",
+  submission: {
+    email: "test@test.com",
+  },
+  form: {
+    version: "1",
+    titleEn: "Test JSON!",
+    titleFr: "Test JSON!",
+    layout: [1],
+    elements: [
+      {
+        id: 1,
+        type: FormElementTypes.textField,
+        properties: {
+          titleEn: "test Element!",
+          titleFr: "test Element!",
         },
-      ],
-    },
+      },
+    ],
   },
 };
 

--- a/components/admin/JsonUpload/JsonUpload.test.js
+++ b/components/admin/JsonUpload/JsonUpload.test.js
@@ -19,15 +19,14 @@ describe("JSON Upload Component", () => {
   });
   it("renders existing form JSON if passed in", async () => {
     const form = {
-      formConfig: formConfig,
+      id: "test",
+      ...formConfig,
     };
     render(<JSONUpload form={form}></JSONUpload>);
     expect(screen.queryByTestId("jsonInput").value).toBe(JSON.stringify(formConfig, null, 2));
   });
   it("Shows an error message if unparseable JSON is entered", async () => {
-    const form = {
-      formConfig: undefined,
-    };
+    const form = {};
     render(<JSONUpload form={form}></JSONUpload>);
     fireEvent.click(screen.queryByTestId("upload"));
     expect(mockedAxios.mock.calls.length).toBe(0);
@@ -35,7 +34,8 @@ describe("JSON Upload Component", () => {
   });
   it("Shows a submit status message if successfully submitted to API", async () => {
     const form = {
-      formConfig: formConfig,
+      id: "test",
+      ...formConfig,
     };
     mockedAxios.mockResolvedValue();
 
@@ -43,7 +43,7 @@ describe("JSON Upload Component", () => {
     fireEvent.click(screen.queryByTestId("upload"));
     expect(mockedAxios.mock.calls.length).toBe(1);
     expect(mockedAxios).toHaveBeenCalledWith(
-      expect.objectContaining({ url: "/api/templates", method: "POST" })
+      expect.objectContaining({ url: "/api/templates", method: "PUT" })
     );
     expect(await screen.findByTestId("submitStatus")).toBeInTheDocument();
   });

--- a/components/admin/JsonUpload/JsonUpload.tsx
+++ b/components/admin/JsonUpload/JsonUpload.tsx
@@ -14,13 +14,13 @@ interface JSONUploadProps {
 export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
   const { t, i18n } = useTranslation("admin-templates");
   const { form } = props;
-
-  const [jsonConfig, setJsonConfig] = useState(form ? JSON.stringify(form.formConfig) : "");
+  const { id: formID, ...formConfig } = form || { id: undefined };
+  const [jsonConfig, setJsonConfig] = useState(formID ? JSON.stringify(formConfig, null, 2) : "");
   const [submitStatus, setSubmitStatus] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [errorState, setErrorState] = useState({ message: "" });
-  const { refreshData, isRefreshing } = useRefresh([form]);
-  const formID = form?.formID;
+  const { refreshData, isRefreshing } = useRefresh([formConfig]);
+
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -43,7 +43,7 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
       // Redirect to the appropriate page
 
       if (response?.config.method === "post" && response?.data) {
-        const formID = response.data.formID;
+        const formID = response.data.id;
         router.push({
           pathname: `/${i18n.language}/id/${formID}/settings`,
           query: {
@@ -114,7 +114,7 @@ export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
                 name="jsonInput"
                 className="gc-textarea full-height font-mono"
                 data-testid="jsonInput"
-                defaultValue={form ? JSON.stringify(form.formConfig, null, 2) : ""}
+                defaultValue={jsonConfig}
                 onChange={(e) => {
                   setJsonConfig(e.currentTarget.value);
                 }}

--- a/components/admin/TemplateDelete/Settings.tsx
+++ b/components/admin/TemplateDelete/Settings.tsx
@@ -41,7 +41,7 @@ const handleDelete = async (formID: string) => {
 };
 
 const FormSettings = (props: FormSettingsProps): React.ReactElement => {
-  const { form } = props;
+  const { form: formRecord } = props;
   const router = useRouter();
   const { t, i18n } = useTranslation("admin-templates");
   const language = i18n.language as string;
@@ -56,9 +56,9 @@ const FormSettings = (props: FormSettingsProps): React.ReactElement => {
     <>
       <h1>{t("settings.title")}</h1>
       <div data-testid="formID" className="mb-4">
-        <b>Form Title:</b> {form.formConfig.form[getProperty("title", language)] as string}
+        <b>Form Title:</b> {formRecord.form[getProperty("title", language)] as string}
         <br />
-        <b>Form ID:</b> {form.formID}
+        <b>Form ID:</b> {formRecord.id}
       </div>
       <Tabs>
         <TabList>
@@ -70,21 +70,21 @@ const FormSettings = (props: FormSettingsProps): React.ReactElement => {
         <TabPanel>
           <div>{newText}</div>
           <Label htmlFor="jsonInput">{t("settings.edit")}</Label>
-          <JSONUpload form={form} />
+          <JSONUpload form={formRecord} />
           <br />
           <div>
             <DeleteButton
               action={handleDelete}
-              data={form.formID}
+              data={formRecord.id}
               redirect={`/admin/view-templates`}
             />
           </div>
         </TabPanel>
         <TabPanel>
-          <BearerRefresh formID={form.formID} />
+          <BearerRefresh formID={formRecord.id} />
         </TabPanel>
         <TabPanel>
-          <FormAccess formID={form.formID} />
+          <FormAccess formID={formRecord.id} />
         </TabPanel>
       </Tabs>
     </>

--- a/components/form-builder/layout/Preview.tsx
+++ b/components/form-builder/layout/Preview.tsx
@@ -10,8 +10,8 @@ export const Preview = () => {
   const stringified = getSchema();
 
   const formRecord = {
-    formID: "test0form00000id000asdf11",
-    formConfig: JSON.parse(stringified),
+    id: "test0form00000id000asdf11",
+    ...JSON.parse(stringified),
   };
   const router = useRouter();
   const { t, i18n } = useTranslation();

--- a/components/form-builder/preview/Form.tsx
+++ b/components/form-builder/preview/Form.tsx
@@ -45,10 +45,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
     children,
     handleSubmit,
     isSubmitting,
-    formRecord: {
-      formID,
-      formConfig: { reCaptchaID, form },
-    },
+    formRecord: { id: formID, reCaptchaID, form },
   }: InnerFormProps = props;
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(-1);
@@ -326,8 +323,8 @@ export const Form = withFormik<FormProps, Responses>({
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         event: "form_submission_trigger",
-        formID: formikBag.props.formRecord.formID,
-        formTitle: formikBag.props.formRecord.formConfig.form.titleEn,
+        formID: formikBag.props.formRecord.id,
+        formTitle: formikBag.props.formRecord.form.titleEn,
       });
 
       formikBag.setSubmitting(false);

--- a/components/forms/DynamicRow/DynamicRow.test.js
+++ b/components/forms/DynamicRow/DynamicRow.test.js
@@ -64,16 +64,14 @@ const dynamicRowData = {
 };
 
 const formRecord = {
-  formID: "test0form00000id000asdf11",
-  formConfig: {
-    form: {
-      id: 1,
-      version: 1,
-      titleEn: "Test Form",
-      titleFr: "Formulaire de test",
-      layout: [1],
-      elements: [dynamicRowData],
-    },
+  id: "test0form00000id000asdf11",
+  form: {
+    id: 1,
+    version: 1,
+    titleEn: "Test Form",
+    titleFr: "Formulaire de test",
+    layout: [1],
+    elements: [dynamicRowData],
   },
 };
 

--- a/components/forms/Form/Form.test.js
+++ b/components/forms/Form/Form.test.js
@@ -51,44 +51,42 @@ jest.mock("@lib/hooks", () => {
 });
 
 const formRecord = {
-  formConfig: {
-    form: {
-      id: 1,
-      version: 1,
-      titleEn: "Test Form",
-      titleFr: "Formulaire de test",
-      layout: [1, 2],
-      elements: [
-        {
-          id: 1,
-          type: "textField",
-          properties: {
-            titleEn: "What is your full name?",
-            titleFr: "Quel est votre nom complet?",
-            validation: {
-              required: false,
-            },
-            description: "",
-            placeholderEn: "",
-            placeholderFr: "",
+  form: {
+    id: 1,
+    version: 1,
+    titleEn: "Test Form",
+    titleFr: "Formulaire de test",
+    layout: [1, 2],
+    elements: [
+      {
+        id: 1,
+        type: "textField",
+        properties: {
+          titleEn: "What is your full name?",
+          titleFr: "Quel est votre nom complet?",
+          validation: {
+            required: false,
           },
+          description: "",
+          placeholderEn: "",
+          placeholderFr: "",
         },
-        {
-          id: 2,
-          type: "textField",
-          properties: {
-            titleEn: "What is your email address?",
-            titleFr: "Quelle est votre adresse électronique?",
-            validation: {
-              required: false,
-            },
-            description: "",
-            placeholderEn: "",
-            placeholderFr: "",
+      },
+      {
+        id: 2,
+        type: "textField",
+        properties: {
+          titleEn: "What is your email address?",
+          titleFr: "Quelle est votre adresse électronique?",
+          validation: {
+            required: false,
           },
+          description: "",
+          placeholderEn: "",
+          placeholderFr: "",
         },
-      ],
-    },
+      },
+    ],
   },
 };
 

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -24,10 +24,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
     children,
     handleSubmit,
     isSubmitting,
-    formRecord: {
-      formID,
-      formConfig: { reCaptchaID, form },
-    },
+    formRecord: { id: formID, reCaptchaID, form },
   }: InnerFormProps = props;
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(-1);
@@ -256,8 +253,8 @@ export const Form = withFormik<FormProps, Responses>({
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         event: "form_submission_trigger",
-        formID: formikBag.props.formRecord.formID,
-        formTitle: formikBag.props.formRecord.formConfig.form.titleEn,
+        formID: formikBag.props.formRecord.id,
+        formTitle: formikBag.props.formRecord.form.titleEn,
       });
 
       formikBag.setSubmitting(false);

--- a/components/forms/TextPage/TextPage.tsx
+++ b/components/forms/TextPage/TextPage.tsx
@@ -42,9 +42,7 @@ export const TextPage = (props: TextPageProps): React.ReactElement => {
   const { i18n } = useTranslation("confirmation");
   const {
     formRecord: {
-      formConfig: {
-        form: { endPage },
-      },
+      form: { endPage },
     },
   } = props;
   const language = i18n.language as string;

--- a/components/globals/Base.js
+++ b/components/globals/Base.js
@@ -17,7 +17,7 @@ const Base = ({ children }) => {
   const isAdmin = children?.props?.user?.role === UserRole.ADMINISTRATOR;
   const isEmbeddable = formRecord && children?.props?.isEmbeddable;
 
-  const shouldDisplayAlphaBanner = formRecord?.formConfig.displayAlphaBanner ?? true;
+  const shouldDisplayAlphaBanner = formRecord?.displayAlphaBanner ?? true;
   const { t } = useTranslation("common");
 
   return (
@@ -40,11 +40,7 @@ const Base = ({ children }) => {
         )}
         <main id="content">{children}</main>
         {!isEmbeddable && (
-          <Footer
-            disableGcBranding={
-              children.props.formRecord?.formConfig?.form?.brand?.disableGcBranding
-            }
-          />
+          <Footer disableGcBranding={children.props.formRecord?.form?.brand?.disableGcBranding} />
         )}
       </div>
     </>

--- a/components/globals/Base.test.js
+++ b/components/globals/Base.test.js
@@ -9,17 +9,15 @@ describe("Generate the Base structure of a page", () => {
 
   test("Alpha banner should be displayed if form property is set to true", () => {
     const formRecordTest = {
-      formConfig: {
-        form: {
-          id: 1,
-          version: 1,
-          titleEn: "Test Form",
-          titleFr: "Formulaire de test",
-          layout: [1, 2],
-          elements: [],
-        },
-        displayAlphaBanner: true,
+      form: {
+        id: 1,
+        version: 1,
+        titleEn: "Test Form",
+        titleFr: "Formulaire de test",
+        layout: [1, 2],
+        elements: [],
       },
+      displayAlphaBanner: true,
     };
 
     render(
@@ -35,17 +33,15 @@ describe("Generate the Base structure of a page", () => {
 
   test("Alpha banner should be hidden if form property is set to false", () => {
     const formRecordTest = {
-      formConfig: {
-        form: {
-          id: 1,
-          version: 1,
-          titleEn: "Test Form",
-          titleFr: "Formulaire de test",
-          layout: [1, 2],
-          elements: [],
-        },
-        displayAlphaBanner: false,
+      form: {
+        id: 1,
+        version: 1,
+        titleEn: "Test Form",
+        titleFr: "Formulaire de test",
+        layout: [1, 2],
+        elements: [],
       },
+      displayAlphaBanner: false,
     };
     render(
       <SessionProvider session={null}>

--- a/components/globals/Fip.js
+++ b/components/globals/Fip.js
@@ -11,9 +11,7 @@ const Fip = (props) => {
   const { t, i18n } = useTranslation("common");
 
   // Check if custom branding was provided, otherwise show the Government of Canada branding
-  const formTheme = props.formRecord?.formConfig?.form
-    ? props.formRecord.formConfig.form.brand
-    : null;
+  const formTheme = props.formRecord?.form ? props.formRecord.form.brand : null;
 
   const logo =
     formTheme && formTheme[getProperty("logo", i18n.language)]

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,11 +34,9 @@ Cypress.Commands.add("mockForm", (file) => {
           set(serverSideProps) {
             // here is our change to modify the injected parsed data
             serverSideProps.props.pageProps.formRecord = {
-              formID: "test0form00000id000asdf11",
-              formConfig: {
-                securityAttribute: mockedForm.securityAttribute,
-                form: mockedForm.form,
-              },
+              id: "test0form00000id000asdf11",
+              securityAttribute: mockedForm.securityAttribute,
+              form: mockedForm.form,
             };
             nextData = serverSideProps;
           },
@@ -56,8 +54,8 @@ Cypress.Commands.add("mockForm", (file) => {
       return req.continue((res) => {
         // let's use the same test greeting
         res.body.pageProps.formRecord = {
-          formID: "test0form00000id000asdf11",
-          formConfig: { form: mockedForm.form },
+          id: "test0form00000id000asdf11",
+          form: mockedForm.form,
         };
       });
     });

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -258,18 +258,16 @@ function _buildForm(element: FormElement, lang: string, t: TFunction): ReactElem
  * @param language
  */
 const _getRenderedForm = (formRecord: PublicFormRecord, language: string, t: TFunction) => {
-  if (!formRecord?.formConfig) {
+  if (!formRecord?.form) {
     return null;
   }
 
-  return formRecord.formConfig.form.layout.map((item: number) => {
-    const element = formRecord.formConfig.form.elements.find(
-      (element: FormElement) => element.id === item
-    );
+  return formRecord.form.layout.map((item: number) => {
+    const element = formRecord.form.elements.find((element: FormElement) => element.id === item);
     if (element) {
       return <GenerateElement key={element.id} element={element} language={language} t={t} />;
     } else {
-      logMessage.error(`Failed component ID look up ${item} on form ID ${formRecord.formID}`);
+      logMessage.error(`Failed component ID look up ${item} on form ID ${formRecord.id}`);
     }
   });
 };
@@ -314,13 +312,13 @@ const _getElementInitialValue = (element: FormElement, language: string): Respon
  * @param language
  */
 const _getFormInitialValues = (formRecord: PublicFormRecord, language: string): Responses => {
-  if (!formRecord?.formConfig) {
+  if (!formRecord?.form) {
     return {};
   }
 
   const initialValues: Responses = {};
 
-  formRecord.formConfig.form.elements
+  formRecord.form.elements
     .filter((element) => ![FormElementTypes.richText].includes(element.type))
     .forEach((element: FormElement) => {
       initialValues[element.id] = _getElementInitialValue(element, language);

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -4,7 +4,7 @@ import { extractFormData } from "./helpers";
 import { Submission } from "@lib/types";
 
 export default logger((formResponse: Submission): string => {
-  const formResponseFormObject = formResponse.form.formConfig.form;
+  const formResponseFormObject = formResponse.form.form;
   const subjectEn = formResponseFormObject.emailSubjectEn
     ? formResponseFormObject.emailSubjectEn
     : formResponseFormObject.titleEn;

--- a/lib/middleware/jsonIDValidator.ts
+++ b/lib/middleware/jsonIDValidator.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { MiddlewareRequest, MiddlewareReturn } from "@lib/types";
-import { FormConfiguration, FormElement, FormElementTypes } from "@lib/types/form-types";
+import { BetterOmit, MiddlewareRequest, MiddlewareReturn } from "@lib/types";
+import { FormElement, FormElementTypes, FormRecord } from "@lib/types/form-types";
 
 export type ValidateOptions = {
   jsonKey: string;
@@ -17,7 +17,9 @@ export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest 
       if (req.method !== "POST" && req.method !== "PUT") {
         return { next: true };
       }
-      const jsonConfig: FormConfiguration = options?.jsonKey ? req.body[options.jsonKey] : req.body;
+      const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
+        ? req.body[options.jsonKey]
+        : req.body;
       const elementIDs: Array<number> = jsonConfig.form.elements.map((element) => {
         return element.id;
       });
@@ -50,7 +52,9 @@ export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest 
       if (req.method !== "POST" && req.method !== "PUT") {
         return { next: true };
       }
-      const jsonConfig: FormConfiguration = options?.jsonKey ? req.body[options.jsonKey] : req.body;
+      const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
+        ? req.body[options.jsonKey]
+        : req.body;
       const elementIDs: Array<number> = jsonConfig.form.elements.map((element) => {
         return element.id;
       });
@@ -83,7 +87,9 @@ export const subElementsIDValidator = (options?: ValidateOptions): MiddlewareReq
       if (req.method !== "POST" && req.method !== "PUT") {
         return { next: true };
       }
-      const jsonConfig: FormConfiguration = options?.jsonKey ? req.body[options.jsonKey] : req.body;
+      const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
+        ? req.body[options.jsonKey]
+        : req.body;
 
       const dynamicRowElements: Array<FormElement> = jsonConfig.form.elements.filter((element) => {
         return element.type === FormElementTypes.dynamicRow;

--- a/lib/routeUtils.ts
+++ b/lib/routeUtils.ts
@@ -4,9 +4,7 @@ import { PublicFormRecord } from "@lib/types";
 
 export const getPageClassNames = (formRecord: PublicFormRecord): string => {
   const pageNameUrl = getPageNameUrl();
-  const brandName = formRecord?.formConfig?.form?.brand
-    ? formRecord.formConfig.form.brand.name
-    : "";
+  const brandName = formRecord?.form?.brand ? formRecord.form.brand.name : "";
   return classnames("outer-container", `page${pageNameUrl.replace(/\//g, "-")}`, brandName);
 };
 

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,9 +1,8 @@
 import { logger } from "@lib/logger";
 import { formCache } from "./formCache";
 import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
-import { PublicFormRecord, SubmissionProperties, FormRecord } from "@lib/types";
+import { PublicFormRecord, SubmissionProperties, FormRecord, BetterOmit } from "@lib/types";
 import { Prisma } from "@prisma/client";
-import { FormConfiguration } from "./types/form-types";
 import jwt, { Secret } from "jsonwebtoken";
 
 // Get the submission format by using the form ID
@@ -19,7 +18,7 @@ async function _getSubmissionTypeByID(formID: string): Promise<SubmissionPropert
       },
     });
     if (template?.jsonConfig) {
-      return (template.jsonConfig as Prisma.JsonObject as FormConfiguration).submission;
+      return (template.jsonConfig as Prisma.JsonObject as FormRecord).submission;
     }
 
     return null;
@@ -42,8 +41,7 @@ async function _getTemplateByStatus(status: boolean): Promise<(PublicFormRecord 
     const sanitizedResponse = templates.map((template) => onlyIncludePublicProperties(template));
     if (sanitizedResponse && sanitizedResponse?.length > 0) {
       return sanitizedResponse.filter(
-        (val) =>
-          typeof val !== "undefined" && val !== null && val.formConfig.publishingStatus === status
+        (val) => typeof val !== "undefined" && val !== null && val.publishingStatus === status
       );
     }
     return [];
@@ -58,7 +56,7 @@ async function _getTemplateByStatus(status: boolean): Promise<(PublicFormRecord 
  * @returns Form Record or null if creation was not sucessfull.
  */
 
-async function _createTemplate(config: FormConfiguration): Promise<FormRecord | null> {
+async function _createTemplate(config: BetterOmit<FormRecord, "id">): Promise<FormRecord | null> {
   try {
     const createdTemplate = _parseTemplate(
       await prisma.template.create({
@@ -70,7 +68,7 @@ async function _createTemplate(config: FormConfiguration): Promise<FormRecord | 
 
     const bearerToken = jwt.sign(
       {
-        formID: createdTemplate.formID,
+        formID: createdTemplate.id,
       },
       process.env.TOKEN_SECRET as Secret,
       {
@@ -80,7 +78,7 @@ async function _createTemplate(config: FormConfiguration): Promise<FormRecord | 
     return _parseTemplate(
       await prisma.template.update({
         where: {
-          id: createdTemplate.formID,
+          id: createdTemplate.id,
         },
         data: {
           bearerToken,
@@ -103,7 +101,7 @@ async function _createTemplate(config: FormConfiguration): Promise<FormRecord | 
  */
 async function _updateTemplate(
   formID: string,
-  formConfig: FormConfiguration
+  formConfig: BetterOmit<FormRecord, "id" | "bearerToken">
 ): Promise<FormRecord | null> {
   try {
     const updatedTempate = await prisma.template.update({
@@ -213,30 +211,30 @@ async function _getTemplateByID(formID: string): Promise<FormRecord | null> {
  */
 const _onlyIncludePublicProperties = (template: FormRecord): PublicFormRecord => {
   return {
-    formID: template.formID,
-    formConfig: {
-      publishingStatus: template.formConfig.publishingStatus,
-      displayAlphaBanner: template.formConfig.displayAlphaBanner ?? true,
-      securityAttribute: template.formConfig.securityAttribute ?? "Unclassified",
-      ...(process.env.RECAPTCHA_V3_SITE_KEY && {
-        reCaptchaID: process.env.RECAPTCHA_V3_SITE_KEY,
-      }),
-      form: template.formConfig.form,
-    },
+    id: template.id,
+
+    publishingStatus: template.publishingStatus,
+    displayAlphaBanner: template.displayAlphaBanner ?? true,
+    securityAttribute: template.securityAttribute ?? "Unclassified",
+    ...(process.env.RECAPTCHA_V3_SITE_KEY && {
+      reCaptchaID: process.env.RECAPTCHA_V3_SITE_KEY,
+    }),
+    form: template.form,
   };
 };
 
 const _parseTemplate = (template: { id: string; jsonConfig: Prisma.JsonValue }): FormRecord => {
   return {
-    formID: template.id,
+    id: template.id,
     // Converting to unknown first as Prisma is not aware of what is stored
     // in the JSON Object type, only that it is an object.
-    formConfig: {
-      ...(template.jsonConfig as unknown as FormConfiguration),
-      ...(process.env.RECAPTCHA_V3_SITE_KEY && {
-        reCaptchaID: process.env.RECAPTCHA_V3_SITE_KEY,
-      }),
-    },
+    ...(template.jsonConfig as unknown as BetterOmit<
+      FormRecord,
+      "id" | "reCaptchaID" | "bearerToken"
+    >),
+    ...(process.env.RECAPTCHA_V3_SITE_KEY && {
+      reCaptchaID: process.env.RECAPTCHA_V3_SITE_KEY,
+    }),
   };
 };
 

--- a/lib/tests/helpers.test.js
+++ b/lib/tests/helpers.test.js
@@ -51,7 +51,7 @@ describe("Extract Form data", () => {
       iterateResponseArray(formResponses, value);
       iterateResponseArray(
         formResponses,
-        TestForm.formConfig.form.elements.filter((q) => {
+        TestForm.form.elements.filter((q) => {
           q.id === key ? q.properties.titleEn : false;
         })
       );
@@ -163,7 +163,7 @@ describe("Submit and Template helpers", () => {
       data: {
         data: [
           {
-            formID: "test0form00000id000asdf11",
+            id: "test0form00000id000asdf11",
             elements: { test: "test" },
             publishingStatus: true,
             securityAttribute: "Unclassified",
@@ -176,7 +176,7 @@ describe("Submit and Template helpers", () => {
     expect(mockedAxios).toHaveBeenCalledWith(
       expect.objectContaining({ url: "/api/templates", method: "GET" })
     );
-    expect(form.formID).toEqual("test0form00000id000asdf11");
+    expect(form.id).toEqual("test0form00000id000asdf11");
     expect(form.publishingStatus).toBe(true);
     expect(form.securityAttribute).toEqual("Unclassified");
   });

--- a/lib/tests/markdown.test.js
+++ b/lib/tests/markdown.test.js
@@ -8,11 +8,9 @@ jest.mock("../helpers", () => ({
 describe("JSON to markdown", () => {
   const mockForm = {
     form: {
-      formConfig: {
-        form: {
-          titleEn: "I'm a title",
-          titleFr: "Je suis une titre",
-        },
+      form: {
+        titleEn: "I'm a title",
+        titleFr: "Je suis une titre",
       },
     },
     responses: {},
@@ -29,24 +27,20 @@ describe("JSON to markdown", () => {
 describe("Custom email subject - JSON to markdown", () => {
   const mockForm = {
     form: {
-      formConfig: {
-        form: {
-          titleEn: "I'm a title",
-          titleFr: "Je suis une titre",
-          emailSubjectEn: "I'm an email subject title",
-          emailSubjectFr: "Je suis une couriel sujet titre",
-        },
+      form: {
+        titleEn: "I'm a title",
+        titleFr: "Je suis une titre",
+        emailSubjectEn: "I'm an email subject title",
+        emailSubjectFr: "Je suis une couriel sujet titre",
       },
     },
     responses: {},
   };
   test("Renders email subject", () => {
     const response = markdown(mockForm);
-    expect(response).toEqual(
-      expect.stringContaining("# I'm an email subject title / Je suis une couriel sujet titre")
-    );
-    expect(response).toEqual(expect.stringContaining("one"));
-    expect(response).toEqual(expect.stringContaining("two"));
-    expect(response).toEqual(expect.stringContaining("three"));
+    expect(response).toMatch(/# I'm an email subject title \/ Je suis une couriel sujet titre/);
+    expect(response).toMatch(/one/);
+    expect(response).toMatch(/two/);
+    expect(response).toMatch(/three/);
   });
 });

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -10,7 +10,8 @@ import {
   getSubmissionTypeByID,
   onlyIncludePublicProperties,
 } from "../templates";
-import { FormConfiguration, FormRecord } from "@lib/types/form-types";
+
+import { BetterOmit, FormRecord } from "@lib/types";
 import formConfiguration from "@jestFixtures/cdsIntakeTestForm.json";
 
 // structuredClone is available starting in Node 17.
@@ -41,7 +42,9 @@ describe("Template CRUD functions", () => {
       jsonConfig: formConfiguration,
     });
 
-    const newTemplate = await createTemplate(formConfiguration as FormConfiguration);
+    const newTemplate = await createTemplate(
+      formConfiguration as BetterOmit<FormRecord, "id" | "bearerToken">
+    );
 
     expect(prismaMock.template.create).toHaveBeenCalledWith({
       data: {
@@ -50,8 +53,8 @@ describe("Template CRUD functions", () => {
     });
 
     expect(newTemplate).toEqual({
-      formID: "formtestID",
-      formConfig: formConfiguration,
+      id: "formtestID",
+      ...formConfiguration,
     });
   });
   test("Get a single Template", async () => {
@@ -73,8 +76,8 @@ describe("Template CRUD functions", () => {
     });
 
     expect(template).toEqual({
-      formID: "formtestID",
-      formConfig: formConfiguration,
+      id: "formtestID",
+      ...formConfiguration,
     });
   });
   test("Null returned when Template does not Exist", async () => {
@@ -98,12 +101,12 @@ describe("Template CRUD functions", () => {
     const templates = await getAllTemplates();
     expect(templates).toEqual([
       {
-        formID: "formtestID",
-        formConfig: formConfiguration,
+        id: "formtestID",
+        ...formConfiguration,
       },
       {
-        formID: "formtestID2",
-        formConfig: formConfiguration,
+        id: "formtestID2",
+        ...formConfiguration,
       },
     ]);
   });
@@ -114,7 +117,9 @@ describe("Template CRUD functions", () => {
     expect(template).toEqual([]);
   });
   test("Update Template", async () => {
-    const updatedFormConfig = structuredClone(formConfiguration as FormConfiguration);
+    const updatedFormConfig = structuredClone(
+      formConfiguration as BetterOmit<FormRecord, "id" | "bearerToken">
+    );
     updatedFormConfig.publishingStatus = true;
     (prismaMock.template.update as jest.MockedFunction<any>).mockResolvedValue({
       id: "formtestID",
@@ -137,8 +142,8 @@ describe("Template CRUD functions", () => {
     });
 
     expect(updatedTemplate).toEqual({
-      formID: "formtestID",
-      formConfig: updatedFormConfig,
+      id: "formtestID",
+      ...updatedFormConfig,
     });
   });
   test("Delete template", async () => {
@@ -160,12 +165,14 @@ describe("Template CRUD functions", () => {
     });
 
     expect(deletedTemplate).toEqual({
-      formID: "formtestID",
-      formConfig: formConfiguration,
+      id: "formtestID",
+      ...formConfiguration,
     });
   });
   test("Get Templates by publishing status", async () => {
-    const updatedFormConfig = structuredClone(formConfiguration as FormConfiguration);
+    const updatedFormConfig = structuredClone(
+      formConfiguration as BetterOmit<FormRecord, "id" | "bearerToken">
+    );
     updatedFormConfig.publishingStatus = true;
     (prismaMock.template.findMany as jest.MockedFunction<any>).mockResolvedValue([
       {
@@ -182,13 +189,11 @@ describe("Template CRUD functions", () => {
     expect(publishedTemplates).toHaveLength(1);
     expect(publishedTemplates).toMatchObject([
       {
-        formID: "formtestID2",
-        formConfig: {
-          publishingStatus: true,
-          displayAlphaBanner: true,
-          securityAttribute: "Unclassified",
-          form: updatedFormConfig.form,
-        },
+        id: "formtestID2",
+        publishingStatus: true,
+        displayAlphaBanner: true,
+        securityAttribute: "Unclassified",
+        form: updatedFormConfig.form,
       },
     ]);
   });
@@ -212,15 +217,15 @@ describe("Template CRUD functions", () => {
   });
   test("Only include public properties", async () => {
     const formRecord = {
-      formID: "testID",
-      formConfig: formConfiguration,
+      id: "testID",
+      ...formConfiguration,
     };
 
     const publicFormRecord = onlyIncludePublicProperties(formRecord as FormRecord);
-    expect(publicFormRecord.formConfig).not.toHaveProperty("submission");
-    expect(publicFormRecord.formConfig).not.toHaveProperty("internalTitleEn");
-    expect(publicFormRecord.formConfig).not.toHaveProperty("internalTitleFr");
-    expect(publicFormRecord.formConfig).toHaveProperty("displayAlphaBanner");
-    expect(publicFormRecord.formConfig).toHaveProperty("securityAttribute");
+    expect(publicFormRecord).not.toHaveProperty("submission");
+    expect(publicFormRecord).not.toHaveProperty("internalTitleEn");
+    expect(publicFormRecord).not.toHaveProperty("internalTitleFr");
+    expect(publicFormRecord).toHaveProperty("displayAlphaBanner");
+    expect(publicFormRecord).toHaveProperty("securityAttribute");
   });
 });

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -7,23 +7,21 @@ import emailDomains from "../../email.domains.json";
 function getFormMetaData(type, textType, required = false, formElement = null) {
   return {
     formRecord: {
-      formConfig: {
-        form: {
-          elements: [
-            {
-              id: 1,
-              type: type,
-              properties: {
-                ...formElement?.properties,
-                validation: {
-                  type: textType,
-                  required: required,
-                  ...formElement?.properties?.validation,
-                },
+      form: {
+        elements: [
+          {
+            id: 1,
+            type: type,
+            properties: {
+              ...formElement?.properties,
+              validation: {
+                type: textType,
+                required: required,
+                ...formElement?.properties?.validation,
               },
             },
-          ],
-        },
+          },
+        ],
       },
     },
     t: (key) => key,
@@ -248,84 +246,82 @@ describe("Test input validation", () => {
 
   describe("DynamicRow element tests", () => {
     const formRecord = {
-      formConfig: {
-        form: {
-          elements: [
-            {
-              id: 0,
-              type: "dynamicRow",
-              properties: {
-                titleEn: "",
-                titleFr: "",
-                validation: {
-                  required: true,
-                },
-                subElements: [
-                  {
-                    id: 1,
-                    type: "richText",
-                    properties: {
-                      validation: {
-                        required: false,
-                      },
-                      descriptionEn:
-                        "You can add another representative, up to three, by clicking 'add row' below.",
-                      descriptionFr:
-                        "[FR] - You can add another representative, up to three, by clicking 'add row' below.",
-                    },
-                    subId: "7.0.0",
-                  },
-                  {
-                    id: 2,
-                    type: "textField",
-                    properties: {
-                      titleEn: "Name of Representative",
-                      titleFr: "[fr] Name of Representative",
-                      validation: {
-                        type: "text",
-                        required: true,
-                      },
-                      description: "",
-                      placeholderEn: "",
-                      placeholderFr: "",
-                    },
-                    subId: "7.0.1",
-                  },
-                  {
-                    id: 3,
-                    type: "richText",
-                    properties: {
-                      validation: {
-                        required: false,
-                      },
-                      descriptionEn:
-                        "You can add another representative, up to three, by clicking 'add row' below.",
-                      descriptionFr:
-                        "[FR] - You can add another representative, up to three, by clicking 'add row' below.",
-                    },
-                    subId: "7.0.2",
-                  },
-                  {
-                    id: 4,
-                    type: "textField",
-                    properties: {
-                      titleEn: "Email Address of Representative",
-                      titleFr: "[fr] Email Address of Representative",
-                      validation: {
-                        type: "text",
-                        required: false,
-                      },
-                      description: "",
-                      placeholderEn: "",
-                      placeholderFr: "",
-                    },
-                    subId: "7.0.3",
-                  },
-                ],
+      form: {
+        elements: [
+          {
+            id: 0,
+            type: "dynamicRow",
+            properties: {
+              titleEn: "",
+              titleFr: "",
+              validation: {
+                required: true,
               },
+              subElements: [
+                {
+                  id: 1,
+                  type: "richText",
+                  properties: {
+                    validation: {
+                      required: false,
+                    },
+                    descriptionEn:
+                      "You can add another representative, up to three, by clicking 'add row' below.",
+                    descriptionFr:
+                      "[FR] - You can add another representative, up to three, by clicking 'add row' below.",
+                  },
+                  subId: "7.0.0",
+                },
+                {
+                  id: 2,
+                  type: "textField",
+                  properties: {
+                    titleEn: "Name of Representative",
+                    titleFr: "[fr] Name of Representative",
+                    validation: {
+                      type: "text",
+                      required: true,
+                    },
+                    description: "",
+                    placeholderEn: "",
+                    placeholderFr: "",
+                  },
+                  subId: "7.0.1",
+                },
+                {
+                  id: 3,
+                  type: "richText",
+                  properties: {
+                    validation: {
+                      required: false,
+                    },
+                    descriptionEn:
+                      "You can add another representative, up to three, by clicking 'add row' below.",
+                    descriptionFr:
+                      "[FR] - You can add another representative, up to three, by clicking 'add row' below.",
+                  },
+                  subId: "7.0.2",
+                },
+                {
+                  id: 4,
+                  type: "textField",
+                  properties: {
+                    titleEn: "Email Address of Representative",
+                    titleFr: "[fr] Email Address of Representative",
+                    validation: {
+                      type: "text",
+                      required: false,
+                    },
+                    description: "",
+                    placeholderEn: "",
+                    placeholderFr: "",
+                  },
+                  subId: "7.0.3",
+                },
+              ],
             },
-          ],
-        },
+          },
+        ],
       },
     };
     test("validates required dynamicRow fields row correctly", () => {
@@ -380,7 +376,7 @@ describe("Test getErrorList function", () => {
       1: "input-validation.required",
       2: "input-validation.phone",
     },
-    formRecord: { formConfig: { form: { layout: [1, 2] } } },
+    formRecord: { form: { layout: [1, 2] } },
   };
   test("Error list renders", () => {
     const errors = getErrorList(props);
@@ -428,7 +424,7 @@ describe("Test getErrorList function when error order doesn't match display orde
       1: "input-validation.required",
       2: "input-validation.phone",
     },
-    formRecord: { formConfig: { form: { layout: [2, 1] } } },
+    formRecord: { form: { layout: [2, 1] } },
   };
   it("Renders error list in order matching display order", () => {
     const errors = getErrorList(props);

--- a/lib/types/form-types.ts
+++ b/lib/types/form-types.ts
@@ -4,6 +4,7 @@
  */
 import { ChangeEvent } from "react";
 import { HTMLTextInputTypeAttribute } from "./utility-types";
+import { BetterOmit } from ".";
 
 /**
  * form element types which is used to configure a single field or element in a form
@@ -118,8 +119,10 @@ export interface FormProperties {
     | undefined;
 }
 
-// defines the fields for the top level form object
-export interface FormConfiguration {
+// defines the fields for the form record that is available in authenticated spaces and backend processes
+export type FormRecord = {
+  id: string;
+  bearerToken?: string;
   internalTitleEn?: string;
   internalTitleFr?: string;
   publishingStatus: boolean;
@@ -128,26 +131,11 @@ export interface FormConfiguration {
   form: FormProperties;
   securityAttribute: string;
   reCaptchaID?: string;
-  [key: string]: unknown;
-}
-
-export interface PublicFormConfiguration {
-  publishingStatus: boolean;
-  displayAlphaBanner?: boolean;
-  form: FormProperties;
-  securityAttribute: string;
-  reCaptchaID?: string;
-  [key: string]: unknown;
-}
+  [key: string]: string | boolean | SubmissionProperties | FormProperties | undefined;
+};
 
 // defines the fields for the form record that is available to unauthenticated users
-export interface PublicFormRecord {
-  formID: string;
-  formConfig: PublicFormConfiguration;
-}
-
-// defines the fields for the form record that is available in authenticated spaces and backend processes
-export interface FormRecord extends PublicFormRecord {
-  formConfig: FormConfiguration;
-  bearerToken?: string;
-}
+export type PublicFormRecord = BetterOmit<
+  FormRecord,
+  "bearerToken" | "internalTitleEn" | "internalTitleFr" | "submission"
+>;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -31,3 +31,5 @@ export type {
 export type { BearerTokenPayload, TemporaryTokenPayload, BearerResponse } from "./retrieval-types";
 
 export type { FormOwner } from "./user-types";
+
+export type BetterOmit<T, K extends PropertyKey> = { [P in keyof T as Exclude<P, K>]: T[P] };

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -205,7 +205,7 @@ export const validateOnSubmit = (
   const errors: Responses = {};
 
   for (const item in values) {
-    const formElement = props.formRecord.formConfig.form.elements.find(
+    const formElement = props.formRecord.form.elements.find(
       (element) => element.id == parseInt(item)
     );
     if (!formElement) return errors;
@@ -234,12 +234,12 @@ export const validateOnSubmit = (
 export const getErrorList = (
   props: { formRecord: PublicFormRecord } & FormikProps<Responses>
 ): JSX.Element | null => {
-  if (!props.formRecord?.formConfig?.form || !props.errors) {
+  if (!props.formRecord?.form || !props.errors) {
     return null;
   }
   let errorList;
 
-  const sortedFormElementErrors = props.formRecord.formConfig.form.layout
+  const sortedFormElementErrors = props.formRecord.form.layout
     .filter((element) => {
       return element in props.errors;
     })

--- a/pages/admin/view-templates.tsx
+++ b/pages/admin/view-templates.tsx
@@ -11,7 +11,7 @@ import { UserRole } from "@prisma/client";
 
 interface DataViewProps {
   templates: Array<{
-    formID: string;
+    id: string;
     titleEn: string;
     titleFr: string;
     publishingStatus: boolean;
@@ -54,24 +54,21 @@ const DataView = (props: DataViewProps): React.ReactElement => {
         <tbody>
           {templates.map((template) => {
             return (
-              <tr key={template.formID} className="border-t-4 border-b-1 border-gray-400">
+              <tr key={template.id} className="border-t-4 border-b-1 border-gray-400">
                 <td className="pl-4">{template[getProperty("title", i18n.language)]} </td>
                 <td className="text-center">
                   {template.publishingStatus ? t("view.published") : t("view.draft")}
                 </td>
                 <td>
                   <button
-                    onClick={() => redirectToSettings(template.formID)}
+                    onClick={() => redirectToSettings(template.id)}
                     className="gc-button w-full"
                   >
                     {t("view.update")}
                   </button>
                 </td>
                 <td>
-                  <button
-                    onClick={() => redirectToForm(template.formID)}
-                    className="gc-button w-full"
-                  >
+                  <button onClick={() => redirectToForm(template.id)} className="gc-button w-full">
                     {t("view.view")}
                   </button>
                 </td>
@@ -91,14 +88,12 @@ export const getServerSideProps = requireAuthentication(async (context) => {
 
     const templates = (await getAllTemplates()).map((template) => {
       const {
-        formID,
-        formConfig: {
-          form: { titleEn, titleFr },
-          publishingStatus,
-        },
+        id,
+        form: { titleEn, titleFr },
+        publishingStatus,
       } = template;
       return {
-        formID,
+        id,
         titleEn,
         titleFr,
         publishingStatus,

--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -311,7 +311,7 @@ const processFormData = async (
     }
     try {
       await callLambda(
-        form.formID,
+        form.id,
         fields,
         // pass in the language from the header content language... assume english as the default
         req.headers?.["content-language"] ? req.headers["content-language"] : "en",

--- a/pages/api/templates.ts
+++ b/pages/api/templates.ts
@@ -6,7 +6,7 @@ import {
   createTemplate,
   updateTemplate,
 } from "@lib/templates";
-import { FormConfiguration, FormRecord } from "@lib/types/form-types";
+import { FormRecord } from "@lib/types/form-types";
 
 import { middleware, jsonValidator, cors, sessionExists } from "@lib/middleware";
 import templatesSchema from "@lib/middleware/schemas/templates.schema.json";
@@ -18,6 +18,7 @@ import {
   subElementsIDValidator,
   uniqueIDValidator,
 } from "@lib/middleware/jsonIDValidator";
+import { BetterOmit } from "@lib/types";
 
 const allowedMethods = ["GET", "POST", "PUT", "DELETE"];
 const authenticatedMethods = ["POST", "PUT", "DELETE"];
@@ -39,7 +40,7 @@ const templates = async (req: NextApiRequest, res: NextApiResponse) => {
           session.user.userId,
           AdminLogAction.Create,
           AdminLogEvent.UploadForm,
-          `Form id: ${(response as FormRecord).formID} has been uploaded`
+          `Form id: ${(response as FormRecord).id} has been uploaded`
         );
       }
       if (req.method === "PUT") {
@@ -83,7 +84,7 @@ const templateCRUD = async ({
 }: {
   method: string;
   formID?: string;
-  formConfig?: FormConfiguration;
+  formConfig?: BetterOmit<FormRecord, "id" | "bearerToken">;
 }) => {
   switch (method) {
     case "GET":

--- a/pages/id/[form]/[[...step]].tsx
+++ b/pages/id/[form]/[[...step]].tsx
@@ -20,7 +20,7 @@ const RenderForm = ({ formRecord }: { formRecord: PublicFormRecord }): React.Rea
   const language = i18n.language as string;
   const classes = classnames("gc-form-wrapper");
   const currentForm = getRenderedForm(formRecord, language, t);
-  const formTitle = formRecord.formConfig.form[getProperty("title", language)] as string;
+  const formTitle = formRecord.form[getProperty("title", language)] as string;
   const router = useRouter();
   const { step } = router.query;
 
@@ -83,7 +83,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   // Short circuit only if Cypress testing
   if (
     process.env.APP_ENV !== "test" &&
-    (!publicForm || (!publicForm?.formConfig?.publishingStatus && !unpublishedForms))
+    (!publicForm || (!publicForm?.publishingStatus && !unpublishedForms))
   ) {
     return redirect(context.locale);
   }


### PR DESCRIPTION
# Summary | Résumé

Simplifying the FormRecord and PublicFormRecord types throughout the application.
This merges the FormRecord and FormConfiguration Types by adding the `id` and `bearerToken` to the FormConfiguration type.  These properties are then explicitly omitted when being referenced in code as Form Objects that are not yet created or jsonConfig prisma responses.

This PR also introduce sthe `BetterOmit` typescript helper which correctly identifies new types and their sub-properties that are created with Omit from types that previously contain type indexes.

Previous:
```js
// defines the fields for the top level form object
export interface FormConfiguration {
  internalTitleEn?: string;
  internalTitleFr?: string;
  publishingStatus: boolean;
  submission: SubmissionProperties;
  displayAlphaBanner?: boolean;
  form: FormProperties;
  securityAttribute: string;
  reCaptchaID?: string;
  [key: string]: unknown;
}

export interface PublicFormConfiguration {
  publishingStatus: boolean;
  displayAlphaBanner?: boolean;
  form: FormProperties;
  securityAttribute: string;
  reCaptchaID?: string;
  [key: string]: unknown;
}

// defines the fields for the form record that is available to unauthenticated users
export interface PublicFormRecord {
  formID: string;
  formConfig: PublicFormConfiguration;
}

// defines the fields for the form record that is available in authenticated spaces and backend processes
export interface FormRecord extends PublicFormRecord {
  formConfig: FormConfiguration;
  bearerToken?: string;
}
```


Proposed:
```js
// defines the fields for the form record that is available in authenticated spaces and backend processes
export type FormRecord = {
  id: string;
  bearerToken?: string;
  internalTitleEn?: string;
  internalTitleFr?: string;
  publishingStatus: boolean;
  submission: SubmissionProperties;
  displayAlphaBanner?: boolean;
  form: FormProperties;
  securityAttribute: string;
  reCaptchaID?: string;
  [key: string]: string | boolean | SubmissionProperties | FormProperties | undefined;
};

// defines the fields for the form record that is available to unauthenticated users
export type PublicFormRecord = BetterOmit<
  FormRecord,
  "bearerToken" | "internalTitleEn" | "internalTitleFr" | "submission"
>;
```