### PR TITLE
Fix / Missing email domain check on register API

### DIFF
--- a/__tests__/api/signup/register.test.ts
+++ b/__tests__/api/signup/register.test.ts
@@ -89,6 +89,27 @@ describe("/signup/register", () => {
         message: "username and password need to be provided in the body of the request",
       });
     });
+    it("handler returns 400 status code when username is not part of the acceptable domain", async () => {
+      mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
+
+      const { req, res } = createMocks({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": "valid_csrf",
+        },
+        body: {
+          username: "test@uknown_domain.com",
+          password: "test",
+          name: "test",
+        },
+      });
+      await register(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: "username does not meet requirements",
+      });
+    });
     it("handler returns empty body and cognito status code when command succeeds", async () => {
       mockGetCSRFToken.mockResolvedValueOnce("valid_csrf");
       sendFunctionMock.mockImplementation(async () => {
@@ -109,7 +130,7 @@ describe("/signup/register", () => {
           "x-csrf-token": "valid_csrf",
         },
         body: {
-          username: "test",
+          username: "test@domain.gc.ca",
           password: "test",
           name: "test",
         },
@@ -120,7 +141,7 @@ describe("/signup/register", () => {
       expect(mockedCognitoIdentityProviderClient).toBeCalledTimes(1);
       expect(mockedSignUpCommand.mock.calls[0][0]).toEqual({
         ClientId: "somemockvalue",
-        Username: "test",
+        Username: "test@domain.gc.ca",
         Password: "test",
         UserAttributes: [
           {
@@ -150,7 +171,7 @@ describe("/signup/register", () => {
           "x-csrf-token": "valid_csrf",
         },
         body: {
-          username: "test",
+          username: "test@domain.gc.ca",
           password: "test",
           name: "test",
         },

--- a/pages/api/signup/register.ts
+++ b/pages/api/signup/register.ts
@@ -6,13 +6,22 @@ import {
 } from "@aws-sdk/client-cognito-identity-provider";
 import { NextApiRequest, NextApiResponse } from "next";
 import { middleware, cors, csrfProtected } from "@lib/middleware";
+import { isValidGovEmail } from "@lib/validation";
 
 const register = async (req: NextApiRequest, res: NextApiResponse) => {
   const { COGNITO_REGION, COGNITO_APP_CLIENT_ID } = process.env;
+
   // craft registration params for the SignUpCommand
   if (!req.body.username || !req.body.password || !req.body.name) {
     return res.status(400).json({
       message: "username and password need to be provided in the body of the request",
+    });
+  }
+
+  // Ensure email is part of acceptable domain list
+  if (!isValidGovEmail(req.body.username)) {
+    return res.status(400).json({
+      message: "username does not meet requirements",
     });
   }
   const params: SignUpCommandInput = {


### PR DESCRIPTION
# Summary | Résumé
This PR adds email domain validation check to the Register API endpoint.  It was previously possible that any email address could register with Cognito by directly calling the Register endpoint.

# Test instructions | Instructions pour tester la modification

A request to the Register API endpoint that includes a non valid gov email address should now return a 400 error.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
