### PR TITLE
Fix 1786 - page text

### DIFF
--- a/components/form-builder/app/edit/elements/lexical-editor/RichTextEditor.tsx
+++ b/components/form-builder/app/edit/elements/lexical-editor/RichTextEditor.tsx
@@ -5,6 +5,10 @@ import { Language } from "../../../../types";
 import debounce from "lodash.debounce";
 import { useTranslation } from "next-i18next";
 
+const _debounced = debounce((updater) => {
+  updater();
+}, 100);
+
 export const RichTextEditor = ({
   path,
   content,
@@ -30,27 +34,12 @@ export const RichTextEditor = ({
     setValue(content);
   }, [content]);
 
-  const _debounced = debounce(
-    useCallback(
-      (value: string) => {
-        if (typeof value === "undefined") {
-          value = "";
-        }
-        updateField(path, value);
-      },
-      [updateField, path]
-    ),
-    100
-  );
-
   const updateValue = useCallback(
     (value: string) => {
       setValue(value);
-      _debounced(value);
+      _debounced(() => updateField(path, value));
     },
-    // exclude _debounced from the dependency array
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setValue]
+    [setValue, path, updateField]
   );
 
   return (


### PR DESCRIPTION
# Summary | Résumé

Fixes: #1786 

Updates dependancies for 

```
const updateValue = useCallback(
```

Simplifies the debounce call and removes the secondary `useCallback` 

The "parent" callback `path` dependancy wasn't being passed updateValue the path index was getting a stale value

# Test instructions | Instructions pour tester la modification

see: https://github.com/cds-snc/platform-forms-client/issues/1786#issue-1642558235

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
