### PR TITLE
Add scheme prefix to url in share email

### DIFF
--- a/pages/api/share.ts
+++ b/pages/api/share.ts
@@ -40,7 +40,7 @@ To preview this form:
 - **Step 1**:
   Save the attached JSON form file to your computer.
 - **Step 2**:
-  Go to [GC Forms](${req.headers.host}). No account needed.
+  Go to [GC Forms](https://${req.headers.host}). No account needed.
 - **Step 3**:
   Select open a form file.
       `,


### PR DESCRIPTION
# Summary | Résumé

The URL in the share email was missing the https:// prefix.
