### PR TITLE
WAF regex rule

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,14 @@
-import { NextRequest, NextResponse, userAgent } from "next/server";
-
+import { NextRequest, NextResponse } from "next/server";
+// only to test
 export function middleware(req: NextRequest) {
-  const browserNameList = ["internet explorer 11", "ie11", "ie"];
-  if (req.nextUrl.pathname.match(/\/(id.+)/)) {
-    const { browser } = userAgent(req);
-    if (browser.name && browserNameList.includes(browser.name.toLowerCase())) {
-      return NextResponse.rewrite(`${req.nextUrl.origin}/not-supported`);
-    }
+  if (
+    req.nextUrl.pathname.match(
+      /^\/(?:en|fr)?\/?(?:(admin|id|api|auth|signup|myforms|not-supported|terms-avis|index|404|js-disabled|form-builder|sla|unlock-publishing|changelog|static|_next|img)(?:\/[\w-]+)*)?(?:\/.*)?$/
+    )
+  ) {
+    return NextResponse.next();
+  } else {
+    // should display 404 page
+    return NextResponse.rewrite(`${req.nextUrl.origin}/invalid`);
   }
-  return NextResponse.next();
 }


### PR DESCRIPTION
# Summary | Résumé
A quick middleware to test WAF rule.
This PR is not going to be merged. It sole purpose is to test the regex exp against app's Uris locally. 
 