### PR TITLE
Bugfix: Get updated_at into the getTemplate endpoint

### DIFF
--- a/components/form-builder/app/shared/SaveButton.tsx
+++ b/components/form-builder/app/shared/SaveButton.tsx
@@ -50,7 +50,7 @@ export const SaveButton = () => {
     <div
       data-id={id}
       className={`mt-12 p-4 -ml-4 w-52 xl:w-40 xl:text-sm ${
-        error ? "bg-red-100" : "bg-yellow-100"
+        id && (error ? "bg-red-100" : "bg-yellow-100")
       }`}
     >
       <Button onClick={handleSave}>{t("saveDraft", { ns: "form-builder" })}</Button>

--- a/components/form-builder/hooks/useTemplateStatus.tsx
+++ b/components/form-builder/hooks/useTemplateStatus.tsx
@@ -7,10 +7,14 @@ import { useTemplateStore } from "../store";
 
 interface FormTemplate {
   id: string;
-  updatedAt: number;
+  updated_at: number;
 }
 
 export const byId = async (id: string): Promise<FormTemplate | null> => {
+  if (!id) {
+    return null;
+  }
+
   try {
     const result = await axios({
       url: `/api/templates/${id}`,
@@ -22,7 +26,6 @@ export const byId = async (id: string): Promise<FormTemplate | null> => {
     if (result.status !== 200) {
       return null;
     }
-
     return result.data;
   } catch (err) {
     logMessage.error(err);
@@ -41,7 +44,7 @@ export const useTemplateStatus = () => {
   const getTemplateById = useCallback(async () => {
     if ("authenticated" === status) {
       const template = await byId(id);
-      setUpdatedAt(template?.updatedAt);
+      setUpdatedAt(template?.updated_at);
     }
   }, [id, status]);
 

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -208,6 +208,7 @@ async function _unprotectedGetTemplateWithAssociatedUsers(
         id: true,
         jsonConfig: true,
         isPublished: true,
+        updated_at: true,
         ttl: true,
         users: {
           select: {

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -234,6 +234,7 @@ describe("Template CRUD functions", () => {
         jsonConfig: true,
         isPublished: true,
         ttl: true,
+        updated_at: true,
         users: {
           select: {
             id: true,
@@ -295,6 +296,7 @@ describe("Template CRUD functions", () => {
         jsonConfig: true,
         isPublished: true,
         ttl: true,
+        updated_at: true,
         users: {
           select: {
             id: true,


### PR DESCRIPTION
# Summary | Résumé

A previous PR changed the payload of the get single template api route and needed to be updated to include the updated_at property to support the SaveButton.

# Test instructions | Instructions pour tester la modification

Save button should work again.
