### PR TITLE
Ignore hydration errors when running test mode 

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,9 +17,26 @@ which generates a warning in the browser console.
 */
 
 const SafeHydrate = ({ children }: { children: React.ReactNode }) => {
+  const isTestEnv = Boolean(process.env.APP_ENV === "test");
   return (
-    <div id="safeHydrate" suppressHydrationWarning={Boolean(process.env.APP_ENV === "test")}>
-      {typeof window === "undefined" && process.env.APP_ENV === "test" ? null : children}
+    <div id="safeHydrate" suppressHydrationWarning={isTestEnv}>
+      {/* in test mode avoid Next JS dialog overlay */}
+      {isTestEnv && (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+        window.addEventListener('error', event => {
+          event.stopImmediatePropagation()
+        })
+      
+        window.addEventListener('unhandledrejection', event => {
+          event.stopImmediatePropagation()
+        })
+    `,
+          }}
+        />
+      )}
+      {typeof window === "undefined" ? null : children}
     </div>
   );
 };


### PR DESCRIPTION
# Summary | Résumé

When running Cypress test locally using `yarn dev:test` we're seeing the Next JS dialog.  Cypress tests are failing as click events don't happen as the dialog is over the elements.

`suppressHydrationWarning` doesn't seem to be handling.

<img width="500" alt="Screen Shot 2023-01-11 at 10 25 26 AM" src="https://user-images.githubusercontent.com/62242/211849966-667e5265-d45e-430b-9b4b-9f96449608d5.png">

This PR adds some JS in test mode only to suppress the dialog from displaying.


# Test instructions | Instructions pour tester la modification

- run `yarn dev:test` visit localhost:3000 note no dialog is displayed
- switch to the develop branch --- note dialog shows

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
