### PR TITLE
Fix example fr description

### DIFF
--- a/components/form-builder/app/edit/PanelBodyRoot.tsx
+++ b/components/form-builder/app/edit/PanelBodyRoot.tsx
@@ -7,15 +7,13 @@ import { useTemplateStore } from "../../store";
 
 export const PanelBodyRoot = ({ item }: { item: FormElementWithIndex }) => {
   const { t } = useTranslation("form-builder");
-  const { localizeField, updateField, unsetField, resetChoices, translationLanguagePriority } =
-    useTemplateStore((s) => ({
-      localizeField: s.localizeField,
-      elements: s.form.elements,
-      updateField: s.updateField,
-      unsetField: s.unsetField,
-      resetChoices: s.resetChoices,
-      translationLanguagePriority: s.translationLanguagePriority,
-    }));
+  const { localizeField, updateField, unsetField, resetChoices } = useTemplateStore((s) => ({
+    localizeField: s.localizeField,
+    elements: s.form.elements,
+    updateField: s.updateField,
+    unsetField: s.unsetField,
+    resetChoices: s.resetChoices,
+  }));
 
   // all element state updaters should be setup at this level
   // we should be able to pass and `item` + `updaters`to build up each element panel
@@ -73,12 +71,21 @@ export const PanelBodyRoot = ({ item }: { item: FormElementWithIndex }) => {
       case "phone":
       case "date":
       case "number":
+        // update default description en
         updateField(
           `form.elements[${itemIndex}].properties[${localizeField(
             LocalizedElementProperties.DESCRIPTION,
-            translationLanguagePriority
+            "en"
           )}]`,
-          t(`defaultElementDescription.${id}`)
+          t(`defaultElementDescription.${id}`, { lng: "en" })
+        );
+        // update default description fr
+        updateField(
+          `form.elements[${itemIndex}].properties[${localizeField(
+            LocalizedElementProperties.DESCRIPTION,
+            "fr"
+          )}]`,
+          t(`defaultElementDescription.${id}`, { lng: "fr" })
         );
         break;
       default:

--- a/components/form-builder/app/edit/elements/ShortAnswer.tsx
+++ b/components/form-builder/app/edit/elements/ShortAnswer.tsx
@@ -2,7 +2,10 @@ import React from "react";
 
 export const ShortAnswer = ({ children, ...props }: { children: string }) => {
   return (
-    <div {...props} className="text-gray-600 mt-3 border-b-1.5 border-solid border-gray-200">
+    <div
+      {...props}
+      className="example-text text-gray-600 mt-3 border-b-1.5 border-solid border-gray-200"
+    >
       {children}
     </div>
   );

--- a/cypress/e2e/form-builder-field-with-description.cy.js
+++ b/cypress/e2e/form-builder-field-with-description.cy.js
@@ -23,14 +23,6 @@ describe("Form builder description text", () => {
     });
   });
 
-  it("Renders phone element with example text", () => {
-    cy.get("button").contains("Add element").click();
-    cy.get(".builder-element-dropdown").click();
-    cy.get('[data-testid="phone"]').click();
-    cy.get(".description-text").should("exist").contains("Enter a phone number like, 111-222-3333");
-    cy.get(".example-text").should("exist").contains("111-222-3333");
-  });
-
   it("Renders email element with example text", () => {
     cy.get("button").contains("Add element").click();
     cy.get(".builder-element-dropdown").click();
@@ -55,5 +47,18 @@ describe("Form builder description text", () => {
     cy.get('[data-testid="number"]').click();
     cy.get(".description-text").should("exist").contains("Only enter numbers");
     cy.get(".example-text").should("exist").contains("0123456789");
+  });
+
+  it("Renders phone element with example text + toggles to FR", () => {
+    cy.get("button").contains("Add element").click();
+    cy.get(".builder-element-dropdown").click();
+    cy.get('[data-testid="phone"]').click();
+    cy.get(".description-text").should("exist").contains("Enter a phone number like, 111-222-3333");
+    cy.get(".example-text").should("exist").contains("111-222-3333");
+
+    cy.get("#switch-english").click();
+    cy.get(".description-text")
+      .should("exist")
+      .contains("Entrez un numéro de téléphone comme 111-222-3333");
   });
 });

--- a/cypress/e2e/form-builder-field-with-description.cy.js
+++ b/cypress/e2e/form-builder-field-with-description.cy.js
@@ -1,0 +1,59 @@
+describe("Form builder description text", () => {
+  beforeEach(() => {
+    cy.visit("/form-builder/edit", {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        let nextData;
+        Object.defineProperty(win, "__NEXT_DATA__", {
+          set(serverSideProps) {
+            serverSideProps.context = {
+              user: {
+                acceptableUse: false,
+                name: null,
+                userId: "testId",
+              },
+            };
+            nextData = serverSideProps;
+          },
+          get() {
+            return nextData;
+          },
+        });
+      },
+    });
+  });
+
+  it("Renders phone element with example text", () => {
+    cy.get("button").contains("Add element").click();
+    cy.get(".builder-element-dropdown").click();
+    cy.get('[data-testid="phone"]').click();
+    cy.get(".description-text").should("exist").contains("Enter a phone number like, 111-222-3333");
+    cy.get(".example-text").should("exist").contains("111-222-3333");
+  });
+
+  it("Renders email element with example text", () => {
+    cy.get("button").contains("Add element").click();
+    cy.get(".builder-element-dropdown").click();
+    cy.get('[data-testid="email"]').click();
+    cy.get(".description-text")
+      .should("exist")
+      .contains("Enter an email address like, name@example.com");
+    cy.get(".example-text").should("exist").contains("name@example.com");
+  });
+
+  it("Renders date element with example text", () => {
+    cy.get("button").contains("Add element").click();
+    cy.get(".builder-element-dropdown").click();
+    cy.get('[data-testid="date"]').click();
+    cy.get(".description-text").should("exist").contains("Enter a date like, mm/dd/yyyy");
+    cy.get(".example-text").should("exist").contains("mm/dd/yyyy");
+  });
+
+  it("Renders numeric element with example text", () => {
+    cy.get("button").contains("Add element").click();
+    cy.get(".builder-element-dropdown").click();
+    cy.get('[data-testid="number"]').click();
+    cy.get(".description-text").should("exist").contains("Only enter numbers");
+    cy.get(".example-text").should("exist").contains("0123456789");
+  });
+});

--- a/pages/form-builder/index.tsx
+++ b/pages/form-builder/index.tsx
@@ -80,7 +80,8 @@ export const getServerSideProps: GetServerSideProps = async ({
   return {
     props: {
       ...FormbuilderParams,
-      ...(locale && (await serverSideTranslations(locale, ["common", "form-builder"]))),
+      ...(locale &&
+        (await serverSideTranslations(locale, ["common", "form-builder"], null, ["fr", "en"]))),
     },
   };
 };


### PR DESCRIPTION
# Summary | Résumé

Fixes bug for missing default description when toggling `En, Fr` with a date, numeric, phone, email selected

See before and after:
https://www.youtube.com/watch?v=Ch8e1tayjK8


# Test instructions | Instructions pour tester la modification

- On `develop` add a form element
- Select a date element
- Note the default description shows
- Change edit mode to `FR` note the description is now empty

---

- Swap to this branch 
- Select a date element
- Note the default description shows
- Change edit mode to `FR` note the default description is now in fr


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
