### PR TITLE
Ensure default flags are applied for Cypress tests

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -22,6 +22,8 @@ import "./commands";
 // Import Axe-Core library
 import "cypress-axe";
 
+import flagsDefault from "../../flag_initialization/default_flag_settings.json";
+
 Cypress.on("uncaught:exception", () => {
   // returning false here prevents Cypress from
   // failing the test
@@ -29,5 +31,7 @@ Cypress.on("uncaught:exception", () => {
 });
 
 beforeEach(() => {
-  cy.useFlag("reCaptcha", false);
+  Object.keys(flagsDefault).forEach((key) => {
+    cy.useFlag(`${key}`, flagsDefault[key]);
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

In debugging Cypress tests I noticed that the default flags were not being applied to all tests.  In the past we  had left it up to the developers to ensure that flags their tests were using were properly intercepted.  However, as the project grows this  pattern is no longer sustainable.

This quick little code change ensures that default flag values are used to intercept all `checkFlag` requests.  The `cy.useFlag` used directly in a test will override these default settings allowing to create tests for features that may be normally off in Production / Staging. 