### PR TITLE
Feature/move publishing status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Terms and conditions page + text link in the footer [#863](https://github.com/cds-snc/platform-forms-client/issues/863)
 - Modified Role Based to Asset Based Access Control [#1176](https://github.com/cds-snc/platform-forms-client/pull/1176)
 - Form templates are now marked as archived and will stay in the database for 30 more days before being deleted by a Lambda function. [#1166](https://github.com/cds-snc/platform-forms-client/issues/1166)
+- The existing `publishingStatus` field from the form JSON configuration has been replaced by a `isPublished` data field in the database. It can be switch to `true` or `false` using the Template API. A soft migration process will automatically happen when updating the `isPublished` value for existing form configuration containing the `publishingStatus` field. [#1181](https://github.com/cds-snc/platform-forms-client/issues/1181)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Terms and conditions page + text link in the footer [#863](https://github.com/cds-snc/platform-forms-client/issues/863)
 - Modified Role Based to Asset Based Access Control [#1176](https://github.com/cds-snc/platform-forms-client/pull/1176)
 - Form templates are now marked as archived and will stay in the database for 30 more days before being deleted by a Lambda function. [#1166](https://github.com/cds-snc/platform-forms-client/issues/1166)
-- The existing `publishingStatus` field from the form JSON configuration has been replaced by a `isPublished` data field in the database. It can be switch to `true` or `false` using the Template API. A soft migration process will automatically happen when updating the `isPublished` value for existing form configuration containing the `publishingStatus` field. [#1181](https://github.com/cds-snc/platform-forms-client/issues/1181)
+- The existing `publishingStatus` field from the form JSON configuration has been replaced by a `isPublished` data field in the database. It can be switch to `true` or `false` using the Template API. A migration process will automatically happen through the Prisma seeding process. [#1181](https://github.com/cds-snc/platform-forms-client/issues/1181)
 
 ### Fixed
 

--- a/__fixtures__/accessibilityTestForm.json
+++ b/__fixtures__/accessibilityTestForm.json
@@ -325,6 +325,5 @@
     "email": "forms-formulaires@cds-snc.ca"
   },
   "internalTitleEn": "CDS - Lemonade Stand Funding",
-  "internalTitleFr": "CDS - Lemonade Stand Funding",
-  "publishingStatus": true
+  "internalTitleFr": "CDS - Lemonade Stand Funding"
 }

--- a/__fixtures__/attestationTestForm.json
+++ b/__fixtures__/attestationTestForm.json
@@ -1,50 +1,47 @@
 {
-    "form": {
-      "layout": [
-        1
-      ],
-      "titleEn": "Lemonade Stand Funding",
-      "titleFr": "Financement des stands de limonade",
-      "version": 1,
-      "elements": [
-        {
-          "id": 1,
-          "type": "checkbox",
-          "properties": {
-            "titleEn": "Do you attest that the information you are providing is true and correct to your knowledge?",
-            "titleFr": "Attestez-vous que les informations que vous fournissez sont, à votre connaissance, vraies et correctes ?",
-            "choices": [
-              {
-                "en": "I prefer lemons to oranges.",
-                "fr": "Je préfère les citrons aux oranges."
-              },
-              {
-                "en": "I agree to keep my lemonade stand a minimum of 1 metre from the sidewalk.",
-                "fr": "Je m'engage à maintenir mon stand de limonade à un minimum d'un mètre du trottoir."
-              }
-            ],
-            "validation": {
-              "all": true,
-              "required": true
+  "form": {
+    "layout": [1],
+    "titleEn": "Lemonade Stand Funding",
+    "titleFr": "Financement des stands de limonade",
+    "version": 1,
+    "elements": [
+      {
+        "id": 1,
+        "type": "checkbox",
+        "properties": {
+          "titleEn": "Do you attest that the information you are providing is true and correct to your knowledge?",
+          "titleFr": "Attestez-vous que les informations que vous fournissez sont, à votre connaissance, vraies et correctes ?",
+          "choices": [
+            {
+              "en": "I prefer lemons to oranges.",
+              "fr": "Je préfère les citrons aux oranges."
             },
-            "descriptionEn": "",
-            "descriptionFr": ""
-          }
+            {
+              "en": "I agree to keep my lemonade stand a minimum of 1 metre from the sidewalk.",
+              "fr": "Je m'engage à maintenir mon stand de limonade à un minimum d'un mètre du trottoir."
+            }
+          ],
+          "validation": {
+            "all": true,
+            "required": true
+          },
+          "descriptionEn": "",
+          "descriptionFr": ""
         }
-      ],
-      "emailSubjectEn": "Lemonade Stand Funding Testing Response",
-      "emailSubjectFr": ""
-    },
-    "submission": {
-      "vault": true
-    },
-    "endPage": {
-        "descriptionEn": "#Your submission has been received \n\r Thank you for your interest. We will contact you within 3-5 business days.  \n\r <a href='https://digital.canada.ca'>Go back</a>",
-        "descriptionFr": "#[fr] Your submission has been received. \n\r Thank you for your interest. We will contact you within 3-5 business days. \n\r <a href='https://digital.canada.ca'>Go back</a>",
-        "referrerUrlEn": "",
-        "referrerUrlFr": ""
-    },
-    "internalTitleEn": "CDS - Lemonade Stand Funding",
-    "internalTitleFr": "CDS - Lemonade Stand Funding",
-    "publishingStatus": false
-  }
+      }
+    ],
+    "emailSubjectEn": "Lemonade Stand Funding Testing Response",
+    "emailSubjectFr": ""
+  },
+  "submission": {
+    "vault": true
+  },
+  "endPage": {
+    "descriptionEn": "#Your submission has been received \n\r Thank you for your interest. We will contact you within 3-5 business days.  \n\r <a href='https://digital.canada.ca'>Go back</a>",
+    "descriptionFr": "#[fr] Your submission has been received. \n\r Thank you for your interest. We will contact you within 3-5 business days. \n\r <a href='https://digital.canada.ca'>Go back</a>",
+    "referrerUrlEn": "",
+    "referrerUrlFr": ""
+  },
+  "internalTitleEn": "CDS - Lemonade Stand Funding",
+  "internalTitleFr": "CDS - Lemonade Stand Funding"
+}

--- a/__fixtures__/brokenFormTemplate.json
+++ b/__fixtures__/brokenFormTemplate.json
@@ -642,6 +642,5 @@
   },
   "internalTitleEn": "Public Service Award of Excellence 2020",
   "internalTitleFr": "Prix d’excellence de la fonction publique 2020",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/cdsIntakeTestForm.json
+++ b/__fixtures__/cdsIntakeTestForm.json
@@ -126,6 +126,5 @@
   },
   "internalTitleEn": "CDS Intake Form",
   "internalTitleFr": "SNC Formulaire d'admission",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/duplicateElementIds.json
+++ b/__fixtures__/duplicateElementIds.json
@@ -380,6 +380,5 @@
   },
   "internalTitleEn": "Public Service Award of Excellence 2020",
   "internalTitleFr": "Prix d’excellence de la fonction publique 2020",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/dynamicRowsTestForm.json
+++ b/__fixtures__/dynamicRowsTestForm.json
@@ -8,15 +8,7 @@
       "logoTitleEn": "Copyright Board of Canada",
       "logoTitleFr": "Commission du droit d'auteur du Canada"
     },
-    "layout": [
-      1,
-      2,
-      3,
-      6,
-      7,
-      11,
-      12
-    ],
+    "layout": [1, 2, 3, 6, 7, 11, 12],
     "endPage": {
       "descriptionEn": "# Thank you for your tariff. \n\r The Proposed Tariff(s) has/have been successfully filed. The Board will inform you when this proposed tariff has/have been published on the Board’s website or if we require additional information. \n\r <a href='https://cb-cda.gc.ca/en'>Go back</a>",
       "descriptionFr": "# Merci pour votre entrée. \n\r The Proposed Tariff(s) has/have been successfully filed. The Board will inform you when this proposed tariff has/have been published on the Board’s website or if we require additional information. \n\r <a href='https://cb-cda.gc.ca/fr'>Retour</a>",
@@ -412,6 +404,5 @@
   },
   "internalTitleEn": "Copyright Board of Canada - Proposed Tariff Filing Form",
   "internalTitleFr": "FR - Copyright Board of Canada - Proposed Tariff Filing Form",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/invalidLayoutIds.json
+++ b/__fixtures__/invalidLayoutIds.json
@@ -640,6 +640,5 @@
   },
   "internalTitleEn": "Public Service Award of Excellence 2020",
   "internalTitleFr": "Prix d’excellence de la fonction publique 2020",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/invalidSubElementIds.json
+++ b/__fixtures__/invalidSubElementIds.json
@@ -173,6 +173,5 @@
   },
   "internalTitleEn": "Public Service Award of Excellence 2020",
   "internalTitleFr": "Prix d’excellence de la fonction publique 2020",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/platformIntakeTestForm.json
+++ b/__fixtures__/platformIntakeTestForm.json
@@ -1,14 +1,6 @@
 {
   "form": {
-    "layout": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7
-    ],
+    "layout": [1, 2, 3, 4, 5, 6, 7],
     "endPage": {
       "descriptionEn": "",
       "descriptionFr": "",
@@ -138,6 +130,5 @@
   },
   "internalTitleEn": "Work with CDS on a Digital Form",
   "internalTitleFr": "Travailler avec le SNC sur un formulaire numérique",
-  "publishingStatus": true,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/tsbContactTestForm.json
+++ b/__fixtures__/tsbContactTestForm.json
@@ -9,15 +9,7 @@
       "logoTitleEn": "Transportation Safety Board of Canada",
       "logoTitleFr": "Bureau de la sécurité des transports du Canada"
     },
-    "layout": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7
-    ],
+    "layout": [1, 2, 3, 4, 5, 6, 7],
     "endPage": {
       "descriptionEn": "#Thank you for your message \n\r The Transportation Safety Board of Canada will respond to you within a week. \n\r <a href='https://www.tsb.gc.ca/eng/index.html'>Go back.</a>",
       "descriptionFr": "#Merci pour votre message  \n\r Le Bureau de la sécurité des transports du Canada vous répondra d’ici une semaine. \n\r <a href='https://www.tsb.gc.ca/fra/index.html'>Retour.</a>"
@@ -184,6 +176,5 @@
   },
   "internalTitleEn": "Contact Us - TSB",
   "internalTitleFr": "Nous joindre - BST",
