### PR TITLE
Use the same DownloadFile button from Settings on Share Modal

### DIFF
--- a/components/form-builder/app/ShareModalUnauthenticated.tsx
+++ b/components/form-builder/app/ShareModalUnauthenticated.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useRef } from "react";
+import React, { useRef } from "react";
 import { useTranslation } from "next-i18next";
 import { FormElementTypes } from "@lib/types";
 
-import { useDialogRef, Dialog, Button, InfoDetails } from "./shared";
-import { useTemplateStore } from "../store";
+import { useDialogRef, Dialog, Button, InfoDetails, DownloadFileButton } from "./shared";
 import Markdown from "markdown-to-jsx";
 
 export const ShareModalUnauthenticated = ({
@@ -17,34 +16,12 @@ export const ShareModalUnauthenticated = ({
 
   const dialog = useDialogRef();
 
-  const { getSchema } = useTemplateStore((s) => ({
-    getSchema: s.getSchema,
-  }));
-
   const handleCopyToClipboard = async () => {
     if ("clipboard" in navigator) {
       const stringified = instructions.current?.innerText || "";
       await navigator.clipboard.writeText(stringified);
     }
   };
-
-  const handleDownloadJson = useCallback(async () => {
-    async function retrieveFileBlob() {
-      try {
-        const blob = new Blob([getSchema()], { type: "application/json" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = "form.json";
-        a.click();
-        URL.revokeObjectURL(url);
-      } catch (e) {
-        alert("error creating file download");
-      }
-    }
-
-    retrieveFileBlob();
-  }, [getSchema]);
 
   const actions = (
     <>
@@ -83,16 +60,8 @@ export const ShareModalUnauthenticated = ({
 
           <section className="my-8">
             <h3>{t("share.unauthenticated.step1")}</h3>
-            <p>{t("share.unauthenticated.step1Details")}</p>
-            <Button
-              theme="secondary"
-              className="mt-4"
-              onClick={() => {
-                handleDownloadJson();
-              }}
-            >
-              {t("share.unauthenticated.downloadFormFile")}
-            </Button>
+            <p className="mb-4">{t("share.unauthenticated.step1Details")}</p>
+            <DownloadFileButton showInfo={false} />
           </section>
 
           <section className="my-8">


### PR DESCRIPTION
# Summary | Résumé

The Download File button in the unauthenticated Share Modal was downloading a file called `form.json` whereas the Download File button in Settings gave the file a name based on the form title and the date. This brings the same download action from Settings to Share Modal.


| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| Insert Image showing before the change was made | Insert Image showing after a change was made |

# Test instructions | Instructions pour tester la modification

Sequential steps (1., 2., 3., ...) that describe how to test this change. You should include
anything outside the README that will help the developer access your changes and be able to test
them such as any environmental setup steps and/or any time-based elements that this requires.
This will help a developer test things out without too much detective work.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
