### PR TITLE
Branding preview alt text 

### DIFF
--- a/components/form-builder/app/ResponseDelivery.tsx
+++ b/components/form-builder/app/ResponseDelivery.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "next-i18next";
 import { useTemplateStore } from "../store";
 import { Input } from "./shared";
 import { isValidGovEmail } from "@lib/validation";
-import { DeleteForm } from "./DeleteForm";
 
 const Label = ({ htmlFor, children }: { htmlFor: string; children?: JSX.Element | string }) => {
   return (

--- a/components/form-builder/app/branding/Branding.tsx
+++ b/components/form-builder/app/branding/Branding.tsx
@@ -53,7 +53,10 @@ export const Branding = ({ hasBrandingRequestForm }: { hasBrandingRequestForm: b
     label: option[logoTitle],
   }));
 
-  brandingOptions.unshift({ value: "", label: t("branding.defaultOption") });
+  brandingOptions.unshift({
+    value: "",
+    label: `${t("branding.defaultOption")} ${t("branding.default")}`,
+  });
 
   return (
     <div>
@@ -76,7 +79,7 @@ export const Branding = ({ hasBrandingRequestForm }: { hasBrandingRequestForm: b
         {logo ? (
           <img alt={altText} src={logo} width={300} />
         ) : (
-          <Image src={defaultLogo} width="360" height="33" />
+          <Image alt={t("branding.defaultOption")} src={defaultLogo} width="360" height="33" />
         )}
       </div>
       {hasBrandingRequestForm && (

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -161,7 +161,8 @@
   },
   "backToForm": "Back to form",
   "branding": {
-    "defaultOption": "Government of Canada (default)",
+    "defaultOption": "Government of Canada",
+    "default": "(default)",
     "heading": "Branding",
     "notFound": "Didn’t find your department or agency in the list?",
     "preview": "Preview of logo",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -161,7 +161,8 @@
   },
   "backToForm": "Retourner au formulaire",
   "branding": {
-    "defaultOption": "Gouvernement du Canada (par défault)",
+    "defaultOption": "Gouvernement du Canada",
+    "default": "(par défault)",
     "heading": "Image de marque",
     "notFound": "[FR] Didn’t find your department or agency in the list?",
     "preview": "Prévisualisation",


### PR DESCRIPTION
# Summary | Résumé

Discovered on  branch #1563 fixes missing alt text for logo preview

<img width="914" alt="Screen Shot 2023-03-16 at 3 48 30 PM" src="https://user-images.githubusercontent.com/62242/225738851-600d000e-84f8-4068-b31b-d6e0ff8bf917.png">

Also split the text out for (default)

# Test instructions | Instructions pour tester la modification

- Check alt text for branding preview logo

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
