### PR TITLE
Don't show "resume" form when session is empty

### DIFF
--- a/components/form-builder/app/Settings.tsx
+++ b/components/form-builder/app/Settings.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import Markdown from "markdown-to-jsx";
 
-import { useTemplateStore } from "../store";
+import { useTemplateStore, clearTemplateStore } from "../store";
 import {
   Button,
   Input,
@@ -230,6 +230,7 @@ export const Settings = () => {
               return;
             }
             setFormDeleted(true);
+            clearTemplateStore();
             initialize(); // Reset the form
           }}
           isPublished={isPublished}

--- a/components/form-builder/app/shared/ResumeEditingForm.tsx
+++ b/components/form-builder/app/shared/ResumeEditingForm.tsx
@@ -1,4 +1,7 @@
 import React, { ReactElement, useEffect } from "react";
+
+import { clearTemplateStore } from "../../store";
+
 export const ResumeEditingForm = ({ children }: { children: ReactElement }) => {
   const [hasSession, setHasSession] = React.useState(false);
 
@@ -26,7 +29,7 @@ export const ResumeEditingForm = ({ children }: { children: ReactElement }) => {
       throw new Error("Invalid form session");
     } catch (e) {
       // noop
-      sessionStorage.removeItem("form-storage");
+      clearTemplateStore();
     }
   }, []);
 

--- a/components/form-builder/app/shared/ResumeEditingForm.tsx
+++ b/components/form-builder/app/shared/ResumeEditingForm.tsx
@@ -1,12 +1,34 @@
 import React, { ReactElement, useEffect } from "react";
 export const ResumeEditingForm = ({ children }: { children: ReactElement }) => {
-  const [isReady, setReady] = React.useState(false);
+  const [hasSession, setHasSession] = React.useState(false);
 
   useEffect(() => {
-    if (typeof sessionStorage !== "undefined" && sessionStorage.getItem("form-storage")) {
-      setReady(true);
+    if (typeof sessionStorage === "undefined") {
+      return;
+    }
+
+    try {
+      // check if there is a valid form session
+      const data = sessionStorage.getItem("form-storage");
+      const parsedData = data && JSON.parse(data);
+      const {
+        state: {
+          form: { titleEn, titleFr },
+        },
+      } = parsedData;
+
+      if (titleEn !== "" || titleFr !== "") {
+        setHasSession(true);
+        return;
+      }
+
+      // clean up empty sessions
+      throw new Error("Invalid form session");
+    } catch (e) {
+      // noop
+      sessionStorage.removeItem("form-storage");
     }
   }, []);
 
-  return isReady ? <div className="inline">{children}</div> : null;
+  return hasSession ? <div className="inline">{children}</div> : null;
 };

--- a/components/form-builder/store/index.ts
+++ b/components/form-builder/store/index.ts
@@ -1,2 +1,2 @@
-export { useTemplateStore, TemplateStoreProvider } from "./useTemplateStore";
+export { useTemplateStore, TemplateStoreProvider, clearTemplateStore } from "./useTemplateStore";
 export { useModalStore } from "./useModalStore";


### PR DESCRIPTION
# Summary | Résumé

Update to ensure a form session has data before showing the resume form option.

I noticed this after working on the delete from dialog yesterday - deleted for session still existed for deleted form but the session was cleared when calling form initialize after the deletion.

# Test instructions | Instructions pour tester la modification

**Form without data**

1) From the start screen create a new form.  **Don't enter any information**.  Visit my forms ... resume button should not appear.

<hr>


**Form with data**

1)  From the start screen create a new form.  **Enter a form title**.  Visit my forms ... resume button should be available


<hr>

**Form deletion**

1) Create a form and save it.
2) Visit my forms + delete the form via the delete dialog
3) Visit my my form --- no resume session should exist


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
