### PR TITLE
Last saved date

### DIFF
--- a/components/form-builder/app/shared/SaveButton.tsx
+++ b/components/form-builder/app/shared/SaveButton.tsx
@@ -63,7 +63,7 @@ export const SaveButton = () => {
       {dateTime.length == 2 && (
         <div className="mt-4 " role="alert" aria-live="polite">
           <div className="font-bold">{t("lastSaved", { ns: "form-builder" })}</div>
-          <div className="text-sm" aria-label={fullDate}>
+          <div aria-label={fullDate} className="text-sm">
             {dateTime[0]} {t("at")} {dateTime[1]}{" "}
           </div>
         </div>

--- a/components/form-builder/app/shared/SaveButton.tsx
+++ b/components/form-builder/app/shared/SaveButton.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { Button } from "../shared";
 import { useTemplateStore } from "../../store";
 import { useAllowPublish, useTemplateStatus, useTemplateApi } from "../../hooks";
-import { formatDateTime } from "../../util";
+import { formatDateTime, formatDateTimeLong } from "../../util";
 import Markdown from "markdown-to-jsx";
 
 export const SaveButton = () => {
@@ -45,6 +45,7 @@ export const SaveButton = () => {
   }, [asPath, isReady]);
 
   const dateTime = (updatedAt && formatDateTime(new Date(updatedAt).getTime())) || [];
+  const fullDate = (updatedAt && formatDateTimeLong(new Date(updatedAt).getTime())) || "";
 
   return !isStartPage && isSaveable() && status === "authenticated" ? (
     <div
@@ -62,7 +63,7 @@ export const SaveButton = () => {
       {dateTime.length == 2 && (
         <div className="mt-4 " role="alert" aria-live="polite">
           <div className="font-bold">{t("lastSaved", { ns: "form-builder" })}</div>
-          <div className="text-sm">
+          <div className="text-sm" aria-label={fullDate}>
             {dateTime[0]} {t("at")} {dateTime[1]}{" "}
           </div>
         </div>

--- a/components/form-builder/app/shared/SaveButton.tsx
+++ b/components/form-builder/app/shared/SaveButton.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { Button } from "../shared";
 import { useTemplateStore } from "../../store";
 import { useAllowPublish, useTemplateStatus, useTemplateApi } from "../../hooks";
-import { formatDateTime, formatDateTimeLong } from "../../util";
+import { formatDateTime } from "../../util";
 import Markdown from "markdown-to-jsx";
 
 export const SaveButton = () => {
@@ -45,7 +45,6 @@ export const SaveButton = () => {
   }, [asPath, isReady]);
 
   const dateTime = (updatedAt && formatDateTime(new Date(updatedAt).getTime())) || [];
-  const fullDate = (updatedAt && formatDateTimeLong(new Date(updatedAt).getTime())) || "";
 
   return !isStartPage && isSaveable() && status === "authenticated" ? (
     <div
@@ -60,11 +59,11 @@ export const SaveButton = () => {
           <Markdown options={{ forceBlock: true }}>{error}</Markdown>
         </div>
       )}
-      <div className="mt-4" role="alert" aria-atomic="true" aria-live="polite">
+      <div className="mt-4" aria-live="polite">
         {dateTime.length == 2 && (
           <>
             <div className="font-bold">{t("lastSaved", { ns: "form-builder" })}</div>
-            <div aria-label={fullDate} className="text-sm">
+            <div className="text-sm">
               {dateTime[0]} {t("at")} {dateTime[1]}{" "}
             </div>
           </>

--- a/components/form-builder/app/shared/SaveButton.tsx
+++ b/components/form-builder/app/shared/SaveButton.tsx
@@ -60,14 +60,16 @@ export const SaveButton = () => {
           <Markdown options={{ forceBlock: true }}>{error}</Markdown>
         </div>
       )}
-      {dateTime.length == 2 && (
-        <div className="mt-4 " role="alert" aria-live="polite">
-          <div className="font-bold">{t("lastSaved", { ns: "form-builder" })}</div>
-          <div aria-label={fullDate} className="text-sm">
-            {dateTime[0]} {t("at")} {dateTime[1]}{" "}
-          </div>
-        </div>
-      )}
+      <div className="mt-4" role="alert" aria-atomic="true" aria-live="polite">
+        {dateTime.length == 2 && (
+          <>
+            <div className="font-bold">{t("lastSaved", { ns: "form-builder" })}</div>
+            <div aria-label={fullDate} className="text-sm">
+              {dateTime[0]} {t("at")} {dateTime[1]}{" "}
+            </div>
+          </>
+        )}
+      </div>
     </div>
   ) : null;
 };

--- a/components/form-builder/util.ts
+++ b/components/form-builder/util.ts
@@ -154,7 +154,7 @@ export const formatDateTime = (updatedAt: number | undefined, locale = "en-CA") 
     return [];
   }
 
-  const yearMonthDay = parts[0].replace(/-/g, "/");
+  const yearMonthDay = parts[0];
   const time = parts[1].replace(/\./g, "").trim();
   return [yearMonthDay, time];
 };

--- a/components/form-builder/util.ts
+++ b/components/form-builder/util.ts
@@ -158,3 +158,17 @@ export const formatDateTime = (updatedAt: number | undefined, locale = "en-CA") 
   const time = parts[1].replace(/\./g, "").trim();
   return [yearMonthDay, time];
 };
+
+export const formatDateTimeLong = (updatedAt: number | undefined, locale = "en-CA") => {
+  const date = new Date(updatedAt || 0);
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "numeric",
+    hour12: true,
+  };
+
+  return date.toLocaleDateString(locale, options);
+};


### PR DESCRIPTION
# Summary | Résumé

When navigating from my form the date is not being read properly.

1). The date really should be read when navigating from "my forms" but given _**we're making a fetch call and the text is in an aria live region it gets picked up by a screen reader.**_ To fix how the text is read the code us updated to use use `-` vs `/`


When navigating "on purpose" to the last saved the aria label with now gets picked up
-----

**Notes:**
- Moved aria-polite out + adds aria-atomic="true" to ensure full text read when an update happen



# Test instructions | Instructions pour tester la modification

See:  #1511

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
