### PR TITLE
Adds initial work for contactus and support forms

### DIFF
--- a/pages/form-builder/contactus.tsx
+++ b/pages/form-builder/contactus.tsx
@@ -1,0 +1,203 @@
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { GetServerSideProps } from "next";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { Formik } from "formik";
+import { useTranslation } from "next-i18next";
+import * as Yup from "yup";
+import {
+  Button,
+  TextInput,
+  Label,
+  Alert,
+  ErrorListItem,
+  MultipleChoiceGroup,
+} from "@components/forms";
+
+export default function Contactus() {
+  const { t, i18n } = useTranslation(["form-builder", "common"]);
+  // const [errorState, setErrorState] = useState({ message: "" });
+  const [submitting, setSubmitting] = useState(false);
+  const [isSuccessScreen, setIsSuccessScreen] = useState(false);
+
+  // const handleRequest = async (name: string, email: string, request: string) => {
+  //   // TODO send email
+  // };
+
+  const validationSchema = Yup.object().shape({
+    name: Yup.string()
+      .required(t("input-validation.required", { ns: "common" }))
+      .max(50, t("signUpRegistration.fields.name.error.maxLength")),
+    email: Yup.string()
+      .required(t("input-validation.required", { ns: "common" }))
+      .email(t("input-validation.email", { ns: "common" })),
+    request: Yup.string().required(t("input-validation.required", { ns: "common" })),
+  });
+
+  return (
+    <div aria-live="polite">
+      {!isSuccessScreen && (
+        <Formik
+          initialValues={{ name: "", email: "", request: "" }}
+          onSubmit={async () => {
+            setSubmitting(true);
+            //todo
+            // await handleRequest(name, email, request);
+            setSubmitting(false);
+            setIsSuccessScreen(true);
+          }}
+          validateOnChange={false}
+          validateOnBlur={false}
+          validationSchema={validationSchema}
+        >
+          {({ handleSubmit, errors }) => (
+            <>
+              {/* {errorState.message && (
+                <Alert
+                  type="error"
+                  validation={true}
+                  tabIndex={0}
+                  id="requestSubmissionError"
+                  heading={t("input-validation.heading", { ns: "common" })}
+                >
+                  {errorState.message}
+                </Alert>
+              )} */}
+
+              {Object.keys(errors).length > 0 && (
+                <Alert
+                  type="error"
+                  validation={true}
+                  tabIndex={0}
+                  id="unlockPublishingValidationErrors"
+                  heading={t("input-validation.heading", { ns: "common" })}
+                >
+                  <ol className="gc-ordered-list">
+                    {Object.entries(errors).map(([fieldKey, fieldValue]) => {
+                      return (
+                        <ErrorListItem
+                          key={`error-${fieldKey}`}
+                          errorKey={fieldKey}
+                          value={fieldValue}
+                        />
+                      );
+                    })}
+                  </ol>
+                </Alert>
+              )}
+
+              <h1>{t("contactus.title")}</h1>
+              <p className="mb-14">
+                {t("contactus.intro")}{" "}
+                <Link href={`/${i18n.language}/form-builder/support`}>
+                  {t("contactus.supportLink")}
+                </Link>
+                .
+              </p>
+
+              <form id="contactus" method="POST" onSubmit={handleSubmit} noValidate>
+                <div className="focus-group">
+                  <Label id={"label-name"} htmlFor={"name"} className="required" required>
+                    {t("contactus.name")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"name"}
+                    name={"name"}
+                    className="required w-[34rem]"
+                  />
+                </div>
+
+                <div className="focus-group">
+                  <Label id={"label-email"} htmlFor={"email"} className="required" required>
+                    {t("contactus.email")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"email"}
+                    name={"email"}
+                    className="required w-[34rem]"
+                    required
+                  />
+                </div>
+
+                <fieldset className="focus-group">
+                  <legend className="gc-label required">
+                    {t("contactus.request.title")}{" "}
+                    <span data-testid="required" aria-hidden>
+                      ({t("required")})
+                    </span>
+                  </legend>
+                  <MultipleChoiceGroup
+                    name="request"
+                    type="radio"
+                    choicesProps={[
+                      {
+                        id: "request-question",
+                        name: "question",
+                        label: t("contactus.request.option1"),
+                        required: true,
+                      },
+                      {
+                        id: "request-feedback",
+                        name: "feedback",
+                        label: t("contactus.request.option2"),
+                        required: true,
+                      },
+                      {
+                        id: "request-demo",
+                        name: "demo",
+                        label: t("contactus.request.option3"),
+                        required: true,
+                      },
+                      {
+                        id: "request-other",
+                        name: "other",
+                        label: t("contactus.request.option4"),
+                        required: true,
+                      },
+                    ]}
+                  ></MultipleChoiceGroup>
+                </fieldset>
+
+                <div className="flex mt-14">
+                  <Button
+                    type="submit"
+                    className={` 
+                        mr-8
+                        bg-blue-dark text-white-default border-black-default py-4 px-8 rounded-lg border-2 border-solid
+                        hover:text-white-default hover:bg-blue-light active:text-white-default active:bg-blue-active active:top-0.5
+                        focus:outline-[3px] focus:outline-blue-focus focus:outline focus:outline-offset-2 focus:bg-blue-focus focus:text-white-default disabled:cursor-not-allowed disabled:text-gray-500
+                      `}
+                    disabled={submitting}
+                  >
+                    {t("submitButton", { ns: "common" })}
+                  </Button>
+                </div>
+              </form>
+            </>
+          )}
+        </Formik>
+      )}
+      {isSuccessScreen && (
+        <>
+          <h1>Success</h1>
+          <p className="mb-8">Thank you for you submission!</p>
+          <p>
+            We have received your request and someone from CDS will be in touch with you shortly.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    props: {
+      ...(context.locale &&
+        (await serverSideTranslations(context.locale, ["common", "form-builder"]))),
+    },
+  };
+};

--- a/pages/form-builder/support.tsx
+++ b/pages/form-builder/support.tsx
@@ -1,0 +1,197 @@
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { GetServerSideProps } from "next";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { Formik } from "formik";
+import { useTranslation } from "next-i18next";
+import * as Yup from "yup";
+import {
+  Button,
+  TextInput,
+  Label,
+  Alert,
+  ErrorListItem,
+  MultipleChoiceGroup,
+} from "@components/forms";
+
+export default function Support() {
+  const { t, i18n } = useTranslation(["form-builder", "common"]);
+  // const [errorState, setErrorState] = useState({ message: "" });
+  const [submitting, setSubmitting] = useState(false);
+  const [isSuccessScreen, setIsSuccessScreen] = useState(false);
+
+  // const handleRequest = async (name: string, email: string, request: string) => {
+  //   // TODO send email
+  // };
+
+  const validationSchema = Yup.object().shape({
+    name: Yup.string()
+      .required(t("input-validation.required", { ns: "common" }))
+      .max(50, t("signUpRegistration.fields.name.error.maxLength")),
+    email: Yup.string()
+      .required(t("input-validation.required", { ns: "common" }))
+      .email(t("input-validation.email", { ns: "common" })),
+    request: Yup.string().required(t("input-validation.required", { ns: "common" })),
+  });
+
+  return (
+    <div aria-live="polite">
+      {!isSuccessScreen && (
+        <Formik
+          initialValues={{ name: "", email: "", request: "" }}
+          onSubmit={async () => {
+            setSubmitting(true);
+            //todo
+            // await handleRequest(name, email, request);
+            setSubmitting(false);
+            setIsSuccessScreen(true);
+          }}
+          validateOnChange={false}
+          validateOnBlur={false}
+          validationSchema={validationSchema}
+        >
+          {({ handleSubmit, errors }) => (
+            <>
+              {/* {errorState.message && (
+                <Alert
+                  type="error"
+                  validation={true}
+                  tabIndex={0}
+                  id="requestSubmissionError"
+                  heading={t("input-validation.heading", { ns: "common" })}
+                >
+                  {errorState.message}
+                </Alert>
+              )} */}
+
+              {Object.keys(errors).length > 0 && (
+                <Alert
+                  type="error"
+                  validation={true}
+                  tabIndex={0}
+                  id="unlockPublishingValidationErrors"
+                  heading={t("input-validation.heading", { ns: "common" })}
+                >
+                  <ol className="gc-ordered-list">
+                    {Object.entries(errors).map(([fieldKey, fieldValue]) => {
+                      return (
+                        <ErrorListItem
+                          key={`error-${fieldKey}`}
+                          errorKey={fieldKey}
+                          value={fieldValue}
+                        />
+                      );
+                    })}
+                  </ol>
+                </Alert>
+              )}
+
+              <h1>{t("support.title")}</h1>
+              <p className="mb-14">
+                {t("support.intro")}{" "}
+                <Link href={`/${i18n.language}/form-builder/contactus`}>
+                  {t("support.contactLink")}
+                </Link>
+                .
+              </p>
+
+              <form id="contactus" method="POST" onSubmit={handleSubmit} noValidate>
+                <div className="focus-group">
+                  <Label id={"label-name"} htmlFor={"name"} className="required" required>
+                    {t("contactus.name")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"name"}
+                    name={"name"}
+                    className="required w-[34rem]"
+                  />
+                </div>
+
+                <div className="focus-group">
+                  <Label id={"label-email"} htmlFor={"email"} className="required" required>
+                    {t("contactus.email")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"email"}
+                    name={"email"}
+                    className="required w-[34rem]"
+                    required
+                  />
+                </div>
+
+                <fieldset className="focus-group">
+                  <legend className="gc-label required">
+                    {t("support.request.title")}{" "}
+                    <span data-testid="required" aria-hidden>
+                      ({t("required")})
+                    </span>
+                  </legend>
+                  <MultipleChoiceGroup
+                    name="request"
+                    type="radio"
+                    choicesProps={[
+                      {
+                        id: "request-question",
+                        name: "question",
+                        label: t("support.request.option1"),
+                        required: true,
+                      },
+                      {
+                        id: "request-technical",
+                        name: "feedback",
+                        label: t("support.request.option2"),
+                        required: true,
+                      },
+                      {
+                        id: "request-other",
+                        name: "demo",
+                        label: t("support.request.option3"),
+                        required: true,
+                      },
+                    ]}
+                  ></MultipleChoiceGroup>
+                </fieldset>
+
+                <div className="flex mt-14">
+                  <Button
+                    type="submit"
+                    className={` 
+                        mr-8
+                        bg-blue-dark text-white-default border-black-default py-4 px-8 rounded-lg border-2 border-solid
+                        hover:text-white-default hover:bg-blue-light active:text-white-default active:bg-blue-active active:top-0.5
+                        focus:outline-[3px] focus:outline-blue-focus focus:outline focus:outline-offset-2 focus:bg-blue-focus focus:text-white-default disabled:cursor-not-allowed disabled:text-gray-500
+                      `}
+                    disabled={submitting}
+                  >
+                    {t("submitButton", { ns: "common" })}
+                  </Button>
+                </div>
+              </form>
+            </>
+          )}
+        </Formik>
+      )}
+      {isSuccessScreen && (
+        <>
+          <h1>Success</h1>
+          <p className="mb-8">Thank you for you submission!</p>
+          <p>
+            We have received your request and someone from CDS will be in touch with you shortly.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    props: {
+      ...(context.locale &&
+        (await serverSideTranslations(context.locale, ["common", "form-builder"]))),
+    },
+  };
+};

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -9,7 +9,7 @@
       "desc": "Service level agreement"
     },
     "support": {
-      "link": "/tbd",
+      "link": "/en/form-builder/support",
       "desc": "Support"
     }
   },

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -161,5 +161,37 @@
   "unlockPublishing": "Unlock publishing",
   "unlockPublishingDescription": "To unlock publishing, provide the contact information of the person you report to.",
   "updateResponseDestination": "Update response destination.",
-  "viewCode": "View code"
+  "viewCode": "View code",
+  "contactus": {
+    "title": "Contact Us",
+    "intro": "If you experience technical issues, please fill out the",
+    "supportLink": "Support Form",
+    "name": "Your Name",
+    "email": "Your Email",
+    "request": {
+      "title": "How can we help?",
+      "option1": "Ask a question about the product and how it can work in your department",
+      "option2": "Give feedback",
+      "option3": "Set up a demo to learn more about GC Forms",
+      "option4": "Other"
+    },
+    "success": {
+      "title": "Success",
+      "paragraph1": "Thank you for you submission!",
+      "paragraph2": "We have received your request and someone from CDS will be in touch with you shortly."
+    }
+  },
+  "support": {
+    "title": "Support",
+    "intro": "If you would like to learn more about the product or set up a demo, please fill out the",
+    "contactLink": "Contact us form",
+    "name": "Your Name",
+    "email": "Your Email",
+    "request": {
+      "title": "How can we help?",
+      "option1": "Ask a question",
+      "option2": "Get technical support",
+      "option3": "Other"
+    }
+  }
 }

--- a/public/static/locales/fr/common.json
+++ b/public/static/locales/fr/common.json
@@ -9,7 +9,7 @@
       "desc": "Accord sur les niveaux de service"
     },
     "support": {
-      "link": "/tbd",
+      "link": "/fr/form-builder/support",
       "desc": "Soutien"
     }
   },

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -161,5 +161,37 @@
   "unlockPublishing": "Soumettre",
   "unlockPublishingDescription": "Pour déverrouiller la publication, fournissez les coordonnées de la personne a qui vous relevez. ",
   "updateResponseDestination": " Actualiser la destination des réponses. ",
