### PR TITLE
Fix typo preventing privacyPolicy from displaying on form

### DIFF
--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -226,7 +226,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
 
               <RichText>
                 {form.privacyPolicy &&
-                  form.privacyPolicy[props.language == "en" ? "descrptionEn" : "descriptionFr"]}
+                  form.privacyPolicy[props.language == "en" ? "descriptionEn" : "descriptionFr"]}
               </RichText>
 
               <div className="buttons">


### PR DESCRIPTION
# Summary | Résumé

Fixes #1368 - Privacy Policy was not displaying on Preview (or any Form render) due to a typo.
