### PR TITLE
Only show Preview menu when logged in

### DIFF
--- a/components/form-builder/app/navigation/PreviewNavigation.tsx
+++ b/components/form-builder/app/navigation/PreviewNavigation.tsx
@@ -1,20 +1,14 @@
 import React from "react";
 import { useTranslation } from "next-i18next";
-import { useSession } from "next-auth/react";
 import { SubNavLink } from "./SubNavLink";
 
 export const PreviewNavigation = () => {
   const { t } = useTranslation("form-builder");
-  const { status } = useSession();
 
   return (
     <nav className="mb-8 flex divide-x-2 divide-gray-600" aria-label={t("navLabelPreview")}>
       <SubNavLink href="/form-builder/preview">{t("preview")}</SubNavLink>
-      {status === "authenticated" && (
-        <>
-          <SubNavLink href="/form-builder/preview/test-data-delivery">{t("test")}</SubNavLink>
-        </>
-      )}
+      <SubNavLink href="/form-builder/preview/test-data-delivery">{t("test")}</SubNavLink>
     </nav>
   );
 };

--- a/pages/form-builder/preview/[[...params]].tsx
+++ b/pages/form-builder/preview/[[...params]].tsx
@@ -4,12 +4,18 @@ import { NextPageWithLayout } from "../../_app";
 import { PageProps } from "@lib/types";
 import { getServerSideProps } from "../index";
 import { Preview, PreviewNavigation, Template, PageTemplate } from "@components/form-builder/app";
+import { useSession } from "next-auth/react";
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
   const title = `${t("gcFormsPreview")} — ${t("gcForms")}`;
+  const { status } = useSession();
+
   return (
-    <PageTemplate title={title} navigation={<PreviewNavigation />}>
+    <PageTemplate
+      title={title}
+      navigation={status === "authenticated" ? <PreviewNavigation /> : undefined}
+    >
       <Preview />
     </PageTemplate>
   );

--- a/pages/form-builder/preview/test-data-delivery.tsx
+++ b/pages/form-builder/preview/test-data-delivery.tsx
@@ -9,12 +9,18 @@ import {
   PageTemplate,
   Template,
 } from "@components/form-builder/app";
+import { useSession } from "next-auth/react";
 
 const Page: NextPageWithLayout<PageProps> = () => {
   const { t } = useTranslation("form-builder");
   const title = `${t("gcFormsTest")} — ${t("gcForms")}`;
+  const { status } = useSession();
+
   return (
-    <PageTemplate title={title} navigation={<PreviewNavigation />}>
+    <PageTemplate
+      title={title}
+      navigation={status === "authenticated" ? <PreviewNavigation /> : undefined}
+    >
       <TestDataDelivery />
     </PageTemplate>
   );


### PR DESCRIPTION
# Summary | Résumé

The menu is only needed when logged in and you have Preview/Test options. When not logged in, there is no Test option, so don't show the menu.