### PR TITLE
Fix typo preventing english intro from displaying

### DIFF
--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -161,7 +161,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
         <>
           <RichText>
             {form.introduction &&
-              form.introduction[props.language == "en" ? "descrptionEn" : "descriptionFr"]}
+              form.introduction[props.language == "en" ? "descriptionEn" : "descriptionFr"]}
           </RichText>
 
           <form


### PR DESCRIPTION
# Summary | Résumé

Fixes #1272 
There was a typo in the name of the description property that was preventing the English introduction from displaying.

