### PR TITLE
Fill in missing [FR] translations 

### DIFF
--- a/form-builder-templates/address.json
+++ b/form-builder-templates/address.json
@@ -15,7 +15,7 @@
         "required": false
       },
       "descriptionEn": "### What is your address?",
-      "descriptionFr": "### [FR] What is your address?",
+      "descriptionFr": "### Quelle est votre adresse?",
       "placeholderEn": "",
       "placeholderFr": ""
     }
@@ -31,12 +31,12 @@
         }
       ],
       "titleEn": "Street address",
-      "titleFr": "[FR] Street address",
+      "titleFr": "Adresse municipale",
       "validation": {
         "required": false
       },
       "descriptionEn": "Include your civic number and street name, apartment or suite, and other address details",
-      "descriptionFr": "[FR] Include your civic number and street name, apartment or suite, and other address details",
+      "descriptionFr": "Indiquez votre numéro civique et le nom de la rue, l'appartement ou la suite, ainsi que d'autres détails de l'adresse",
       "placeholderEn": "",
       "placeholderFr": "",
       "autoComplete": "street-address"
@@ -53,7 +53,7 @@
         }
       ],
       "titleEn": "City, town or community",
-      "titleFr": "[FR] City, town or community",
+      "titleFr": "Ville ou communauté",
       "validation": {
         "required": false
       },
@@ -75,7 +75,7 @@
         }
       ],
       "titleEn": "Province",
-      "titleFr": "[FR] Province",
+      "titleFr": "Province",
       "validation": {
         "required": false
       },
@@ -96,8 +96,8 @@
           "fr": ""
         }
       ],
-      "titleEn": "Postal Code",
-      "titleFr": "[FR] Postal Code",
+      "titleEn": "Postal code",
+      "titleFr": "Code postal",
       "validation": {
         "required": false
       },

--- a/form-builder-templates/attestation.json
+++ b/form-builder-templates/attestation.json
@@ -6,19 +6,19 @@
       "choices": [
         {
           "en": "Condition 1",
-          "fr": "[FR] Condition 1"
+          "fr": "Condition 1"
         },
         {
           "en": "Condition 2",
-          "fr": "[FR] Condition 2"
+          "fr": "Condition 2"
         },
         {
           "en": "Condition 3",
-          "fr": "[FR] Condition 2"
+          "fr": "Condition 3"
         }
       ],
       "titleEn": "I agree to:",
