### PR TITLE
Page access restrictions

### DIFF
--- a/__tests__/api/acceptable-use.test.ts
+++ b/__tests__/api/acceptable-use.test.ts
@@ -49,7 +49,8 @@ describe("Test acceptable use endpoint", () => {
     expect(res.statusCode).toBe(200);
   });
 
-  it("Should return 404 for undefined userID", async () => {
+  it("Should return 401 for unauthenticated user", async () => {
+    mockGetSession.mockReset();
     const { req, res } = createMocks({
       method: "POST",
       headers: {
@@ -62,8 +63,8 @@ describe("Test acceptable use endpoint", () => {
       },
     });
     await acceptableUse(req, res);
-    expect(res.statusCode).toBe(404);
-    expect(JSON.parse(res._getData())).toEqual(expect.objectContaining({ error: "Bad request" }));
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res._getData())).toEqual(expect.objectContaining({ error: "Unauthorized" }));
   });
 
   it("Should throw an error and return 500 status code", async () => {

--- a/components/globals/AdminNav.tsx
+++ b/components/globals/AdminNav.tsx
@@ -27,9 +27,6 @@ const AdminNav = (props: AdminNavProps): React.ReactElement => {
           </li>
         )}
 
-        <li className="gc-horizontal-item">
-          <Link href="/admin/vault">{t("adminNav.vault")}</Link>
-        </li>
         {ability?.can("view", "User") && (
           <li className="gc-horizontal-item">
             <Link href="/admin/users">{t("adminNav.users")}</Link>
@@ -40,17 +37,21 @@ const AdminNav = (props: AdminNavProps): React.ReactElement => {
             <Link href="/admin/privileges">{t("adminNav.privileges")}</Link>
           </li>
         )}
-        <li className="gc-horizontal-item">
-          <Link href="/admin/upload">{t("adminNav.upload")}</Link>
-        </li>
+        {ability?.can("create", "FormRecord") && (
+          <li className="gc-horizontal-item">
+            <Link href="/admin/upload">{t("adminNav.upload")}</Link>
+          </li>
+        )}
         {ability?.can("view", "FormRecord") && (
           <li className="gc-horizontal-item">
             <Link href="/admin/view-templates">{t("adminNav.templates")}</Link>
           </li>
         )}
-        <li className="gc-horizontal-item">
-          <Link href="/admin/flags">{t("adminNav.features")}</Link>
-        </li>
+        {ability?.can("view", "Flag") && (
+          <li className="gc-horizontal-item">
+            <Link href="/admin/flags">{t("adminNav.features")}</Link>
+          </li>
+        )}
         <li className="gc-horizontal-item">
           {(!user || !user.name) && (
             <Link href="/admin/login" locale={i18n.language}>

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -153,7 +153,7 @@ async function _updateTemplate(
   formID: string,
   formConfig: BetterOmit<FormRecord, "id" | "bearerToken">
 ): Promise<FormRecord | null> {
-  const formRecordWithAssociatedUsers = await getFormRecordWithAssociatedUsers(formID);
+  const formRecordWithAssociatedUsers = await _getFormRecordWithAssociatedUsers(formID);
   if (!formRecordWithAssociatedUsers) return null;
 
   checkPrivileges(ability, [
@@ -196,7 +196,7 @@ async function _updateTemplate(
  * @returns A boolean status if operation is sucessful
  */
 async function _deleteTemplate(ability: Ability, formID: string): Promise<FormRecord | null> {
-  const formRecordWithAssociatedUsers = await getFormRecordWithAssociatedUsers(formID);
+  const formRecordWithAssociatedUsers = await _getFormRecordWithAssociatedUsers(formID);
   if (!formRecordWithAssociatedUsers) return null;
 
   checkPrivileges(ability, [
@@ -232,7 +232,7 @@ async function _deleteTemplate(ability: Ability, formID: string): Promise<FormRe
   return _parseTemplate(deletedTemplate);
 }
 
-async function getFormRecordWithAssociatedUsers(
+async function _getFormRecordWithAssociatedUsers(
   formID: string
 ): Promise<{ formRecord: FormRecord; users: User[] } | null> {
   try {

--- a/pages/admin/flags.tsx
+++ b/pages/admin/flags.tsx
@@ -5,6 +5,7 @@ import { requireAuthentication } from "@lib/auth";
 import { useTranslation } from "next-i18next";
 import Loader from "@components/globals/Loader";
 import { Button } from "@components/forms";
+import { checkPrivileges } from "@lib/privileges";
 
 const fetcher = (url: string) => fetch(url).then((response) => response.json());
 
@@ -64,11 +65,11 @@ const Flags: React.FC = () => {
   );
 };
 
-export const getServerSideProps = requireAuthentication(async (context) => {
+export const getServerSideProps = requireAuthentication(async ({ locale, user: { ability } }) => {
+  checkPrivileges(ability, [{ action: "view", subject: "Flag" }]);
   return {
     props: {
-      ...(context.locale &&
-        (await serverSideTranslations(context.locale, ["common", "admin-flags"]))),
+      ...(locale && (await serverSideTranslations(locale, ["common", "admin-flags"]))),
     },
   };
 });

--- a/pages/admin/form-builder.tsx
+++ b/pages/admin/form-builder.tsx
@@ -3,7 +3,6 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import { Layout } from "../../components/form-builder/layout/Layout";
 import { User } from "next-auth";
-import { createAbility } from "@lib/policyBuilder";
 
 type WelcomeProps = {
   user: User;
@@ -21,16 +20,7 @@ const Welcome: React.FC<WelcomeProps> = () => {
   );
 };
 
-export const getServerSideProps = requireAuthentication(async ({ user, locale }) => {
-  const userAbility = user?.privileges && createAbility(user.privileges);
-  if (userAbility?.cannot("update", "FormRecord")) {
-    return {
-      redirect: {
-        destination: `/${locale}/admin/unauthorized/`,
-        permanent: false,
-      },
-    };
-  }
+export const getServerSideProps = requireAuthentication(async ({ user: { ability }, locale }) => {
   return {
     props: {
       ...(locale && (await serverSideTranslations(locale, ["common", "form-builder"]))),

--- a/pages/admin/form-builder.tsx
+++ b/pages/admin/form-builder.tsx
@@ -3,6 +3,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import { Layout } from "../../components/form-builder/layout/Layout";
 import { User } from "next-auth";
+import { checkPrivileges } from "@lib/privileges";
 
 type WelcomeProps = {
   user: User;
@@ -21,6 +22,7 @@ const Welcome: React.FC<WelcomeProps> = () => {
 };
 
 export const getServerSideProps = requireAuthentication(async ({ user: { ability }, locale }) => {
+  checkPrivileges(ability, [{ action: "update", subject: "FormRecord" }]);
   return {
     props: {
       ...(locale && (await serverSideTranslations(locale, ["common", "form-builder"]))),

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -30,7 +30,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (session)
     return {
-      props: {},
       redirect: {
         destination: `/${context.locale}/admin/`,
         permanent: false,
@@ -39,7 +38,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (session)
     return {
-      props: {},
       redirect: {
         destination: `/${context.locale}/admin/unauthorized/`,
         permanent: false,

--- a/pages/admin/privileges.tsx
+++ b/pages/admin/privileges.tsx
@@ -185,18 +185,19 @@ const ModifyPrivilege = ({
 const Privileges = ({ allPrivileges }: { allPrivileges: Privilege[] }): React.ReactElement => {
   const { t } = useTranslation("admin-privileges");
   const [modifyMode, setModifyMode] = useState(false);
-  const [selectedPrivilege, setSelectedPrivealge] = useState<Privilege | null>(null);
+  const [selectedPrivilege, setSelectedPrivilege] = useState<Privilege | null>(null);
   const { refreshData } = useRefresh();
   const { ability } = useAccessControl();
 
   const editPrivilege = (privilege: Privilege) => {
-    setSelectedPrivealge(privilege);
+    setSelectedPrivilege(privilege);
     setModifyMode(true);
   };
 
   const cancelEdit = () => {
     setModifyMode(false);
-    setSelectedPrivealge(null);
+    setSelectedPrivilege(null);
+
     refreshData();
   };
 
@@ -228,7 +229,7 @@ const Privileges = ({ allPrivileges }: { allPrivileges: Privilege[] }): React.Re
               <Button
                 type="button"
                 onClick={() => {
-                  setSelectedPrivealge(null);
+                  setSelectedPrivilege(null);
                   setModifyMode(true);
                 }}
               >

--- a/pages/admin/privileges.tsx
+++ b/pages/admin/privileges.tsx
@@ -187,6 +187,7 @@ const Privileges = ({ allPrivileges }: { allPrivileges: Privilege[] }): React.Re
   const [modifyMode, setModifyMode] = useState(false);
   const [selectedPrivilege, setSelectedPrivealge] = useState<Privilege | null>(null);
   const { refreshData } = useRefresh();
+  const { ability } = useAccessControl();
 
   const editPrivilege = (privilege: Privilege) => {
     setSelectedPrivealge(privilege);
@@ -223,15 +224,17 @@ const Privileges = ({ allPrivileges }: { allPrivileges: Privilege[] }): React.Re
                 })}
               </tbody>
             </table>
-            <Button
-              type="button"
-              onClick={() => {
-                setSelectedPrivealge(null);
-                setModifyMode(true);
-              }}
-            >
-              Create
-            </Button>
+            {ability?.can("create", "Privilege") && (
+              <Button
+                type="button"
+                onClick={() => {
+                  setSelectedPrivealge(null);
+                  setModifyMode(true);
+                }}
+              >
+                Create
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/pages/admin/unauthorized.tsx
+++ b/pages/admin/unauthorized.tsx
@@ -20,7 +20,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (!session)
     return {
-      props: {},
       redirect: {
         destination: `/${context.locale}/admin/login/`,
         permanent: false,

--- a/pages/admin/upload.tsx
+++ b/pages/admin/upload.tsx
@@ -3,12 +3,13 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import React from "react";
 import { useTranslation } from "next-i18next";
+import { checkPrivileges } from "@lib/privileges";
 
-export const getServerSideProps = requireAuthentication(async (context) => {
+export const getServerSideProps = requireAuthentication(async ({ locale, user: { ability } }) => {
+  checkPrivileges(ability, [{ action: "create", subject: "FormRecord" }]);
   return {
     props: {
-      ...(context.locale &&
-        (await serverSideTranslations(context.locale, ["common", "admin-templates"]))),
+      ...(locale && (await serverSideTranslations(locale, ["common", "admin-templates"]))),
     },
   };
 });

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -56,11 +56,12 @@ const ManageUser = ({
     { id: string; action: "add" | "remove" }[]
   >([]);
 
-  const { ability } = useAccessControl();
+  const { ability, refreshAbility } = useAccessControl();
   const canManageUsers = ability?.can("update", "User") ?? false;
 
   const save = async () => {
     await updatePrivilege(user.id, changedPrivileges);
+    await refreshAbility();
     unselectUser();
   };
 

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -6,7 +6,7 @@ import { useRefresh } from "@lib/hooks";
 import React, { useState } from "react";
 import axios from "axios";
 import { useTranslation } from "next-i18next";
-import { getAllPrivileges } from "@lib/privileges";
+import { checkPrivileges, getAllPrivileges } from "@lib/privileges";
 import { Privilege } from "@prisma/client";
 import { useAccessControl } from "@lib/hooks/useAccessControl";
 import { Button } from "@components/forms";
@@ -178,6 +178,14 @@ const Users = ({
 export default Users;
 
 export const getServerSideProps = requireAuthentication(async ({ user: { ability }, locale }) => {
+  checkPrivileges(
+    ability,
+    [
+      { action: "view", subject: "User" },
+      { action: "view", subject: "Privilege" },
+    ],
+    "all"
+  );
   const allUsers = await getUsers(ability);
   const allPrivileges = (await getAllPrivileges(ability)).map(
     ({ id, nameEn, nameFr, descriptionFr, descriptionEn }) => ({

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "next-i18next";
 import axios from "axios";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+// import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import { getFormByID } from "@lib/helpers";
 import convertMessage from "@lib/markdown";
@@ -111,7 +111,7 @@ const FormResponse = ({
       <div className="p-5">
         <RichText className="email-preview">{response}</RichText>
       </div>
-      <div className="inline-block justify-center flex space-x-20">
+      <div className="justify-center flex space-x-20">
         {index > 0 && (
           <Button
             className="gc-button rounded-lg float-left"
@@ -271,7 +271,7 @@ const AdminVault: React.FC = () => {
         </div>
       </div>
       {responses.Items.length ? (
-        <div className="mt-4 inline-block justify-left flex space-x-20">
+        <div className="mt-4 justify-left flex space-x-20">
           <Button
             className="gc-button rounded-lg"
             type="button"

--- a/pages/admin/vault.tsx
+++ b/pages/admin/vault.tsx
@@ -244,7 +244,7 @@ const AdminVault: React.FC = () => {
       </div>
       <div>
         <form id="form" onSubmit={handleSubmit}>
-          <label className={"gc-label"} htmlFor={"formTextInput"} id={"1"}>
+          <label className={"gc-label"} htmlFor={"formTextInput"}>
             {t("formInput")}
           </label>
           <div className="inline-block space-x-3">
@@ -292,12 +292,21 @@ const AdminVault: React.FC = () => {
 };
 
 export const getServerSideProps = requireAuthentication(async (context) => {
+  // Disabling this page until the Vault feature is ready.
+  return {
+    redirect: {
+      destination: `/${context.locale}/admin/`,
+      permanent: false,
+    },
+  };
+  /*
   return {
     props: {
       ...(context.locale &&
         (await serverSideTranslations(context.locale, ["common", "admin-vault"]))),
     },
   };
+  */
 });
 
 export default AdminVault;

--- a/pages/api/acceptableuse.ts
+++ b/pages/api/acceptableuse.ts
@@ -1,12 +1,16 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { cors, middleware, csrfProtected, sessionExists } from "@lib/middleware";
 import { setAcceptableUse } from "@lib/acceptableUseCache";
+import { MiddlewareProps } from "@lib/types";
 
-const acceptableUse = async (req: NextApiRequest, res: NextApiResponse) => {
+const acceptableUse = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  { session }: MiddlewareProps
+) => {
   try {
-    const { userID } = req.body;
-    if (!userID) return res.status(404).json({ error: "Bad request" });
-    await setAcceptableUse(userID);
+    if (!session) return res.status(401).json({ error: "Unauthorized" });
+    await setAcceptableUse(session.user.id);
     res.status(200).json({});
   } catch (err) {
     res.status(500).json({ error: "Malformed API Request" });

--- a/pages/api/acceptableuse.ts
+++ b/pages/api/acceptableuse.ts
@@ -4,7 +4,7 @@ import { setAcceptableUse } from "@lib/acceptableUseCache";
 import { MiddlewareProps } from "@lib/types";
 
 const acceptableUse = async (
-  req: NextApiRequest,
+  _req: NextApiRequest,
   res: NextApiResponse,
   { session }: MiddlewareProps
 ) => {

--- a/pages/api/privileges.ts
+++ b/pages/api/privileges.ts
@@ -13,7 +13,7 @@ import {
 } from "@lib/privileges";
 const allowedMethods = ["GET", "PUT", "POST"];
 
-const getPrivilegeList = async (res: NextApiResponse, ability: Ability) => {
+const getPrivilegeList = async (ability: Ability, res: NextApiResponse) => {
   const privileges = await getAllPrivileges(ability);
   if (privileges.length === 0) {
     res.status(500).json({ error: "Could not process request" });
@@ -23,9 +23,9 @@ const getPrivilegeList = async (res: NextApiResponse, ability: Ability) => {
 };
 
 const createPrivilege = async (
+  ability: Ability,
   req: NextApiRequest,
   res: NextApiResponse,
-  ability: Ability,
   session?: Session
 ) => {
   const { privilege } = req.body;
@@ -52,9 +52,9 @@ const createPrivilege = async (
 };
 
 const updatePrivilege = async (
+  ability: Ability,
   req: NextApiRequest,
   res: NextApiResponse,
-  ability: Ability,
   session?: Session
 ) => {
   const { privilege } = req.body;
@@ -95,13 +95,13 @@ const handler = async (
 
     switch (req.method) {
       case "POST":
-        await createPrivilege(req, res, ability, session);
+        await createPrivilege(ability, req, res, session);
         break;
       case "PUT":
-        await updatePrivilege(req, res, ability, session);
+        await updatePrivilege(ability, req, res, session);
         break;
       case "GET":
-        await getPrivilegeList(res, ability);
+        await getPrivilegeList(ability, res);
         break;
     }
   } catch (error) {

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -11,7 +11,7 @@ import { updatePrivilegesForUser } from "@lib/privileges";
 
 const allowedMethods = ["GET", "PUT"];
 
-const getUserList = async (res: NextApiResponse, ability: Ability) => {
+const getUserList = async (ability: Ability, res: NextApiResponse) => {
   const users = await getUsers(ability);
   if (users.length === 0) {
     res.status(500).json({ error: "Could not process request" });
@@ -21,9 +21,9 @@ const getUserList = async (res: NextApiResponse, ability: Ability) => {
 };
 
 const updatePrivilegeOnUser = async (
+  ability: Ability,
   req: NextApiRequest,
   res: NextApiResponse,
-  ability: Ability,
   session?: Session
 ) => {
   const { userID, privileges } = req.body;
@@ -66,10 +66,10 @@ const handler = async (
 
     switch (req.method) {
       case "GET":
-        await getUserList(res, ability);
+        await getUserList(ability, res);
         break;
       case "PUT":
-        await updatePrivilegeOnUser(req, res, ability, session);
+        await updatePrivilegeOnUser(ability, req, res, session);
         break;
     }
   } catch (error) {

--- a/pages/id/[form]/retrieval.tsx
+++ b/pages/id/[form]/retrieval.tsx
@@ -2,6 +2,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import { useTranslation } from "next-i18next";
 import React from "react";
+import { checkPrivileges } from "@lib/privileges";
 
 const retrieval = (): React.ReactElement => {
   const { t } = useTranslation("forms-responses-retrieval");
@@ -15,12 +16,21 @@ const retrieval = (): React.ReactElement => {
   );
 };
 
-export const getServerSideProps = requireAuthentication(async (context) => {
-  if (!context.user?.acceptableUse) {
+export const getServerSideProps = requireAuthentication(async ({ locale, params }) => {
+  // Disabling this page until the Vault feature is ready.
+  return {
+    redirect: {
+      destination: `/${locale}/id/${params?.form}`,
+      permanent: false,
+    },
+  };
+
+  /*
+  if (!user?.acceptableUse) {
     return {
       redirect: {
         //redirect to acceptable use page
-        destination: `/${context.locale}/auth/policy`,
+        destination: `/${locale}/auth/policy`,
         permanent: false,
       },
     };
@@ -28,10 +38,11 @@ export const getServerSideProps = requireAuthentication(async (context) => {
 
   return {
     props: {
-      ...(context.locale &&
-        (await serverSideTranslations(context?.locale, ["common", "forms-responses-retrieval"]))),
+      ...(locale &&
+        (await serverSideTranslations(locale, ["common", "forms-responses-retrieval"]))),
     },
   };
+  */
 });
 
 export default retrieval;

--- a/pages/id/[form]/retrieval.tsx
+++ b/pages/id/[form]/retrieval.tsx
@@ -1,8 +1,7 @@
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+// import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import { useTranslation } from "next-i18next";
 import React from "react";
-import { checkPrivileges } from "@lib/privileges";
 
 const retrieval = (): React.ReactElement => {
   const { t } = useTranslation("forms-responses-retrieval");

--- a/pages/id/[form]/settings.tsx
+++ b/pages/id/[form]/settings.tsx
@@ -2,6 +2,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { requireAuthentication } from "@lib/auth";
 import { getTemplateByID } from "@lib/templates";
 import Settings from "@components/admin/TemplateDelete/Settings";
+import { checkPrivileges } from "@lib/privileges";
 
 const redirect = (locale: string | undefined) => {
   return {
@@ -13,29 +14,32 @@ const redirect = (locale: string | undefined) => {
   };
 };
 
-export const getServerSideProps = requireAuthentication(async (context) => {
-  const formID = context?.params?.form;
+export const getServerSideProps = requireAuthentication(
+  async ({ locale, params, user: { ability } }) => {
+    // Only users who have the ManageForms privilege can view this page for now
+    checkPrivileges(ability, [{ action: "update", subject: { type: "FormRecord", object: {} } }]);
 
-  // Needed for typechecking of a ParsedURLQuery type which can be a string or string[]
-  if (!formID || Array.isArray(formID)) return redirect(context.locale);
+    const formID = params?.form;
+    // Needed for typechecking of a ParsedURLQuery type which can be a string or string[]
+    if (!formID || Array.isArray(formID)) return redirect(locale);
 
-  if (formID) {
-    // get form info from db
+    if (formID) {
+      // get form info from db
 
-    const template = await getTemplateByID(formID);
+      const template = await getTemplateByID(formID);
 
-    if (template) {
-      return {
-        props: {
-          form: template,
-          ...(context.locale &&
-            (await serverSideTranslations(context.locale, ["common", "admin-templates"]))),
-        },
-      };
+      if (template) {
+        return {
+          props: {
+            form: template,
+            ...(locale && (await serverSideTranslations(locale, ["common", "admin-templates"]))),
+          },
+        };
+      }
     }
+    // if no form returned, 404
+    return redirect(locale);
   }
-  // if no form returned, 404
-  return redirect(context.locale);
-});
+);
 
 export default Settings;


### PR DESCRIPTION
# Summary | Résumé
This PR:
- wraps the various pages that require privileges and ensures the user has the minimum privileges required to be interactive.
- fixes a security issue where on acceptable-use API any valid session had the ability to modify any other user's acceptance flag.  The user id is now pulled from the active session and is not passed in the body of the request.
- disables Vault page and API as the feature is not in use until a future major release
-   small refactors for code style commonality and more interactive state changes.
