### PR TITLE
Add resume form to "My Form"

### DIFF
--- a/components/form-builder/app/shared/ResumeEditingForm.tsx
+++ b/components/form-builder/app/shared/ResumeEditingForm.tsx
@@ -1,0 +1,4 @@
+import React, { ReactElement } from "react";
+export const ResumeEditingForm = ({ children }: { children: ReactElement }) => {
+  return sessionStorage.getItem("form-storage") ? <div>{children}</div> : null;
+};

--- a/components/form-builder/app/shared/ResumeEditingForm.tsx
+++ b/components/form-builder/app/shared/ResumeEditingForm.tsx
@@ -1,4 +1,12 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 export const ResumeEditingForm = ({ children }: { children: ReactElement }) => {
-  return sessionStorage.getItem("form-storage") ? <div>{children}</div> : null;
+  const [isReady, setReady] = React.useState(false);
+
+  useEffect(() => {
+    if (typeof sessionStorage !== "undefined" && sessionStorage.getItem("form-storage")) {
+      setReady(true);
+    }
+  }, []);
+
+  return isReady ? <div>{children}</div> : null;
 };

--- a/components/form-builder/app/shared/index.ts
+++ b/components/form-builder/app/shared/index.ts
@@ -4,3 +4,4 @@ export { Dialog } from "./Dialog";
 export { Input } from "./Input";
 export { TextArea } from "./TextArea";
 export { Radio, Checkbox } from "./MultipleChoice";
+export { ResumeEditingForm } from "./ResumeEditingForm";

--- a/pages/myforms/[[...path]].tsx
+++ b/pages/myforms/[[...path]].tsx
@@ -15,6 +15,7 @@ import UserNavLayout from "@components/globals/layouts/UserNavLayout";
 import { NextPageWithLayout } from "@pages/_app";
 import { StyledLink } from "@components/globals/StyledLink/StyledLink";
 import { clearTemplateStore } from "@components/form-builder/store/useTemplateStore";
+import { ResumeEditingForm } from "@components/form-builder/app/shared";
 
 interface FormsDataItem {
   id: string;
@@ -120,10 +121,17 @@ const RenderMyForms: NextPageWithLayout<MyFormsProps> = ({ templates }: MyFormsP
         )}
       </TabPanel>
 
-      <div className="absolute top-48" ref={createNewFormRef}>
-        <StyledLink href="/form-builder">
-          {t("actions.createNewForm")} <span aria-hidden="true">+</span>
-        </StyledLink>
+      <div className="absolute top-40">
+        <ResumeEditingForm>
+          <StyledLink href="/form-builder/edit">
+            <span aria-hidden="true"> ← </span> {t("actions.resumeForm")}
+          </StyledLink>
+        </ResumeEditingForm>
+        <div ref={createNewFormRef}>
+          <StyledLink href="/form-builder">
+            {t("actions.createNewForm")} <span aria-hidden="true">+</span>
+          </StyledLink>
+        </div>
       </div>
     </div>
   );

--- a/public/static/locales/en/my-forms.json
+++ b/public/static/locales/en/my-forms.json
@@ -6,6 +6,7 @@
     "all": "All"
   },
   "actions": {
+    "resumeForm": "Resume editing form",
     "createNewForm": "Create new form"
   },
   "cards": {

--- a/public/static/locales/fr/my-forms.json
+++ b/public/static/locales/fr/my-forms.json
@@ -6,6 +6,7 @@
     "all": "Tous"
   },
   "actions": {
+    "resumeForm": "[fr] Resume editing form",
     "createNewForm": "Créer un nouveau formulaire +"
   },
   "cards": {


### PR DESCRIPTION
# Summary | Résumé

Adds a resume form button under my forms "if a form session exists"

partially fixes #1393

☝️
you can now resume editing

>at the end of the process when trying to publish it you will "lose" your form because the sign-in process will redirect you to the /myforms page.

partially fixes #1320

☝️ 
you can now resume editing
 

https://user-images.githubusercontent.com/62242/205718889-bb76a784-a983-4c52-ae86-46dbfb55e20c.mp4


# Test instructions | Instructions pour tester la modification

- Visit form builder
- Start creating a form
- Visit "my forms" (when logged in)
- Note a resume editing form button should now exist
- Resume editing a form --- should take you back to your previous form

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
