### PR TITLE
Add hint text for vault option

### DIFF
--- a/components/form-builder/app/SetResponseDelivery.tsx
+++ b/components/form-builder/app/SetResponseDelivery.tsx
@@ -17,7 +17,7 @@ enum DeliveryOption {
 }
 
 export const SetResponseDelivery = () => {
-  const { t } = useTranslation("form-builder");
+  const { t, i18n } = useTranslation("form-builder");
   const { status } = useSession();
   const { updateResponseDelivery, uploadJson } = usePublish();
 
@@ -82,6 +82,8 @@ export const SetResponseDelivery = () => {
     setDeliveryOption(value as DeliveryOption);
   }, []);
 
+  const responsesLink = `/${i18n.language}/responses`;
+
   return (
     <>
       <h1 className="visually-hidden">{t("formSettings")}</h1>
@@ -96,7 +98,12 @@ export const SetResponseDelivery = () => {
               value={DeliveryOption.vault}
               label={t("settingsResponseDelivery.vaultOption")}
               onChange={updateDeliveryOption}
-            />
+            >
+              <span className="block ml-3 text-sm mb-1">
+                {t("settingsResponseDelivery.vaultOptionHint.text1")}{" "}
+                <a href={responsesLink}>{t("settingsResponseDelivery.vaultOptionHint.text2")}.</a>
+              </span>
+            </Radio>
             <Radio
               id={`delivery-option-${DeliveryOption.email}`}
               checked={deliveryOption === DeliveryOption.email}

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -449,6 +449,10 @@
   "settingsResponseDelivery": {
     "title": "Select a response delivery option",
     "vaultOption": "Download responses from GC Forms",
+    "vaultOptionHint": {
+      "text1": "Submitted responses will appear on the",
+      "text2": "Responses page"
+    },
     "emailOption": "Email the responses to an inbox",
     "saveButton": "Save changes",
     "savedSuccessMessage": "Your changes have been saved.",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -449,6 +449,10 @@
   "settingsResponseDelivery": {
     "title": "[FR] Select a response delivery option",
     "vaultOption": "[FR] Download responses from GC Forms",
+    "vaultOptionHint": {
+      "text1": "[FR] Submitted responses will appear on the",
+      "text2": "[FR] Responses page"
+    },
     "emailOption": "[FR] Email the responses to an inbox",
     "saveButton": "[FR] Save changes",
     "savedSuccessMessage": "[FR] Your changes have been saved.",


### PR DESCRIPTION
# Summary | Résumé

Adds vault option hint text with link to `Responses`

<img width="611" alt="Screen Shot 2023-03-21 at 1 30 14 PM" src="https://user-images.githubusercontent.com/62242/226693286-7ac96418-f8ed-4cf0-8faf-377196acd994.png">

# Test instructions | Instructions pour tester la modification

- As a logged in user visit setting + vault option


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
