### PR TITLE
Add settings page

### DIFF
--- a/components/form-builder/layout/Header.tsx
+++ b/components/form-builder/layout/Header.tsx
@@ -15,13 +15,23 @@ const StyledH2 = styled.h2`
 export const Header = () => {
   const { status } = useSession();
   const { isSaveable } = useAllowPublish();
-  const { currentTab } = useNavigationStore();
+  const { currentTab, setTab } = useNavigationStore();
+
+  const handleClick = (tab: string) => {
+    return (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+      setTab(tab);
+    };
+  };
+
   return (
     <div className="border-b-3 border-blue-dark mt-10 mb-10">
       <div className="container--wet">
         <div className="flex" style={{ justifyContent: "space-between" }}>
           <div className="">
-            <StyledH2>GC Forms</StyledH2>
+            <StyledH2>
+              <button onClick={handleClick("start")}>GC Forms</button>
+            </StyledH2>
             {currentTab !== "start" && isSaveable() && <DownloadFileButton />}
           </div>
           <div className="inline-flex">

--- a/components/form-builder/layout/Layout.tsx
+++ b/components/form-builder/layout/Layout.tsx
@@ -14,6 +14,7 @@ import { Translate } from "../translate/Translate";
 import { EditNavigation } from "./EditNavigation";
 import { PreviewNavigation } from "./PreviewNavigation";
 import { Publish } from "./Publish";
+import { Settings } from "./Settings";
 
 const StyledHeader = styled.h1`
   border-bottom: none;
