### PR TITLE
Bugfix: Duplicated elements updating original

### DIFF
--- a/components/form-builder/elements/Option.tsx
+++ b/components/form-builder/elements/Option.tsx
@@ -56,16 +56,16 @@ export const Option = ({
   };
 
   const _debounced = useCallback(
-    debounce((val) => {
+    debounce((parentIndex, val) => {
       updateField(`form.elements[${parentIndex}].properties.choices[${index}].${lang}`, val);
     }, 100),
     []
   );
 
   const updateValue = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
-      _debounced(e.target.value);
+    (parentIndex: number, value: string) => {
+      setValue(value);
+      _debounced(parentIndex, value);
     },
     [setValue]
   );
@@ -79,7 +79,9 @@ export const Option = ({
         type="text"
         value={value}
         placeholder={`${t("option")} ${index + 1}`}
-        onChange={updateValue}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          updateValue(parentIndex, e.target.value)
+        }
         onKeyDown={handleKeyDown}
         className="ml-5 w-80 max-h-9 !my-0"
       />

--- a/components/form-builder/panel/QuestionInput.tsx
+++ b/components/form-builder/panel/QuestionInput.tsx
@@ -39,7 +39,7 @@ export const QuestionInput = ({
   }, [initialValue]);
 
   const _debounced = useCallback(
-    debounce((val) => {
+    debounce((index, val) => {
       updateField(
         `form.elements[${index}].properties.${localizeField(LocalizedElementProperties.TITLE)}`,
         val
@@ -49,9 +49,9 @@ export const QuestionInput = ({
   );
 
   const updateValue = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
-      _debounced(e.target.value);
+    (index: number, value: string) => {
+      setValue(value);
+      _debounced(index, value);
     },
     [setValue]
   );
@@ -66,7 +66,7 @@ export const QuestionInput = ({
       className="w-full"
       value={value}
       aria-describedby={hasDescription ? `item${index}-describedby` : undefined}
-      onChange={updateValue}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateValue(index, e.target.value)}
       theme="title"
     />
   );


### PR DESCRIPTION
# Summary | Résumé

Fixes a bug where duplicated items would update the original on change.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/1187115/202018200-be8a4122-0654-4c24-a13d-6e8cd5e7610b.png) | Insert Image showing after a change was made |