-      "titleFr": "[FR] I agree to:",
+      "titleFr": "J'accepte :",
       "validation": {
         "required": true,
         "all": true

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -77,11 +77,11 @@
       "title": "What is your address?",
       "street": {
         "label": "Street address",
-        "description": "Include your civic number and street name, apartment or suite, and other address details"
+        "description": "Include your civic number and street name, apartment or suite, and other address details."
       },
       "city": "City, town or community",
       "province": "Province or state",
-      "country": "City, town or community",
+      "country": "Country",
       "postal": "Postal or zip code"
     },
     "name": {
@@ -111,7 +111,7 @@
       },
       "email": {
         "label": "Email address",
-        "description": "Enter your email number like, name@example.com"
+        "description": "Enter your email address like, name@example.com"
       },
       "language": {
         "label": "What is your preferred language for communication?",
@@ -136,8 +136,8 @@
     "address-line1": "Address line 1 (civic number and street name)",
     "address-line2": "Address line 2 (apartment or suite)",
     "address-line3": "Address line 3 (other address details)",
-    "bday": "Birthdate",
-    "bday-day": "Day of birthday",
+    "bday": "Date of birth",
+    "bday-day": "Birth day",
     "bday-month": "Birth month",
     "bday-year": "Birth year",
     "country": "Country code (2 letter country identifier)",
@@ -409,7 +409,7 @@
     "toPreview": "To preview this form:",
     "unauthenticated": {
       "copyInstructions": "Copy instructions",
-      "description": "You cannot share a form directly from GC Forms without an account. <a href=\"/auth/login\">Sign in</a> or <a href=\"/signup/register\">Sign up</a> today to get access to this feature and more.",
+      "description": "You cannot share a form directly from GC Forms without an account. <a href=\"/auth/login\">Sign in</a> or <a href=\"/signup/register\">create an account</a> to get access to this feature and more.",
       "downloadFormFile": "Download form file",
       "instructions": "You can download a copy of this form file to your computer and share it through your email.",
       "step1": "Step 1",

--- a/public/static/locales/en/my-forms.json
+++ b/public/static/locales/en/my-forms.json
@@ -37,9 +37,9 @@
     }
   },
   "responseTemplate": {
-    "responseNumber": "Response Number",
-    "submissionDate": "Submission Date",
-    "errorNoQuestionsAnswers": "Error no questions and answers were found.",
+    "responseNumber": "Response number",
+    "submissionDate": "Submission date",
+    "errorNoQuestionsAnswers": "No questions and answers were found.",
     "jumpTo": "Jump to:",
     "columnTable": "Column table",
     "rowTable": "Row table",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -77,7 +77,7 @@
       "title": "Quelle est votre adresse?",
       "street": {
         "label": "Adresse municipale",
-        "description": "Veuillez inclure votre numéro civique, le nom de la rue, l'appartement, et d'autres détails de l'adresse."
+        "description": "Indiquez votre numéro civique, le nom de la rue, l'appartement, et d'autres détails de l'adresse."
       },
       "city": "Ville ou communauté",
       "province": "Province ou état",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -3,21 +3,21 @@
   "addElementDialog": {
     "addButton": "Sélectionner ce bloc",
     "advancedBlocks": "Blocs avancés",
-    "allRequired": "[FR] all required",
+    "allRequired": "Tous obligatoires",
     "answer": "Réponse...",
-    "attest": "[FR] I agree to:",
+    "attest": "J'accepte :",
     "attestation": {
-      "description": "[FR] Use a legal attestation block when form fillers must agree to certain conditions to continue. This block allows you to add one or several required checkboxes.",
-      "title": "[FR] Legal attestation"
+      "description": "Utilisez un bloc d'attestation légale lorsque les personnes qui remplissent le formulaire doivent accepter certaines conditions afin de continuer. Ce bloc permet d'ajouter une ou plusieurs cases à cocher obligatoires.",
+      "title": "Attestation légale"
     },
     "checkbox": {
       "description": "Description des choix multiples",
       "title": "Choix multiples"
     },
     "checkboxItem": "Case à cocher",
-    "condition1": "[FR] Condition 1",
-    "condition2": "[FR] Condition 2",
-    "condition3": "[FR] Condition 3",
+    "condition1": "Condition 1",
+    "condition2": "Condition 2",
+    "condition3": "Condition 3",
     "date": {
       "description": "Description de la date",
       "title": "Date"
@@ -27,7 +27,7 @@
       "title": "Liste déroulante"
     },
     "dynamicRow": {
-      "description": "[FR] The repeating question block provides form fillers with the option to add another set of answers to the section. This block works with one question or a section of questions.",
+      "description": "Le bloc de questions répétitives offre aux remplisseurs de formulaires la possibilité d'ajouter une autre série de réponse à la section. Ce bloc fonctionne avec une seule question ou une section de questions.",
       "title": "Série répétitive de questions"
     },
     "email": {
@@ -67,55 +67,55 @@
       "title": "Question à réponse courte"
     },
     "postal-code": {
-      "label": "[FR] Postal code",
-      "description": "[FR] Postal code description",
-      "title": "[FR] Postal code title"
+      "label": "Code postal",
+      "description": "Description du code postal",
+      "title": "Titre du code postal"
     },
     "address": {
-      "label": "[FR] Address",
-      "description": "[FR] Address description",
-      "title": "[FR] What is your address?",
+      "label": "Adresse",
+      "description": "Description de l'adresse",
+      "title": "Quelle est votre adresse?",
       "street": {
-        "label": "[FR] Street address",
-        "description": "[FR] Include your civic number and street name, apartment or suite, and other address details"
+        "label": "Adresse municipale",
+        "description": "Veuillez inclure votre numéro civique, le nom de la rue, l'appartement, et d'autres détails de l'adresse."
       },
-      "city": "[FR] City, town or community",
-      "province": "[FR] Province or state",
-      "country": "[FR] City, town or community",
-      "postal": "[FR] Postal or zip code"
+      "city": "Ville ou communauté",
+      "province": "Province ou état",
+      "country": "Pays",
+      "postal": "Code postal ou zip"
     },
     "name": {
-      "label": "[FR] Name",
-      "description": "[FR] Name description",
-      "title": "[FR] Name title",
+      "label": "Nom",
+      "description": "Description du nom",
+      "title": "Titre du nom",
       "first": {
-        "label": "[FR] First name",
-        "description": "[FR] First name description"
+        "label": "Prénom",
+        "description": "Description du prénom"
       },
       "middle": {
-        "label": "[FR] Middle name",
-        "description": "[FR] Middle name description"
+        "label": "Deuxième prénom",
+        "description": "Description du deuxième prénom"
       },
       "last": {
-        "label": "[FR] Last name",
-        "description": "[FR] Last name description"
+        "label": "Nom de famille",
+        "description": "Description du nom de famille"
       }
     },
     "contact": {
-      "label": "[FR] Contact",
-      "title": "[FR] How can we contact you?",
-      "description": "[FR] Contact description",
+      "label": "Contact",
+      "title": "Comment pouvons-nous vous contacter?",
+      "description": "Description du contact",
       "phone": {
-        "label": "[FR] Phone number",
-        "description": "[FR] Enter your phone number like, 111-222-3333"
+        "label": "Numéro de téléphone",
+        "description": "Entrez votre numéro de téléphone, comme 111-222-3333"
       },
       "email": {
-        "label": "[FR] Email address",
-        "description": "[FR] Enter your email number like, name@example.com"
+        "label": "Adresse courriel",
+        "description": "Entrez votre adresse courriel, comme nom@exemple.com"
       },
       "language": {
-        "label": "[FR] What is your preferred language for communication?",
-        "description": "[FR] We offer our services in both official languages, French and English",
+        "label": "Quelle est votre langue préférée de communication?",
+        "description": "Nous offrons nos services dans les deux langues officielles, le français et l'anglais.",
         "english": "Anglais",
         "french": "Français"
       }
@@ -128,34 +128,34 @@
   "addRules": "Ajouter des règles",
   "addToSet": "Ajouter à la série",
   "at": "à",
-  "attestation": "[FR] Legal attestation",
+  "attestation": "Attestation légale",
   "autocompleteOptions": {
-    "additional-name": "[FR] Middle name",
-    "address-level1": "[FR] Province, State",
-    "address-level2": "[FR] City, town, community",
-    "address-line1": "[FR] Address line 1 (civic number and street name)",
-    "address-line2": "[FR] Address line 2 (apartment or suite)",
-    "address-line3": "[FR] Address line 3 (other address details)",
-    "bday": "[FR] Birthdate",
-    "bday-day": "[FR] Day of birthday",
-    "bday-month": "[FR] Birth month",
-    "bday-year": "[FR] Birth year",
-    "country": "[FR] Country code (2 letter country identifier)",
-    "country-name": "[FR] Country",
-    "email": "[FR] Email address",
-    "family-name": "[FR] Last name",
-    "given-name": "[FR] First name",
-    "honorific-prefix": "[FR] Name prefix, Mr, Mrs, Dr",
-    "honorific-suffix": "[FR] Name suffix, Jr, B.Sc,",
-    "language": "[FR] Language",
-    "name": "[FR] Full name (includes first, middle and last names)",
-    "organization-title": "[FR] Job title",
-    "phone": "[FR] Phone number",
-    "postal-code": "[FR] Postal or zip code",
-    "street-address": "[FR] Full street address (includes address lines 1-3)",
-    "url": "[FR] Website address"
+    "additional-name": "Deuxième prénom",
+    "address-level1": "Province, État",
+    "address-level2": "Ville ou communauté",
+    "address-line1": "Ligne d'adresse 1 (numéro civique et nom de la rue)",
+    "address-line2": "Ligne d'adresse 2 (appartement ou suite)",
+    "address-line3": "Ligne d'adresse 3 (autre détails de l'adresse)",
+    "bday": "Date de naissance",
+    "bday-day": "Jour de naissance",
+    "bday-month": "Mois de naissance",
+    "bday-year": "Année de naissance",
+    "country": "Code du pays (identifiant du pays à 2 lettres)",
+    "country-name": "Pays",
+    "email": "Adresse courriel",
+    "family-name": "Nom de famille",
+    "given-name": "Prénom",
+    "honorific-prefix": "Préfix du nom, M., Mme, Dr",
+    "honorific-suffix": "Suffix du nom, Jr, B.Sc,",
+    "language": "Langue",
+    "name": "Nom complet (y compris le prénom, le deuxième prénom et le nom de famille)",
+    "organization-title": "Titre du poste",
+    "phone": "Numéro de téléphone",
+    "postal-code": "Code postal ou zip",
+    "street-address": "Adresse complète (y compris les lignes 1 à 3 de l'adresse)",
+    "url": "Adresse du site Web"
   },
-  "autocompleteWhenNotToUse": "[FR] When not to use autocomplete",
+  "autocompleteWhenNotToUse": "Qnad ne pas utiliser l'autocomplétion",
   "backToForm": "Retourner au formulaire",
   "cancel": "Annuler  ",
   "characterLimitDescription": "N'utilisez une limite de caractères que lorsqu'il existe une bonne raison de limiter le nombre de caractères que les utilisateur·rice·s peuvent entrer.",
@@ -215,7 +215,7 @@
   "edit": "Modifier",
   "editingIn": "Modifier en :",
   "editLink": "Modifier un lien  ",
-  "elementActions": "[FR] Element actions",
+  "elementActions": "Actions des éléments",
   "email": "Courriel",
   "english": "anglais",
   "errorSaving": "Le téléchargement du fichier de formulaire a échoué. <a href=\"/fr/form-builder/support\" target=\"_blank\">Contacter l’équipe de soutien</a>.",
@@ -367,8 +367,8 @@
   "save": "Enregistrer",
   "saveAndRequest": "Enregistrer le formulaire et demander la capacité de publier",
   "saveDraft": "Enregistrer l’ébauche",
-  "selectAutocomplete": "[FR] Select an autocomplete attribute",
-  "selectAutocompleteHint": "[FR] This option is great when the form filler is providing personal information like their address, email or phone number.",
+  "selectAutocomplete": "Sélectionnez un attribut d'autocomplétion",
+  "selectAutocompleteHint": "Cette option est utile lorsque les personnes qui remplissent le formulaire fournissent des informations personnelles telles que leur adresse, courriel ou numéro de téléphone.",
   "selectElement": "Sélectionnez un type d'élément",
   "send": "Envoyer",
   "settingsDeleteButton": "Supprimer le formulaire",
@@ -408,14 +408,14 @@
     "title": "Partager",
     "toPreview": "Pour prévisualiser ce formulaire :",
     "unauthenticated": {
-      "copyInstructions": "[FR] Copy instructions",
-      "description": "[FR] You cannot share a form directly from GC Forms without an account. <a href=\"/auth/login\">Sign in</a> or <a href=\"/signup/register\">Sign up</a> today to get access to this feature and more.",
-      "downloadFormFile": "[FR] Download form file",
-      "instructions": "[FR] You can download a copy of this form file to your computer and share it through your email.",
-      "step1": "[FR] Step 1",
-      "step1Details": "[FR] Download a copy of your form as a JSON form file to your computer",
-      "step2": "[FR] Step 2",
-      "step2Details": "[FR] Copy and paste the email instructions into an email and attach the form file"
+      "copyInstructions": "Copier les instructions",
+      "description": "Vous ne pouvez pas partager un formulaire directement de Formulaires GC sans compte. <a href=\"/auth/login\">Connectez-vous</a> ou <a href=\"/signup/register\">créez un compte</a> pour accéder a1 cette fonctionalité et d'autres.",
+      "downloadFormFile": "Télécharger le fichier du formulaire",
+      "instructions": "Vous pouvez télécharger une copie de ce fichier de formulaire sur votre ordinateur et le partager par courriel.",
+      "step1": "Étape 1",
+      "step1Details": "Téléchargez une copie de votre formulaire en tant que fichier JSON sur votre ordinateur",
+      "step2": "Étape 2",
+      "step2Details": "Copiez et collez les instructions dans un courriel et joignez le fichier du formulaire"
     },
     "unpublished": "Lien n'est pas disponible pour les formulaires non publiés"
   },

--- a/public/static/locales/fr/my-forms.json
+++ b/public/static/locales/fr/my-forms.json
@@ -37,26 +37,26 @@
     }
   },
   "responseTemplate": {
-    "responseNumber": "Response Number [fr]",
-    "submissionDate": "Submission Date [fr]",
-    "errorNoQuestionsAnswers": "Error no questions and answers were found. [fr]",
-    "jumpTo": "Jump To: [fr]",
-    "columnTable": "Column table [fr]",
-    "rowTable": "Row table [fr]",
-    "rowTableInfo": "A row table is most useful when copy and pasting into a spreadsheet. [fr]",
-    "confirmReceiptResponse": "Confirm receipt of response [fr]",
-    "confirmReceipt": "Confirm receipt [fr]",
-    "confirmReceiptInfo": "Copy the code below and paste it into the Confirm Receipt of Responses page in the website. [fr]",
-    "copyCode": "Copy code [fr]",
-    "copyCodeClipboard": "Copy code to clipboard [fr]",
-    "copiedToCipboard": "Copied to clipboard [fr]",
-    "errorrCopyingToClipboard": "Error copying to clipboard [fr]",
-    "submissionID": "[FR] Submission ID",
-    "copyResponse": "Copy answer row to clipboard [fr]"
+    "responseNumber": "Numéro de réponse",
+    "submissionDate": "Date de soumission",
+    "errorNoQuestionsAnswers": "Aucune question ou réponse n'a été trouvée.",
+    "jumpTo": "Passer à :",
+    "columnTable": "Tableau de colonnes",
+    "rowTable": "Tableau de lignes",
+    "rowTableInfo": "Un tableau de lignes est plus utile lorsqu'il s'agit de copier-coller dans une feuille de calcul.",
+    "confirmReceiptResponse": "Confirmer la réception de réponses",
+    "confirmReceipt": "Confirmer la réception",
+    "confirmReceiptInfo": "Copiez le code ci-dessous et collez-le dans la page Confirmation de réception des réponses du site Web.",
+    "copyCode": "Copier le code",
+    "copyCodeClipboard": "Copier le code dans le presse-papiers",
+    "copiedToCipboard": "Copié dans le presse-papiers",
+    "errorrCopyingToClipboard": "Erreur lors de la copie dans le presse-papiers",
+    "submissionID": "Identifiant de la soumission",
+    "copyResponse": "Copier la ligne de réponse dans le presse-papiers"
   },
   "protectedBWarning": {
-    "officialRecord": "[Fr] This is an official record [/Fr]",
-    "retainCopy": "[Fr] Retain this copy in accordance to your retention policy. [/Fr]",
+    "officialRecord": "Ceci est un document officiel",
+    "retainCopy": "Conservez cette copie conformément à votre politique de conservation.",
     "protectedB": "PROTÉGÉ B"
   }
 }


### PR DESCRIPTION
Added in French equivalents for files including `my-forms.json` and `form-builder.json` where they were missing, as well as a few other files.

=====

Notable tweaks in English:

> - Country ≠ city
> - Date of birth ≠ birth day
> - Create an account ≠ sign up

Notable translations in French:

> - Clipboard = Presse-papiers
> - Spreadsheet = Feuille de calcul
> - Street address = Adresse municipale
> - Middle name = Deuxième prénom
> - Legal attestation = Attestation légale
> - City, town, or community = Ville ou communauté
> - Postal or zip code = Code postal ou zip