### PR TITLE
fix: Update design for form title and rich text fields

### DIFF
--- a/components/form-builder/elements/RichText.tsx
+++ b/components/form-builder/elements/RichText.tsx
@@ -1,12 +1,7 @@
 import React from "react";
-import styled from "styled-components";
 import useTemplateStore from "../store/useTemplateStore";
 import { RichTextEditor } from "../lexical-editor/RichTextEditor";
 import { LocalizedElementProperties } from "../types";
-
-const OptionWrapper = styled.div`
-  display: flex;
-`;
 
 export const RichText = ({ parentIndex }: { parentIndex: number }) => {
   const { localizeField, form, lang } = useTemplateStore();
@@ -15,7 +10,7 @@ export const RichText = ({ parentIndex }: { parentIndex: number }) => {
     form.elements[parentIndex].properties[localizeField(LocalizedElementProperties.DESCRIPTION)];
 
   return (
-    <OptionWrapper>
+    <div className="flex mx-7 mt-5 mb-7 border-2 rounded">
       <RichTextEditor
         autoFocusEditor={true}
         path={`form.elements[${parentIndex}].properties.${localizeField(
@@ -24,6 +19,6 @@ export const RichText = ({ parentIndex }: { parentIndex: number }) => {
         content={content}
         lang={lang}
       />
-    </OptionWrapper>
+    </div>
   );
 };

--- a/components/form-builder/elements/RichTextLocked.tsx
+++ b/components/form-builder/elements/RichTextLocked.tsx
@@ -7,10 +7,7 @@ import { LocalizedElementProperties } from "../types";
 
 const ElementWrapperDiv = styled.div`
   border: 1.5px solid #000000;
-  position: relative;
   max-width: 800px;
-  height: auto;
-  margin-top: -1px;
 `;
 
 export const RichTextLocked = ({
@@ -29,16 +26,18 @@ export const RichTextLocked = ({
   const { localizeField, lang } = useTemplateStore();
 
   return (
-    <ElementWrapperDiv>
-      {beforeContent && beforeContent}
-      <div className="flex mt-6 mx-7">{children}</div>
-      <div className="flex">
-        <RichTextEditor
-          path={`form.${schemaProperty}.${localizeField(LocalizedElementProperties.DESCRIPTION)}`}
-          content={initialValue}
-          lang={lang}
-          autoFocusEditor={false}
-        />
+    <ElementWrapperDiv className="h-auto relative -mt-px">
+      <div className="mx-7 mt-5 mb-7">
+        {beforeContent && beforeContent}
+        <div className="flex">{children}</div>
+        <div className="flex border-2 rounded">
+          <RichTextEditor
+            path={`form.${schemaProperty}.${localizeField(LocalizedElementProperties.DESCRIPTION)}`}
+            content={initialValue}
+            lang={lang}
+            autoFocusEditor={false}
+          />
+        </div>
       </div>
       <PanelActionsLocked addElement={addElement} />
     </ElementWrapperDiv>

--- a/components/form-builder/elements/RichTextLocked.tsx
+++ b/components/form-builder/elements/RichTextLocked.tsx
@@ -13,23 +13,6 @@ const ElementWrapperDiv = styled.div`
   margin-top: -1px;
 `;
 
-const ContentWrapper = styled.div`
-  display: flex;
-  margin: 0px 20px;
-
-  & h2 {
-    font-size: 26px;
-    line-height: 32px;
-    margin-top: 15px;
-    margin-bottom: 10px;
-    padding-bottom: 0;
-  }
-`;
-
-const OptionWrapper = styled.div`
-  display: flex;
-`;
-
 export const RichTextLocked = ({
   beforeContent = null,
   addElement,
@@ -48,15 +31,15 @@ export const RichTextLocked = ({
   return (
     <ElementWrapperDiv>
       {beforeContent && beforeContent}
-      <ContentWrapper>{children}</ContentWrapper>
-      <OptionWrapper>
+      <div className="flex mt-6 mx-7">{children}</div>
+      <div className="flex">
         <RichTextEditor
           path={`form.${schemaProperty}.${localizeField(LocalizedElementProperties.DESCRIPTION)}`}
           content={initialValue}
           lang={lang}
           autoFocusEditor={false}
         />
-      </OptionWrapper>
+      </div>
       <PanelActionsLocked addElement={addElement} />
     </ElementWrapperDiv>
   );

--- a/components/form-builder/layout/EditNavigation.tsx
+++ b/components/form-builder/layout/EditNavigation.tsx
@@ -10,29 +10,33 @@ export const EditNavigation = ({
 }) => {
   const { t } = useTranslation("form-builder");
   return (
-    <>
-      <div className="mb-8">
-        <button
-          className={`mr-5 ${currentTab === "create" ? "font-bold" : ""}`}
-          onClick={handleClick("create")}
-        >
-          {t("questions")}
-        </button>
-        |
-        <button
-          className={`ml-5 mr-5 ${currentTab === "translate" ? "font-bold" : ""}`}
-          onClick={handleClick("translate")}
-        >
-          {t("translate")}
-        </button>
-        |
-        <button
-          className={`ml-5 ${currentTab === "settings" ? "font-bold" : ""}`}
-          onClick={handleClick("settings")}
-        >
-          {t("settings")}
-        </button>
-      </div>
-    </>
+    <nav className="mb-8" aria-label={t("navLabelEditor")}>
+      <button
+        className={`mr-5 ${
+          currentTab === "create" ? "font-bold" : ""
+        } outline-blue-focus outline-offset-2`}
+        onClick={handleClick("create")}
+      >
+        {t("questions")}
+      </button>
+      |
+      <button
+        className={`ml-5 mr-5 ${
+          currentTab === "translate" ? "font-bold" : ""
+        } outline-blue-focus outline-offset-2`}
+        onClick={handleClick("translate")}
+      >
+        {t("translate")}
+      </button>
+      |
+      <button
+        className={`ml-5 ${
+          currentTab === "settings" ? "font-bold" : ""
+        } outline-blue-focus outline-offset-2`}
+        onClick={handleClick("settings")}
+      >
+        {t("settings")}
+      </button>
+    </nav>
   );
 };

--- a/components/form-builder/layout/LeftNavigation.tsx
+++ b/components/form-builder/layout/LeftNavigation.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "next-i18next";
 import { DesignIcon, PreviewIcon, ShareIcon, PublishIcon, SaveIcon } from "../icons";
 import { useAllowPublish } from "../hooks/useAllowPublish";
 
-function Link({
+function Button({
   children,
   handleClick,
   icon,
@@ -41,45 +41,45 @@ export const LeftNavigation = ({
     "inline-block group-hover:fill-blue-hover group-focus:fill-white-default group-active:fill-white-default mr-2 -mt-1";
 
   return (
-    <div className="col-span-3">
-      <Link
+    <nav className="col-span-3" aria-label={t("navLabelFormBuilder")}>
+      <Button
         isCurrentTab={currentTab === "start"}
         icon={<DesignIcon className={iconClassname} />}
         handleClick={handleClick("start")}
       >
         {t("start")}
-      </Link>
-      <Link
+      </Button>
+      <Button
         isCurrentTab={["create", "translate", "settings"].includes(currentTab)}
         icon={<PreviewIcon className={iconClassname} />}
         handleClick={handleClick("create")}
       >
         {t("design")}
-      </Link>
-      <Link
+      </Button>
+      <Button
         isCurrentTab={["preview", "test-data-delivery"].includes(currentTab)}
         icon={<ShareIcon className={iconClassname} />}
         handleClick={handleClick("preview")}
       >
         {t("preview")}
-      </Link>
+      </Button>
 
       {isSaveable() && (
-        <Link
+        <Button
           isCurrentTab={currentTab === "save"}
           icon={<SaveIcon className={iconClassname} />}
           handleClick={handleClick("save")}
         >
           {t("save")}
-        </Link>
+        </Button>
       )}
-      <Link
+      <Button
         isCurrentTab={currentTab === "publish"}
         icon={<PublishIcon className={iconClassname} />}
         handleClick={handleClick("publish")}
       >
         {t("publish")}
-      </Link>
-    </div>
+      </Button>
+    </nav>
   );
 };

--- a/components/form-builder/layout/PreviewNavigation.tsx
+++ b/components/form-builder/layout/PreviewNavigation.tsx
@@ -10,22 +10,24 @@ export const PreviewNavigation = ({
 }) => {
   const { t } = useTranslation("form-builder");
   return (
-    <>
-      <div className="mb-8">
-        <button
-          className={`mr-5 ${currentTab === "preview" ? "font-bold" : ""}`}
-          onClick={handleClick("preview")}
-        >
-          {t("preview")}
-        </button>
-        |
-        <button
-          className={`ml-5 ${currentTab === "test-data-delivery" ? "font-bold" : ""}`}
-          onClick={handleClick("test-data-delivery")}
-        >
-          {t("testDataDelivery")}
-        </button>
-      </div>
-    </>
+    <nav className="mb-8" aria-label={t("navLabelPreview")}>
+      <button
+        className={`mr-5 ${
+          currentTab === "preview" ? "font-bold" : ""
+        } outline-blue-focus outline-offset-2`}
+        onClick={handleClick("preview")}
+      >
+        {t("preview")}
+      </button>
+      |
+      <button
+        className={`ml-5 ${
+          currentTab === "test-data-delivery" ? "font-bold" : ""
+        } outline-blue-focus outline-offset-2`}
+        onClick={handleClick("test-data-delivery")}
+      >
+        {t("testDataDelivery")}
+      </button>
+    </nav>
   );
 };

--- a/components/form-builder/layout/Start.tsx
+++ b/components/form-builder/layout/Start.tsx
@@ -25,6 +25,10 @@ const StyledContainer = styled.div`
     padding: 110px 20px 0 25px;
     text-align: left;
 
+    &:first-child svg {
+      transform: scale(1.33);
+    }
+
     &:hover,
     &:focus {
       cursor: pointer;

--- a/components/form-builder/lexical-editor/Editor.tsx
+++ b/components/form-builder/lexical-editor/Editor.tsx
@@ -18,6 +18,8 @@ import {
 } from "@lexical/markdown";
 
 const RichTextWrapper = styled.div`
+  height: 100%;
+
   .editor-input {
     padding: 20px;
   }

--- a/components/form-builder/lexical-editor/Editor.tsx
+++ b/components/form-builder/lexical-editor/Editor.tsx
@@ -22,6 +22,10 @@ const RichTextWrapper = styled.div`
 
   .editor-input {
     padding: 20px;
+
+    &:focus {
+      outline: 2px #303fc3 solid;
+    }
   }
 `;
 

--- a/components/form-builder/lexical-editor/RichTextEditor.tsx
+++ b/components/form-builder/lexical-editor/RichTextEditor.tsx
@@ -23,7 +23,7 @@ export const RichTextEditor = ({
   };
 
   return (
-    <div key={lang} className="mx-7 mb-6 mt-2 w-full border-2 rounded">
+    <div key={lang} className="w-full">
       <Editor autoFocusEditor={autoFocusEditor} content={content} onChange={handleChange} />
     </div>
   );

--- a/components/form-builder/lexical-editor/RichTextEditor.tsx
+++ b/components/form-builder/lexical-editor/RichTextEditor.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { Editor } from "./Editor";
 import useTemplateStore from "../store/useTemplateStore";
-import styled from "styled-components";
 import { Language } from "../types";
-
-const EditorWrapper = styled.div`
-  width: 100%;
-`;
 
 export const RichTextEditor = ({
   path,
@@ -28,8 +23,8 @@ export const RichTextEditor = ({
   };
 
   return (
-    <EditorWrapper key={lang}>
+    <div key={lang} className="mx-7 mb-6 mt-2 w-full border-2 rounded">
       <Editor autoFocusEditor={autoFocusEditor} content={content} onChange={handleChange} />
-    </EditorWrapper>
+    </div>
   );
 };

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -176,15 +176,6 @@ const LabelHidden = styled(FormLabel)`
   border-width: 0;
 `;
 
-const FormWrapper = styled.div<RowProps>`
-  padding: 30px 25px;
-  ${({ isRichText }) =>
-    isRichText &&
-    `
-      padding: 0;
-    `}
-`;
-
 const RequiredWrapper = styled.div`
   margin-top: 20px;
 
@@ -196,16 +187,6 @@ const RequiredWrapper = styled.div`
   label {
     padding-top: 4px;
   }
-`;
-
-const QuestionNumber = styled.span`
-  position: absolute;
-  background: #ebebeb;
-  left: 0;
-  margin-left: -25px;
-  padding: 7px 4px;
-  border-radius: 0 4px 4px 0;
-  font-size: 20px;
 `;
 
 const Form = ({ item }: { item: ElementTypeWithIndex }) => {
@@ -284,7 +265,9 @@ const Form = ({ item }: { item: ElementTypeWithIndex }) => {
         <div>
           {!isRichText && (
             <>
-              <QuestionNumber>{questionNumber}</QuestionNumber>
+              <span className="absolute left-0 bg-gray-default py-2.5 px-1.5 rounded-r -ml-7">
+                {questionNumber}
+              </span>
               <LabelHidden htmlFor={`item${item.index}`}>{t("Question")}</LabelHidden>
               <TitleInput
                 ref={input}
@@ -552,9 +535,9 @@ export const ElementWrapper = ({ item }: { item: ElementTypeWithIndex }) => {
 
   return (
     <ElementWrapperDiv className={`element-${item.index}`}>
-      <FormWrapper isRichText={isRichText}>
+      <div className={isRichText ? "mt-7" : "mx-7 my-7"}>
         <Form item={item} />
-      </FormWrapper>
+      </div>
       <PanelActions
         item={item}
         renderSaveButton={() => (
@@ -580,15 +563,11 @@ export const ElementWrapper = ({ item }: { item: ElementTypeWithIndex }) => {
   );
 };
 
-const FormTitleWrapper = styled.div`
-  margin: 10px;
-  input {
-    width: 100%;
-    padding: 22px 10px;
-    border: 1.5px solid #000000;
-    max-height: 36px;
-    border-radius: 4px;
-  }
+const FormTitleInput = styled(TitleInput)`
+  font-size: 30px;
+  font-weight: 700;
+  font-family: "Lato", sans-serif;
+  width: 75%;
 `;
 
 const ElementPanelDiv = styled.div`
@@ -626,21 +605,16 @@ export const ElementPanel = () => {
     <ElementPanelDiv>
       <RichTextLocked
         beforeContent={
-          <>
-            <FormTitleWrapper>
-              <Input
-                placeholder={t("placeHolderFormTitle")}
-                value={form[localizeField(LocalizedFormProperties.TITLE)]}
-                onChange={(e) => {
-                  updateField(
-                    `form.${localizeField(LocalizedFormProperties.TITLE)}`,
-                    e.target.value
-                  );
-                }}
-              />
-            </FormTitleWrapper>
+          <div className="mx-7 my-4">
+            <FormTitleInput
+              placeholder={t("placeHolderFormTitle")}
+              value={form[localizeField(LocalizedFormProperties.TITLE)]}
+              onChange={(e) => {
+                updateField(`form.${localizeField(LocalizedFormProperties.TITLE)}`, e.target.value);
+              }}
+            />
             <StyledIntroduction>{t("startFormIntro")}</StyledIntroduction>
-          </>
+          </div>
         }
         addElement={true}
         initialValue={introTextPlaceholder}

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -568,6 +568,7 @@ const FormTitleInput = styled(TitleInput)`
   font-weight: 700;
   font-family: "Lato", sans-serif;
   width: 75%;
+  margin-bottom: 16px;
 `;
 
 const ElementPanelDiv = styled.div`
@@ -581,11 +582,6 @@ const ElementPanelDiv = styled.div`
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
   }
-`;
-
-const StyledIntroduction = styled.div`
-  font-size: 1rem;
-  margin: 20px;
 `;
 
 export const ElementPanel = () => {
@@ -605,7 +601,7 @@ export const ElementPanel = () => {
     <ElementPanelDiv>
       <RichTextLocked
         beforeContent={
-          <div className="mx-7 my-4">
+          <>
             <FormTitleInput
               placeholder={t("placeHolderFormTitle")}
               value={form[localizeField(LocalizedFormProperties.TITLE)]}
@@ -613,8 +609,8 @@ export const ElementPanel = () => {
                 updateField(`form.${localizeField(LocalizedFormProperties.TITLE)}`, e.target.value);
               }}
             />
-            <StyledIntroduction>{t("startFormIntro")}</StyledIntroduction>
-          </div>
+            <p className="text-sm mb-4">{t("startFormIntro")}</p>
+          </>
         }
         addElement={true}
         initialValue={introTextPlaceholder}
@@ -634,7 +630,7 @@ export const ElementPanel = () => {
             aria-label={t("richTextPrivacyTitle")}
           >
             <div>
-              <h2>{t("richTextPrivacyTitle")}</h2>
+              <h2 className="text-h3 pb-3">{t("richTextPrivacyTitle")}</h2>
               <PrivacyDescription />
             </div>
           </RichTextLocked>
@@ -645,7 +641,7 @@ export const ElementPanel = () => {
             aria-label={t("richTextConfirmationTitle")}
           >
             <div>
-              <h2>{t("richTextConfirmationTitle")}</h2>
+              <h2 className="text-h3 pb-3">{t("richTextConfirmationTitle")}</h2>
               <ConfirmationDescription />
             </div>
           </RichTextLocked>

--- a/components/form-builder/translate/RichText.tsx
+++ b/components/form-builder/translate/RichText.tsx
@@ -23,7 +23,7 @@ export const RichText = ({
         <div className="section-heading">
           {t(element.type)}: {t("Description")}
         </div>
-        <div className="section-text">
+        <div className="section-text section-text--rich-text">
           <RichTextEditor
             autoFocusEditor={false}
             path={`form.elements[${index}].properties.${localizeField(

--- a/components/form-builder/translate/Translate.tsx
+++ b/components/form-builder/translate/Translate.tsx
@@ -77,9 +77,20 @@ const SectionDiv = styled.div`
 
     .section-text {
       display: flex;
-      align-items: flex-end;
+      align-items: flex-start;
       margin-bottom: 20px;
       border: 1px solid #cacaca;
+
+      &.section-text--rich-text > div {
+        &:first-of-type {
+          border-right: 1px solid black;
+        }
+
+        &:last-of-type {
+          border-left: 1px solid black;
+          margin-left: -1px;
+        }
+      }
 
       > * {
         flex: 1;
@@ -102,10 +113,6 @@ const SectionDiv = styled.div`
           outline: 0;
           z-index: 10;
         }
-      }
-
-      div[class^="Editor"]:first-of-type {
-        border-right: 1px solid black;
       }
     }
   }
@@ -209,7 +216,7 @@ export const Translate = () => {
               <div className="section-heading">
                 {t("Form introduction")}: {t("Description")}
               </div>
-              <div className="section-text">
+              <div className="section-text section-text--rich-text">
                 <RichTextEditor
                   autoFocusEditor={false}
                   path={`form.introduction.${localizeField(
@@ -320,7 +327,7 @@ export const Translate = () => {
               {t("Page text")}: {t("Description")}
             </div>
 
-            <div className="section-text">
+            <div className="section-text section-text--rich-text">
               <RichTextEditor
                 autoFocusEditor={false}
                 path={`form.privacyPolicy.${localizeField(
@@ -366,7 +373,7 @@ export const Translate = () => {
             <div className="section-heading">
               {t("Page text")}: {t("Description")}
             </div>
-            <div className="section-text">
+            <div className="section-text section-text--rich-text">
               <RichTextEditor
                 autoFocusEditor={false}
                 path={`form.endPage.${localizeField(

--- a/components/form-builder/translate/Translate.tsx
+++ b/components/form-builder/translate/Translate.tsx
@@ -76,12 +76,22 @@ const SectionDiv = styled.div`
     }
 
     .section-text {
-      display: flex;
-      align-items: flex-start;
+      display: grid;
+      grid-auto-flow: column;
       margin-bottom: 20px;
       border: 1px solid #cacaca;
 
       &.section-text--rich-text > div {
+        .editor-input {
+          height: calc(100% - 90px);
+        }
+
+        @media (min-width: 992px) {
+          .editor-input {
+            height: calc(100% - 56px);
+          }
+        }
+
         &:first-of-type {
           border-right: 1px solid black;
         }

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -64,5 +64,8 @@
   "formTitle": "Form title",
   "formConfirmationMessage": "Form confirmation message",
   "complete": "Complete",
-  "incomplete": "Incomplete"
+  "incomplete": "Incomplete",
+  "navLabelFormBuilder": "Form builder navigation",
+  "navLabelEditor": "Edit navigation",
+  "navLabelPreview": "Preview navigation"
 }

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -45,5 +45,8 @@
   "richTextConfirmationTitle": "[FR] Confirmation page and message",
   "richTextPrivacyTitle": "[FR] Privacy statement",
   "translate": "[FR] Translate",
-  "translateTitle": "[FR] Translate view"
+  "translateTitle": "[FR] Translate view",
+  "navLabelFormBuilder": "[FR] Form builder navigation",
+  "navLabelEditor": "[FR] Edit navigation",
+  "navLabelPreview": "[FR] Preview navigation"
 }


### PR DESCRIPTION
# Summary | Résumé

This PR brings us more into alignment with what's in the mockups. 

- Our rich text fields are no longer full-width
- The form title looks like a "title" input now (bottom underline) instead of a regular text input
- Tweaked the "design" icon on the start page because it was too small

Where I made CSS changes, I tried to convert things to tailwind as much as I could. There were still some holdouts, but it moves the needle a little bit.

### Design page screenshots

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="1552" alt="Screen Shot 2022-10-27 at 12 07 37" src="https://user-images.githubusercontent.com/2454380/198344297-95c7432d-997a-41d5-8c27-3529ed454717.png"> | <img width="1552" alt="Screen Shot 2022-10-27 at 12 07 34" src="https://user-images.githubusercontent.com/2454380/198344289-3159a4b6-97d8-4ab0-8dbf-3be18aad4805.png"> |

### Translate page screenshots

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
|   <img width="1325" alt="Screen Shot 2022-10-27 at 14 38 59" src="https://user-images.githubusercontent.com/2454380/198372591-167324f2-dc18-4568-a28f-5c0105f8211b.png">   |      <img width="1325" alt="Screen Shot 2022-10-27 at 14 38 56" src="https://user-images.githubusercontent.com/2454380/198372606-29f3483e-b406-47f6-9cc4-885c4856d43c.png">  |

