### PR TITLE
Bugfix: Refresh CSV data before building

### DIFF
--- a/components/form-builder/app/translate/DownloadCSV.tsx
+++ b/components/form-builder/app/translate/DownloadCSV.tsx
@@ -27,7 +27,7 @@ export const DownloadCSV = () => {
 
   let elementIndex = 0;
   const alphabet = "abcdefghijklmnopqrstuvwxyz".split("");
-  const data = [["description", "english", "french"]];
+  let data = [];
 
   const parseElement = (element: FormElement, index: string | number) => {
     const description = element.type === "richText" ? "Page text" : `Question ${index}`;
@@ -73,6 +73,7 @@ export const DownloadCSV = () => {
   };
 
   const generateCSV = async () => {
+    data = [["description", "english", "french"]];
     data.push(["Form introduction - Title", formatText(form.titleEn), formatText(form.titleFr)]);
     data.push([
       "Form introduction - Description",


### PR DESCRIPTION
# Summary | Résumé

The previous update to CSV download included a bug that caused the CSV to just be appended to every time you click Download. This fixes that so it refreshes the data object before generating.