-  "publishingStatus": true,
   "securityAttribute": "Unclassified"
 }

--- a/__fixtures__/tsbDisableFooterGCBranding.json
+++ b/__fixtures__/tsbDisableFooterGCBranding.json
@@ -10,10 +10,7 @@
       "logoTitleFr": "Bureau de la sécurité des transports du Canada",
       "disableGcBranding": true
     },
-    "layout": [
-      1
-
-    ],
+    "layout": [1],
     "endPage": {
       "descriptionEn": "#Thank you for your message \n\r The Transportation Safety Board of Canada will respond to you within a week. \n\r <a href='https://www.tsb.gc.ca/eng/index.html' rel='noreferrer' target='_blank'>Go back.</a>",
       "descriptionFr": "#Merci pour votre message  \n\r Le Bureau de la sécurité des transports du Canada vous répondra d’ici une semaine. \n\r <a href='https://www.tsb.gc.ca/fra/index.html'>Retour.</a>"
@@ -44,6 +41,5 @@
     "email": "forms-formulaires@cds-snc.ca"
   },
   "internalTitleEn": "Contact Us - TSB",
-  "internalTitleFr": "Nous joindre - BST",
-  "publishingStatus": true
+  "internalTitleFr": "Nous joindre - BST"
 }

--- a/__fixtures__/validFormTemplate.json
+++ b/__fixtures__/validFormTemplate.json
@@ -640,6 +640,5 @@
   },
   "internalTitleEn": "Public Service Award of Excellence 2020",
   "internalTitleFr": "Prix d’excellence de la fonction publique 2020",
-  "publishingStatus": false,
   "securityAttribute": "Unclassified"
 }

--- a/__tests__/api/templates.test.ts
+++ b/__tests__/api/templates.test.ts
@@ -359,40 +359,5 @@ describe("Templates API functions should throw an error if user does not have pe
       expect(res.statusCode).toBe(403);
       expect(JSON.parse(res._getData())).toEqual(expect.objectContaining({ error: "Forbidden" }));
     });
-
-    it("User with Base permissions should not be able to use the DELETE API function on a published template", async () => {
-      const mockSession: Session = {
-        expires: "1",
-        user: {
-          id: "1",
-          email: "forms@cds.ca",
-          name: "forms",
-          privileges: getUserPrivileges(Base, { user: { id: "1" } }),
-        },
-      };
-      mockGetSession.mockReturnValue(Promise.resolve(mockSession));
-
-      (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
-        id: "formtestID",
-        jsonConfig: { ...validFormTemplate, publishingStatus: true },
-        users: [{ id: "1" }],
-      });
-
-      const { req, res } = createMocks({
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Origin: "http://localhost:3000",
-        },
-        body: {
-          formID: "test0form00000id000asdf11",
-        },
-      });
-
-      await templates(req, res);
-
-      expect(res.statusCode).toBe(403);
-      expect(JSON.parse(res._getData())).toEqual(expect.objectContaining({ error: "Forbidden" }));
-    });
   });
 });

