### PR TITLE
Fix preview page when passing id

### DIFF
--- a/pages/form-builder/preview/[[...params]].tsx
+++ b/pages/form-builder/preview/[[...params]].tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from "react";
 import { useTranslation } from "next-i18next";
-import { NextPageWithLayout } from "../_app";
+import { NextPageWithLayout } from "../../_app";
 import { PageProps } from "@lib/types";
-import { getServerSideProps } from "./index";
+import { getServerSideProps } from "../index";
 import { PreviewNavigation, PageTemplate, Template, Preview } from "@components/form-builder/app";
 
 const Page: NextPageWithLayout<PageProps> = () => {


### PR DESCRIPTION
# Summary | Résumé

This fixes the preview / test page to ensure you can pass a form id

Currently the preview link with an ID lands on a missing page

<img width="500" alt="Screen Shot 2022-12-23 at 11 48 28 AM" src="https://user-images.githubusercontent.com/62242/209372168-53b94ca8-1c6e-4bcf-a142-380a9564462f.png">



# Test instructions | Instructions pour tester la modification

- Visit My Forms
- Preview an existing form


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
