### PR TITLE
feat: mark form template as archived instead of deleting them right away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Terms and conditions page + text link in the footer [#863](https://github.com/cds-snc/platform-forms-client/issues/863)
 - Modified Role Based to Asset Based Access Control [#1176](https://github.com/cds-snc/platform-forms-client/pull/1176)
+- Form templates are now marked as archived and will stay in the database for 30 more days before being deleted by a Lambda function. [#1166](https://github.com/cds-snc/platform-forms-client/issues/1166)
 
 ### Fixed
 

--- a/__tests__/api/templates.test.ts
+++ b/__tests__/api/templates.test.ts
@@ -207,7 +207,7 @@ describe("Test templates API functions", () => {
         users: [{ id: "1" }],
       });
 
-      (prismaMock.template.delete as jest.MockedFunction<any>).mockResolvedValue({
+      (prismaMock.template.update as jest.MockedFunction<any>).mockResolvedValue({
         id: "test0form00000id000asdf11",
         jsonConfig: validFormTemplate,
       });

--- a/prisma/migrations/20221031124445_add_ttl_to_template/migration.sql
+++ b/prisma/migrations/20221031124445_add_ttl_to_template/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Template" ADD COLUMN     "ttl" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,8 @@ model Template {
   id          String     @id @default(cuid())
   jsonConfig  Json
   bearerToken String?
-  apiUsers   ApiUser[]
+  ttl         DateTime?
+  apiUsers    ApiUser[]
   users       User[]
 }
 

--- a/prisma/seeds/fixtures/templates.ts
+++ b/prisma/seeds/fixtures/templates.ts
@@ -1,6 +1,6 @@
 import { Template } from "@prisma/client";
 
-type TemplateSeed = Omit<Template, "id" | "bearerToken" | "apiUsers" | "users">;
+type TemplateSeed = Omit<Template, "id" | "bearerToken" | "ttl" | "apiUsers" | "users">;
 type TemplateCollection = {
   development: TemplateSeed[];
   production: TemplateSeed[];


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/1166
linked to https://github.com/cds-snc/forms-terraform/pull/271

- Changed the form template delete API function in order to mark them as archived instead of deleting them

# Test instructions | Instructions pour tester la modification

- Delete a form template using the admin UI
- It should disappear from the list of templates in the UI but will stay in the database (`yarn prisma:studio`)

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
