### PR TITLE
Fix dependancy array for menu dropdown

### DIFF
--- a/components/myforms/MenuDropdown/MenuDropdown.tsx
+++ b/components/myforms/MenuDropdown/MenuDropdown.tsx
@@ -36,9 +36,7 @@ export const MenuDropdown = (props: MenuDropdownProps): React.ReactElement => {
         })
       );
     }
-    // @todo - fix this eslint error
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [menuButtonRef.current, menuListRef.current]);
+  }, []);
 
   return (
     <div className="relative">


### PR DESCRIPTION
# Summary | Résumé

Removes unnecessary dependencies from Menu Dropdown useEffect

The useEffect listed `refs` as dependencies but React will never see those updates.

See: https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/

> useRef is similar to useState except changing the value doesn't trigger a re-render.

> React can't know that the value changed if a change doesn't trigger a render!

# Test instructions | Instructions pour tester la modification

Test the Menu Dropdown under my forms

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
