### PR TITLE
fix: error message when failing to save a form

### DIFF
--- a/components/form-builder/app/TestDataDelivery.tsx
+++ b/components/form-builder/app/TestDataDelivery.tsx
@@ -88,7 +88,7 @@ export const TestDataDelivery = () => {
                 error ? "" : "hidden"
               }`}
             >
-              <p>{t("thereWasAnErrorPublishing")}</p>
+              <p>{t("thereWasAnErrorSaving")}</p>
             </div>
           </li>
         )}

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -169,6 +169,7 @@
   "testYourResponseDelivery": "Test your response delivery",
   "textFormatting": "Text formatting",
   "thereWasAnErrorPublishing": "There was an error publishing the form",
+  "thereWasAnErrorSaving": "There was an error saving the form",
   "tooltipFormatH2": "Heading 2",
   "tooltipFormatH3": "Heading 3",
   "tooltipFormatBold": "Bold (⌘B)",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -169,6 +169,7 @@
   "testYourResponseDelivery": "Tester la réception des réponses",
   "textFormatting": "Formatage du texte  ",
   "thereWasAnErrorPublishing": "Une erreur s'est produite lors de la publication de votre formulaire",
+  "thereWasAnErrorSaving": "Une erreur s'est produite lors de la sauvegarde de votre formulaire",
   "tooltipFormatH2": "[FR] Heading 2",
   "tooltipFormatH3": "[FR] Heading 3",
   "tooltipFormatBold": "[FR] Bold (⌘B)",


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/1367#

- Fix to error message when saving form