### PR TITLE
Add "highlight" effect when adding/duplicating questions

### DIFF
--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -239,10 +239,16 @@ const Form = ({ item }: { item: FormElementWithIndex }) => {
         <div className={isRichText ? undefined : "basis-[460px] xxl:basis-[10px] mr-5"}>
           {!isRichText && (
             <>
-              <span className="absolute left-0 bg-gray-default py-2.5 px-1.5 rounded-r -ml-7">
+              <span
+                className={`absolute left-0 bg-gray-default py-2.5 rounded-r -ml-7 ${
+                  item.index < 9 ? "px-1.5" : "pl-0.5 pr-1 tracking-tighter"
+                }`}
+              >
                 {questionNumber}
               </span>
-              <LabelHidden htmlFor={`item${item.index}`}>{t("question")}</LabelHidden>
+              <LabelHidden htmlFor={`item${item.index}`}>
+                {t("question")} {item.index + 1}
+              </LabelHidden>
               <QuestionInput
                 initialValue={item.properties[localizeField(LocalizedElementProperties.TITLE)]}
                 index={item.index}

--- a/components/form-builder/panel/ElementPanel.tsx
+++ b/components/form-builder/panel/ElementPanel.tsx
@@ -447,12 +447,35 @@ const ElementWrapperDiv = styled.div`
 export const ElementWrapper = ({ item }: { item: FormElementWithIndex }) => {
   const { t } = useTranslation("form-builder");
   const isRichText = item.type == "richText";
-  const { elements, updateField } = useTemplateStore((s) => ({
+  const { elements, getFocusInput, updateField } = useTemplateStore((s) => ({
     updateField: s.updateField,
     elements: s.form.elements,
+    getFocusInput: s.getFocusInput,
   }));
 
   const { isOpen, modals, updateModalProperties, unsetModalField } = useModalStore();
+
+  const [className, setClassName] = useState<string>("");
+  const [ifFocus, setIfFocus] = useState<boolean>(false);
+
+  if (ifFocus === false) {
+    // Only run this 1 time
+    setIfFocus(true);
+
+    // getFocusInput is only ever true if we press "duplicate" or "add question"
+    if (getFocusInput()) {
+      setClassName(
+        "bg-yellow-100 transition-colors ease-out duration-[1500ms] delay-500 outline-[2px] outline-blue-focus outline"
+      );
+    }
+  }
+
+  useEffect(() => {
+    // remove the yellow background immediately, CSS transition will fade the colour
+    setClassName(className.replace("bg-yellow-100 ", ""));
+    // remove the blue outline after 2.1 seconds
+    setTimeout(() => setClassName(""), 2100);
+  }, [getFocusInput]);
 
   React.useEffect(() => {
     if (item.type != "richText") {
@@ -470,7 +493,7 @@ export const ElementWrapper = ({ item }: { item: FormElementWithIndex }) => {
   };
 
   return (
-    <ElementWrapperDiv className={`element-${item.index}`}>
+    <ElementWrapperDiv className={`element-${item.index} ${className}`}>
       <div className={isRichText ? "mt-7" : "mx-7 my-7"}>
         <Form item={item} />
       </div>

--- a/components/form-builder/panel/PanelActions.tsx
+++ b/components/form-builder/panel/PanelActions.tsx
@@ -48,7 +48,7 @@ export const PanelActions = ({
   children?: React.ReactNode;
 }) => {
   const { t } = useTranslation("form-builder");
-  const { lang, remove, moveUp, moveDown, add, duplicateElement, elements, setFocusInput, getPreviousElement } =
+  const { lang, remove, moveUp, moveDown, add, duplicateElement, elements, setFocusInput } =
     useTemplateStore((s) => ({
       lang: s.lang,
       remove: s.remove,
@@ -58,7 +58,6 @@ export const PanelActions = ({
       duplicateElement: s.duplicateElement,
       elements: s.form.elements,
       setFocusInput: s.setFocusInput,
-      getPreviousElement: s.getPreviousElement
     }));
   const isLastItem = item.index === elements.length - 1;
   const isFirstItem = item.index === 0;
@@ -119,7 +118,7 @@ export const PanelActions = ({
         }
         onClick={() => {
           // if index is 0, then highlight the form title
-          const labelId = item.index === 0 ? "formTitle" : `item${getPreviousElement(item.index)}`;
+          const labelId = item.index === 0 ? "formTitle" : `item${item.index - 1}`;
 
           remove(item.id);
           document.getElementById(labelId)?.focus();

--- a/components/form-builder/panel/PanelActions.tsx
+++ b/components/form-builder/panel/PanelActions.tsx
@@ -102,6 +102,7 @@ export const PanelActions = ({
           <Duplicate className="group-hover:fill-white-default group-focus:fill-white-default transition duration-100" />
         }
         onClick={() => {
+          setFocusInput(true);
           duplicateElement(item.index);
         }}
       >

--- a/components/form-builder/panel/PanelActions.tsx
+++ b/components/form-builder/panel/PanelActions.tsx
@@ -48,7 +48,7 @@ export const PanelActions = ({
   children?: React.ReactNode;
 }) => {
   const { t } = useTranslation("form-builder");
-  const { lang, remove, moveUp, moveDown, add, duplicateElement, elements, setFocusInput } =
+  const { lang, remove, moveUp, moveDown, add, duplicateElement, elements, setFocusInput, getPreviousElement } =
     useTemplateStore((s) => ({
       lang: s.lang,
       remove: s.remove,
@@ -58,6 +58,7 @@ export const PanelActions = ({
       duplicateElement: s.duplicateElement,
       elements: s.form.elements,
       setFocusInput: s.setFocusInput,
+      getPreviousElement: s.getPreviousElement
     }));
   const isLastItem = item.index === elements.length - 1;
   const isFirstItem = item.index === 0;
@@ -117,7 +118,11 @@ export const PanelActions = ({
           <Close className="group-hover:fill-white-default group-focus:fill-white-default transition duration-100" />
         }
         onClick={() => {
+          // if index is 0, then highlight the form title
+          const labelId = item.index === 0 ? "formTitle" : `item${getPreviousElement(item.index)}`;
+
           remove(item.id);
+          document.getElementById(labelId)?.focus();
         }}
       >
         <Label>{t("remove")}</Label>

--- a/components/form-builder/shared/Button.tsx
+++ b/components/form-builder/shared/Button.tsx
@@ -10,7 +10,7 @@ export const themes = {
     "bg-white-default text-black-default border-black-default hover:text-white-default hover:bg-gray-600 active:text-white-default active:bg-gray-500",
   destructive:
     "bg-red-default text-white-default border-red-default hover:bg-red-destructive hover:border-red-destructive active:bg-red-hover focus:border-blue-hover",
-  link: "bg-white-default !p-0 !border-none text-black-default underline hover:no-underline focus:!bg-white-default focus:!text-black-default",
+  link: "!p-0 !border-none text-black-default underline bg-transparent hover:no-underline focus:!text-white-default",
   icon: "!border-none bg-gray-selected hover:bg-gray-600 !rounded-full max-h-9 !p-1.5 ml-1.5",
 };
 

--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -74,7 +74,6 @@ export interface TemplateStoreProps {
 export interface TemplateStoreState extends TemplateStoreProps {
   focusInput: boolean;
   getFocusInput: () => boolean;
-  getPreviousElement: (index: number) => number;
   moveUp: (index: number) => void;
   moveDown: (index: number) => void;
   localizeField: {
@@ -179,7 +178,6 @@ const createTemplateStore = (initProps?: Partial<TemplateStoreProps>) => {
             set((state) => {
               unset(state, path);
             }),
-          getPreviousElement: (index) => getPreviousIndex(get().form.elements, index),
           moveUp: (index) =>
             set((state) => {
               state.form.elements = moveUp(state.form.elements, index);

--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -10,6 +10,7 @@ import {
   incrementElementId,
   newlineToOptions,
   getSchemaFromState,
+  getPreviousIndex,
 } from "../util";
 import { Language } from "../types";
 import update from "lodash.set";
@@ -73,6 +74,7 @@ export interface TemplateStoreProps {
 export interface TemplateStoreState extends TemplateStoreProps {
   focusInput: boolean;
   getFocusInput: () => boolean;
+  getPreviousElement: (index: number) => number;
   moveUp: (index: number) => void;
   moveDown: (index: number) => void;
   localizeField: {
@@ -177,6 +179,7 @@ const createTemplateStore = (initProps?: Partial<TemplateStoreProps>) => {
             set((state) => {
               unset(state, path);
             }),
+          getPreviousElement: (index) => getPreviousIndex(get().form.elements, index),
           moveUp: (index) =>
             set((state) => {
               state.form.elements = moveUp(state.form.elements, index);


### PR DESCRIPTION
# Summary | Résumé

The main change in this PR is adding a "highlight" effect when new questions are added or duplicated. It's similar to the Stackoverflow pattern they use when you link directly to an answer ([example here](https://stackoverflow.com/questions/2281087/center-a-div-in-css/2281107#2281107)).

I've also fixed a small layout bug, which happened when you added more than 10 questions.

## Highlight fields

![Screen Recording 2022-11-16 at 12 30 38](https://user-images.githubusercontent.com/2454380/202253329-50ae65d1-c70d-4db8-a75b-2062baa43183.gif)

## Fixing layout bug for 2-digit question numbers

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| The "10" overlaps the question input   |  The "10" does not overlap the input  |
| <img width="819" alt="Screenshot 2022-11-16 at 12 35 15" src="https://user-images.githubusercontent.com/2454380/202253347-8884ed13-c853-4414-abca-e6fa9c93761d.png">  |  <img width="819" alt="Screenshot 2022-11-16 at 12 43 11" src="https://user-images.githubusercontent.com/2454380/202254283-c0a9106b-bec3-448f-8b44-33b1d47fe33e.png">  |


