### PR TITLE
Updates Contactus localization and to use a checkbox

### DIFF
--- a/pages/api/request/support.ts
+++ b/pages/api/request/support.ts
@@ -21,13 +21,23 @@ const requestSupport = async (req: NextApiRequest, res: NextApiResponse) => {
       ? "Contact request / Demande de soutien"
       : "Support request / Demande de soutien";
 
+  // Request may be a list of strings (checkbox), format it a bit if so, or just a string (radio)
+  const requestParsed =
+    request.toString().split(",").length > 1
+      ? request
+          .toString()
+          .split(",")
+          .map((item: string) => `-${item}`)
+          .join("\n")
+      : request;
+
   let emailBody = "";
   if (supportType === "contactus") {
     emailBody = `
 ${name} (${email}) has requested we contact them for the form-builder.
 
 Contact request:
-${request}
+${requestParsed}
 
 Additional details:
 ${description}
@@ -36,7 +46,7 @@ ${description}
 ${name} (${email}) a demandé que nous les contactions pour le générateur de formulaires..
 
 Demande de contact soutien:
-${request}
+${requestParsed}
 
 Détails supplémentaires:
 ${description}
@@ -46,7 +56,7 @@ ${description}
 ${name} (${email}) has requested support for the form-builder.
 
 Support request:
-${request}
+${requestParsed}
 
 Additional details:
 ${description}
@@ -55,7 +65,7 @@ ${description}
 ${name} (${email}) a demandé de soutien des form-builder.
 
 Demande de soutien:
-${request}
+${requestParsed}
 
 Détails supplémentaires:
 ${description}

--- a/pages/form-builder/support/[[...supportType]].tsx
+++ b/pages/form-builder/support/[[...supportType]].tsx
@@ -36,7 +36,7 @@ export default function Contactus() {
   const handleRequest = async (
     name: string,
     email: string,
-    request: string,
+    request: [string] | string,
     description: string
   ) => {
     const token: string = (await getCsrfToken()) || "";
@@ -61,7 +61,12 @@ export default function Contactus() {
     email: Yup.string()
       .required(t("input-validation.required", { ns: "common" }))
       .email(t("input-validation.email", { ns: "common" })),
-    request: Yup.string().required(t("input-validation.required", { ns: "common" })),
+    request:
+      supportType === "contactus"
+        ? Yup.array()
+            .min(1)
+            .of(Yup.string().required(t("input-validation.required", { ns: "common" })))
+        : Yup.string().required(t("input-validation.required", { ns: "common" })),
     description: Yup.string().required(t("input-validation.required", { ns: "common" })),
   });
 
@@ -115,7 +120,7 @@ export default function Contactus() {
           </legend>
           <MultipleChoiceGroup
             name="request"
-            type="radio"
+            type="checkbox"
             choicesProps={[
               {
                 id: "request-question",

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -86,11 +86,11 @@
     "name": "Your Name",
     "needSupport": "Need Support?",
     "request": {
-      "option1": "Ask a question about the product and how it can work in your department",
-      "option2": "Give feedback",
-      "option3": "Set up a demo to learn more about GC Forms",
+      "option1": "Request a product demo",
+      "option2": "Join our mailing list",
+      "option3": "Give feedback",
       "option4": "Other",
-      "title": "How can we help?"
+      "title": "Reason for reaching out"
     },
     "supportFormLink": "Support Form",
     "title": "Contact Us",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -86,11 +86,11 @@
     "name": "Votre nom",
     "needSupport": "Besoin d'aide?",
     "request": {
-      "option1": "Poser une question",
-      "option2": "Donner votre avis",
-      "option3": "Organiser une démo pour en savoir plus sur Formulaires GC ",
+      "option1": "Demandez une démonstration du produit",
+      "option2": "Inscrivez-vous à notre liste de diffusion",
+      "option3": "Donnez votre avis",
       "option4": "Autre",
-      "title": "Quel est votre besoin?"
+      "title": "Raison pour laquelle vous nous contactez"
     },
     "supportFormLink": "formulaire de soutien",
     "title": "Contactez-nous",


### PR DESCRIPTION
# Summary | Résumé

Quick update for some localization strings. Spreadsheet is here:
https://docs.google.com/spreadsheets/d/1_T94VYdANvxV65nw9L4NbflwkWUlp3RCbGPF8ZGxh4g/edit#gid=2014401594

Also updating the Contactus form to use a checkbox. This required a minor change to the API as well.

# Test instructions | Instructions pour tester la modification

Navigate to form-builder/support/contactus and try filling out a form and checking the email. For form sake (hah :) test the related form-builder/support/ form also. 

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Whatever the user's language is that fills out the form, the selected options are printed out in that language in both the English and French versions in the email. Future bug fix.

