### PR TITLE
Stop running tests on every commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
-yarn test


### PR DESCRIPTION
# Summary | Résumé

The .husky config runs tests on every commit, which can disrupt productivity/momentum/flow when working and writing checkpoint commits. It's also a bit redundant since tests must run and pass on PRs before merging.

This PR keeps the lint check, but removes the test suite run.
