### PR TITLE
Fix Tooltip bug

### DIFF
--- a/components/form-builder/app/edit/elements/lexical-editor/ToolTip.tsx
+++ b/components/form-builder/app/edit/elements/lexical-editor/ToolTip.tsx
@@ -1,17 +1,17 @@
-import React, { useId } from "react";
+import React, { useId, Children } from "react";
 
 export const ToolTip = ({ children, text }: { children: React.ReactElement; text: string }) => {
   const id = `tooltip-${useId()}`;
 
-  const Children = () =>
-    React.cloneElement(children, {
-      className: children.props.className + " peer",
-      "aria-labelledby": id,
-    });
-
   return (
     <span className="relative">
-      <Children />
+      {Children.map(children, (child) => {
+        return React.cloneElement(child, {
+          ...child.props,
+          className: child.props.className + " peer",
+          "aria-labelledby": id,
+        });
+      })}
       <span
         id={id}
         className={`invisible whitespace-nowrap peer-hover:visible peer-focus:visible bg-gray-800 text-white rounded absolute p-1 text-sm -top-10 w-36 text-center -left-14 after:content-[''] after:absolute after:left-1/2 after:top-[100%] after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700`}


### PR DESCRIPTION
# Summary | Résumé

Fixes a bug where the RichTextEditor Toolbar buttons required a two clicks to activate. This was caused by some improper child element cloning in the Tooltip component.
