### PR TITLE
Use callback vs redirect for test data delivery

### DIFF
--- a/components/form-builder/layout/TestDataDelivery.tsx
+++ b/components/form-builder/layout/TestDataDelivery.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/router";
 import { getRenderedForm } from "@lib/formBuilder";
 import { useNavigationStore } from "../store/useNavigationStore";
 import Link from "next/link";
+import { RocketIcon } from "../icons/RocketIcon";
 
 export const TestDataDelivery = () => {
   const { localizeField, getSchema, id, setId, email } = useTemplateStore((s) => ({
@@ -35,7 +36,7 @@ export const TestDataDelivery = () => {
   const language = i18n.language as string;
   const currentForm = getRenderedForm(formRecord, language, t);
   const [error, setError] = useState(false);
-  const [sent, setSent] = useState<string | null>(null);
+  const [sent, setSent] = useState<string | null>();
 
   const { uploadJson } = usePublish();
 
@@ -92,7 +93,17 @@ export const TestDataDelivery = () => {
       <div className="border-3 border-dashed border-blue-focus p-4 mb-8">
         <h1>{formRecord.form[localizeField(LocalizedFormProperties.TITLE)]}</h1>
         {sent ? (
-          <div>Form ID: {sent} sent --- check your email</div>
+          <div className="p-7 mb-10 flex bg-green-50">
+            <div className="flex">
+              <div className="flex p-7">
+                <RocketIcon className="block self-center" />
+              </div>
+            </div>
+            <div>
+              <h2 className="mb-1 pb-0"> {t("dataDeliveredTitle")}</h2>
+              <p className="mb-5 mt-0">{t("dataDeliveredMessage")}</p>
+            </div>
+          </div>
         ) : (
           <Form
             formRecord={formRecord}

--- a/components/form-builder/layout/TestDataDelivery.tsx
+++ b/components/form-builder/layout/TestDataDelivery.tsx
@@ -35,6 +35,7 @@ export const TestDataDelivery = () => {
   const language = i18n.language as string;
   const currentForm = getRenderedForm(formRecord, language, t);
   const [error, setError] = useState(false);
+  const [sent, setSent] = useState<string | null>(null);
 
   const { uploadJson } = usePublish();
 
@@ -90,16 +91,20 @@ export const TestDataDelivery = () => {
       </ol>
       <div className="border-3 border-dashed border-blue-focus p-4 mb-8">
         <h1>{formRecord.form[localizeField(LocalizedFormProperties.TITLE)]}</h1>
-
-        <Form
-          formRecord={formRecord}
-          language={language}
-          router={router}
-          t={t1}
-          submitAlert={t("submitToTestDataDelivery")}
-        >
-          {currentForm}
-        </Form>
+        {sent ? (
+          <div>Form ID: {sent} sent --- check your email</div>
+        ) : (
+          <Form
+            formRecord={formRecord}
+            language={language}
+            router={router}
+            t={t1}
+            submitAlert={t("submitToTestDataDelivery")}
+            onSuccess={setSent}
+          >
+            {currentForm}
+          </Form>
+        )}
       </div>
     </div>
   );

--- a/components/form-builder/preview/Form.tsx
+++ b/components/form-builder/preview/Form.tsx
@@ -249,6 +249,7 @@ interface FormProps {
   isReCaptchaEnableOnSite?: boolean;
   isPreview?: boolean;
   submitAlert?: string;
+  onSuccess?: (id: string) => void;
   children?: (JSX.Element | undefined)[] | null;
   t: TFunction;
 }
@@ -271,7 +272,8 @@ export const Form = withFormik<FormProps, Responses>({
 
   handleSubmit: async (values, formikBag) => {
     try {
-      await submitToAPI(values, formikBag);
+      const result = await submitToAPI(values, formikBag, false);
+      result && formikBag.props.onSuccess && formikBag.props.onSuccess(result);
     } catch (err) {
       logMessage.error(err as Error);
     } finally {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -259,7 +259,8 @@ async function _submitToAPI(
       router: NextRouter;
     },
     Responses
-  >
+  >,
+  redirect = true
 ) {
   const { language, router, formRecord } = formikBag.props;
   const { setStatus } = formikBag;
@@ -282,6 +283,9 @@ async function _submitToAPI(
     })
       .then((serverResponse) => {
         if (serverResponse.data.received === true) {
+          if (!redirect) {
+            return formRecord.id;
+          }
           router.push({
             pathname: `/${language}/id/${formRecord.id}/confirmation`,
           });

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -32,7 +32,7 @@
   "saveH2": "Save the form file on your computer",
   "saveP3": "Click the save button to download your form.",
   "saveH3": "Upload the form file again to edit",
-  "saveP4": "Open the form file from the GC Form Builder’s start page to pick-up where you left off.",  
+  "saveP4": "Open the form file from the GC Form Builder’s start page to pick-up where you left off.",
   "viewCode": "View code",
   "copyButton": "Copy to clipboard",
   "copyMessage": "(template copied)",
@@ -103,10 +103,12 @@
   "testYourResponseDelivery": "Test your response delivery",
   "formSubmissionDisabledInPreview": "Form submission is disabled in preview",
   "linkUrl": "Link URL",
-  "editLink" : "Edit link",
+  "editLink": "Edit link",
   "RichTextEditor": "Rich text editor",
   "publishedTitle": "Your form is published!",
   "publishedViewLinks": "View and share your published form with these links:",
   "publishedErrors": "Published form errors",
-  "publishedBack": "Back to My forms"
+  "publishedBack": "Back to My forms",
+  "dataDeliveredTitle": "Success",
+  "dataDeliveredMessage": "Check your email for the data delivered."
 }


### PR DESCRIPTION
# Summary | Résumé

This PR updates the form submission to allow a component to handle submitted / sent confirmation vs the form handling via a redirect. 

- Adds a `redirect` param to the submitAPI (defaults to `true`)

https://github.com/cds-snc/platform-forms-client/pull/1236/files#diff-576e7186db8f40050f59e5bbd8384302a870572e8329fd9915eedf2c03c556d7R263

- Adds an onSuccess prop to allow a component to handle rendering success or fail

<img width="913" alt="Screen Shot 2022-11-09 at 8 23 26 AM" src="https://user-images.githubusercontent.com/62242/200842406-ed79aa26-c2a2-4cae-b0ab-244ba2a32a3f.png">



# Test instructions | Instructions pour tester la modification

- Create a form
- Visit Data Delivery
- Save the form
- Send the form

This should result in a confirmation screen for data delivery 

**Temp Screen**
<img width="400" alt="Screen Shot 2022-11-08 at 4 11 49 PM" src="https://user-images.githubusercontent.com/62242/200676380-2d5c5576-b275-442b-a6ec-56bc810adbf9.png">


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
