### PR TITLE
fix: switch getOrCreate user function to use email instead of token sub

### DIFF
--- a/lib/tests/users.test.ts
+++ b/lib/tests/users.test.ts
@@ -18,7 +18,7 @@ describe("User query tests should fail gracefully", () => {
       new Prisma.PrismaClientKnownRequestError("Timed out", "P2024", "4.3.2")
     );
 
-    const result = await getOrCreateUser({ sub: "3218462" });
+    const result = await getOrCreateUser({ email: "test-user@test.ca" });
     expect(result).toEqual(null);
   });
 
@@ -30,7 +30,7 @@ describe("User query tests should fail gracefully", () => {
     prismaMock.user.create.mockRejectedValue(
       new Prisma.PrismaClientKnownRequestError("Timed out", "P2024", "4.3.2")
     );
-    const result = await getOrCreateUser({ sub: "8465132" });
+    const result = await getOrCreateUser({ email: "test-user@test.ca" });
     expect(result).toEqual(null);
   });
 
@@ -57,7 +57,7 @@ describe("getOrCreateUser", () => {
 
     (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue(user);
 
-    const result = await getOrCreateUser({ sub: "3", email: "fads@asdf.ca" });
+    const result = await getOrCreateUser({ email: "fads@asdf.ca" });
     expect(result).toMatchObject(user);
   });
 
@@ -76,17 +76,15 @@ describe("getOrCreateUser", () => {
     (prismaMock.user.create as jest.MockedFunction<any>).mockResolvedValue(user);
 
     const result = await getOrCreateUser({
-      sub: "3",
       name: "test",
       email: "fads@asdf.ca",
-      privileges: Base,
     });
 
     expect(result).toMatchObject(user);
     expect(prismaMock.user.create).toBeCalledWith({
       data: {
         email: "fads@asdf.ca",
-        id: "3",
+        image: undefined,
         name: "test",
         privileges: {
           connect: {

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -9,12 +9,12 @@ import { MongoAbility } from "@casl/ability";
  * Get or Create a user if a record does not exist
  * @returns A User Object
  */
-export const getOrCreateUser = async ({ sub, name, email, picture }: DefaultJWT) => {
-  if (!sub) throw new Error("Sub does not exist on token");
+export const getOrCreateUser = async ({ name, email, picture }: DefaultJWT) => {
+  if (!email) throw new Error("Sub does not exist on token");
   const user = await prisma.user
     .findUnique({
       where: {
-        id: sub,
+        email: email,
       },
       select: {
         id: true,
@@ -46,7 +46,6 @@ export const getOrCreateUser = async ({ sub, name, email, picture }: DefaultJWT)
     return await prisma.user
       .create({
         data: {
-          id: sub,
           name,
           email,
           image: picture,

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -10,7 +10,7 @@ import { MongoAbility } from "@casl/ability";
  * @returns A User Object
  */
 export const getOrCreateUser = async ({ name, email, picture }: DefaultJWT) => {
-  if (!email) throw new Error("Sub does not exist on token");
+  if (!email) throw new Error("Email does not exist on token");
   const user = await prisma.user
     .findUnique({
       where: {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -150,8 +150,8 @@ export const authOptions: NextAuthOptions = {
     async jwt({ token, account }) {
       // account is only available on the first call to the JWT function
       if (account?.provider) {
-        if (!token.sub) {
-          throw new Error(`JWT token does not have an id for user with email ${token.email}`);
+        if (!token.email) {
+          throw new Error(`JWT token does not have an email for user with name ${token.name}`);
         }
         const user = await getOrCreateUser(token);
         if (user === null)


### PR DESCRIPTION
# Summary | Résumé

No issue 

It was previously possible to create an account with cognito and gsuite that used the same email. Redirect logic has been added such that user's can only sign in with the original way they registered (The way they signed into GC Forms the first time). I.E if one registered with the cognito method and attempted to sign in with a gsuite account with the same email they would be redirected to sign in with the cognito account and vice versa. 

This removes the possibility of an account takeover and as such we can return to using emails to lookup users. This will allow us to use the csv option to migrate users from one cognito user pool to another and have user's still be able to access their accounts after a password reset

# Test instructions | Instructions pour tester la modification

1. Test to make sure the login still works 

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

N/A

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
