### PR TITLE
fix: solve infinite redirect on policy page

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -57,7 +57,11 @@ export function requireAuthentication(
         };
       }
 
-      if (!session.user.acceptableUse && !context.req.url?.startsWith("/auth/policy")) {
+      if (
+        !session.user.acceptableUse &&
+        !context.req.url?.startsWith("/auth/policy") &&
+        !context.req.url?.startsWith("/_next/data")
+      ) {
         // If they haven't agreed to Acceptable Use redirect to policy page for acceptance
         // If already on the policy page don't redirect, aka endless redirect loop.
         // Also check that the path is local and not an external URL

--- a/lib/middleware/jsonValidator.ts
+++ b/lib/middleware/jsonValidator.ts
@@ -2,7 +2,6 @@ import { Schema, Validator, ValidatorResult, PreValidatePropertyFunction } from 
 import { NextApiRequest, NextApiResponse } from "next";
 import { MiddlewareRequest, MiddlewareReturn } from "@lib/types";
 import * as htmlparser2 from "htmlparser2";
-import { logMessage } from "@lib/logger";
 
 export type ValidateOptions = {
   jsonKey: string;


### PR DESCRIPTION
# Summary | Résumé

No issue for this 

On the policy page when NextJS would issue a hydration request the NextJS server would return a redirect since the requireAuth that wraps getServerSide auth returns a redirect. The solution was not to return a redirect if the path starts with /_next/data which is what the client uses for hydration requests 

# Test instructions | Instructions pour tester la modification

Go to the policy page after logging in. Try to switch to french. It should not fail

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

N/A

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
