### PR TITLE
fix: publish button is hidden when permission is not assigned

### DIFF
--- a/components/form-builder/app/Publish.tsx
+++ b/components/form-builder/app/Publish.tsx
@@ -115,24 +115,22 @@ export const Publish = () => {
         </li>
       </ul>
 
-      {userCanPublish && (
-        <div className="mt-10 p-5 bg-yellow-100 flex">
-          <div className="flex">
-            <div className="pr-7">
-              <WarningIcon />
+      {userCanPublish && isPublishable() && (
+        <>
+          <div className="mt-10 p-5 bg-yellow-100 flex">
+            <div className="flex">
+              <div className="pr-7">
+                <WarningIcon />
+              </div>
+            </div>
+            <div>
+              <h2 className="mb-1 text-h3 pb-0 mb-0">{t("publishingDisablesEditing")}</h2>
+              <p>{t("publishingDisablesEditingDescription")}</p>
+              <Markdown options={{ forceBlock: true }}>
+                {t("contactSupportIfYouHaveQuestions")}
+              </Markdown>
             </div>
           </div>
-          <div>
-            <h2 className="mb-1 text-h3 pb-0 mb-0">{t("publishingDisablesEditing")}</h2>
-            <p>{t("publishingDisablesEditingDescription")}</p>
-            <Markdown options={{ forceBlock: true }}>
-              {t("contactSupportIfYouHaveQuestions")}
-            </Markdown>
-          </div>
-        </div>
-      )}
-      {isPublishable() && (
-        <>
           <Button className="mt-5" onClick={handlePublish}>
             {t("publish")}
           </Button>


### PR DESCRIPTION
# Summary | Résumé

- Hide publish button when user does not have permission on page https://forms-staging.cdssandbox.xyz/form-builder/publish. If think it used to work but was probably broken during some refactoring. Also changed the fact that you could see the "Publishing disables editing " warning message even if the form was not in a publishable state. In Figma we either have the warning message with the publish button or none of them.