### PR TITLE
Fix ListBox key issue

### DIFF
--- a/components/form-builder/app/shared/ListBox.tsx
+++ b/components/form-builder/app/shared/ListBox.tsx
@@ -88,7 +88,7 @@ export const ListBox = ({
 
             return (
               /* eslint-disable jsx-a11y/click-events-have-key-events */
-              <>
+              <React.Fragment key={id}>
                 {groupOption}
                 <li
                   id={`row-${id}`}
@@ -100,7 +100,6 @@ export const ListBox = ({
                   className={`${
                     focussed ? "font-bold bg-[#E9ECEF]" : "font-normal"
                   } group pl-1 pr-2 pt-2 pb-2 mb-2 text-black hover:font-bold cursor-pointer`}
-                  key={id}
                   tabIndex={-1}
                   role="option"
                   onClick={() => setFocusIndex(index)}
@@ -113,7 +112,7 @@ export const ListBox = ({
                     )}
                   </span>
                 </li>
-              </>
+              </React.Fragment>
             );
           }
         )}


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue with React keys for the ListBox

# Test instructions | Instructions pour tester la modification

- Enable the add element dialog
- Open the dialog

The key warning should be gone.


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
