### PR TITLE
Add: initial share dropdown + feature flag

### DIFF
--- a/components/form-builder/app/Template.tsx
+++ b/components/form-builder/app/Template.tsx
@@ -11,7 +11,13 @@ import { LeftNavigation, Header } from "@components/form-builder/app";
 import { Language } from "../types";
 import { useActivePathname, TemplateApiProvider } from "../hooks";
 
-export const Template = ({ page }: { page: ReactElement }) => {
+export const Template = ({
+  page,
+  shareMenu = false,
+}: {
+  page: ReactElement;
+  shareMenu?: boolean;
+}) => {
   return (
     <TemplateStoreProvider
       {...{ ...(page.props.initialForm && page.props.initialForm), locale: page.props.locale }}
@@ -24,7 +30,7 @@ export const Template = ({ page }: { page: ReactElement }) => {
         </Head>
         <div className="flex flex-col h-full">
           <SkipLink />
-          <Header />
+          <Header shareMenu={shareMenu} />
           {page}
           <Footer displaySLAAndSupportLinks />
         </div>

--- a/components/form-builder/app/navigation/Header.tsx
+++ b/components/form-builder/app/navigation/Header.tsx
@@ -4,11 +4,14 @@ import Link from "next/link";
 import { useAccessControl } from "@lib/hooks";
 import { useTranslation } from "next-i18next";
 
+import { useFlag } from "@lib/hooks";
 import LanguageToggle from "../../../globals/LanguageToggle";
 import LoginMenu from "../../../auth/LoginMenu";
+import { ShareDropdown } from "./ShareDropdown";
 
-export const Header = () => {
+export const Header = ({ shareMenu = false }: { shareMenu: boolean }) => {
   const { status } = useSession();
+  const { isLoading, status: shareEnabled } = useFlag("shareMenu");
   const { ability, refreshAbility } = useAccessControl();
   const { t, i18n } = useTranslation(["common", "form-builder"]);
 
@@ -34,6 +37,11 @@ export const Header = () => {
           aria-label={t("mainNavAriaLabel", { ns: "form-builder" })}
         >
           <ul className="flex text-base list-none">
+            {shareMenu && !isLoading && shareEnabled && (
+              <li className="md:text-small_base text-base font-normal not-italic mr-4">
+                <ShareDropdown />
+              </li>
+            )}
             <li className="md:text-small_base text-base font-normal not-italic mr-4">
               {ability?.can("view", "FormRecord") && (
                 <Link href={`/${i18n.language}/myforms/drafts`}>

--- a/components/form-builder/app/navigation/ShareDropdown.tsx
+++ b/components/form-builder/app/navigation/ShareDropdown.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useTranslation } from "next-i18next";
+import { UseSelectStateChange } from "downshift";
+
+import { DropDown } from "../edit/elements";
+import { ShareIcon } from "@formbuilder/icons";
+import { ElementOption } from "@formbuilder/types";
+
+export const ShareDropdown = () => {
+  const { t } = useTranslation("form-builder");
+
+  const handleChange = (changes: UseSelectStateChange<ElementOption | null | undefined>) => {
+    alert(changes.selectedItem?.value);
+  };
+
+  const options = [{ id: "email", value: t("share.email"), icon: <ShareIcon />, className: "" }];
+
+  return (
+    <div className="form-builder mt-[-8px]">
+      <DropDown
+        ariaLabel={t("share.title")}
+        items={options}
+        selectedItem={{ id: "share", value: t("share.title"), className: "" }}
+        onChange={handleChange}
+      />
+    </div>
+  );
+};

--- a/components/form-builder/icons/BackArrowIcon copy.tsx
+++ b/components/form-builder/icons/BackArrowIcon copy.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+export const BackArrowIcon = ({ className, title }: { className?: string; title?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    width="24"
+    className={className}
+    viewBox="0 0 24 24"
+    focusable="false"
+    aria-hidden={title ? false : true}
+    role={title ? "img" : "presentation"}
+  >
+    {title && <title>{title}</title>}
+    <path d="m12 20-8-8 8-8 1.425 1.4-5.6 5.6H20v2H7.825l5.6 5.6Z" />
+  </svg>
+);

--- a/components/forms/Form/Form.test.js
+++ b/components/forms/Form/Form.test.js
@@ -37,6 +37,8 @@ jest.mock("@lib/hooks", () => {
           return { isLoading: false, status: false };
         case "formBuilderAddElementDialog":
           return { isLoading: false, status: false };
+        case "shareMenu":
+          return { isLoading: false, status: false };
         default:
           return useFlag(flag);
       }

--- a/flag_initialization/default_flag_settings.json
+++ b/flag_initialization/default_flag_settings.json
@@ -8,5 +8,6 @@
   "passwordReset": false,
   "supportForms": false,
   "formBuilderDebug": false,
-  "formBuilderAddElementDialog": false
+  "formBuilderAddElementDialog": false,
+  "shareMenu": false
 }

--- a/pages/form-builder/edit/[[...params]].tsx
+++ b/pages/form-builder/edit/[[...params]].tsx
@@ -41,7 +41,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
 };
 
 Page.getLayout = (page: ReactElement) => {
-  return <Template page={page} />;
+  return <Template page={page} shareMenu />;
 };
 
 export { getServerSideProps };

--- a/pages/form-builder/edit/translate.tsx
+++ b/pages/form-builder/edit/translate.tsx
@@ -17,7 +17,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
 };
 
 Page.getLayout = (page: ReactElement) => {
-  return <Template page={page} />;
+  return <Template page={page} shareMenu />;
 };
 
 export { getServerSideProps };

--- a/pages/form-builder/preview/[[...params]].tsx
+++ b/pages/form-builder/preview/[[...params]].tsx
@@ -17,7 +17,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
 };
 
 Page.getLayout = (page: ReactElement) => {
-  return <Template page={page} />;
+  return <Template page={page} shareMenu />;
 };
 
 export { getServerSideProps };

--- a/pages/form-builder/publish.tsx
+++ b/pages/form-builder/publish.tsx
@@ -48,7 +48,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
 };
 
 Page.getLayout = (page: ReactElement) => {
-  return <Template page={page} />;
+  return <Template page={page} shareMenu />;
 };
 
 export { getServerSideProps };

--- a/pages/form-builder/settings/[[...params]].tsx
+++ b/pages/form-builder/settings/[[...params]].tsx
@@ -16,7 +16,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
 };
 
 Page.getLayout = (page: ReactElement) => {
-  return <Template page={page} />;
+  return <Template page={page} shareMenu />;
 };
 
 export { getServerSideProps };

--- a/public/static/locales/en/admin-flags.json
+++ b/public/static/locales/en/admin-flags.json
@@ -53,6 +53,10 @@
     "formBuilderAddElementDialog": {
       "title": "Form Builder Add Element Dialog",
       "description": "Enable dialog when adding elements to the form builder"
+    },
+    "shareMenu": {
+      "title": "Share Menu",
+      "description": "Enable share menu dropdown"
     }
   }
 }

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -296,5 +296,9 @@
       "title": "Numeric title",
       "description": "Numeric desc"
     }
+  },
+  "share": {
+    "title": "Share",
+    "email": "Share with email"
   }
 }

