### PR TITLE
Bugfix: set focus on Question when new element added

### DIFF
--- a/components/form-builder/panel/PanelActions.tsx
+++ b/components/form-builder/panel/PanelActions.tsx
@@ -34,6 +34,7 @@ export const PanelActions = ({
   const isRichText = item.type == "richText";
 
   const [currentFocusIndex, setCurrentFocusIndex] = useState(isFirstItem ? 1 : 0);
+  const [isInit, setIsInit] = useState(false);
 
   const itemsRef = useRef<[HTMLButtonElement] | []>([]);
   const [items] = useState([
@@ -45,11 +46,14 @@ export const PanelActions = ({
   ]);
 
   useEffect(() => {
-    const index = `button-${currentFocusIndex}` as unknown as number;
-    const el = itemsRef.current[index];
-    if (el) {
-      el.focus();
+    if (isInit) {
+      const index = `button-${currentFocusIndex}` as unknown as number;
+      const el = itemsRef.current[index];
+      if (el) {
+        el.focus();
+      }
     }
+    setIsInit(true);
   }, [currentFocusIndex]);
 
   const handleNav = useCallback(


### PR DESCRIPTION
# Summary | Résumé

Fixes a small bug introduced in the previous PR that caused focus to go to the element actions toolbar after adding a new element. This restores the original behaviour that gives focus to the Question when a new element is added.

