### PR TITLE
Fix form-builder page titles

### DIFF
--- a/pages/form-builder/preview/[[...params]].tsx
+++ b/pages/form-builder/preview/[[...params]].tsx
@@ -7,7 +7,7 @@ import { Preview, PreviewNavigation, Template, PageTemplate } from "@formbuilder
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
-  const title = `${t("gcFormsSettings")} — ${t("gcForms")}`;
+  const title = `${t("gcFormsPreview")} — ${t("gcForms")}`;
   return (
     <PageTemplate title={title} navigation={<PreviewNavigation />}>
       <Preview />

--- a/pages/form-builder/preview/test-data-delivery.tsx
+++ b/pages/form-builder/preview/test-data-delivery.tsx
@@ -7,7 +7,7 @@ import { PreviewNavigation, TestDataDelivery, PageTemplate, Template } from "@fo
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
-  const title = `${t("gcFormsSettings")} — ${t("gcForms")}`;
+  const title = `${t("gcFormsResponseDelivery")} — ${t("gcForms")}`;
   return (
     <PageTemplate title={title} navigation={<PreviewNavigation />}>
       <TestDataDelivery />

--- a/pages/form-builder/published.tsx
+++ b/pages/form-builder/published.tsx
@@ -8,7 +8,7 @@ import { useTemplateStore } from "@formbuilder/store/useTemplateStore";
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
-  const title = `${t("gcFormsTranslate")} — ${t("gcForms")}`;
+  const title = `${t("gcFormsPublished")} — ${t("gcForms")}`;
 
   const { id } = useTemplateStore((s) => ({
     getSchema: s.getSchema,

--- a/pages/form-builder/save.tsx
+++ b/pages/form-builder/save.tsx
@@ -7,7 +7,7 @@ import { Save, Template, PageTemplate } from "@formbuilder/layout/";
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
-  const title = `${t("gcFormsTranslate")} — ${t("gcForms")}`;
+  const title = `${t("gcFormsSave")} — ${t("gcForms")}`;
   return (
     <PageTemplate title={title}>
       <Save />

--- a/pages/form-builder/share/[[...params]].tsx
+++ b/pages/form-builder/share/[[...params]].tsx
@@ -7,7 +7,7 @@ import { Share, Template, PageTemplate } from "@formbuilder/layout/";
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
-  const title = `${t("gcFormsSettings")} — ${t("gcForms")}`;
+  const title = `${t("gcFormsShare")} — ${t("gcForms")}`;
   return (
     <PageTemplate title={title}>
       <Share />


### PR DESCRIPTION
# Summary | Résumé

In the previous refactor PR, some page titles got overwritten by copy/paste. This restores them.