### PR TITLE
Remove default "my form"

### DIFF
--- a/components/form-builder/__tests__/useTemplateStore.test.tsx
+++ b/components/form-builder/__tests__/useTemplateStore.test.tsx
@@ -18,7 +18,7 @@ const createStore = () => {
 describe("TemplateStore", () => {
   it("Updates the Element title", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     act(() => {
       result.current.updateField(
@@ -32,7 +32,7 @@ describe("TemplateStore", () => {
 
   it("Adds default elements to the Form", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     // Add two elements
     act(() => {
@@ -40,14 +40,14 @@ describe("TemplateStore", () => {
       result.current.add();
     });
 
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
     expect(result.current.form.elements).toHaveLength(2);
     expect(result.current.form.elements[1].properties.titleEn).toBe("");
   });
 
   it("Inserts elements after the specified item index", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     // Add multiple elements
     act(() => {
@@ -73,7 +73,7 @@ describe("TemplateStore", () => {
 
   it("Adds Choices to an Element", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     // Add a default element
     act(() => {
@@ -81,7 +81,7 @@ describe("TemplateStore", () => {
     });
 
     // Default element expectations
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
     expect(result.current.form.elements).toHaveLength(1);
     expect(result.current.form.elements[0].properties.titleEn).toBe("");
     // By default, there is one choice available
@@ -110,7 +110,7 @@ describe("TemplateStore", () => {
 
   it("Updates existing choices", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     act(() => {
       result.current.add();
@@ -130,7 +130,7 @@ describe("TemplateStore", () => {
 
   it("Removes choices", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     // Create an element with three choices
     act(() => {
@@ -151,7 +151,7 @@ describe("TemplateStore", () => {
 
   it("Duplicates an element and inserts after index of copied item", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     // Create an element with three choices
     act(() => {
@@ -177,7 +177,7 @@ describe("TemplateStore", () => {
 
   it("Moves an element up", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     act(() => {
       result.current.add(0);
@@ -200,7 +200,7 @@ describe("TemplateStore", () => {
 
   it("Moves an element down", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     act(() => {
       result.current.add(0);
@@ -223,7 +223,7 @@ describe("TemplateStore", () => {
 
   it("Adds a validation type", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     act(() => {
       result.current.add(0);
@@ -242,7 +242,7 @@ describe("TemplateStore", () => {
 
   it("Removes a validation type", () => {
     const result = createStore();
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
 
     act(() => {
       result.current.add(0);
@@ -274,7 +274,7 @@ describe("TemplateStore", () => {
     const result = createStore();
 
     // Initial state
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
     expect(result.current.form.elements.length).toBe(0);
 
     // Make some changes to the form
@@ -293,7 +293,7 @@ describe("TemplateStore", () => {
       result.current.initialize();
     });
 
-    expect(result.current.form.titleEn).toBe("My Form");
+    expect(result.current.form.titleEn).toBe("");
     expect(result.current.form.elements.length).toBe(0);
   });
 

--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -35,8 +35,8 @@ const defaultField: FormElement = {
 
 export const defaultForm = {
   id: "",
-  titleEn: "My Form",
-  titleFr: "[fr] My Form",
+  titleEn: "",
+  titleFr: "",
   layout: [],
   version: 1,
   endPage: {


### PR DESCRIPTION
# Summary | Résumé

Removes default "my forms" so the form title label gets announced


# Test instructions | Instructions pour tester la modification

- visit the form builder
- should no longer default to "my form"

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
