### PR TITLE
Force Node 16 in Github Actions

### DIFF
--- a/.github/workflows/build-and-deploy-storybooks.yml
+++ b/.github/workflows/build-and-deploy-storybooks.yml
@@ -20,7 +20,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-
+      - name: Node.JS 16
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2.5.1
+        with:
+          node-version: 16
       - name: Install 🔧 # This example project is built using yarn and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: yarn install
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+      - name: Node.JS 16
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2.5.1
+        with:
+          node-version: 16
       - uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
         with:
           browser: chrome

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+      - name: Node.JS 16
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2.5.1
+        with:
+          node-version: 16
       - name: "Install dependencies"
         run: yarn install
       - name: Jest Tests


### PR DESCRIPTION
# Summary | Résumé
The system Node version appears to now default to Node 18.
Since our application is tied to Node 16 at the moment in Docker this PR ensures that Node 16 is used when running tests etc.