### PR TITLE
Fix: announce button messages & allow empty emails when editing

### DIFF
--- a/components/form-builder/layout/Layout.tsx
+++ b/components/form-builder/layout/Layout.tsx
@@ -55,8 +55,8 @@ export const Layout = () => {
         updateField("submission.email", data.user.email);
       }
     };
-    !email && setEmail();
-  }, [email, data]);
+    !email && currentTab !== "settings" && setEmail();
+  }, [email, data, currentTab]);
 
   const renderTab = (tab: string) => {
     switch (tab) {

--- a/components/form-builder/shared/Button.tsx
+++ b/components/form-builder/shared/Button.tsx
@@ -79,6 +79,11 @@ export const withMessage = (
       setShowMessage(true);
       setTimeout(() => {
         setShowMessage(false);
+
+        // 300ms after isMessage is false, remove the message string (the message span has "transition-300" class)
+        setTimeout(() => {
+          setIsCopied("");
+        }, 300);
       }, 1500);
     };
 

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -54,6 +54,8 @@
   "richTextPrivacyTitle": "Privacy statement",
   "save": "Save",
   "saveButton": "Save",
+  "saveDownloadMessage": "Form file downloaded successfully",
+  "saveDraftMessage": "Form saved as a draft",
   "saveH2": "Save the form file on your computer",
   "saveH3": "Upload the form file again to edit",
   "saveP1": "We don’t save your form on our website, but don’t worry, you can save the file to your computer.",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -54,6 +54,8 @@
   "richTextPrivacyTitle": "[FR] Privacy statement",
   "save": "[FR] Save",
   "saveButton": "[FR] Save",
+  "saveDownloadMessage": "[FR] Form file downloaded successfully",
+  "saveDraftMessage": "[FR] Form saved as a draft",
   "saveH2": "[FR] Save the form file on your computer",
   "saveH3": "[FR] Upload the form file again to edit",
   "saveP1": "[FR] We don’t save your form on our website, but don’t worry, you can save the file to your computer.",


### PR DESCRIPTION
# Summary | Résumé

This PR fixes 2 small-ish bugs:

1. When you are editing the email address for the form to send to, you were previously not able to delete the whole string, as it would repopulate with the original email. 
2. The screen reader announcement for the button messages would previously only happen once. 

Now, empty emails are okay while editing (if it is empty when you leave the tab, your previous email will end up in that field again). 

And button messages are reset after the message fades away, so now we are physically removing the message from the DOM rather than just hiding it with CSS. Tested with VoiceOver and it seems like we are good now.

## Email editing

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| Everytime the field is empty, it re-populates with my email | Empty fields are allowed, and I can enter new emails afterwards |
| ![Screen Recording 2022-11-10 at 14 33 45](https://user-images.githubusercontent.com/2454380/201191038-43a65dec-731d-465a-a9af-1318edb9a36e.gif) | ![Screen Recording 2022-11-10 at 14 32 09](https://user-images.githubusercontent.com/2454380/201191037-5756c8d9-f0fe-4f3b-ae68-766d91eff5bb.gif)  |

## Button messages are read by VoiceOver

| VoiceOver reads the message                                          |
| ----------------------------------------------- |
| The message is repeated by VoiceOver (you can see the caption at the bottom) | 
|  ![Screen Recording 2022-11-10 at 14 27 19](https://user-images.githubusercontent.com/2454380/201191031-b66aa791-2716-4c3d-a1ae-074abc02d5f5.gif) |



