### PR TITLE
Only check translation status of choices for relevant types

### DIFF
--- a/components/form-builder/hooks/useAllowPublish.tsx
+++ b/components/form-builder/hooks/useAllowPublish.tsx
@@ -43,9 +43,16 @@ export const isFormElementTranslated = (element: FormElement) => {
       isDescriptionTranslated(element.properties);
     }
 
-    // Check choices if there are any
-    if (element.properties.choices) {
-      areChoicesTranslated(element.properties.choices);
+    // Only check choices for Select, Radio, and Checkbox
+    if (
+      [FormElementTypes.checkbox, FormElementTypes.radio, FormElementTypes.dropdown].includes(
+        element.type
+      )
+    ) {
+      // Check choices if there are any
+      if (element.properties.choices) {
+        areChoicesTranslated(element.properties.choices);
+      }
     }
   }
 };


### PR DESCRIPTION
# Summary | Résumé

When checking the translation status of form elements, only check choices if the element type is one of radio, checkbox, dropdown. There are a few circumstances where you can erroneously end up with an empty option in the state object, and it would cause the translation check to fail if it was empty. This ensures we're only checking those choices when they element type requires them.