--- a/__tests__/id/[form]/settings.test.js
+++ b/__tests__/id/[form]/settings.test.js
@@ -41,6 +41,7 @@ describe("Form Settings Page", () => {
   afterEach(cleanup);
   const form = {
     id: "test0form00000id000asdf11",
+    isPublished: true,
     ...validFormTemplate,
   };
   test("renders without errors", () => {

--- a/__utils__/permissions.ts
+++ b/__utils__/permissions.ts
@@ -15,12 +15,6 @@ export const Base: RawRuleOf<MongoAbility<Abilities>>[] = [
     conditions: { users: { $elemMatch: { id: "${user.id}" } } },
   },
   { action: "update", subject: "FormRecord", fields: ["publishingStatus"], inverted: true },
-  {
-    action: "delete",
-    subject: "FormRecord",
-    conditions: { publishingStatus: true },
-    inverted: true,
-  },
 ];
 
 export const PublishForms: RawRuleOf<MongoAbility<Abilities>>[] = [

--- a/__utils__/permissions.ts
+++ b/__utils__/permissions.ts
@@ -14,14 +14,14 @@ export const Base: RawRuleOf<MongoAbility<Abilities>>[] = [
     subject: "FormRecord",
     conditions: { users: { $elemMatch: { id: "${user.id}" } } },
   },
-  { action: "update", subject: "FormRecord", fields: ["publishingStatus"], inverted: true },
+  { action: "update", subject: "FormRecord", fields: ["isPublished"], inverted: true },
 ];
 
 export const PublishForms: RawRuleOf<MongoAbility<Abilities>>[] = [
   {
     action: ["update"],
     subject: "FormRecord",
-    fields: ["publishingStatus"],
+    fields: ["isPublished"],
     conditions: { users: { $elemMatch: { id: "${user.id}" } } },
   },
 ];

--- a/components/admin/JsonUpload/JsonUpload.stories.tsx
+++ b/components/admin/JsonUpload/JsonUpload.stories.tsx
@@ -11,11 +11,11 @@ export const defaultJSONUpload = (): React.ReactElement => <JSONUpload></JSONUpl
 
 const testForm = {
   id: "test0form00000id000asdf11",
-  publishingStatus: true,
   securityAttribute: "Unclassified",
   submission: {
     email: "test@test.com",
   },
+  isPublished: true,
   form: {
     version: 1,
     titleEn: "Test JSON!",

--- a/components/admin/JsonUpload/JsonUpload.tsx
+++ b/components/admin/JsonUpload/JsonUpload.tsx
@@ -14,7 +14,9 @@ interface JSONUploadProps {
 export const JSONUpload = (props: JSONUploadProps): React.ReactElement => {
   const { t, i18n } = useTranslation("admin-templates");
   const { form } = props;
-  const { id: formID, ...formConfig } = form || { id: undefined };
+  // extracting `isPublished` to avoid having it displayed in the JSON
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: formID, isPublished, ...formConfig } = form || { id: undefined };
   const [jsonConfig, setJsonConfig] = useState(formID ? JSON.stringify(formConfig, null, 2) : "");
   const [submitStatus, setSubmitStatus] = useState("");
   const [submitting, setSubmitting] = useState(false);

--- a/components/admin/TemplateDelete/Settings.tsx
+++ b/components/admin/TemplateDelete/Settings.tsx
@@ -59,6 +59,8 @@ const FormSettings = (props: FormSettingsProps): React.ReactElement => {
         <b>Form Title:</b> {formRecord.form[getProperty("title", language)] as string}
         <br />
         <b>Form ID:</b> {formRecord.id}
+        <br />
+        <b>Is form published:</b> {formRecord.isPublished.toString()}
       </div>
       <Tabs>
         <TabList>

--- a/components/form-builder/__tests__/useAllowPublish.test.tsx
+++ b/components/form-builder/__tests__/useAllowPublish.test.tsx
@@ -10,13 +10,9 @@ import {
   MissingTranslation,
 } from "../hooks/useAllowPublish";
 
-const createTemplateStore = ({
-  form,
-  submission,
-  publishingStatus,
-}: Partial<TemplateStoreProps>) => {
+const createTemplateStore = ({ form, submission, isPublished }: Partial<TemplateStoreProps>) => {
   const wrapper = ({ children }: React.PropsWithChildren) => (
-    <TemplateStoreProvider form={form} submission={submission} publishingStatus={publishingStatus}>
+    <TemplateStoreProvider form={form} submission={submission} isPublished={isPublished}>
       {children}
     </TemplateStoreProvider>
   );
@@ -55,14 +51,14 @@ describe("useAllowPublish", () => {
         endPage: { descriptionEn: "confirm text en", descriptionFr: "confirm text fr" },
       },
       submission: { email: "test@example.com" },
-      publishingStatus: true,
+      isPublished: true,
     };
     const {
       current: { data, hasData, isSaveable, isPublishable },
     } = createTemplateStore({
       form: store.form,
       submission: store.submission,
-      publishingStatus: store.publishingStatus,
+      isPublished: store.isPublished,
     });
 
     expect(data.title).toBe(true);
@@ -105,14 +101,14 @@ describe("useAllowPublish", () => {
         endPage: { descriptionEn: "confirm text en", descriptionFr: "confirm text fr" },
       },
       submission: { email: "test@example.com" },
-      publishingStatus: true,
+      isPublished: true,
     };
     const {
       current: { isPublishable },
     } = createTemplateStore({
       form: store.form,
       submission: store.submission,
-      publishingStatus: store.publishingStatus,
+      isPublished: store.isPublished,
     });
 
     expect(isPublishable()).toBe(true);
@@ -462,7 +458,6 @@ describe("useAllowPublish", () => {
         endPage: { descriptionEn: "confirm text en", descriptionFr: "confirm text fr" },
       },
       submission: { email: "test@example.com" },
-      publishingStatus: true,
     };
 
     it("fails when form title translation is missing", () => {
@@ -475,7 +470,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
       expect(data.translate).toBe(false);
     });
@@ -490,7 +485,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(false);
@@ -506,7 +501,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(false);
@@ -521,7 +516,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(false);
@@ -536,7 +531,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(false);
@@ -553,7 +548,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(true);
@@ -568,7 +563,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(false);
@@ -583,7 +578,7 @@ describe("useAllowPublish", () => {
       } = createTemplateStore({
         form: store.form,
         submission: store.submission,
-        publishingStatus: store.publishingStatus,
+        isPublished: store.isPublished,
       });
 
       expect(data.translate).toBe(false);

--- a/components/form-builder/example-form.json
+++ b/components/form-builder/example-form.json
@@ -1,262 +1,248 @@
 {
-    "form": {
-      "layout": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        9,
-        10,
-        12,
-        13,
-        14
-      ],
-      "endPage": {
-        "descriptionEn": "#Your submission has been received \n\r Thank you for your interest. We will contact you within 3-5 business days.  \n\r <a href='https://digital.canada.ca'>Go back</a>",
-        "descriptionFr": "#[fr] Your submission has been received. \n\r Thank you for your interest. We will contact you within 3-5 business days. \n\r <a href='https://digital.canada.ca'>Go back</a>",
-        "referrerUrlEn": "",
-        "referrerUrlFr": ""
-      },
-      "titleEn": "Lemonade Stand Funding",
-      "titleFr": "[fr] Lemonade Stand Funding",
-      "version": 1,
-      "elements": [
-        {
-          "id": 1,
-          "type": "richText",
-          "properties": {
-            "charLimit": 5000,
-            "validation": {
-              "required": false
-            },
-            "descriptionEn": "##Contact Information",
-            "descriptionFr": "##[fr] Contact Information"
-          }
-        },
-        {
-          "id": 2,
-          "type": "textField",
-          "properties": {
-            "titleEn": "1. What is your name?",
-            "titleFr": "[fr]1. What is your name?]",
-            "validation": {
-              "type": "text",
-              "required": true,
-              "maxLength": 150
-            },
-            "autoComplete": "name",
-            "descriptionEn": "",
-            "descriptionFr": "",
-            "placeholderEn": "",
-            "placeholderFr": ""
-          }
-        },
-        {
-          "id": 3,
-          "type": "radio",
-          "properties": {
-            "choices": [
-              {
-                "en": "English",
-                "fr": "Anglais"
-              },
-              {
-                "en": "French",
-                "fr": "Français"
-              }
-            ],
-            "titleEn": "2. What is your preferred language for communications?",
-            "titleFr": "[fr] 2. What is your preferred language for communications?",
-            "validation": {
-              "required": true
-            },
-            "descriptionEn": "",
-            "descriptionFr": ""
-          }
-        },
-        {
-          "id": 4,
-          "type": "richText",
-          "properties": {
-            "charLimit": 5000,
-            "validation": {
-              "required": false
-            },
-            "descriptionEn": "**Note:** We are not collecting email addresses or phone numbers through this test form to preserve your privacy \n\r ##Poject Information",
-            "descriptionFr": "[fr] **Note:** We are not collecting email addresses or phone numbers through this test form to preserve your privacy \n\r ##Project Information"
-          }
-        },
-        {
-          "id": 5,
-          "type": "textField",
-          "properties": {
-            "titleEn": "3. What is the name of your lemonade stand?",
-            "titleFr": "[fr]3. What is the name of your lemonade stand?",
-            "validation": {
-              "type": "text",
-              "required": true,
-              "maxLength": 300
-            },
-            "descriptionEn": "",
-            "descriptionFr": "",
-            "placeholderEn": "",
-            "placeholderFr": ""
-          }
-        },
-        {
-          "id": 7,
-          "type": "textArea",
-          "properties": {
-            "titleEn": "5. Please describe the taste of your lemonade recipe. ",
-            "titleFr": "[fr] 5. Please describe the taste of your lemonade recipe. ",
-            "validation": {
-              "type": "text",
-              "required": true,
-              "maxLength": 1000
-            },
-            "descriptionEn": "Consider including details about the sweetness or sourness of your lemonade recipe. Maximum characters: 1000",
-            "descriptionFr": "[fr]Consider including details about the sweetness or sourness of your lemonade recipe. Maximum characters: 1000",
-            "placeholderEn": "",
-            "placeholderFr": ""
-          }
-        },
-        {
-          "id": 8,
-          "type": "dropdown",
-          "properties": {
-            "choices": [
-              {
-                "en": "Park",
-                "fr": "[fr] Park"
-              },
-              {
-                "en": "Driveway",
-                "fr": "[fr]Driveway"
-              },
-              {
-                "en": "Building lobby",
-                "fr": "[fr]Building lobby"
-              },
-              {
-                "en": "Parking lot",
-                "fr": "[fr]Parking lot"
-              },
-              {
-                "en": "Other",
-                "fr": "[fr]Other"
-              }
-            ],
-            "titleEn": "6. Where is your lemonade stand going to be located?",
-            "titleFr": "[fr]6. Where is your lemonade stand going to be located?",
-            "validation": {
-              "required": true
-            },
-            "descriptionEn": "",
-            "descriptionFr": ""
-          }
-        },
-        {
-          "id": 9,
-          "type": "textField",
-          "properties": {
-            "titleEn": "7. If you checked Other, please specify",
-            "titleFr": "7. Pour d'autre information veuillez spécifier",
-            "validation": {
-              "type": "text",
-              "required": false,
-              "maxLength": 100
-            },
-            "descriptionEn": "",
-            "descriptionFr": "",
-            "placeholderEn": "",
-            "placeholderFr": ""
-          }
-        },
-        {
-          "id": 10,
-          "type": "richText",
-          "properties": {
-            "charLimit": 5000,
-            "validation": {
-              "required": false
-            },
-            "descriptionEn": "###Materials and Ingredients",
-            "descriptionFr": "###[fr] Materials and Ingredients"
-          }
-        },
-        {
-          "id": 12,
-          "type": "checkbox",
-          "properties": {
-            "choices": [
-              {
-                "en": "Cups",
-                "fr": "[fr] Cups"
-              },
-              {
-                "en": "Napkins",
-                "fr": "[fr]Napkins"
-              },
-              {
-                "en": "Straws",
-                "fr": "[fr]Straws"
-              }
-            ],
-            "titleEn": "9. Which materials will you purchase with this funding? ",
-            "titleFr": "[fr] 9. Which materials will you purchase with this funding? ",
-            "validation": {
-              "required": true
-            },
-            "descriptionEn": "",
-            "descriptionFr": ""
-          }
-        },
-        {
-          "id": 13,
-          "type": "richText",
-          "properties": {
-            "charLimit": 5000,
-            "validation": {
-              "required": false
-            },
-            "descriptionEn": "##Submission",
-            "descriptionFr": "##[fr] Submission"
-          }
-        },
-        {
-          "id": 14,
-          "type": "radio",
-          "properties": {
-            "choices": [
-              {
-                "en": "Yes",
-                "fr": "Oui"
-              },
-              {
-                "en": "No",
-                "fr": "Non"
-              }
-            ],
-            "titleEn": "10. Do you attest that the information you are providing is true and correct to your knowledge?",
-            "titleFr": "[fr] 10. Do you attest that the information you are providing is true and correct to your knowledge?",
-            "validation": {
-              "required": true
-            },
-            "descriptionEn": "",
-            "descriptionFr": ""
-          }
+  "form": {
+    "layout": [1, 2, 3, 4, 5, 7, 8, 9, 10, 12, 13, 14],
+    "endPage": {
+      "descriptionEn": "#Your submission has been received \n\r Thank you for your interest. We will contact you within 3-5 business days.  \n\r <a href='https://digital.canada.ca'>Go back</a>",
+      "descriptionFr": "#[fr] Your submission has been received. \n\r Thank you for your interest. We will contact you within 3-5 business days. \n\r <a href='https://digital.canada.ca'>Go back</a>",
+      "referrerUrlEn": "",
+      "referrerUrlFr": ""
+    },
+    "titleEn": "Lemonade Stand Funding",
+    "titleFr": "[fr] Lemonade Stand Funding",
+    "version": 1,
+    "elements": [
+      {
+        "id": 1,
+        "type": "richText",
+        "properties": {
+          "charLimit": 5000,
+          "validation": {
+            "required": false
+          },
+          "descriptionEn": "##Contact Information",
+          "descriptionFr": "##[fr] Contact Information"
         }
-      ],
-      "emailSubjectEn": "Lemonade Stand Funding Testing Response",
-      "emailSubjectFr": ""
-    },
-    "submission": {
-      "email": "forms-formulaires@cds-snc.ca"
-    },
-    "internalTitleEn": "CDS - Lemonade Stand Funding",
-    "internalTitleFr": "CDS - Lemonade Stand Funding",
-    "publishingStatus": true
-  }
+      },
+      {
+        "id": 2,
+        "type": "textField",
+        "properties": {
+          "titleEn": "1. What is your name?",
+          "titleFr": "[fr]1. What is your name?]",
+          "validation": {
+            "type": "text",
+            "required": true,
+            "maxLength": 150
+          },
+          "autoComplete": "name",
+          "descriptionEn": "",
+          "descriptionFr": "",
+          "placeholderEn": "",
+          "placeholderFr": ""
+        }
+      },
+      {
+        "id": 3,
+        "type": "radio",
+        "properties": {
+          "choices": [
+            {
+              "en": "English",
+              "fr": "Anglais"
+            },
+            {
+              "en": "French",
+              "fr": "Français"
+            }
+          ],
+          "titleEn": "2. What is your preferred language for communications?",
+          "titleFr": "[fr] 2. What is your preferred language for communications?",
+          "validation": {
+            "required": true
+          },
+          "descriptionEn": "",
+          "descriptionFr": ""
+        }
+      },
+      {
+        "id": 4,
+        "type": "richText",
+        "properties": {
+          "charLimit": 5000,
+          "validation": {
+            "required": false
+          },
+          "descriptionEn": "**Note:** We are not collecting email addresses or phone numbers through this test form to preserve your privacy \n\r ##Poject Information",
+          "descriptionFr": "[fr] **Note:** We are not collecting email addresses or phone numbers through this test form to preserve your privacy \n\r ##Project Information"
+        }
+      },
+      {
+        "id": 5,
+        "type": "textField",
+        "properties": {
+          "titleEn": "3. What is the name of your lemonade stand?",
+          "titleFr": "[fr]3. What is the name of your lemonade stand?",
+          "validation": {
+            "type": "text",
+            "required": true,
+            "maxLength": 300
+          },
+          "descriptionEn": "",
+          "descriptionFr": "",
+          "placeholderEn": "",
+          "placeholderFr": ""
+        }
+      },
+      {
+        "id": 7,
+        "type": "textArea",
+        "properties": {
+          "titleEn": "5. Please describe the taste of your lemonade recipe. ",
+          "titleFr": "[fr] 5. Please describe the taste of your lemonade recipe. ",
+          "validation": {
+            "type": "text",
+            "required": true,
+            "maxLength": 1000
+          },
+          "descriptionEn": "Consider including details about the sweetness or sourness of your lemonade recipe. Maximum characters: 1000",
+          "descriptionFr": "[fr]Consider including details about the sweetness or sourness of your lemonade recipe. Maximum characters: 1000",
+          "placeholderEn": "",
+          "placeholderFr": ""
+        }
+      },
+      {
+        "id": 8,
+        "type": "dropdown",
+        "properties": {
+          "choices": [
+            {
+              "en": "Park",
+              "fr": "[fr] Park"
+            },
+            {
+              "en": "Driveway",
+              "fr": "[fr]Driveway"
+            },
+            {
+              "en": "Building lobby",
+              "fr": "[fr]Building lobby"
+            },
+            {
+              "en": "Parking lot",
+              "fr": "[fr]Parking lot"
+            },
+            {
+              "en": "Other",
+              "fr": "[fr]Other"
+            }
+          ],
+          "titleEn": "6. Where is your lemonade stand going to be located?",
+          "titleFr": "[fr]6. Where is your lemonade stand going to be located?",
+          "validation": {
+            "required": true
+          },
+          "descriptionEn": "",
+          "descriptionFr": ""
+        }
+      },
+      {
+        "id": 9,
+        "type": "textField",
+        "properties": {
+          "titleEn": "7. If you checked Other, please specify",
+          "titleFr": "7. Pour d'autre information veuillez spécifier",
+          "validation": {
+            "type": "text",
+            "required": false,
+            "maxLength": 100
+          },
+          "descriptionEn": "",
+          "descriptionFr": "",
+          "placeholderEn": "",
+          "placeholderFr": ""
+        }
+      },
+      {
+        "id": 10,
+        "type": "richText",
+        "properties": {
+          "charLimit": 5000,
+          "validation": {
+            "required": false
+          },
+          "descriptionEn": "###Materials and Ingredients",
+          "descriptionFr": "###[fr] Materials and Ingredients"
+        }
+      },
+      {
+        "id": 12,
+        "type": "checkbox",
+        "properties": {
+          "choices": [
+            {
+              "en": "Cups",
+              "fr": "[fr] Cups"
+            },
+            {
+              "en": "Napkins",
+              "fr": "[fr]Napkins"
+            },
+            {
+              "en": "Straws",
+              "fr": "[fr]Straws"
+            }
+          ],
+          "titleEn": "9. Which materials will you purchase with this funding? ",
+          "titleFr": "[fr] 9. Which materials will you purchase with this funding? ",
+          "validation": {
+            "required": true
+          },
+          "descriptionEn": "",
+          "descriptionFr": ""
+        }
+      },
+      {
+        "id": 13,
+        "type": "richText",
+        "properties": {
+          "charLimit": 5000,
+          "validation": {
+            "required": false
+          },
+          "descriptionEn": "##Submission",
+          "descriptionFr": "##[fr] Submission"
+        }
+      },
+      {
+        "id": 14,
+        "type": "radio",
+        "properties": {
+          "choices": [
+            {
+              "en": "Yes",
+              "fr": "Oui"
+            },
+            {
+              "en": "No",
+              "fr": "Non"
+            }
+          ],
+          "titleEn": "10. Do you attest that the information you are providing is true and correct to your knowledge?",
+          "titleFr": "[fr] 10. Do you attest that the information you are providing is true and correct to your knowledge?",
+          "validation": {
+            "required": true
+          },
+          "descriptionEn": "",
+          "descriptionFr": ""
+        }
+      }
+    ],
+    "emailSubjectEn": "Lemonade Stand Funding Testing Response",
+    "emailSubjectFr": ""
+  },
+  "submission": {
+    "email": "forms-formulaires@cds-snc.ca"
+  },
+  "internalTitleEn": "CDS - Lemonade Stand Funding",
+  "internalTitleFr": "CDS - Lemonade Stand Funding"
+}

--- a/components/form-builder/hooks/useAllowPublish.tsx
+++ b/components/form-builder/hooks/useAllowPublish.tsx
@@ -77,7 +77,7 @@ export const useAllowPublish = () => {
     email = submission?.email;
   }
 
-  const userCanPublish = ability?.can("update", "FormRecord", "[publishingStatus]");
+  const userCanPublish = ability?.can("update", "FormRecord", "isPublished");
 
   const data = {
     title: !!form?.titleEn || !!form?.titleFr,

--- a/components/form-builder/hooks/usePublish.tsx
+++ b/components/form-builder/hooks/usePublish.tsx
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from "axios";
-export const usePublish = (publishingStatus: boolean) => {
+
+export const usePublish = () => {
   const uploadJson = async (jsonConfig: string, formID?: string) => {
     let formData;
     try {
@@ -10,8 +11,6 @@ export const usePublish = (publishingStatus: boolean) => {
       }
     }
 
-    formData.publishingStatus = publishingStatus;
-
     try {
       const result = await axios({
         url: "/api/templates",
@@ -20,8 +19,8 @@ export const usePublish = (publishingStatus: boolean) => {
           "Content-Type": "application/json",
         },
         data: {
-          formConfig: formData,
           formID: formID,
+          formConfig: formData,
         },
         timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
       });

--- a/components/form-builder/layout/DataDeliveryInstructions.tsx
+++ b/components/form-builder/layout/DataDeliveryInstructions.tsx
@@ -11,7 +11,7 @@ export const DataDeliveryInstructions = () => {
     setId: s.setId,
   }));
 
-  const { uploadJson } = usePublish(false);
+  const { uploadJson } = usePublish();
   const handlePublish = useCallback(async () => {
     const result = await uploadJson(getSchema(), id);
     if (result && result?.error) {

--- a/components/form-builder/layout/Publish.tsx
+++ b/components/form-builder/layout/Publish.tsx
@@ -14,7 +14,7 @@ export const Publish = () => {
     isPublishable,
   } = useAllowPublish();
 
-  const { uploadJson } = usePublish(false);
+  const { uploadJson } = usePublish();
   const [error, setError] = useState(false);
 
   const { getSchema, id, setId } = useTemplateStore((s) => ({

--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -65,7 +65,7 @@ export interface TemplateStoreProps {
   submission: {
     email: string;
   };
-  publishingStatus: boolean;
+  isPublished: boolean;
   securityAttribute: string;
 }
 
@@ -109,7 +109,7 @@ const createTemplateStore = (initProps?: Partial<TemplateStoreProps>) => {
     submission: {
       email: "",
     },
-    publishingStatus: false,
+    isPublished: false,
     securityAttribute: "Unclassified",
   };
 
@@ -216,7 +216,7 @@ const createTemplateStore = (initProps?: Partial<TemplateStoreProps>) => {
           state.lang = "en";
           state.form = defaultForm;
           state.submission = { email: "test@example.com" };
-          state.publishingStatus = false;
+          state.isPublished = false;
           state.securityAttribute = "Unclassified";
         });
       },

--- a/components/form-builder/util.ts
+++ b/components/form-builder/util.ts
@@ -129,7 +129,7 @@ export const getSchemaFromState = (state: TemplateStoreState) => {
     id,
     form,
     submission,
-    publishingStatus: true,
+    isPublished: true,
     securityAttribute,
   };
 

--- a/components/globals/AdminNav.tsx
+++ b/components/globals/AdminNav.tsx
@@ -47,12 +47,11 @@ const AdminNav = (props: AdminNavProps): React.ReactElement => {
             <Link href="/admin/view-templates">{t("adminNav.templates")}</Link>
           </li>
         )}
-        {ability?.can("view", "Flag") &&
-          ability?.can("update", "FormRecord", "[publishingStatus]") && (
-            <li className="gc-horizontal-item">
-              <Link href="/admin/flags">{t("adminNav.features")}</Link>
-            </li>
-          )}
+        {ability?.can("view", "Flag") && ability?.can("update", "FormRecord", "isPublished") && (
+          <li className="gc-horizontal-item">
+            <Link href="/admin/flags">{t("adminNav.features")}</Link>
+          </li>
+        )}
         <li className="gc-horizontal-item">
           {(!user || !user.name) && (
             <Link href="/admin/login" locale={i18n.language}>

--- a/components/globals/AdminNav.tsx
+++ b/components/globals/AdminNav.tsx
@@ -47,7 +47,7 @@ const AdminNav = (props: AdminNavProps): React.ReactElement => {
             <Link href="/admin/view-templates">{t("adminNav.templates")}</Link>
           </li>
         )}
-        {ability?.can("view", "Flag") && ability?.can("update", "FormRecord", "isPublished") && (
+        {ability?.can("view", "Flag") && (
           <li className="gc-horizontal-item">
             <Link href="/admin/flags">{t("adminNav.features")}</Link>
           </li>

--- a/documentation/Forms/FormDBSchema.stories.mdx
+++ b/documentation/Forms/FormDBSchema.stories.mdx
@@ -42,7 +42,6 @@ Here's a data model JSON sample, which is used to create the DB schema for the F
       "program": "",
       "internalTitleEn": "",
       "internalTitleFr": "",
-      "publishingStatus": true,
       "uniqueURLEn": "",
       "uniqueURLFr": "",
       "formVersion": [

--- a/documentation/Forms/FormViewer.stories.mdx
+++ b/documentation/Forms/FormViewer.stories.mdx
@@ -12,7 +12,6 @@ The form viewer expects a JSON with the following structure.
 {
   "internalTitleEn": "",
   "internalTitleFr": "",
-  "publishingStatus": false,
   "securityAttribute": "",
   "submission": {
     "email": ""
@@ -55,8 +54,6 @@ There are 2 main parts to the structure:
    `startPage`: Defines what appears on the first, intro page
 
    `endPage`: Defines what appears on the confirmation page, after the form was submitted. Can write markdown within the description.
-
-   `publishingStatus`: If set to false, the link to the form will not appear on the main page, rather under "sandbox"
 
    `displayAlphaBanner`: If set to false, the ALPHA tag will not appear in the header of the page. If not set if will be defaulted to true.
   

--- a/lib/middleware/jsonIDValidator.ts
+++ b/lib/middleware/jsonIDValidator.ts
@@ -15,7 +15,7 @@ export type ValidateOptions = {
 export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (options?.runValidationIf && options.runValidationIf(req) === false) {
+      if (options?.runValidationIf?.(req) === false) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
@@ -50,7 +50,7 @@ export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest 
 export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (options?.runValidationIf && options.runValidationIf(req) === false) {
+      if (options?.runValidationIf?.(req) === false) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
@@ -85,7 +85,7 @@ export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest 
 export const subElementsIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (options?.runValidationIf && options.runValidationIf(req) === false) {
+      if (options?.runValidationIf?.(req) === false) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey

--- a/lib/middleware/jsonIDValidator.ts
+++ b/lib/middleware/jsonIDValidator.ts
@@ -3,8 +3,8 @@ import { BetterOmit, MiddlewareRequest, MiddlewareReturn } from "@lib/types";
 import { FormElement, FormElementTypes, FormRecord } from "@lib/types/form-types";
 
 export type ValidateOptions = {
+  runValidationIf?: (req: NextApiRequest) => boolean;
   jsonKey: string;
-  skipValidationIf?: (req: NextApiRequest) => boolean;
 };
 
 /**
@@ -15,10 +15,7 @@ export type ValidateOptions = {
 export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (
-        (req.method !== "POST" && req.method !== "PUT") ||
-        (options?.skipValidationIf && options?.skipValidationIf(req))
-      ) {
+      if (options?.runValidationIf && options.runValidationIf(req) === false) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
@@ -53,10 +50,7 @@ export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest 
 export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (
-        (req.method !== "POST" && req.method !== "PUT") ||
-        (options?.skipValidationIf && options?.skipValidationIf(req))
-      ) {
+      if (options?.runValidationIf && options.runValidationIf(req) === false) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
@@ -91,10 +85,7 @@ export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest 
 export const subElementsIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (
-        (req.method !== "POST" && req.method !== "PUT") ||
-        (options?.skipValidationIf && options?.skipValidationIf(req))
-      ) {
+      if (options?.runValidationIf && options.runValidationIf(req) === false) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey

--- a/lib/middleware/jsonIDValidator.ts
+++ b/lib/middleware/jsonIDValidator.ts
@@ -4,6 +4,7 @@ import { FormElement, FormElementTypes, FormRecord } from "@lib/types/form-types
 
 export type ValidateOptions = {
   jsonKey: string;
+  skipValidationIf?: (req: NextApiRequest) => boolean;
 };
 
 /**
@@ -14,7 +15,10 @@ export type ValidateOptions = {
 export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (req.method !== "POST" && req.method !== "PUT") {
+      if (
+        (req.method !== "POST" && req.method !== "PUT") ||
+        (options?.skipValidationIf && options?.skipValidationIf(req))
+      ) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
@@ -49,7 +53,10 @@ export const uniqueIDValidator = (options?: ValidateOptions): MiddlewareRequest 
 export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (req.method !== "POST" && req.method !== "PUT") {
+      if (
+        (req.method !== "POST" && req.method !== "PUT") ||
+        (options?.skipValidationIf && options?.skipValidationIf(req))
+      ) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey
@@ -84,7 +91,10 @@ export const layoutIDValidator = (options?: ValidateOptions): MiddlewareRequest 
 export const subElementsIDValidator = (options?: ValidateOptions): MiddlewareRequest => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     try {
-      if (req.method !== "POST" && req.method !== "PUT") {
+      if (
+        (req.method !== "POST" && req.method !== "PUT") ||
+        (options?.skipValidationIf && options?.skipValidationIf(req))
+      ) {
         return { next: true };
       }
       const jsonConfig: BetterOmit<FormRecord, "id" | "bearerToken"> = options?.jsonKey

--- a/lib/middleware/schemas/templates.schema.json
+++ b/lib/middleware/schemas/templates.schema.json
@@ -5,27 +5,30 @@
   "title": "GC Forms Schema - Alpha",
   "description": "A schema to define a Forms configuration.",
   "default": {},
-  "examples": [{"internalTitleEn": "",
-  "internalTitleFr": "",
-  "publishingStatus": false,
-  "securityAttribute": "",
-  "submission": {
-    "email": ""
-  },
-  "form": {
-    "version": 1,
-    "titleEn": "",
-    "titleFr": "",
-    "emailSubjectEn": "",
-    "emailSubjectFr": "",
-    "layout": [ ],
-    "brand": {},
-    "elements": [ ],
-    "startPage": {},
-    "endPage": {},
-    "introduction": {},
-    "privacyPolicy": {}
-  }}],
+  "examples": [
+    {
+      "internalTitleEn": "",
+      "internalTitleFr": "",
+      "securityAttribute": "",
+      "submission": {
+        "email": ""
+      },
+      "form": {
+        "version": 1,
+        "titleEn": "",
+        "titleFr": "",
+        "emailSubjectEn": "",
+        "emailSubjectFr": "",
+        "layout": [],
+        "brand": {},
+        "elements": [],
+        "startPage": {},
+        "endPage": {},
+        "introduction": {},
+        "privacyPolicy": {}
+      }
+    }
+  ],
   "properties": {
     "internalTitleEn": {
       "description": "The internal title of the form in English",
@@ -52,7 +55,7 @@
         "description": "The displayed title of the form to the user in French",
         "id": "#/properties/titleFr",
         "type": "string"
-      },      
+      },
       "type": "object",
       "properties": {
         "layout": {
@@ -63,7 +66,7 @@
           },
           "uniqueItems": true,
           "examples": [[2, 3, 4, 6, 9, 5]]
-        },        
+        },
         "elements": {
           "description": "A list of elements contained within the form.",
           "type": "array",
@@ -104,7 +107,7 @@
                 "descriptionEn": "",
                 "descriptionFr": ""
               }
-            }            
+            }
           ]
         },
         "brand": {
@@ -170,8 +173,8 @@
             "referrerUrlFr": {
               "type": "string"
             }
-          }       
-        }       
+          }
+        }
       },
       "required": ["elements", "layout", "titleEn", "titleFr"]
     },
@@ -199,15 +202,10 @@
         }
       ]
     },
-    "publishingStatus": {
-      "description": "If set to false, the link to the form will not appear on the main page, rather under 'sandbox'",
-      "id": "#/properties/publishingStatus",
-      "type": "boolean"
-    },
     "displayAlphaBanner": {
       "description": "If set to false, the ALPHA tag will not appear in the header of the page. If not set if will be defaulted to true.",
       "id": "#/properties/displayAlphaBanner",
-      "type": "boolean"      
+      "type": "boolean"
     },
     "securityAttribute": {
       "description": "It shows an administrator what procedure should be taken when accessing a form's responses",
@@ -220,7 +218,7 @@
       "description": ""
     }
   },
-  "required": ["form", "submission", "publishingStatus"],
+  "required": ["form", "submission"],
   "additionalProperties": true,
   "definitions": {
     "element": {
@@ -320,19 +318,23 @@
                   "type": "boolean"
                 }
               },
-              "examples":[
-                {"validation": {
-                  "required": true,
-                  "type": "email",
-                  "descriptionEN": "Please enter a valid email address.",
-                  "descriptionFR": "Veuillez entrer une adresse courriel valide."
-                }},
-                {"validation": {
-                  "required": false,
-                  "type": "alphanumeric",
-                  "descriptionEN": "Please enter your home street address.",
-                  "descriptionFR": "Veuillez entrer votre adresse postale."
-                }}      
+              "examples": [
+                {
+                  "validation": {
+                    "required": true,
+                    "type": "email",
+                    "descriptionEN": "Please enter a valid email address.",
+                    "descriptionFR": "Veuillez entrer une adresse courriel valide."
+                  }
+                },
+                {
+                  "validation": {
+                    "required": false,
+                    "type": "alphanumeric",
+                    "descriptionEN": "Please enter your home street address.",
+                    "descriptionFR": "Veuillez entrer votre adresse postale."
+                  }
+                }
               ]
             }
           }

--- a/lib/privileges.ts
+++ b/lib/privileges.ts
@@ -257,20 +257,21 @@ export const checkPrivileges = (
   rules: {
     action: Action;
     subject: Subject | ForcedSubjectType;
+    field?: string;
   }[],
   logic: "all" | "one" = "all"
 ): void => {
   // helper to define if we are force typing a passed object
   try {
-    const result = rules.map(({ action, subject }) => {
+    const result = rules.map(({ action, subject, field }) => {
       let ruleResult = false;
       if (_isForceTyping(subject)) {
-        ruleResult = ability.can(action, setSubjectType(subject.type, subject.object));
+        ruleResult = ability.can(action, setSubjectType(subject.type, subject.object), field);
         logMessage.debug(
           `Privilege Check ${ruleResult ? "PASS" : "FAIL"}: Can ${action} on ${subject.type} `
         );
       } else {
-        ruleResult = ability.can(action, subject);
+        ruleResult = ability.can(action, subject, field);
         logMessage.debug(
           `Privilege Check ${ruleResult ? "PASS" : "FAIL"}: Can ${action} on ${subject} `
         );

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -293,7 +293,7 @@ async function _deleteTemplate(ability: MongoAbility, formID: string): Promise<F
 
 async function _getFormRecordWithAssociatedUsers(
   formID: string
-): Promise<{ formRecord: FormRecord; users: User[]; formConfig: Prisma.JsonValue } | null> {
+): Promise<{ formRecord: FormRecord; users: User[] } | null> {
   try {
     const templateWithUsers = await prisma.template.findUnique({
       where: {
@@ -313,7 +313,6 @@ async function _getFormRecordWithAssociatedUsers(
     return {
       formRecord: parsedTemplate,
       users: templateWithUsers.users,
-      formConfig: templateWithUsers.jsonConfig,
     };
   } catch (e) {
     return prismaErrors(e, null);

--- a/lib/tests/helpers.test.js
+++ b/lib/tests/helpers.test.js
@@ -165,7 +165,6 @@ describe("Submit and Template helpers", () => {
           {
             id: "test0form00000id000asdf11",
             elements: { test: "test" },
-            publishingStatus: true,
             securityAttribute: "Unclassified",
           },
         ],
@@ -177,7 +176,6 @@ describe("Submit and Template helpers", () => {
       expect.objectContaining({ url: "/api/templates", method: "GET" })
     );
     expect(form.id).toEqual("test0form00000id000asdf11");
-    expect(form.publishingStatus).toBe(true);
     expect(form.securityAttribute).toEqual("Unclassified");
   });
   test("getFormByID handles error when it occurs", async () => {

--- a/lib/tests/jsonIDValidator.test.js
+++ b/lib/tests/jsonIDValidator.test.js
@@ -118,4 +118,27 @@ describe("Test JSON ID validation scenarios", () => {
     expect(JSON.parse(res._getData()).error).toContain("Incorrect subElement IDs detected:");
     expect(res.statusCode).toBe(400);
   });
+
+  it("JSON validator can be skipped under specific condition", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        formConfig: invalidSubElementIds,
+      },
+    });
+
+    await subElementsIDValidator({ runValidationIf: () => true, jsonKey: "formConfig" })(req, res);
+    expect(JSON.parse(res._getData()).error).toContain("Incorrect subElement IDs detected:");
+    expect(res.statusCode).toBe(400);
+
+    const skipResult = await subElementsIDValidator({
+      runValidationIf: () => false,
+      jsonKey: "formConfig",
+    })(req, res);
+
+    expect(skipResult).toEqual({ next: true });
+  });
 });

--- a/lib/tests/privileges.test.ts
+++ b/lib/tests/privileges.test.ts
@@ -6,13 +6,13 @@ import { interpolatePermissionCondition } from "@lib/privileges";
 
 describe("Provided values can be interpolated in permission condition", () => {
   it("Should succeed if condition does not require any interpolation", async () => {
-    const condition = { "formConfig.publishingStatus": false };
+    const condition = { "formConfig.something": false };
 
     const result = interpolatePermissionCondition(condition, {
       userId: "1B712DD4-9263-41C2-AAA0-B0D4F430FEC9",
     });
 
-    const expectedResult = { "formConfig.publishingStatus": false };
+    const expectedResult = { "formConfig.something": false };
 
     expect(result).toMatchObject(expectedResult);
   });

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -367,18 +367,4 @@ describe("Template CRUD functions", () => {
       await deleteTemplate(ability, "formtestID");
     }).rejects.toThrowError(new AccessControlError(`Access Control Forbidden Action`));
   });
-
-  it("User with Base permissions should not be able to delete a template that is published", async () => {
-    const ability = createAbility(getUserPrivileges(Base, { user: { id: "1" } }));
-
-    (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
-      id: "formtestID",
-      jsonConfig: { ...formConfiguration, publishingStatus: true },
-      users: [{ id: "1" }],
-    });
-
-    await expect(async () => {
-      await deleteTemplate(ability, "formtestID");
-    }).rejects.toThrowError(new AccessControlError(`Access Control Forbidden Action`));
-  });
 });

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -305,42 +305,6 @@ describe("Template CRUD functions", () => {
     });
   });
 
-  /**
-   * Can be deleted once we think that the progressive migration is not needed anymore and the code in lib/templates.ts has been removed
-   */
-  it("Update `isPublished` on a specific form should handle soft migration with existing `publishingStatus`", async () => {
-    const ability = createAbility(getUserPrivileges(PublishForms, { user: { id: "1" } }));
-
-    (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
-      id: "formtestID",
-      jsonConfig: { ...formConfiguration, publishingStatus: true },
-      users: [{ id: "1" }],
-    });
-
-    (prismaMock.template.update as jest.MockedFunction<any>).mockResolvedValue({
-      id: "formtestID",
-      jsonConfig: formConfiguration,
-      isPublished: true,
-    });
-
-    await updateIsPublishedForTemplate(ability, "formtestID", false);
-
-    expect(prismaMock.template.update).toHaveBeenCalledWith({
-      where: {
-        id: "formtestID",
-      },
-      data: {
-        isPublished: false,
-        jsonConfig: formConfiguration as unknown as Prisma.JsonObject,
-      },
-      select: {
-        id: true,
-        jsonConfig: true,
-        isPublished: true,
-      },
-    });
-  });
-
   it.each([[Base], [ManageForms]])("Delete template", async (privileges) => {
     const ability = createAbility(getUserPrivileges(privileges, { user: { id: "1" } }));
 

--- a/lib/types/form-types.ts
+++ b/lib/types/form-types.ts
@@ -126,7 +126,7 @@ export type FormRecord = {
   bearerToken?: string;
   internalTitleEn?: string;
   internalTitleFr?: string;
-  publishingStatus: boolean;
+  isPublished: boolean;
   submission: SubmissionProperties;
   displayAlphaBanner?: boolean;
   form: FormProperties;

--- a/pages/admin/view-templates.tsx
+++ b/pages/admin/view-templates.tsx
@@ -8,22 +8,37 @@ import { useTranslation } from "next-i18next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { checkPrivileges } from "@lib/privileges";
-import { useAccessControl } from "@lib/hooks";
+import { useAccessControl, useRefresh } from "@lib/hooks";
+import axios from "axios";
+import { logMessage } from "@lib/logger";
 
 interface DataViewProps {
   templates: Array<{
     id: string;
     titleEn: string;
     titleFr: string;
-    publishingStatus: boolean;
+    isPublished: boolean;
     [key: string]: string | boolean;
   }>;
 }
+
+const handlePublish = async (formID: string, isPublished: boolean) => {
+  return await axios({
+    url: "/api/templates",
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    data: { formID, isPublished },
+    timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
+  }).catch((err) => logMessage.error(err));
+};
 
 const DataView = (props: DataViewProps): React.ReactElement => {
   const { t, i18n } = useTranslation("admin-templates");
   const { templates } = props;
   const router = useRouter();
+  const { refreshData } = useRefresh();
 
   const redirectToSettings = (formID: string) => {
     router.push({
@@ -52,34 +67,55 @@ const DataView = (props: DataViewProps): React.ReactElement => {
             <th>{t("view.status")}</th>
             <th className="w-1/12">{t("view.update")}</th>
             <th className="w-1/12">{t("view.view")}</th>
+            <th className="w-1/12">{t("view.publishForm")}</th>
           </tr>
         </thead>
         <tbody>
-          {templates.map((template) => {
-            return (
-              <tr key={template.id} className="border-t-4 border-b-1 border-gray-400">
-                <td className="pl-4">{template[getProperty("title", i18n.language)]} </td>
-                <td className="text-center">
-                  {template.publishingStatus ? t("view.published") : t("view.draft")}
-                </td>
-                <td>
-                  {ability?.can("update", "FormRecord") && (
+          {templates
+            .sort((a, b) => {
+              return (a[getProperty("title", i18n.language)] as string).localeCompare(
+                b[getProperty("title", i18n.language)] as string
+              );
+            })
+            .map((template) => {
+              return (
+                <tr key={template.id} className="border-t-4 border-b-1 border-gray-400">
+                  <td className="pl-4">{template[getProperty("title", i18n.language)]} </td>
+                  <td className="text-center">
+                    {template.isPublished ? t("view.published") : t("view.draft")}
+                  </td>
+                  <td>
+                    {ability?.can("update", "FormRecord") && (
+                      <button
+                        onClick={() => redirectToSettings(template.id)}
+                        className="gc-button w-full"
+                      >
+                        {t("view.update")}
+                      </button>
+                    )}
+                  </td>
+                  <td>
                     <button
-                      onClick={() => redirectToSettings(template.id)}
+                      onClick={() => redirectToForm(template.id)}
                       className="gc-button w-full"
                     >
-                      {t("view.update")}
+                      {t("view.view")}
                     </button>
-                  )}
-                </td>
-                <td>
-                  <button onClick={() => redirectToForm(template.id)} className="gc-button w-full">
-                    {t("view.view")}
-                  </button>
-                </td>
-              </tr>
-            );
-          })}
+                  </td>
+                  <td>
+                    <button
+                      onClick={async () => {
+                        await handlePublish(template.id, !template.isPublished);
+                        refreshData();
+                      }}
+                      className="gc-button w-full"
+                    >
+                      {template.isPublished ? t("view.unpublishForm") : t("view.publishForm")}
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
         </tbody>
       </table>
     </>
@@ -104,13 +140,13 @@ export const getServerSideProps = requireAuthentication(
         const {
           id,
           form: { titleEn, titleFr },
-          publishingStatus,
+          isPublished,
         } = template;
         return {
           id,
           titleEn,
           titleFr,
-          publishingStatus,
+          isPublished,
         };
       });
 

--- a/pages/api/templates.ts
+++ b/pages/api/templates.ts
@@ -127,8 +127,8 @@ const templateCRUD = async ({
   }
 };
 
-const skipValidationCondition = (req: NextApiRequest) => {
-  return req.body.isPublished !== undefined;
+const runValidationCondition = (req: NextApiRequest) => {
+  return req.body.formConfig !== undefined;
 };
 
 export default middleware(
@@ -137,16 +137,16 @@ export default middleware(
     sessionExists(authenticatedMethods),
     jsonValidator(templatesSchema, { jsonKey: "formConfig" }),
     uniqueIDValidator({
+      runValidationIf: runValidationCondition,
       jsonKey: "formConfig",
-      skipValidationIf: skipValidationCondition,
     }),
     layoutIDValidator({
+      runValidationIf: runValidationCondition,
       jsonKey: "formConfig",
-      skipValidationIf: skipValidationCondition,
     }),
     subElementsIDValidator({
+      runValidationIf: runValidationCondition,
       jsonKey: "formConfig",
-      skipValidationIf: skipValidationCondition,
     }),
   ],
   templates

--- a/pages/api/templates.ts
+++ b/pages/api/templates.ts
@@ -5,6 +5,7 @@ import {
   deleteTemplate,
   createTemplate,
   updateTemplate,
+  updateIsPublishedForTemplate,
 } from "@lib/templates";
 
 import { middleware, jsonValidator, cors, sessionExists } from "@lib/middleware";
@@ -57,7 +58,9 @@ const templates = async (
           session.user.id,
           AdminLogAction.Update,
           AdminLogEvent.UpdateForm,
-          `Form id: ${req.body.formID} has been updated`
+          req.body.isPublished !== undefined
+            ? `Form id: ${req.body.formID} 'isPublished' value has been updated`
+            : `Form id: ${req.body.formID} has been updated`
         );
       }
       if (req.method === "DELETE") {
@@ -93,12 +96,14 @@ const templateCRUD = async ({
   user,
   formID,
   formConfig,
+  isPublished,
 }: {
   ability: MongoAbility;
   method: string;
   user: Session["user"];
   formID?: string;
   formConfig?: BetterOmit<FormRecord, "id" | "bearerToken">;
+  isPublished: boolean;
 }) => {
   switch (method) {
     case "GET":
@@ -108,7 +113,11 @@ const templateCRUD = async ({
       if (formConfig) return await createTemplate(ability, user.id, formConfig);
       throw new Error("Missing Form Configuration");
     case "PUT":
-      if (formID && formConfig) return await updateTemplate(ability, formID, formConfig);
+      if (formID && formConfig) {
+        return await updateTemplate(ability, formID, formConfig);
+      } else if (formID && isPublished !== undefined) {
+        return await updateIsPublishedForTemplate(ability, formID, isPublished);
+      }
       throw new Error("Missing formID and/or formConfig");
     case "DELETE":
       if (formID) return await deleteTemplate(ability, formID);
@@ -118,14 +127,27 @@ const templateCRUD = async ({
   }
 };
 
+const skipValidationCondition = (req: NextApiRequest) => {
+  return req.body.isPublished !== undefined;
+};
+
 export default middleware(
   [
     cors({ allowedMethods }),
     sessionExists(authenticatedMethods),
     jsonValidator(templatesSchema, { jsonKey: "formConfig" }),
-    uniqueIDValidator({ jsonKey: "formConfig" }),
-    layoutIDValidator({ jsonKey: "formConfig" }),
-    subElementsIDValidator({ jsonKey: "formConfig" }),
+    uniqueIDValidator({
+      jsonKey: "formConfig",
+      skipValidationIf: skipValidationCondition,
+    }),
+    layoutIDValidator({
+      jsonKey: "formConfig",
+      skipValidationIf: skipValidationCondition,
+    }),
+    subElementsIDValidator({
+      jsonKey: "formConfig",
+      skipValidationIf: skipValidationCondition,
+    }),
   ],
   templates
 );

--- a/pages/id/[form]/[[...step]].tsx
+++ b/pages/id/[form]/[[...step]].tsx
@@ -83,7 +83,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   // Short circuit only if Cypress testing
   if (
     process.env.APP_ENV !== "test" &&
-    (!publicForm || (!publicForm?.publishingStatus && !unpublishedForms))
+    (!publicForm || (!publicForm?.isPublished && !unpublishedForms))
   ) {
     return redirect(context.locale);
   }

--- a/prisma/migrations/20221031175512_add_ispublished_to_template/migration.sql
+++ b/prisma/migrations/20221031175512_add_ispublished_to_template/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Template" ADD COLUMN     "isPublished" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,9 +66,10 @@ model Session {
 }
 
 model Template {
-  id          String     @id @default(cuid())
+  id          String    @id @default(cuid())
   jsonConfig  Json
   bearerToken String?
+  isPublished Boolean   @default(false)
   ttl         DateTime?
   apiUsers    ApiUser[]
   users       User[]

--- a/prisma/seeds/fixtures/privileges.ts
+++ b/prisma/seeds/fixtures/privileges.ts
@@ -19,7 +19,7 @@ const Base: PrivilegeSeed = {
       subject: "FormRecord",
       conditions: { users: { $elemMatch: { id: "${user.id}" } } },
     },
-    { action: "update", subject: "FormRecord", fields: ["publishingStatus"], inverted: true },
+    { action: "update", subject: "FormRecord", fields: ["isPublished"], inverted: true },
   ],
   priority: 0,
 };
@@ -33,7 +33,7 @@ const PublishForms: PrivilegeSeed = {
     {
       action: ["update"],
       subject: "FormRecord",
-      fields: ["publishingStatus"],
+      fields: ["isPublished"],
       conditions: { users: { $elemMatch: { id: "${user.id}" } } },
     },
   ],

--- a/prisma/seeds/fixtures/privileges.ts
+++ b/prisma/seeds/fixtures/privileges.ts
@@ -20,12 +20,6 @@ const Base: PrivilegeSeed = {
       conditions: { users: { $elemMatch: { id: "${user.id}" } } },
     },
     { action: "update", subject: "FormRecord", fields: ["publishingStatus"], inverted: true },
-    {
-      action: "delete",
-      subject: "FormRecord",
-      conditions: { publishingStatus: true },
-      inverted: true,
-    },
   ],
   priority: 0,
 };

--- a/prisma/seeds/fixtures/templates.ts
+++ b/prisma/seeds/fixtures/templates.ts
@@ -1,6 +1,9 @@
 import { Template } from "@prisma/client";
 
-type TemplateSeed = Omit<Template, "id" | "bearerToken" | "ttl" | "apiUsers" | "users">;
+type TemplateSeed = Omit<
+  Template,
+  "id" | "bearerToken" | "isPublished" | "ttl" | "apiUsers" | "users"
+>;
 type TemplateCollection = {
   development: TemplateSeed[];
   production: TemplateSeed[];
@@ -356,7 +359,6 @@ const LemonadeStand = {
     },
     internalTitleEn: "CDS - Lemonade Stand Funding",
     internalTitleFr: "CDS - Lemonade Stand Funding",
-    publishingStatus: true,
   },
 };
 const SimpleForm = {
@@ -588,7 +590,6 @@ const SimpleForm = {
     submission: {
       email: "",
     },
-    publishingStatus: true,
     securityAttribute: "Unclassified",
   },
 };

--- a/prisma/seeds/seed.ts
+++ b/prisma/seeds/seed.ts
@@ -38,6 +38,8 @@ async function publishingStatusMigration() {
     },
   });
 
+  let numOfTemplates = 0;
+
   templates
     .filter((template) => {
       return (template.jsonConfig as Record<string, unknown>).publishingStatus !== undefined;
@@ -55,7 +57,10 @@ async function publishingStatusMigration() {
           isPublished: publishingStatus as boolean,
         },
       });
+      numOfTemplates++;
     });
+
+  console.log(`${numOfTemplates} were migrated for Publishing Status`);
 }
 
 async function main() {

--- a/public/static/locales/en/admin-templates.json
+++ b/public/static/locales/en/admin-templates.json
@@ -14,7 +14,9 @@
     "formTitle": "Form Title",
     "status": "Status",
     "published": "Published",
-    "draft": "Draft"
+    "draft": "Draft",
+    "publishForm": "Publish",
+    "unpublishForm": "Draft"
   },
   "settings": {
     "title": "Form Settings",

--- a/public/static/locales/fr/admin-templates.json
+++ b/public/static/locales/fr/admin-templates.json
@@ -14,7 +14,9 @@
     "formTitle": "Titre du formulaire",
     "status": "Statut",
     "published": "Publié",
-    "draft": "Brouillon"
+    "draft": "Brouillon",
+    "publishForm": "Publier",
+    "unpublishForm": "Brouillon"
   },
   "settings": {
     "title": "Paramètres du formulaire",


### PR DESCRIPTION
# Things to do while merging the pull request

To be in sync with the changes from [45e79f86a32e011e3ec59f56bc8687a82648eba4](https://github.com/cds-snc/platform-forms-client/pull/1198/commits/45e79f86a32e011e3ec59f56bc8687a82648eba4)

- Manually remove permission that prevents users from deleting published forms (in the staging database)
- Manually replace `publishingStatus` by `isPublished` in the existing permissions (in the staging database)

# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/1181

- Replaced `publishingStatus` with new `isPublished` boolean flag that is stored directly in the database Template schema
- Added new API path to change `isPublished` for a specific form (PUT with body including formID and isPublished)
- The new API that switches the `isPublished` flag to `true` or `false` will do a soft migration in order to remove existing `publishingStatus` field from old form JSON configuration

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
|<img width="1334" alt="Screen Shot 2022-11-02 at 10 34 41 AM" src="https://user-images.githubusercontent.com/1763961/199518592-5d5fda7c-f7bc-42f2-8192-00670130c902.png">|<img width="1331" alt="Screen Shot 2022-11-02 at 10 34 14 AM" src="https://user-images.githubusercontent.com/1763961/199518612-2ee96e1b-00e0-48a9-9c4e-3a659a84d0f9.png">|

# Test instructions | Instructions pour tester la modification

Normal flow:
- Navigate to http://localhost:3000/admin/view-templates
- Using the new button in the Publish column, you can set the `isPublished` flag for a form (either Draft or Published)
- You should see that the value in the Status column is updated as you publish or unpublish the form

Migration flow:
- Navigate to http://localhost:3000/admin/view-templates
- Change the status (published or draft) for a form that has a `publishingStatus` value in its JSON configuration or edit a form in order to add the `publishingStatus` field
- The status (published or draft) should now prioritize the `publishingStatus` as the `isPublished` value in the templates table
- Using the new button in the Publish column, change the `isPublished` value of the form you have used/created
- The `publishingStatus` field should have disappeared from the JSON configuration

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
