### PR TITLE
Fix fileName input bugs

### DIFF
--- a/components/form-builder/app/navigation/FileName.tsx
+++ b/components/form-builder/app/navigation/FileName.tsx
@@ -10,16 +10,23 @@ export const FileNameInput = () => {
     updateField: s.updateField,
   }));
 
-  const [content, setContent] = useState("");
+  const fileName = getName();
+
+  const [content, setContent] = useState(fileName);
+  const [isEditing, setIsEditing] = useState(false);
+  const [width, setWidth] = useState(0);
+  const span = useRef<HTMLElement>(null);
 
   useEffect(() => {
+    // check if the fileName has changed from outside the component
+    if (!isEditing && content === "" && fileName !== content) {
+      setContent(fileName);
+    }
+
     if (span?.current) {
       setWidth(span.current?.offsetWidth + 50);
     }
-  }, [content]);
-
-  const [width, setWidth] = useState(0);
-  const span = useRef<HTMLElement>(null);
+  }, [content, fileName, isEditing]);
 
   const widthStyle = width ? { width: `${width}px` } : {};
 
@@ -33,13 +40,15 @@ export const FileNameInput = () => {
         className="px-2 min-w-[200px] max-w-[500px] border-2 border-white text-base font-bold placeholder-black hover:border-2 hover:border-gray-default"
         name="filename"
         placeholder={t("untitledForm", { ns: "form-builder" })}
-        value={content ? content : getName()}
+        value={content}
+        onFocus={() => setIsEditing(true)}
         onBlur={() => {
-          updateField(`name`, content);
+          if (content !== getName()) {
+            updateField(`name`, content);
+          }
+          setIsEditing(false);
         }}
-        onChange={(e) => {
-          setContent(e.target.value);
-        }}
+        onChange={(e) => setContent(e.target.value)}
       />
     </div>
   );


### PR DESCRIPTION
# Summary | Résumé

- Fixes issue where you couldn't backspace out the entire file name (it would reset to the "old" fileName)
- Fixes issue where the input width was not getting set when reloading when using a longer fileName and or the form title width

# Test instructions | Instructions pour tester la modification

1)
- Type in a fileName
- Backspace to remove the fileName --- this should now allow the field to be empty

2)
- Add a really long file name
- Save the form + reload
- The fileName input should have a width that fits the fileName i.e. not cut off (unless it's too long for the screen)

3) 
- Fill in the form title not the fileName 
- The fileName should get filled + take on the width of the file title


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
