### PR TITLE
Lexical editor Tab/shift-Tab to escape

### DIFF
--- a/components/form-builder/lexical-editor/Editor.tsx
+++ b/components/form-builder/lexical-editor/Editor.tsx
@@ -16,6 +16,7 @@ import {
   $convertToMarkdownString,
   TRANSFORMERS,
 } from "@lexical/markdown";
+import { TabEscape } from "./plugins/TabEscape";
 
 const RichTextWrapper = styled.div`
   height: 100%;
@@ -74,6 +75,7 @@ export const Editor = ({
         />
         <LinkPlugin />
         <ListPlugin />
+        <TabEscape />
       </LexicalComposer>
     </RichTextWrapper>
   );

--- a/components/form-builder/lexical-editor/plugins/TabEscape.tsx
+++ b/components/form-builder/lexical-editor/plugins/TabEscape.tsx
@@ -1,0 +1,14 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { COMMAND_PRIORITY_HIGH, KEY_TAB_COMMAND } from "lexical";
+
+export const TabEscape = () => {
+  const [editor] = useLexicalComposerContext();
+  editor.registerCommand<KeyboardEvent>(
+    KEY_TAB_COMMAND,
+    () => {
+      return true;
+    },
+    COMMAND_PRIORITY_HIGH
+  );
+  return null;
+};


### PR DESCRIPTION
# Summary | Résumé

Adds a Lexical plugin to intercept the Tab keypress to exit the editor rather than insert a Tab character.

Previously, once inside the editor textarea, pressing Tab would insert a Tab character. But since indents are not processed by the markdown renderer, they just got stripped anyway.

Now, once inside the editor, pressing Tab will escape the textarea and set focus to the next item in the tab order.