### PR TITLE
Permissions Feature ... One more time.... 🎧  Daft Punk

### DIFF
--- a/__tests__/api/acceptable-use.test.ts
+++ b/__tests__/api/acceptable-use.test.ts
@@ -6,13 +6,32 @@ import { createMocks } from "node-mocks-http";
 import acceptableUse from "@pages/api/acceptableuse";
 import { setAcceptableUse } from "@lib/acceptableUseCache";
 import { getCsrfToken } from "next-auth/react";
+import { unstable_getServerSession } from "next-auth/next";
+import { Session } from "next-auth";
 
+jest.mock("next-auth/next");
 jest.mock("next-auth/react");
 jest.mock("@lib/acceptableUseCache");
-const mockedSetAcceptableUse = jest.mocked(setAcceptableUse, true);
-const mockedGetCsrfToken = jest.mocked(getCsrfToken, true);
+const mockedSetAcceptableUse = jest.mocked(setAcceptableUse, { shallow: true });
+const mockedGetCsrfToken = jest.mocked(getCsrfToken, { shallow: true });
+//Needed in the typescript version of the test so types are inferred correclty
+const mockGetSession = jest.mocked(unstable_getServerSession, { shallow: true });
 
 describe("Test acceptable use endpoint", () => {
+  beforeEach(() => {
+    const mockSession: Session = {
+      expires: "1",
+      user: {
+        id: "1",
+        email: "forms@cds.ca",
+        name: "forms user",
+        privileges: [],
+      },
+    };
+
+    mockGetSession.mockResolvedValue(mockSession);
+  });
+  afterEach(() => mockGetSession.mockReset());
   mockedGetCsrfToken.mockResolvedValue("CsrfToken");
   it("Should set acceptableuse value to true for userID 1 and return 200", async () => {
     const { req, res } = createMocks({

--- a/__tests__/api/flags.test.ts
+++ b/__tests__/api/flags.test.ts
@@ -7,110 +7,174 @@ import enable from "@pages/api/flags/[key]/enable";
 import disable from "@pages/api/flags/[key]/disable";
 import check from "@pages/api/flags/[key]/check";
 import checkAllFlags from "@pages/api/flags";
-import defaultFlags from "../../flag_initialization/default_flag_settings.json";
-import * as flags from "@lib/flags";
-import { UserRole } from "@prisma/client";
+import { ViewApplicationSettings, ManageApplicationSettings } from "__utils__/permissions";
+import Redis from "ioredis-mock";
+const redis = new Redis();
+
+jest.mock("@lib/integration/redisConnector", () => ({
+  getRedisInstance: jest.fn(() => redis),
+}));
+
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(unstable_getServerSession, true);
-
-jest.mock("@lib/flags");
-
-const mockedFlags = jest.mocked(flags, true);
-
-const { checkOne, checkAll, enableFlag, disableFlag } = mockedFlags;
+const mockGetSession = jest.mocked(unstable_getServerSession, { shallow: true });
 
 describe("Flags API endpoint", () => {
   describe("Authenticated", () => {
-    beforeEach(() => {
-      const mockSession = {
-        expires: "1",
-        user: {
-          email: "forms@cds.ca",
-          name: "forms user",
-          role: UserRole.ADMINISTRATOR,
-          userId: "1",
-        },
-      };
-      mockGetSession.mockResolvedValue(mockSession);
-    });
-    afterEach(() => {
-      mockGetSession.mockReset();
-    });
-
-    it("Enable a feature flag", async () => {
-      enableFlag.mockImplementation(jest.fn());
-      checkAll.mockResolvedValue(defaultFlags);
-
-      const { req, res } = createMocks({
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Origin: "http://localhost:3000",
-        },
-        url: "/api/flags/featureFlag/enable",
-        query: {
-          key: "featureFlag",
-        },
+    describe("ViewApplicationSettings", () => {
+      beforeEach(async () => {
+        const mockSession = {
+          expires: "1",
+          user: {
+            email: "forms@cds.ca",
+            name: "forms user",
+            id: "1",
+            privileges: ViewApplicationSettings,
+          },
+        };
+        mockGetSession.mockResolvedValue(mockSession);
+        // Intialize mockRedis with default flags
+        const testFlags = {
+          flag1: true,
+          flag2: false,
+        };
+        for (const [key, value] of Object.entries(testFlags)) {
+          await redis
+            .multi()
+            .sadd("flags", key)
+            .set(`flag:${key}`, value ? "1" : "0")
+            .exec();
+        }
+      });
+      afterEach(() => {
+        redis.flushall();
+        mockGetSession.mockReset();
       });
 
-      await enable(req, res);
+      it("Enable a feature flag", async () => {
+        const { req, res } = createMocks({
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+          url: "/api/flags/featureFlag/enable",
+          query: {
+            key: "featureFlag",
+          },
+        });
 
-      expect(res.statusCode).toBe(200);
-      expect(res._getJSONData()).toMatchObject(defaultFlags);
-      expect(enableFlag).toHaveBeenCalledWith("featureFlag");
-    });
+        await enable(req, res);
 
-    it("Disable a feature flag", async () => {
-      disableFlag.mockImplementation(jest.fn());
-      checkAll.mockResolvedValue(defaultFlags);
-
-      const { req, res } = createMocks({
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Origin: "http://localhost:3000",
-        },
-        url: "/api/flags/featureFlag/disable",
-        query: {
-          key: "featureFlag",
-        },
+        expect(res.statusCode).toBe(403);
+        expect(res._getJSONData()).toMatchObject({ error: "Forbidden" });
       });
 
-      await disable(req, res);
+      it("Disable a feature flag", async () => {
+        const { req, res } = createMocks({
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+          url: "/api/flags/featureFlag/disable",
+          query: {
+            key: "featureFlag",
+          },
+        });
 
-      expect(res.statusCode).toBe(200);
-      expect(res._getJSONData()).toMatchObject(defaultFlags);
-      expect(disableFlag).toHaveBeenCalledWith("featureFlag");
+        await disable(req, res);
+
+        expect(res.statusCode).toBe(403);
+        expect(res._getJSONData()).toMatchObject({ error: "Forbidden" });
+      });
+      it("Gets a list of all feature flags", async () => {
+        const { req, res } = createMocks({
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+          url: "/api/flags/",
+        });
+
+        await checkAllFlags(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res._getJSONData()).toMatchObject({ flag1: true, flag2: false });
+      });
     });
-  });
+    describe("ManageApplicationSettings", () => {
+      beforeEach(async () => {
+        const mockSession = {
+          expires: "1",
+          user: {
+            email: "forms@cds.ca",
+            name: "forms user",
+            id: "1",
+            privileges: ManageApplicationSettings,
+          },
+        };
+        mockGetSession.mockResolvedValue(mockSession);
 
-  describe("Unauthenticated", () => {
-    it("Check a feature flag", async () => {
-      (checkOne as jest.Mock).mockReturnValue(true);
-
-      const { req, res } = createMocks({
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Origin: "http://localhost:3000",
-        },
-        url: "/api/flags/featureFlag/check",
-        query: {
-          key: "featureFlag",
-        },
+        // Intialize mockRedis with default flags
+        const testFlags = {
+          flag1: true,
+          flag2: false,
+        };
+        for (const [key, value] of Object.entries(testFlags)) {
+          await redis
+            .multi()
+            .sadd("flags", key)
+            .set(`flag:${key}`, value ? "1" : "0")
+            .exec();
+        }
+      });
+      afterEach(() => {
+        redis.flushall();
+        mockGetSession.mockReset();
       });
 
-      await check(req, res);
+      it("Enable a feature flag", async () => {
+        const { req, res } = createMocks({
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+          url: "/api/flags/flag2/enable",
+          query: {
+            key: "flag2",
+          },
+        });
 
-      expect(res.statusCode).toBe(200);
-      expect(res._getJSONData()).toMatchObject({ status: true });
-      expect(checkOne).toHaveBeenCalledWith("featureFlag");
+        await enable(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res._getJSONData()).toMatchObject({ flag2: true });
+      });
+
+      it("Disable a feature flag", async () => {
+        const { req, res } = createMocks({
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+          url: "/api/flags/flag1/disable",
+          query: {
+            key: "flag1",
+          },
+        });
+
+        await disable(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res._getJSONData()).toMatchObject({ flag1: false });
+      });
     });
     it("Gets a list of all feature flags", async () => {
-      checkAll.mockResolvedValue(defaultFlags);
-
       const { req, res } = createMocks({
         method: "GET",
         headers: {
@@ -123,7 +187,46 @@ describe("Flags API endpoint", () => {
       await checkAllFlags(req, res);
 
       expect(res.statusCode).toBe(200);
-      expect(res._getJSONData()).toMatchObject(defaultFlags);
+      expect(res._getJSONData()).toMatchObject({ flag1: true, flag2: false });
+    });
+  });
+
+  describe("Unauthenticated", () => {
+    beforeAll(async () => {
+      // Intialize mockRedis with default flags
+      const testFlags = {
+        flag1: true,
+        flag2: false,
+      };
+      for (const [key, value] of Object.entries(testFlags)) {
+        await redis
+          .multi()
+          .sadd("flags", key)
+          .set(`flag:${key}`, value ? "1" : "0")
+          .exec();
+      }
+    });
+    afterAll(() => {
+      redis.flushall();
+    });
+
+    it("Check a feature flag", async () => {
+      const { req, res } = createMocks({
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        url: "/api/flags/flag1/check",
+        query: {
+          key: "flag1",
+        },
+      });
+
+      await check(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res._getJSONData()).toMatchObject({ status: true });
     });
   });
 });

--- a/__tests__/api/flags.test.ts
+++ b/__tests__/api/flags.test.ts
@@ -21,6 +21,13 @@ jest.mock("next-auth/next");
 const mockGetSession = jest.mocked(unstable_getServerSession, { shallow: true });
 
 describe("Flags API endpoint", () => {
+  beforeAll(() => {
+    // Adding URL to process.env because we are mocking out Redis for these tests
+    process.env.REDIS_URL = "test_url";
+  });
+  afterAll(() => {
+    delete process.env.REDIS_URL;
+  });
   describe("Authenticated", () => {
     describe("ViewApplicationSettings", () => {
       beforeEach(async () => {

--- a/__tests__/api/flags.test.ts
+++ b/__tests__/api/flags.test.ts
@@ -173,21 +173,21 @@ describe("Flags API endpoint", () => {
         expect(res.statusCode).toBe(200);
         expect(res._getJSONData()).toMatchObject({ flag1: false });
       });
-    });
-    it("Gets a list of all feature flags", async () => {
-      const { req, res } = createMocks({
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Origin: "http://localhost:3000",
-        },
-        url: "/api/flags/",
+      it("Gets a list of all feature flags", async () => {
+        const { req, res } = createMocks({
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+          url: "/api/flags/",
+        });
+
+        await checkAllFlags(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res._getJSONData()).toMatchObject({ flag1: true, flag2: false });
       });
-
-      await checkAllFlags(req, res);
-
-      expect(res.statusCode).toBe(200);
-      expect(res._getJSONData()).toMatchObject({ flag1: true, flag2: false });
     });
   });
 

--- a/__tests__/api/id/form/apiUsers.test.ts
+++ b/__tests__/api/id/form/apiUsers.test.ts
@@ -6,7 +6,7 @@
 
 import { createMocks, RequestMethod } from "node-mocks-http";
 import { unstable_getServerSession } from "next-auth/next";
-import apiUsers from "@pages/api/id/[form]/apiUsers";
+import apiUsers from "@pages/api/id/[form]/apiusers";
 import { logAdminActivity } from "@lib/adminLogs";
 import { prismaMock } from "@jestUtils";
 import { Prisma } from "@prisma/client";

--- a/__tests__/api/id/form/retrieval.test.ts
+++ b/__tests__/api/id/form/retrieval.test.ts
@@ -12,11 +12,12 @@ import jwt, { Secret } from "jsonwebtoken";
 
 jest.mock("next-auth/next");
 jest.mock("@lib/logger");
-const mockLogMessage = jest.mocked(logMessage, true);
+const mockLogMessage = jest.mocked(logMessage, { shallow: true });
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
-describe("/api/retrieval", () => {
+// Skipping until API is reactivated.  Currently all methods are blocked from accessing.
+describe.skip("/api/retrieval", () => {
   let dateNowSpy: jest.SpyInstance;
   beforeEach(() => {
     dateNowSpy = jest.spyOn(Date, "now");

--- a/__tests__/api/log.test.ts
+++ b/__tests__/api/log.test.ts
@@ -9,7 +9,7 @@ import { logMessage } from "@lib/logger";
 import { Level } from "pino";
 
 jest.mock("next-auth/react");
-const mockedGetCsrfToken = jest.mocked(getCsrfToken, true);
+const mockedGetCsrfToken = jest.mocked(getCsrfToken, { shallow: true });
 
 describe("Log API Endpoint", () => {
   it.each(["info", "warn", "error"])("Receives and Saves a log for %s level", async (level) => {

--- a/__tests__/api/token/temporary.test.ts
+++ b/__tests__/api/token/temporary.test.ts
@@ -7,7 +7,6 @@ import { createMocks } from "node-mocks-http";
 import temporary from "@pages/api/token/temporary";
 import jwt, { Secret } from "jsonwebtoken";
 import { prismaMock } from "@jestUtils";
-import { getTokenById } from "@pages/api/id/[form]/bearer";
 
 const redis = new Redis();
 
@@ -17,7 +16,6 @@ jest.mock("@lib/integration/redisConnector", () => ({
 
 jest.mock("next-auth/react");
 jest.mock("@pages/api/id/[form]/bearer");
-const mockedGetTokenById = jest.mocked(getTokenById, true);
 
 let IsGCNotifyServiceAvailable = true;
 
@@ -65,7 +63,10 @@ describe("TemporaryBearerToken tests", () => {
         email: "test@cds-snc.ca",
       },
     });
-    mockedGetTokenById.mockResolvedValue({ bearerToken: token });
+    (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      bearerToken: token,
+    });
+
     (prismaMock.apiUser.findUnique as jest.MockedFunction<any>).mockResolvedValue({
       templateId: 1,
       email: "test@cds-snc.ca",
@@ -149,7 +150,9 @@ describe("TemporaryBearerToken tests", () => {
         email: "test@cds-snc.ca",
       },
     });
-    mockedGetTokenById.mockResolvedValue({ bearerToken: token });
+    (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      bearerToken: token,
+    });
     (prismaMock.apiUser.findUnique as jest.MockedFunction<any>).mockResolvedValue({
       templateId: 1,
       email: "test@cds-snc.ca",
@@ -198,7 +201,9 @@ describe("TemporaryBearerToken tests", () => {
         email: "test@cds-snc.ca",
       },
     });
-    mockedGetTokenById.mockResolvedValue({ bearerToken: token });
+    (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      bearerToken: token,
+    });
     (prismaMock.apiUser.findUnique as jest.MockedFunction<any>).mockResolvedValue({
       templateId: 1,
       email: "test@cds-snc.ca",

--- a/__tests__/api/users.test.ts
+++ b/__tests__/api/users.test.ts
@@ -51,7 +51,6 @@ describe("Users API endpoint", () => {
         },
         body: {
           userId: "1",
-          isAdmin: "false",
         },
       });
 
@@ -172,7 +171,7 @@ describe("Users API endpoint", () => {
       mockGetSession.mockReset();
     });
 
-    it("Should return 400 invalid payload error when isAdmin is missing", async () => {
+    it("Should return 400 invalid payload error when privileges is missing", async () => {
       const { req, res } = createMocks({
         method: "PUT",
         headers: {
@@ -200,7 +199,7 @@ describe("Users API endpoint", () => {
           Origin: "http://localhost:3000/api/id/11/owners",
         },
         body: {
-          isAdmin: true,
+          privileges: [{ id: "2", action: "add" }],
         },
       });
 

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,5 +1,5 @@
 import { getRedisInstance } from "@lib/integration/redisConnector";
-
+import flagInitialSettings from "../flag_initialization/default_flag_settings.json";
 import { checkPrivileges } from "@lib/privileges";
 import { Ability } from "./policyBuilder";
 
@@ -36,6 +36,10 @@ const getKeys = async () => {
  * @returns Boolean value of Flag key
  */
 export const checkOne = async (key: string): Promise<boolean> => {
+  // If REDIS is not configured return the default values for the flags
+  if (!process.env.REDIS_URL) {
+    return (flagInitialSettings as Record<string, boolean>)[key];
+  }
   const redis = await getRedisInstance();
   const value = await redis.get(`flag:${key}`);
   return value === "1";

--- a/lib/integration/prismaConnector.ts
+++ b/lib/integration/prismaConnector.ts
@@ -31,9 +31,6 @@ export const prismaErrors = <Error, T>(e: Error, returnValue?: T): T => {
     logMessage.warn(e as Error);
     if (returnValue !== undefined) return returnValue;
   }
-  if (process.env.APP_ENV === "test") {
-    if (returnValue !== undefined) return returnValue;
-  }
   logMessage.error(e as Error);
   throw e;
 };

--- a/lib/middleware/middleware.ts
+++ b/lib/middleware/middleware.ts
@@ -16,7 +16,7 @@ export const middleware = (
     try {
       let props = {};
       for (const middlewareLayer of middlewareArray) {
-        const { next: pass, props: middlewareProps } = await middlewareLayer(req, res, props);
+        const { next: pass, props: middlewareProps } = await middlewareLayer(req, res);
         if (!pass) return;
 
         props = { ...props, ...middlewareProps };

--- a/lib/privileges.ts
+++ b/lib/privileges.ts
@@ -10,7 +10,7 @@ import {
 } from "@lib/policyBuilder";
 import { Prisma } from "@prisma/client";
 import { logMessage } from "./logger";
-import { subject as setSubjectType, subject } from "@casl/ability";
+import { subject as setSubjectType } from "@casl/ability";
 
 interface ForcedSubjectType {
   type: Extract<Subject, string>;

--- a/lib/privileges.ts
+++ b/lib/privileges.ts
@@ -10,7 +10,7 @@ import {
 } from "@lib/policyBuilder";
 import { Prisma } from "@prisma/client";
 import { logMessage } from "./logger";
-import { subject as setSubjectType } from "@casl/ability";
+import { subject as setSubjectType, subject } from "@casl/ability";
 
 interface ForcedSubjectType {
   type: Extract<Subject, string>;
@@ -219,6 +219,23 @@ export const checkPrivileges = (
     }
   });
   let accessAllowed = false;
+  if (process.env.NODE_ENV !== "production") {
+    rules.map((rule, index) => {
+      if (isForceTyping(rule.subject)) {
+        logMessage.debug(
+          `Privilege Check ${result[index] ? "PASS" : "FAIL"}: Can ${rule.action} on ${
+            rule.subject.type
+          } `
+        );
+      } else {
+        logMessage.debug(
+          `Privilege Check ${result[index] ? "PASS" : "FAIL"}: Can ${rule.action} on ${
+            rule.subject
+          } `
+        );
+      }
+    });
+  }
   switch (logic) {
     case "all":
       // The initial value needs to be true because of the AND logic

--- a/lib/tests/auth.test.ts
+++ b/lib/tests/auth.test.ts
@@ -2,27 +2,188 @@
  * @jest-environment node
  */
 
-import { isAdmin, validateTemporaryToken } from "@lib/auth";
+import { isAuthenticated, validateTemporaryToken, requireAuthentication } from "@lib/auth";
+import { Base, getUserPrivileges } from "__utils__/permissions";
 import { createMocks } from "node-mocks-http";
 import { unstable_getServerSession } from "next-auth/next";
 import jwt, { Secret } from "jsonwebtoken";
 import { prismaMock } from "@jestUtils";
-import { UserRole } from "@prisma/client";
+import { checkPrivileges } from "@lib/privileges";
+import { Prisma } from "@prisma/client";
 
 jest.mock("next-auth/next");
 
 //Needed in the typescript version of the test so types are inferred correclty
-const mockGetSession = jest.mocked(unstable_getServerSession, true);
+const mockGetSession = jest.mocked(unstable_getServerSession, { shallow: true });
 
 describe("Test Auth lib", () => {
-  describe("isAdmin", () => {
+  describe("requireAuthentication", () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
     afterEach(() => {
       mockGetSession.mockReset();
     });
-    it("User is an administrator", async () => {
+    it("Redirects users without a session to login screen", async () => {
+      const { req, res } = createMocks({
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      // No user session exists
+      mockGetSession.mockResolvedValue(null);
+
+      const context = {
+        req,
+        res,
+        query: {},
+        resolvedUrl: "",
+      };
+
+      const result = await requireAuthentication(async () => ({
+        props: {
+          test: "1",
+        },
+      }))(context);
+      expect(result).toEqual({
+        redirect: {
+          destination: `/undefined/admin/login`,
+          permanent: false,
+        },
+      });
+    });
+    it("Adds user to props when a session is present", async () => {
+      const { req, res } = createMocks({
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const mockSession = {
+        expires: "1",
+        user: {
+          email: "test@cds.ca",
+          name: "test",
+          image: "null",
+          id: "1",
+          privileges: getUserPrivileges(Base, { user: { id: "1" } }),
+        },
+      };
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const context = {
+        req,
+        res,
+        query: {},
+        resolvedUrl: "",
+      };
+
+      const result = await requireAuthentication(async () => ({ props: {} }))(context);
+      expect(result).toEqual({
+        props: {
+          user: {
+            email: "test@cds.ca",
+            name: "test",
+            image: "null",
+            id: "1",
+            privileges: getUserPrivileges(Base, { user: { id: "1" } }),
+          },
+        },
+      });
+    });
+    it("Adds user to props when a session is present and keeps innerFunction props", async () => {
+      const { req, res } = createMocks({
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const mockSession = {
+        expires: "1",
+        user: {
+          email: "test@cds.ca",
+          name: "test",
+          image: "null",
+          id: "1",
+          privileges: getUserPrivileges(Base, { user: { id: "1" } }),
+        },
+      };
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const context = {
+        req,
+        res,
+        query: {},
+        resolvedUrl: "",
+      };
+
+      const result = await requireAuthentication(async () => ({ props: { test: "1" } }))(context);
+      expect(result).toEqual({
+        props: {
+          test: "1",
+          user: {
+            email: "test@cds.ca",
+            name: "test",
+            image: "null",
+            id: "1",
+            privileges: getUserPrivileges(Base, { user: { id: "1" } }),
+          },
+        },
+      });
+    });
+  });
+  it("Throws Access Control Error from InnerFunction and redirects", async () => {
+    const { req, res } = createMocks({
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const mockSession = {
+      expires: "1",
+      user: {
+        email: "test@cds.ca",
+        name: "test",
+        image: "null",
+        id: "1",
+        privileges: getUserPrivileges(Base, { user: { id: "1" } }),
+      },
+    };
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const context = {
+      req,
+      res,
+      query: {},
+      resolvedUrl: "",
+    };
+
+    const result = await requireAuthentication(async ({ user: { ability } }) => {
+      checkPrivileges(ability, [{ action: "view", subject: "Privilege" }]);
+      return {
+        props: {},
+      };
+    })(context);
+    expect(result).toEqual({
+      redirect: {
+        destination: "/undefined/admin/unauthorized",
+        permanent: false,
+      },
+    });
+  });
+  describe("isAuthenticated", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    afterEach(() => {
+      mockGetSession.mockReset();
+    });
+    it("User has a valid session", async () => {
       const { req, res } = createMocks({
         method: "GET",
         headers: {
@@ -35,33 +196,24 @@ describe("Test Auth lib", () => {
           email: "test@cds.ca",
           name: "test",
           image: "null",
-          role: UserRole.ADMINISTRATOR,
-          userId: "1",
+          id: "1",
+          privileges: getUserPrivileges(Base, { user: { id: "1" } }),
         },
       };
       mockGetSession.mockResolvedValue(mockSession);
-      const userSession = await isAdmin({ req, res });
+      const userSession = await isAuthenticated({ req, res });
       expect(userSession).toEqual(mockSession);
     });
-    it("User is an administrator", async () => {
+    it("User does not have a valid session", async () => {
       const { req, res } = createMocks({
         method: "GET",
         headers: {
           "Content-Type": "application/json",
         },
       });
-      const mockSession = {
-        expires: "1",
-        user: {
-          email: "test@cds.ca",
-          name: "test",
-          image: "null",
-          role: UserRole.PROGRAM_ADMINISTRATOR,
-          userId: "1",
-        },
-      };
+      const mockSession = null;
       mockGetSession.mockResolvedValue(mockSession);
-      const userSession = await isAdmin({ req, res });
+      const userSession = await isAuthenticated({ req, res });
       expect(userSession).toEqual(null);
     });
   });
@@ -149,6 +301,21 @@ describe("Test Auth lib", () => {
         active: true,
         temporaryToken: token,
       });
+    });
+    it("Returns null is there is a Prisma Error", async () => {
+      // Mocking prisma to throw an error
+      prismaMock.apiUser.findUnique.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Can't reach database server", "P1001", "4.3.2")
+      );
+      const token = jwt.sign(
+        { email: "test@test.ca", formID: "test0form00000id000asdf11" },
+        process.env.TOKEN_SECRET as Secret,
+        {
+          expiresIn: "1d",
+        }
+      );
+      const session = await validateTemporaryToken(token);
+      expect(session).toEqual(null);
     });
   });
 });

--- a/lib/tests/sessionExists.test.js
+++ b/lib/tests/sessionExists.test.js
@@ -5,7 +5,6 @@
 import { createMocks } from "node-mocks-http";
 import { unstable_getServerSession } from "next-auth/next";
 import { sessionExists } from "@lib/middleware";
-import { UserRole } from "@prisma/client";
 
 jest.mock("next-auth/next");
 
@@ -23,40 +22,17 @@ describe("Test a session middleware", () => {
     });
 
     await sessionExists()(req, res);
-    expect(JSON.parse(res._getData()).error).toEqual("Access Denied");
-    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res._getData()).error).toEqual("Unauthorized");
+    expect(res.statusCode).toBe(401);
   });
 
-  it("Shouldn't allow a request without being admin", async () => {
+  it("Should allow a request with a valid session", async () => {
     const mockSession = {
       expires: "1",
       user: {
         email: "test@cds.ca",
         name: "Testing session middleware",
         image: "null",
-        role: UserRole.PROGRAM_ADMINISTRATOR,
-      },
-    };
-    unstable_getServerSession.mockReturnValueOnce(mockSession);
-    const { req, res } = createMocks({
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    await sessionExists()(req, res);
-    expect(res.statusCode).toBe(403);
-  });
-
-  it("Should allow a request with being admin", async () => {
-    const mockSession = {
-      expires: "1",
-      user: {
-        email: "test@cds.ca",
-        name: "Testing session middleware",
-        image: "null",
-        role: UserRole.ADMINISTRATOR,
       },
     };
     unstable_getServerSession.mockReturnValueOnce(mockSession);
@@ -80,12 +56,32 @@ describe("Test a session middleware", () => {
     });
 
     await sessionExists(["GET"])(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(401);
   });
 
   it("Should allow a request method that doesn't requires authentication", async () => {
     const { req, res } = createMocks({
       method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    await sessionExists(["POST"])(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+  it("Should allow a request method that requires authentication", async () => {
+    const mockSession = {
+      expires: "1",
+      user: {
+        email: "test@cds.ca",
+        name: "Testing session middleware",
+        image: "null",
+      },
+    };
+    unstable_getServerSession.mockReturnValueOnce(mockSession);
+    const { req, res } = createMocks({
+      method: "POST",
       headers: {
         "Content-Type": "application/json",
       },

--- a/lib/tests/users.test.ts
+++ b/lib/tests/users.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { prismaMock } from "@jestUtils";
-import { getUsers, getOrCreateUser, getApiUser } from "@lib/users";
+import { getUsers, getOrCreateUser } from "@lib/users";
 import { Prisma } from "@prisma/client";
 import { AccessControlError, createAbility } from "@lib/policyBuilder";
 import { getUserPrivileges, ManageUsers } from "__utils__/permissions";
@@ -114,7 +114,7 @@ describe("Users CRUD functions should throw an error if user does not have suffi
   it("User with no permission should not be able to use CRUD functions", async () => {
     const ability = createAbility([]);
 
-    expect(async () => {
+    await expect(async () => {
       await getUsers(ability);
     }).rejects.toThrowError(new AccessControlError(`Access Control Forbidden Action`));
   });

--- a/lib/types/utility-types.ts
+++ b/lib/types/utility-types.ts
@@ -19,8 +19,7 @@ export interface MiddlewareReturn {
 
 export type MiddlewareRequest = (
   req: NextApiRequest,
-  res: NextApiResponse,
-  props: Record<string, unknown>
+  res: NextApiResponse
 ) => Promise<MiddlewareReturn>;
 
 export interface MiddlewareProps {

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -85,10 +85,10 @@ export const getOrCreateUser = async (userToken: JWT) => {
  * @returns An array of all Users
  */
 export const getUsers = async (ability: Ability) => {
-  try {
-    checkPrivileges(ability, [{ action: "view", subject: "User" }]);
+  checkPrivileges(ability, [{ action: "view", subject: "User" }]);
 
-    const users = await prisma.user.findMany({
+  const users = await prisma.user
+    .findMany({
       select: {
         id: true,
         name: true,
@@ -106,12 +106,10 @@ export const getUsers = async (ability: Ability) => {
       orderBy: {
         id: "asc",
       },
-    });
+    })
+    .catch((e) => prismaErrors(e, []));
 
-    return users;
-  } catch (e) {
-    return prismaErrors(e, []);
-  }
+  return users;
 };
 
 /**

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,5 +1,5 @@
 import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
-import { ApiAccessLog, ApiUser } from "@prisma/client";
+import { ApiAccessLog } from "@prisma/client";
 import { JWT } from "next-auth";
 import { LoggingAction } from "./auth";
 import { Ability } from "./policyBuilder";
@@ -115,7 +115,7 @@ export const getUsers = async (ability: Ability) => {
 };
 
 /**
- * Retrieves the accessLog entry for the last login for a user
+ * Retrieves the accessLog entry for the last login for an API user
  * @param userId
  * @returns AccessLog object
  */

--- a/pages/admin/flags.tsx
+++ b/pages/admin/flags.tsx
@@ -5,7 +5,6 @@ import { requireAuthentication } from "@lib/auth";
 import { useTranslation } from "next-i18next";
 import Loader from "@components/globals/Loader";
 import { Button } from "@components/forms";
-import { UserRole } from "@prisma/client";
 
 const fetcher = (url: string) => fetch(url).then((response) => response.json());
 

--- a/pages/admin/upload.tsx
+++ b/pages/admin/upload.tsx
@@ -3,7 +3,6 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import React from "react";
 import { useTranslation } from "next-i18next";
-import { UserRole } from "@prisma/client";
 
 export const getServerSideProps = requireAuthentication(async (context) => {
   return {

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -8,7 +8,6 @@ import convertMessage from "@lib/markdown";
 import { Button, RichText } from "@components/forms";
 import { logMessage } from "@lib/logger";
 import { PublicFormRecord } from "@lib/types";
-import { UserRole } from "@prisma/client";
 
 interface ResponseListInterface {
   Items: {

--- a/pages/api/acceptableuse.ts
+++ b/pages/api/acceptableuse.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { cors, middleware, csrfProtected } from "@lib/middleware";
+import { cors, middleware, csrfProtected, sessionExists } from "@lib/middleware";
 import { setAcceptableUse } from "@lib/acceptableUseCache";
 
 const acceptableUse = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -14,6 +14,6 @@ const acceptableUse = async (req: NextApiRequest, res: NextApiResponse) => {
 };
 
 export default middleware(
-  [cors({ allowedMethods: ["POST"] }), csrfProtected(["POST"])],
+  [cors({ allowedMethods: ["POST"] }), csrfProtected(["POST"]), sessionExists()],
   acceptableUse
 );

--- a/pages/api/flags/[key]/check.tsx
+++ b/pages/api/flags/[key]/check.tsx
@@ -1,8 +1,13 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { checkOne } from "@lib/flags";
+import { middleware, cors } from "@lib/middleware";
 
-export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+const allowedMethods = ["GET"];
+
+const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   const key = req.query.key as string;
   const status = await checkOne(key);
   res.status(200).json({ status });
 };
+
+export default middleware([cors({ allowedMethods })], handler);

--- a/pages/api/flags/[key]/disable.tsx
+++ b/pages/api/flags/[key]/disable.tsx
@@ -1,14 +1,26 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { disableFlag, checkAll } from "@lib/flags";
-import { isAdmin } from "@lib/auth";
+import { middleware, cors, sessionExists } from "@lib/middleware";
 import { logAdminActivity, AdminLogAction, AdminLogEvent } from "@lib/adminLogs";
+import { MiddlewareProps } from "@lib/types";
+import { AccessControlError, createAbility } from "@lib/policyBuilder";
 
-export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
-  const session = await isAdmin({ req, res });
-  if (session) {
+const allowedMethods = ["GET"];
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  { session }: MiddlewareProps
+): Promise<void> => {
+  try {
+    if (!session) return res.status(401).send("Unauthorized");
     const key = req.query.key as string;
-    await disableFlag(key);
-    const flags = await checkAll();
+    if (Array.isArray(key) || !key)
+      return res.status(400).json({ error: "Malformed API Request Flag Key is not defined" });
+    const ability = createAbility(session.user.privileges);
+
+    await disableFlag(ability, key);
+    const flags = await checkAll(ability);
 
     if (session.user.id) {
       await logAdminActivity(
@@ -20,7 +32,10 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
     }
 
     res.status(200).json(flags);
-  } else {
-    res.status(403).send("Forbidden");
+  } catch (e) {
+    if (e instanceof AccessControlError) return res.status(403).json({ error: "Forbidden" });
+    res.status(500).json({ error: "Internal Server Error" });
   }
 };
+
+export default middleware([cors({ allowedMethods }), sessionExists()], handler);

--- a/pages/api/flags/[key]/enable.tsx
+++ b/pages/api/flags/[key]/enable.tsx
@@ -1,14 +1,25 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { isAdmin } from "@lib/auth";
 import { enableFlag, checkAll } from "@lib/flags";
+import { middleware, cors, sessionExists } from "@lib/middleware";
 import { logAdminActivity, AdminLogAction, AdminLogEvent } from "@lib/adminLogs";
+import { MiddlewareProps } from "@lib/types";
+import { AccessControlError, createAbility } from "@lib/policyBuilder";
 
-export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
-  const session = await isAdmin({ req, res });
-  if (session) {
+const allowedMethods = ["GET"];
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  { session }: MiddlewareProps
+): Promise<void> => {
+  try {
+    if (!session) return res.status(401).send("Unauthorized");
     const key = req.query.key as string;
-    await enableFlag(key);
-    const flags = await checkAll();
+    if (Array.isArray(key) || !key)
+      return res.status(400).json({ error: "Malformed API Request Flag Key is not defined" });
+    const ability = createAbility(session.user.privileges);
+    await enableFlag(ability, key);
+    const flags = await checkAll(ability);
 
     if (session.user.id) {
       await logAdminActivity(
@@ -20,7 +31,10 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
     }
 
     res.status(200).json(flags);
-  } else {
-    res.status(403).send("Forbidden");
+  } catch (e) {
+    if (e instanceof AccessControlError) return res.status(403).json({ error: "Forbidden" });
+    res.status(500).json({ error: "Internal Server Error" });
   }
 };
+
+export default middleware([cors({ allowedMethods }), sessionExists()], handler);

--- a/pages/api/flags/index.tsx
+++ b/pages/api/flags/index.tsx
@@ -1,7 +1,25 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { checkAll } from "@lib/flags";
+import { MiddlewareProps } from "@lib/types";
+import { AccessControlError, createAbility } from "@lib/policyBuilder";
+import { middleware, cors, sessionExists } from "@lib/middleware";
 
-export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
-  const flags = await checkAll();
-  res.status(200).json(flags);
+const allowedMethods = ["GET"];
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  { session }: MiddlewareProps
+): Promise<void> => {
+  try {
+    if (!session) return res.status(401).send("Unauthorized");
+    const ability = createAbility(session.user.privileges);
+    const flags = await checkAll(ability);
+    res.status(200).json(flags);
+  } catch (e) {
+    if (e instanceof AccessControlError) return res.status(403).json({ error: "Forbidden" });
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 };
+
+export default middleware([cors({ allowedMethods }), sessionExists()], handler);

--- a/pages/api/id/[form]/apiusers.ts
+++ b/pages/api/id/[form]/apiusers.ts
@@ -6,7 +6,6 @@ import { isValidGovEmail } from "@lib/validation";
 import emailDomainList from "../../../../email.domains.json";
 import { Session } from "next-auth";
 import { logAdminActivity, AdminLogAction, AdminLogEvent } from "@lib/adminLogs";
-import { logMessage } from "@lib/logger";
 import { MiddlewareProps } from "@lib/types";
 import { createAbility, AccessControlError, Ability } from "@lib/policyBuilder";
 import { checkPrivileges } from "@lib/privileges";

--- a/pages/api/id/[form]/bearer.ts
+++ b/pages/api/id/[form]/bearer.ts
@@ -1,27 +1,42 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { isAdmin } from "@lib/auth";
 import jwt from "jsonwebtoken";
 import { logMessage } from "@lib/logger";
-import { prisma } from "@lib/integration/prismaConnector";
+import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
 import { cors, sessionExists, middleware } from "@lib/middleware";
 import { logAdminActivity, AdminLogAction, AdminLogEvent } from "@lib/adminLogs";
-import { Prisma } from "@prisma/client";
+import { MiddlewareProps } from "@lib/types";
+import { createAbility, Ability, AccessControlError } from "@lib/policyBuilder";
+import { checkPrivileges } from "@lib/privileges";
+import { Session } from "next-auth";
 
-const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
-  if (req.method === "GET") {
-    try {
-      return await getToken(req, res);
-    } catch (err) {
-      logMessage.error(err as Error);
-      return res.status(500).json({ error: "Internal Service Error" });
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  { session }: MiddlewareProps
+): Promise<void> => {
+  try {
+    const formID = req.query.form;
+    if (Array.isArray(formID) || !formID)
+      return res
+        .status(400)
+        .json({ error: "form ID parameter was not provided in the resource path" });
+
+    if (!session) return res.status(401).json({ error: "Unauthorized" });
+    const ability = createAbility(session.user.privileges);
+
+    switch (req.method) {
+      case "GET":
+        return await getToken(ability, formID, res);
+      case "POST":
+        return await createToken(ability, formID, res, session);
+
+      default:
+        return res.status(500).json({ error: "Method not supported" });
     }
-  } else if (req.method === "POST") {
-    try {
-      return await createToken(req, res);
-    } catch (err) {
-      logMessage.error(err as Error);
-      return res.status(500).json({ error: "Internal Service Error" });
-    }
+  } catch (e) {
+    if (e instanceof AccessControlError) return res.status(403).json({ error: "Forbidden" });
+    logMessage.error(e as Error);
+    return res.status(500).json({ error: "Internal Service Error" });
   }
 };
 
@@ -32,103 +47,108 @@ const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void>
  * @param req The request object containing data of the request
  * @param res The response object containing all that is needed to return a response
  */
-export async function createToken(req: NextApiRequest, res: NextApiResponse): Promise<void> {
-  const formID = req.query.form as string;
-  if (formID) {
-    // get the session which is important for traceability purposes in logs
-    const session = await isAdmin({ req, res });
-    // create the bearer token with the payload being the form ID
-    // and signed by the token secret. The expiry time for this token is set to be one
-    // year
-    const token = jwt.sign(
-      {
-        formID,
+export async function createToken(
+  ability: Ability,
+  formID: string,
+  res: NextApiResponse,
+  session: Session
+): Promise<void> {
+  // Verify if use can update the bearer token on this form
+  const targetFormRecord = await prisma.template
+    .findUnique({
+      where: {
+        id: formID,
       },
-      process.env.TOKEN_SECRET as string,
-      {
-        expiresIn: "1y",
-      }
+      select: {
+        users: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    })
+    .catch((e) => prismaErrors(e, null));
+
+  if (targetFormRecord === null) return res.status(404).json({ error: "Form Not Found" });
+  checkPrivileges(ability, [
+    { action: "update", subject: { type: "FormRecord", object: targetFormRecord } },
+  ]);
+
+  // create the bearer token with the payload being the form ID
+  // and signed by the token secret. The expiry time for this token is set to be one
+  // year
+  const token = jwt.sign(
+    {
+      formID,
+    },
+    process.env.TOKEN_SECRET as string,
+    {
+      expiresIn: "1y",
+    }
+  );
+  // update the row with the new bearer token
+  // return the id and the updated bearer_token field
+  const updatedBearerToken = await prisma.template
+    .update({
+      where: {
+        id: formID,
+      },
+      data: {
+        bearerToken: token,
+      },
+      select: {
+        id: true,
+        bearerToken: true,
+      },
+    })
+    .catch((e) => prismaErrors(e, null));
+
+  // return the record with the id and the updated bearer token. Log the success
+  if (session && session.user.id) {
+    await logAdminActivity(
+      session.user.id,
+      AdminLogAction.Update,
+      AdminLogEvent.RefreshBearerToken,
+      `Bearer token for form id: ${formID} has been refreshed`
     );
-    // update the row with the new bearer token
-    // return the id and the updated bearer_token field
-    try {
-      const updatedBearerToken = await prisma.template.update({
-        where: {
-          id: formID,
-        },
-        data: {
-          bearerToken: token,
-        },
-        select: {
-          id: true,
-          bearerToken: true,
-        },
-      });
-
-      // return the record with the id and the updated bearer token. Log the success
-      logMessage.info(
-        `A bearer token was refreshed for form ${formID} by user ${session?.user?.name}`
-      );
-      if (session && session.user.id) {
-        await logAdminActivity(
-          session.user.id,
-          AdminLogAction.Update,
-          AdminLogEvent.RefreshBearerToken,
-          `Bearer token for form id: ${formID} has been refreshed`
-        );
-      }
-      return res.status(200).json(updatedBearerToken);
-    } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
-        logMessage.warn(
-          `A bearer token was attempted to be created for form ${formID} by user ${session?.user?.name} but the form does not exist`
-        );
-        return res.status(404).json({ error: "Not Found" });
-      }
-      // Continue the error chain if it isn't an object not found error
-      throw e;
-    }
   }
-  return res.status(400).json({ error: "form ID parameter was not provided in the resource path" });
+  return res.status(200).json(updatedBearerToken);
 }
 
 /**
- * Will return a bearer token if there is one associated with a given formID
- * It might return a Not found (404) if token doest exist ( undefined or null)
- * otherwise 400 as status code.
- * @param req The request object containing data of the request
- * @param res The response object containing all that is needed to return a response
+ * Gets a bearer token associated with a form.
+ * @param ability Users Ability Instance
+ * @param formID Id of the form being referenced
+ * @param res Next JS response instance
+ * @returns Bearer Token if it exists
  */
-export async function getToken(req: NextApiRequest, res: NextApiResponse): Promise<void> {
-  const formID = req.query.form as string;
-  if (formID) {
-    //Fetching the token returns the bearer token or null.
-    const result = await getTokenById(formID);
-    if (typeof result?.bearerToken !== "undefined") {
-      return res.status(200).json({ bearerToken: result.bearerToken });
-    }
-    // otherwise the resource was not found
-    return res.status(404).json({ error: "Not Found" });
-  }
-  return res.status(400).json({ error: "form ID parameter was not provided in the resource path" });
-}
+export async function getToken(
+  ability: Ability,
+  formID: string,
+  res: NextApiResponse
+): Promise<void> {
+  //Fetching the token returns the bearer token or null.
 
-/**
- * Will return the query including the bearerToken from the database
- * @param formID - The id of the form
- * @returns the query result
- */
-export const getTokenById = async (
-  formID: string
-): Promise<{ bearerToken: string | null } | null> => {
-  return await prisma.template.findUnique({
-    where: {
-      id: formID,
-    },
-    select: {
-      bearerToken: true,
-    },
-  });
-};
+  const result = await prisma.template
+    .findUnique({
+      where: {
+        id: formID,
+      },
+      select: {
+        bearerToken: true,
+        users: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    })
+    .catch((e) => prismaErrors(e, null));
+  if (result === null) return res.status(404).json({ error: "Not Found" });
+  // To save a database call we retrieve the bearer token but additionally return the users.
+  checkPrivileges(ability, [{ action: "view", subject: { type: "FormRecord", object: result } }]);
+
+  return res.status(200).json({ bearerToken: result.bearerToken });
+}
 
 export default middleware([cors({ allowedMethods: ["GET", "POST"] }), sessionExists()], handler);

--- a/pages/api/id/[form]/retrieval.ts
+++ b/pages/api/id/[form]/retrieval.ts
@@ -201,11 +201,8 @@ async function deleteFormResponses(
   }
 }
 
+// Removing access for all Methods until this API is ready for use.
 export default middleware(
-  [
-    cors({ allowedMethods: ["GET", "DELETE"] }),
-    validTemporaryToken(),
-    jsonValidator(retrievalSchema),
-  ],
+  [cors({ allowedMethods: [] }), validTemporaryToken(), jsonValidator(retrievalSchema)],
   handler
 );

--- a/pages/auth/policy.tsx
+++ b/pages/auth/policy.tsx
@@ -12,7 +12,7 @@ const TermsOfUse = ({ content, user }: TermsOfUse) => {
   const acceptableProps: AcceptableUseProps = {
     content,
     lastLoginTime: user.lastLoginTime,
-    userId: user.userId,
+    userId: user.id,
     formID: user.authorizedForm,
   };
   return (


### PR DESCRIPTION
# Summary | Résumé
This is one of the last PR's that covers off the permissions feature.
Wrapped:
- Bearer token API and CRUD functions
- Flags aka Application Settings API and CRUD functions
- Auth lib

Fixed:
- Typescript error in CORS Middleware
- Removed Retrieval API from play by denying access to all methods (For now until Vault is a priority)
- Small refactors to remove UserRole from the code base
- Fixed tests that were failing because of a dependence on UserRole.Admin
- Fixed AcceptableUse API to require a valid session (was previously allowing unauthenticated calls)
- some other small refactors along the way.