### PR TITLE
Bugfix: Share menu should copy URL not JSON

### DIFF
--- a/components/form-builder/app/navigation/LinksSubMenu.tsx
+++ b/components/form-builder/app/navigation/LinksSubMenu.tsx
@@ -30,7 +30,7 @@ export const LinksSubMenu = () => {
     },
   ];
 
-  const handleCopyToClipboard = async (link) => {
+  const handleCopyToClipboard = async (link: string) => {
     if ("clipboard" in navigator) {
       await navigator.clipboard.writeText(link);
     }

--- a/components/form-builder/app/navigation/LinksSubMenu.tsx
+++ b/components/form-builder/app/navigation/LinksSubMenu.tsx
@@ -30,10 +30,9 @@ export const LinksSubMenu = () => {
     },
   ];
 
-  const handleCopyToClipboard = async () => {
+  const handleCopyToClipboard = async (link) => {
     if ("clipboard" in navigator) {
-      const stringified = getSchema();
-      await navigator.clipboard.writeText(stringified);
+      await navigator.clipboard.writeText(link);
     }
   };
 
@@ -50,7 +49,7 @@ export const LinksSubMenu = () => {
             <button
               className="inline-block mr-2 flex"
               onClick={() => {
-                handleCopyToClipboard();
+                handleCopyToClipboard(url);
               }}
             >
               <CopyIcon className="scale-[80%]" />


### PR DESCRIPTION
# Summary | Résumé

The Share menu "Copy" option was configured to copy the JSON but should just copy the link to the published form.