@@ -89,6 +90,14 @@ export const Layout = () => {
         {currentTab === "publish" && (
           <div className="col-start-4 col-span-9">
             <Publish />
+          </div>
+        )}
+
+        {currentTab === "settings" && (
+          <div className="col-start-4 col-span-9">
+            <EditNavigation currentTab={currentTab} handleClick={handleClick} />
+            <h1 className="visually-hidden">Form settings</h1>
+            <Settings />
           </div>
         )}
 

--- a/components/form-builder/layout/LeftNavigation.tsx
+++ b/components/form-builder/layout/LeftNavigation.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import { useTranslation } from "next-i18next";
-import { DesignIcon, PreviewIcon, ShareIcon, PublishIcon, SaveIcon } from "../icons";
+import { DesignIcon, PreviewIcon, ShareIcon, PublishIcon } from "../icons";
 import { useAllowPublish } from "../hooks/useAllowPublish";
 
 function Button({
@@ -43,22 +43,15 @@ export const LeftNavigation = ({
   return (
     <nav className="col-span-3" aria-label={t("navLabelFormBuilder")}>
       <Button
-        isCurrentTab={currentTab === "start"}
-        icon={<DesignIcon className={iconClassname} />}
-        handleClick={handleClick("start")}
-      >
-        {t("start")}
-      </Button>
-      <Button
         isCurrentTab={["create", "translate", "settings"].includes(currentTab)}
-        icon={<PreviewIcon className={iconClassname} />}
+        icon={<DesignIcon className={iconClassname} />}
         handleClick={handleClick("create")}
       >
-        {t("design")}
+        {t("edit")}
       </Button>
       <Button
         isCurrentTab={["preview", "test-data-delivery"].includes(currentTab)}
-        icon={<ShareIcon className={iconClassname} />}
+        icon={<PreviewIcon className={iconClassname} />}
         handleClick={handleClick("preview")}
       >
         {t("preview")}
@@ -67,7 +60,7 @@ export const LeftNavigation = ({
       {isSaveable() && (
         <Button
           isCurrentTab={currentTab === "save"}
-          icon={<SaveIcon className={iconClassname} />}
+          icon={<ShareIcon className={iconClassname} />}
           handleClick={handleClick("save")}
         >
           {t("save")}

--- a/components/form-builder/layout/Settings.tsx
+++ b/components/form-builder/layout/Settings.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useTranslation } from "next-i18next";
+
+const Label = ({ htmlFor, children }: { htmlFor: string; children?: JSX.Element | string }) => {
+  return (
+    <label className="block font-bold mb-1" htmlFor={htmlFor}>
+      {children}
+    </label>
+  );
+};
+
+const HintText = ({ id, children }: { id: string; children?: JSX.Element | string }) => {
+  return (
+    <span className="block text-sm mb-1" id={id}>
+      {children}
+    </span>
+  );
+};
+
+const TextInput = ({ id, describedBy }: { id: string; describedBy?: string }) => {
+  return (
+    <input
+      id={id}
+      aria-describedby={describedBy}
+      type="text"
+      className="w-3/5 py-2 px-3 my-2 rounded border-2 border-black-default border-solid focus:outline-2 focus:outline-blue-focus focus:outline focus:border-blue-focus"
+    />
+  );
+};
+
+export const Button = ({
+  children,
+  onClick,
+  className,
+  id,
+  disabled = false,
+  "aria-label": ariaLabel = undefined,
+  theme = "primary",
+}: {
+  children?: JSX.Element | string;
+  id?: string;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  className?: string;
+  disabled?: boolean;
+  "aria-label"?: string;
+  theme?: "primary" | "secondary" | "destructive";
+}) => {
+  const themes = {
+    primary:
+      "bg-blue-dark text-white-default border-black-default hover:text-white-default hover:bg-blue-light active:text-white-default active:bg-blue-active",
+    secondary:
+      "bg-white-default text-black-default border-black-default hover:text-white-default hover:bg-gray-600 active:text-white-default active:bg-gray-500",
+    destructive:
+      "bg-red-default text-white-default border-red-default hover:bg-red-destructive hover:border-red-destructive active:bg-red-hover focus:border-blue-hover",
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      className={`${className} ${themes[theme]} relative py-2 px-5 rounded-lg border-2  border-solid active:top-0.5 focus:outline-2 focus:outline-blue-focus focus:outline focus:outline-offset-2 focus:bg-blue-focus focus:text-white-default`}
+      id={id}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+};
+
+export const Settings = () => {
+  const { t } = useTranslation("form-builder");
+
+  return (
+    <>
+      <form>
+        <div className="mb-10">
+          <Label htmlFor="response-delivery">{t("settingsReponseTitle")}</Label>
+          <HintText id="response-delivery-hint-1">{t("settingsReponseHint1")}</HintText>
+          <HintText id="response-delivery-hint-2">{t("settingsReponseHint2")}</HintText>
+          <TextInput
+            id="response-delivery"
+            describedBy="response-delivery-hint-1 response-delivery-hint-2"
+          />
+        </div>
+
+        <div className="mb-10">
+          <Label htmlFor="format">{t("settingsFormatTitle")}</Label>
+          <HintText id="format-hint">{t("settingsFormatHint")}</HintText>
+          <select
+            id="format"
+            className="w-1/2 py-2 px-3 my-2 rounded border-2 border-black-default border-solid focus:outline-2 focus:outline-blue-focus focus:outline focus:border-blue-focus"
+          >
+            <option value="pdf">{t("settingsFormatOption1")}</option>
+            <option value="paper">{t("settingsFormatOption2")}</option>
+            <option value="work">{t("settingsFormatOption3")}</option>
+            <option value="other">{t("settingsFormatOption4")}</option>
+          </select>
+        </div>
+
+        <div className="mb-10">
+          <Label htmlFor="delete">{t("settingsDeleteTitle")}</Label>
+          <HintText id="delete-hint">{t("settingsDeleteHint")}</HintText>
+          <div className="mt-4">
+            <Button id="delete-form" theme="destructive">
+              {t("settingsDeleteButton")}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </>
+  );
+};

--- a/components/form-builder/layout/Settings.tsx
+++ b/components/form-builder/layout/Settings.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useTranslation } from "next-i18next";
+import useTemplateStore from "../store/useTemplateStore";
+import useNavigationStore from "../store/useNavigationStore";
 
 const Label = ({ htmlFor, children }: { htmlFor: string; children?: JSX.Element | string }) => {
   return (
@@ -70,6 +72,8 @@ export const Button = ({
 
 export const Settings = () => {
   const { t } = useTranslation("form-builder");
+  const { initialize } = useTemplateStore();
+  const { setTab } = useNavigationStore();
 
   return (
     <>
@@ -102,7 +106,14 @@ export const Settings = () => {
           <Label htmlFor="delete">{t("settingsDeleteTitle")}</Label>
           <HintText id="delete-hint">{t("settingsDeleteHint")}</HintText>
           <div className="mt-4">
-            <Button id="delete-form" theme="destructive">
+            <Button
+              id="delete-form"
+              theme="destructive"
+              onClick={() => {
+                initialize(); // Reset the form
+                setTab("start"); // Back to start page
+              }}
+            >
               {t("settingsDeleteButton")}
             </Button>
           </div>

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -24,6 +24,7 @@
   "placeHolderFormTitle": "Form Title",
   "share": "Share",
   "save": "Save",
+  "edit": "Edit",
   "saveH1": "Save your progress",
   "saveP1": "We don’t save your form on our website, but don’t worry, you can save the file to your computer.",
   "saveP2": "Save the form file to work on later, and open it again to pick-up where you left off.",

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -67,5 +67,17 @@
   "incomplete": "Incomplete",
   "navLabelFormBuilder": "Form builder navigation",
   "navLabelEditor": "Edit navigation",
-  "navLabelPreview": "Preview navigation"
+  "navLabelPreview": "Preview navigation",
+  "settingsReponseTitle": "Response delivery destination",
+  "settingsReponseHint1": "Provide a Government of Canada email address to send form responses to.",
+  "settingsReponseHint2": "In order to publish, you need to provide a response delivery destination.",
+  "settingsFormatTitle": "Original format",
+  "settingsFormatHint": "What is the original form format you are designing from?",
+  "settingsFormatOption1": "PDF",
+  "settingsFormatOption2": "Paper document",
+  "settingsFormatOption3": "Work document",
+  "settingsFormatOption4": "Other",
+  "settingsDeleteTitle": "Delete form",
+  "settingsDeleteHint": "Once you delete a form, there is no way to retrieve it back again. Please save a copy before deleting your form.",
+  "settingsDeleteButton": "Delete"
 }

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -48,5 +48,19 @@
   "translateTitle": "[FR] Translate view",
   "navLabelFormBuilder": "[FR] Form builder navigation",
   "navLabelEditor": "[FR] Edit navigation",
-  "navLabelPreview": "[FR] Preview navigation"
+  "navLabelPreview": "[FR] Preview navigation",
+  "testDataDelivery": "[FR] Test data delivery",
+  "settings": "[FR] Settings",
+  "settingsReponseTitle": "[FR] Response delivery destination",
+  "settingsReponseHint1": "[FR] Provide a Government of Canada email address to send form responses to.",
+  "settingsReponseHint2": "[FR] In order to publish, you need to provide a response delivery destination.",
+  "settingsFormatTitle": "[FR] Original format",
+  "settingsFormatHint": "[FR] What is the original form format you are designing from?",
+  "settingsFormatOption1": "[FR] PDF",
+  "settingsFormatOption2": "[FR] Paper document",
+  "settingsFormatOption3": "[FR] Work document",
+  "settingsFormatOption4": "[FR] Other",
+  "settingsDeleteTitle": "[FR] Delete form",
+  "settingsDeleteHint": "[FR] Once you delete a form, there is no way to retrieve it back again. Please save a copy before deleting your form.",
+  "settingsDeleteButton": "[FR] Delete"
 }

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -22,6 +22,7 @@
   "placeHolderFormTitle": "[FR] Form Title",
   "share": "[FR] Share",
   "save": "[FR] Save",
+  "edit": "[FR] Edit",
   "saveH1": "[FR] Save your progress",
   "saveP1": "[FR] We don’t save your form on our website, but don’t worry, you can save the file to your computer.",
   "saveP2": "[FR] Save the form file to work on later, and open it again to pick-up where you left off.",


### PR DESCRIPTION
# Summary | Résumé

Add a "settings" page that is close to the one in Figma. It the first 2 fields are non-functional, but the delete button works. 
If you click the delete button, it reinitializes the form and navigates you back to the start page. It's super abrupt, so we can ask Sam what to do about this in future.

A also changed the left nav to remove the "Start" nav link. You can now click the top nav button ("GC Forms") to get you back to the form builder landing page.



| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
|  <img width="784" alt="Screenshot 2022-10-31 at 10 47 27" src="https://user-images.githubusercontent.com/2454380/199039152-f7488918-1a55-474f-b3e6-5b37d1d282cb.png">  |  <img width="800" alt="Screenshot 2022-10-31 at 10 46 03" src="https://user-images.githubusercontent.com/2454380/199039147-02220ea0-a119-4782-9a38-f22e952e3c3e.png">  |
