### PR TITLE
fix: attempt to fix "deploy to staging" Github action

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Deploy image for Form Viewer
         timeout-minutes: 10
-        # v1.4.2
-        uses: aws-actions/amazon-ecs-deploy-task-definition@67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f
+        # v1.4.11
+        uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
         with:
           task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
           service: form-viewer


### PR DESCRIPTION
# Summary | Résumé

According to Github logs we have not been able to deploy to staging for the past few days. It happened right after https://github.com/cds-snc/platform-forms-client/pull/1402 was merged.
The error logs are:
````
Run aws-actions/amazon-ecs-deploy-task-definition@67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '@actions/core'
Require stack:
- /home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:[1](https://github.com/cds-snc/platform-forms-client/actions/runs/3838434406/jobs/6534886553#step:9:1)5)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.67105 (/home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js:35822:33)
    at __nccwpck_require__ (/home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js:41745:43)
    at Object.25456 (/home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js:8:[14](https://github.com/cds-snc/platform-forms-client/actions/runs/3838434406/jobs/6534886553#step:9:15))
    at __nccwpck_require__ (/home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js:4[17](https://github.com/cds-snc/platform-forms-client/actions/runs/3838434406/jobs/6534886553#step:9:18)45:43)
    at /home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js:41765:37
    at Object.<anonymous> (/home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb880[29](https://github.com/cds-snc/platform-forms-client/actions/runs/3838434406/jobs/6534886553#step:9:30)45a7f/dist/index.js:41768:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/runner/work/_actions/aws-actions/amazon-ecs-deploy-task-definition/67f6f62a733c5de6ba4ba69fc2a2bb8802945a7f/dist/index.js'
  ]
}
````

After looking at the commits on https://github.com/aws-actions/amazon-ecs-deploy-task-definition/commits/master I noticed that a recent revert on the commit we have used so I figured it could be the reason why it is not working anymore.