### PR TITLE
Cypress: Check for H1 before starting test

### DIFF
--- a/components/globals/Loader.tsx
+++ b/components/globals/Loader.tsx
@@ -6,7 +6,7 @@ interface LoaderProps {
 
 export const Loader = ({ message }: LoaderProps): React.ReactElement => {
   return (
-    <div role="status" className="text-center">
+    <div data-testid="loading-spinner" role="status" className="text-center">
       <p className="pb-8">{message}</p>
       <div className="flex items-center justify-center">
         <div className="w-40 h-40 border-t-4 border-b-4 border-green-default rounded-full animate-spin"></div>

--- a/cypress/e2e/accessibility.cy.js
+++ b/cypress/e2e/accessibility.cy.js
@@ -38,6 +38,8 @@ describe("Accessibility (A11Y) Check", () => {
       ({ path }) => {
         cy.visit(path);
         cy.injectAxe();
+        // Ensure page has fully loaded
+        cy.get("h1").should("exist");
         cy.checkA11y(null, A11Y_OPTIONS);
       }
     );


### PR DESCRIPTION
# Summary | Résumé
This should hopefully fix some of failing E2E tests on github.  The A11y test for the Registration page often failed as the test sometimes started while the spinning loader was still displaying.

This new check for the A11y tests ensures that an H1 is in the DOM before starting the A11y check.