### PR TITLE
Remove panel actions locked

### DIFF
--- a/components/form-builder/app/edit/ElementPanel.tsx
+++ b/components/form-builder/app/edit/ElementPanel.tsx
@@ -1,19 +1,15 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 
 import { FormElementWithIndex } from "../../types";
 import { useTemplateStore } from "../../store";
 import { PanelActions, PanelBodyRoot, MoreModal } from "./index";
-import { FormElementTypes } from "@lib/types";
-import { useIsWithin, useUpdateElement } from "@components/form-builder/hooks";
-import { blockLoader, LoaderType } from "../../blockLoader";
-import { allowedTemplates } from "@formbuilder/util";
+import { useIsWithin, useHandleAdd } from "@components/form-builder/hooks";
 
 export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
   const {
     lang,
     getFocusInput,
     setFocusInput,
-    add,
     remove,
     moveUp,
     moveDown,
@@ -23,7 +19,6 @@ export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
     lang: s.lang,
     getFocusInput: s.getFocusInput,
     setFocusInput: s.setFocusInput,
-    add: s.add,
     remove: s.remove,
     moveUp: s.moveUp,
     moveDown: s.moveDown,
@@ -33,7 +28,7 @@ export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
 
   const [className, setClassName] = useState<string>("");
   const [ifFocus, setIfFocus] = useState<boolean>(false);
-  const { addElement, isTextField } = useUpdateElement();
+  const { handleAddElement } = useHandleAdd();
 
   if (ifFocus === false) {
     // Only run this 1 time
@@ -53,26 +48,6 @@ export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
     // remove the blue outline after 2.1 seconds
     setTimeout(() => setClassName(""), 2100);
   }, [className]);
-
-  /* Note this callback is also in PanelActionsLocked */
-  const handleAddElement = useCallback(
-    (index: number, type: FormElementTypes | undefined) => {
-      if (allowedTemplates.includes(type as LoaderType)) {
-        blockLoader(type as LoaderType, (data) => add(index, data.type, data));
-        return;
-      }
-
-      setFocusInput(true);
-      add(
-        index,
-        isTextField(type as string) && type !== FormElementTypes.textArea
-          ? FormElementTypes.textField
-          : type
-      );
-      addElement(type as string, `form.elements[${index + 1}]`);
-    },
-    [add, setFocusInput, addElement, isTextField]
-  );
 
   const { focusWithinProps, isWithin } = useIsWithin();
 

--- a/components/form-builder/app/edit/elements/RichTextLocked.tsx
+++ b/components/form-builder/app/edit/elements/RichTextLocked.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useTemplateStore } from "../../../store/useTemplateStore";
 import { RichTextEditor } from "./lexical-editor/RichTextEditor";
-import { PanelActionsLocked } from "../PanelActionsLocked";
+import { AddElementButton } from "./element-dialog/AddElementButton";
 import { LocalizedElementProperties } from "../../../types";
 import { LockedBadge } from "../../shared/LockedBadge";
+import { useHandleAdd } from "@components/form-builder/hooks";
 
 export const RichTextLocked = ({
   beforeContent = null,
@@ -33,6 +34,8 @@ export const RichTextLocked = ({
 
   const path = `form.${schemaProperty}[${localizedField}]]`;
 
+  const { handleAddElement } = useHandleAdd();
+
   return (
     <div className="max-w-[800px] border-1 border-black h-auto -mt-px x-[10000] first-of-type:rounded-t-md last-of-type:rounded-b-md">
       <div className="mx-7 mt-5 mb-7">
@@ -49,7 +52,13 @@ export const RichTextLocked = ({
           />
         </div>
       </div>
-      <PanelActionsLocked addElement={addElement} />
+      <div className="flex">
+        {addElement && (
+          <div className="mx-auto bottom-0 -mb-5 xl:mr-2 z-10">
+            <AddElementButton position={-1} handleAdd={handleAddElement} />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/components/form-builder/app/edit/index.ts
+++ b/components/form-builder/app/edit/index.ts
@@ -1,7 +1,6 @@
 export { Edit } from "./Edit";
 export { ElementPanel } from "./ElementPanel";
 export { PanelActions } from "./PanelActions";
-export { PanelActionsLocked } from "./PanelActionsLocked";
 export { ConfirmationDescription } from "./ConfirmationDescription";
 export { Modal, ModalButton } from "./Modal";
 export { ModalForm } from "./ModalForm";

--- a/components/form-builder/hooks/index.ts
+++ b/components/form-builder/hooks/index.ts
@@ -8,3 +8,4 @@ export { TemplateApiProvider, useTemplateApi } from "./useTemplateApi";
 export { useIsWithin } from "./useIsWithin";
 export { usePanelActions } from "./usePanelActions";
 export { useUpdateElement } from "./useUpdateElement";
+export { useHandleAdd } from "./useHandleAdd";

--- a/components/form-builder/hooks/useHandleAdd.tsx
+++ b/components/form-builder/hooks/useHandleAdd.tsx
@@ -1,13 +1,12 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 
 import { FormElementTypes } from "@lib/types";
-import { AddElementButton } from "./elements/element-dialog/AddElementButton";
 import { useTemplateStore } from "@components/form-builder/store";
-import { blockLoader, LoaderType } from "../../blockLoader";
+import { blockLoader, LoaderType } from "../blockLoader";
 import { useUpdateElement } from "@components/form-builder/hooks";
 import { allowedTemplates } from "@formbuilder/util";
 
-export const PanelActionsLocked = ({ addElement }: { addElement: boolean }) => {
+export const useHandleAdd = () => {
   const { add, setFocusInput } = useTemplateStore((s) => ({
     add: s.add,
     setFocusInput: s.setFocusInput,
@@ -36,13 +35,5 @@ export const PanelActionsLocked = ({ addElement }: { addElement: boolean }) => {
     [add, setFocusInput, updateElement, isTextField]
   );
 
-  if (!addElement) return null;
-
-  return (
-    <div className="flex last-of-type:rounded-b-md">
-      <div className="mx-auto bottom-0 -mb-5 xl:mr-2 z-10">
-        <AddElementButton position={-1} handleAdd={handleAddElement} />
-      </div>
-    </div>
-  );
+  return { handleAddElement };
 };


### PR DESCRIPTION
# Summary | Résumé

Removes Panel Actions locked component and moves handle add block to a hook

Given alterations to the UI Panel Actions Locked is no longer needed as it's been paired down to just an add button.

# Test instructions | Instructions pour tester la modification

- Test adding a block from both locked and non-locked panels


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
