### PR TITLE
fix: set emailSubject properties to Title - Response

### DIFF
--- a/components/form-builder/app/edit/Edit.tsx
+++ b/components/form-builder/app/edit/Edit.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 import debounce from "lodash.debounce";
 import { useTranslation } from "next-i18next";
 
-import { LocalizedElementProperties, LocalizedFormProperties } from "../../types";
+import { Language, LocalizedElementProperties, LocalizedFormProperties } from "../../types";
 import { useTemplateStore } from "../../store";
 import { RichTextLocked } from "./elements";
 import { ElementPanel, ConfirmationDescription, PrivacyDescription } from ".";
@@ -34,8 +34,13 @@ export const Edit = () => {
   const [value, setValue] = useState<string>(title);
 
   const _debounced = useCallback(
-    debounce((val: string | boolean, lang) => {
+    debounce((val: string, lang: Language) => {
       updateField(`form.${localizeField(LocalizedFormProperties.TITLE, lang)}`, val);
+      // Temporary fix (see function `formatEmailSubject` in Edit.tsx file)
+      updateField(
+        `form.${localizeField(LocalizedFormProperties.EMAIL_SUBJECT, lang)}`,
+        formatEmailSubject(val, lang)
+      );
     }, 100),
     [translationLanguagePriority]
   );
@@ -123,4 +128,12 @@ export const Edit = () => {
       )}
     </>
   );
+};
+
+/**
+ * This is part of a temporary fix as the current email response implementation relies on the `emailSubject` property to be set.
+ * The email reponse design will be reworked at some point in the future so we will probably get rid of it when we get there.
+ */
+export const formatEmailSubject = (title: string, lang: Language) => {
+  return `${title} - ${lang === "en" ? "Response" : "Réponse"}`;
 };

--- a/components/form-builder/app/translate/Translate.tsx
+++ b/components/form-builder/app/translate/Translate.tsx
@@ -5,11 +5,12 @@ import { RichText } from "./RichText";
 import { Title } from "./Title";
 import { Description } from "./Description";
 import { Options } from "./Options";
-import { LocalizedElementProperties } from "../../types";
+import { LocalizedElementProperties, LocalizedFormProperties } from "../../types";
 import { DownloadCSV } from "./DownloadCSV";
 import { RichTextEditor } from "../edit/elements/lexical-editor/RichTextEditor";
 import { LanguageLabel } from "./LanguageLabel";
 import { FieldsetLegend, SectionTitle } from ".";
+import { formatEmailSubject } from "../edit/Edit";
 
 export const Translate = () => {
   const { updateField, form, localizeField } = useTemplateStore((s) => ({
@@ -57,11 +58,19 @@ export const Translate = () => {
                   id="form-title-en"
                   aria-describedby="form-title-en-language"
                   type="text"
-                  value={form[localizeField(LocalizedElementProperties.TITLE, primaryLanguage)]}
+                  value={form[localizeField(LocalizedFormProperties.TITLE, primaryLanguage)]}
                   onChange={(e) => {
                     updateField(
-                      `form.${localizeField(LocalizedElementProperties.TITLE, primaryLanguage)}`,
+                      `form.${localizeField(LocalizedFormProperties.TITLE, primaryLanguage)}`,
                       e.target.value
+                    );
+                    // Temporary fix (see function `formatEmailSubject` in Edit.tsx file)
+                    updateField(
+                      `form.${localizeField(
+                        LocalizedFormProperties.EMAIL_SUBJECT,
+                        primaryLanguage
+                      )}`,
+                      formatEmailSubject(e.target.value, primaryLanguage)
                     );
                   }}
                 />
@@ -78,11 +87,19 @@ export const Translate = () => {
                   id="form-title-fr"
                   aria-describedby="form-title-fr-language"
                   type="text"
-                  value={form[localizeField(LocalizedElementProperties.TITLE, secondaryLanguage)]}
+                  value={form[localizeField(LocalizedFormProperties.TITLE, secondaryLanguage)]}
                   onChange={(e) => {
                     updateField(
-                      `form.${localizeField(LocalizedElementProperties.TITLE, secondaryLanguage)}`,
+                      `form.${localizeField(LocalizedFormProperties.TITLE, secondaryLanguage)}`,
                       e.target.value
+                    );
+                    // Temporary fix (see function `formatEmailSubject` in Edit.tsx file)
+                    updateField(
+                      `form.${localizeField(
+                        LocalizedFormProperties.EMAIL_SUBJECT,
+                        secondaryLanguage
+                      )}`,
+                      formatEmailSubject(e.target.value, secondaryLanguage)
                     );
                   }}
                 />

--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -53,8 +53,8 @@ export const defaultForm = {
     descriptionFr: "",
   },
   elements: [],
-  emailSubjectEn: "Form builder test [en]",
-  emailSubjectFr: "Form builder test [fr]",
+  emailSubjectEn: "",
+  emailSubjectFr: "",
   securityAttribute: "Unclassified",
 };
 


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/1319

- Quick fix to set the `emailSubject` properties to `__title__ - Response` in order for the current email response design to continue working properly