--- a/public/static/locales/fr/admin-flags.json
+++ b/public/static/locales/fr/admin-flags.json
@@ -53,6 +53,10 @@
     "formBuilderAddElementDialog": {
       "title": "[FR] Form Builder Add Element Dialog",
       "description": "[FR] Enable dialog when adding elements to the form builder"
+    },
+    "shareMenu": {
+      "title": "[FR] Share Menu",
+      "description": "[FR] Enable share menu dropdown"
     }
   }
 }

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -296,5 +296,9 @@
       "title": "Numeric title",
       "description": "Numeric desc"
     }
+  },
+  "share": {
+    "title": "[FR] Share",
+    "email": "[FR] Share with email"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Adds initial share drop down behind a feature flag. 

<img width="665" alt="Screen Shot 2023-01-25 at 2 14 19 PM" src="https://user-images.githubusercontent.com/62242/214663687-bf62454e-f154-4ec8-97c8-0ec5d2eed23b.png">

**Noting this menu doesn't match the Figma designs** 

- This PR just gets the files and feature flag in place.

<hr>

As a followup once this in in place we can look at using https://www.radix-ui.com/docs/primitives/components/dropdown-menu for the menu which will allow us to have sub level items.

<hr>


# Test instructions | Instructions pour tester la modification

- Turn on feature flag 
- Ensure share menu is only showing on pages where the form would be available to be emailed

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
