### PR TITLE
fix: Add useEffect hooks to debounced fields

### DIFF
--- a/components/form-builder/elements/Option.tsx
+++ b/components/form-builder/elements/Option.tsx
@@ -51,6 +51,10 @@ export const Option = ({
     }
   }, [getFocusInput]);
 
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === "Enter") {
       setFocusInput(true);

--- a/components/form-builder/lexical-editor/RichTextEditor.tsx
+++ b/components/form-builder/lexical-editor/RichTextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { Editor } from "./Editor";
 import { useTemplateStore } from "../store/useTemplateStore";
 import { Language } from "../types";
@@ -27,6 +27,10 @@ export const RichTextEditor = ({
     }, 100),
     []
   );
+
+  useEffect(() => {
+    setValue(content);
+  }, [content]);
 
   const updateValue = useCallback(
     (value: string) => {

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
@@ -579,6 +579,10 @@ export const ElementPanel = () => {
     }, 100),
     []
   );
+
+  useEffect(() => {
+    setValue(title);
+  }, [title]);
 
   const updateValue = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/form-builder/panel/QuestionInput.tsx
+++ b/components/form-builder/panel/QuestionInput.tsx
@@ -50,6 +50,10 @@ export const QuestionInput = ({
     }
   }, [getFocusInput]);
 
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
   const _debounced = useCallback(
     debounce((val) => {
       updateField(


### PR DESCRIPTION
# Summary | Résumé

Basically, we want to update the value in the field(s) when the language changes.

Before this PR, we were just getting the value that was passed in the first time and it would only be updated when a user starts typing, not when the language changed across the app.

Just to be clear, _saving_ fields is totally fine. When you switch languages and you update an input field, it updates in the right place (the `en` or `fr` value, as required), but the value displayed to users wasn't changing to reflect that.

## How do I test this?

If you look at a form previous to this PR and you switch between English and French, you won't see the question titles, the form titles, the options or the rich text descriptions change. On this PR, they all change as you would expect.
