### PR TITLE
fix: generate Docker SBOM step

### DIFF
--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -83,10 +83,6 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
-      - name: Logout of Staging Amazon ECR
-        if: always()
-        run: docker logout ${{ steps.login-ecr-staging.outputs.registry }}
-
       - name: Docker generate SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
         env:
@@ -96,3 +92,7 @@ jobs:
           dockerfile_path: "Dockerfile"
           sbom_name: "forms-client"
           token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Logout of Staging Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr-staging.outputs.registry }}


### PR DESCRIPTION
# Summary
Generate the SBOM before logging out of the ECR.

The latest version of the Docker generate-sbom action now pulls the newly pushed image from the ECR.  This was done to support multi-architecture Docker image scan, but unfortunately broke workflows that logged out of the ECR before the SBOM was generated.