-  "viewCode": "Afficher le code"
+  "viewCode": "Afficher le code",
+  "contactus": {
+    "title": "Contact Us [FR]",
+    "intro": "If you experience technical issues, please fill out the [FR]",
+    "supportLink": "Support Form [FR]",
+    "name": "Your Name [FR]",
+    "email": "Your Email [FR]",
+    "request": {
+      "title": "How can we help? [FR]",
+      "option1": "Ask a question about the product and how it can work in your department [FR]",
+      "option2": "Give feedback [FR]",
+      "option3": "Set up a demo to learn more about GC Forms [FR]",
+      "option4": "Other [FR]"
+    },
+    "success": {
+      "title": "Success [FR]",
+      "paragraph1": "Thank you for you submission! [FR]",
+      "paragraph2": "We have received your request and someone from CDS will be in touch with you shortly. [FR]"
+    }
+  },
+  "support": {
+    "title": "Support [FR]",
+    "intro": "If you would like to learn more about the product or set up a demo, please fill out the [FR]",
+    "contactLink": "Contact us form [FR]",
+    "name": "Your Name [FR]",
+    "email": "Your Email [FR]",
+    "request": {
+      "title": "How can we help? [FR]",
+      "option1": "Ask a question [FR]",
+      "option2": "Get technical support [FR]",
+      "option3": "Other [FR]"
+    }
+  }
 }


### PR DESCRIPTION
# Summary | Résumé

Adds initial work for contact us and support forms.

Note: this is incomplete work and the goal is to have a form for user testing tomorrow.

# Test instructions | Instructions pour tester la modification

Navigate to /form-builder/contactus and try filling out the form. Validation should catch empty fields and an invalid email. then do the same for /form-builder/support. On success a basic Success page should be displayed.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

-sending an email
-success page (none developer content :)
-more edits probably
-potentially some automated tests


