### PR TITLE
Handle input focus refs

### DIFF
--- a/components/form-builder/app/Template.tsx
+++ b/components/form-builder/app/Template.tsx
@@ -9,7 +9,6 @@ import { useTemplateStore, TemplateStoreProvider } from "@components/form-builde
 import { LeftNavigation, Header } from "@components/form-builder/app";
 import { Language } from "../types";
 import { TemplateApiProvider } from "../hooks";
-import { RefsProvider } from "./edit/RefsContext";
 import { ToastContainer } from "./shared/Toast";
 
 export const Template = ({
@@ -34,7 +33,7 @@ export const Template = ({
         <div className={`flex flex-col h-full ${className}`}>
           <SkipLink />
           <Header isFormBuilder={isFormBuilder} />
-          <RefsProvider>{page}</RefsProvider>
+          {page}
           <Footer displaySLAAndSupportLinks />
         </div>
       </TemplateApiProvider>

--- a/components/form-builder/app/Template.tsx
+++ b/components/form-builder/app/Template.tsx
@@ -9,6 +9,7 @@ import { useTemplateStore, TemplateStoreProvider } from "@components/form-builde
 import { LeftNavigation, Header } from "@components/form-builder/app";
 import { Language } from "../types";
 import { TemplateApiProvider } from "../hooks";
+import { RefsProvider } from "./edit/RefsContext";
 import { ToastContainer } from "./shared/Toast";
 
 export const Template = ({
@@ -33,7 +34,7 @@ export const Template = ({
         <div className={`flex flex-col h-full ${className}`}>
           <SkipLink />
           <Header isFormBuilder={isFormBuilder} />
-          {page}
+          <RefsProvider>{page}</RefsProvider>
           <Footer displaySLAAndSupportLinks />
         </div>
       </TemplateApiProvider>

--- a/components/form-builder/app/edit/Edit.tsx
+++ b/components/form-builder/app/edit/Edit.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "next-i18next";
 
 import { Language, LocalizedFormProperties } from "../../types";
 import { ElementPanel, ConfirmationDescription, PrivacyDescription } from ".";
+import { RefsProvider } from "./RefsContext";
 import { RichTextLocked } from "./elements";
 import { Input } from "../shared";
 import { useTemplateStore } from "../../store";
@@ -87,10 +88,12 @@ export const Edit = () => {
         schemaProperty="introduction"
         ariaLabel={t("richTextIntroTitle")}
       />
-      {elements.map((element, index: number) => {
-        const item = { ...element, index };
-        return <ElementPanel item={item} key={item.id} />;
-      })}
+      <RefsProvider>
+        {elements.map((element, index: number) => {
+          const item = { ...element, index };
+          return <ElementPanel item={item} key={item.id} />;
+        })}
+      </RefsProvider>
 
       {elements?.length >= 1 && (
         <>

--- a/components/form-builder/app/edit/ElementPanel.tsx
+++ b/components/form-builder/app/edit/ElementPanel.tsx
@@ -4,6 +4,7 @@ import { FormElementWithIndex } from "../../types";
 import { useTemplateStore } from "../../store";
 import { PanelActions, PanelBodyRoot, MoreModal } from "./index";
 import { useIsWithin, useHandleAdd } from "@components/form-builder/hooks";
+import { useRefsContext } from "./RefsContext";
 
 export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
   const { getFocusInput, setFocusInput, remove, moveUp, moveDown, duplicateElement, elements } =
@@ -41,6 +42,7 @@ export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
   }, [className]);
 
   const { focusWithinProps, isWithin } = useIsWithin();
+  const { refs } = useRefsContext();
 
   return (
     <div
@@ -63,9 +65,11 @@ export const ElementPanel = ({ item }: { item: FormElementWithIndex }) => {
         }}
         handleMoveUp={() => {
           moveUp(item.index);
+          refs && refs.current && refs.current[item.id].focus();
         }}
         handleMoveDown={() => {
           moveDown(item.index);
+          refs && refs.current && refs.current[item.id].focus();
         }}
         handleDuplicate={() => {
           setFocusInput(true);

--- a/components/form-builder/app/edit/Modal.tsx
+++ b/components/form-builder/app/edit/Modal.tsx
@@ -25,12 +25,14 @@ export const Modal = ({
   openButton,
   saveButton,
   defaultOpen = false,
+  handleClose = () => null,
 }: {
   title: string;
   children: React.ReactNode;
   openButton?: React.ReactElement;
   saveButton?: React.ReactElement | string | undefined;
   defaultOpen?: boolean;
+  handleClose?: () => void;
 }) => {
   const { updateIsOpen } = useModalStore();
   const [isOpen, setIsOpen] = React.useState<boolean>(defaultOpen);
@@ -47,7 +49,7 @@ export const Modal = ({
         <ModalButton isOpenButton={true} />
       )}
 
-      <ModalContainer title={title} saveButton={saveButton}>
+      <ModalContainer title={title} saveButton={saveButton} handleClose={handleClose}>
         {children}
       </ModalContainer>
     </ModalContext.Provider>
@@ -106,10 +108,12 @@ export const ModalContainer = ({
   title,
   children,
   saveButton,
+  handleClose = () => null,
 }: {
   title: string;
   children: React.ReactNode;
   saveButton?: React.ReactElement | string | undefined;
+  handleClose?: () => void;
 }) => {
   const { t } = useTranslation("form-builder");
   const { isOpen, changeOpen } = useContext(ModalContext);
@@ -119,7 +123,8 @@ export const ModalContainer = ({
   const close = useCallback(() => {
     modalContainer.current?.close();
     changeOpen(false);
-  }, [changeOpen]);
+    handleClose && handleClose();
+  }, [changeOpen, handleClose]);
 
   // focus modal when opened
   useEffect(() => {

--- a/components/form-builder/app/edit/MoreModal.tsx
+++ b/components/form-builder/app/edit/MoreModal.tsx
@@ -6,6 +6,7 @@ import { useTemplateStore, useModalStore } from "../../store";
 import { Button } from "../shared";
 import { Modal } from "./index";
 import { ModalButton, ModalForm } from "./index";
+import { useRefsContext } from "@formbuilder/app/edit/RefsContext";
 
 export const MoreModal = ({
   item,
@@ -21,9 +22,9 @@ export const MoreModal = ({
     getFocusInput: s.getFocusInput,
   }));
 
+  const { refs } = useRefsContext();
   const { t } = useTranslation("form-builder");
   const isRichText = item.type == "richText";
-
   const { isOpen, modals, updateModalProperties, unsetModalField } = useModalStore();
 
   useEffect(() => {
@@ -54,7 +55,14 @@ export const MoreModal = ({
   };
 
   return (
-    <Modal title={t("moreOptions")} openButton={moreButton} saveButton={renderSaveButton()}>
+    <Modal
+      title={t("moreOptions")}
+      openButton={moreButton}
+      saveButton={renderSaveButton()}
+      handleClose={() => {
+        refs && refs.current && refs.current[item.id].focus();
+      }}
+    >
       {!isRichText && modals[item.index] && (
         <ModalForm
           item={item}

--- a/components/form-builder/app/edit/PanelBody.tsx
+++ b/components/form-builder/app/edit/PanelBody.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 
 import {
@@ -39,7 +39,6 @@ export const PanelBody = ({
   const maxLength = properties?.validation?.maxLength;
   const initialSelected = useGetSelectedOption(item);
   const [selectedItem, setSelectedItem] = useState<ElementOption>();
-  const questionInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (selectedItem?.id !== initialSelected.id) {
@@ -77,7 +76,6 @@ export const PanelBody = ({
       {isRichText || isDynamicRow ? (
         <>
           <Question
-            questionInputRef={questionInputRef}
             elements={elements}
             elIndex={elIndex}
             item={item}
@@ -103,7 +101,6 @@ export const PanelBody = ({
             )}
             <div className="w-full mt-4 laptop:mt-0 laptop:w-3/5">
               <Question
-                questionInputRef={questionInputRef}
                 elements={elements}
                 elIndex={elIndex}
                 item={item}

--- a/components/form-builder/app/edit/RefsContext.tsx
+++ b/components/form-builder/app/edit/RefsContext.tsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext, useRef, RefObject } from "react";
+
+interface RefsContextType {
+  refs?: RefObject<HTMLInputElement[]> | undefined;
+}
+
+const RefsContext = createContext<RefsContextType>({});
+
+export function RefsProvider({ children }: { children: React.ReactNode }) {
+  const refs = useRef<HTMLInputElement[]>([]);
+
+  return <RefsContext.Provider value={{ refs }}>{children}</RefsContext.Provider>;
+}
+
+export const useRefsContext = () => useContext(RefsContext);

--- a/components/form-builder/app/edit/elements/question/Question.tsx
+++ b/components/form-builder/app/edit/elements/question/Question.tsx
@@ -9,14 +9,12 @@ export const Question = ({
   elements,
   elIndex,
   onQuestionChange,
-  questionInputRef,
   describedById,
 }: {
   item: FormElementWithIndex;
   elements: FormElement[];
   elIndex?: number;
   onQuestionChange: (itemIndex: number, val: string, lang: Language) => void;
-  questionInputRef: React.RefObject<HTMLInputElement>;
   describedById?: string;
 }) => {
   const { localizeField, translationLanguagePriority } = useTemplateStore((s) => ({
@@ -35,7 +33,6 @@ export const Question = ({
       <QuestionNumber elIndex={elIndex} item={item} elements={elements} />
 
       <QuestionInput
-        questionInputRef={questionInputRef}
         initialValue={title}
         index={itemIndex}
         id={item.id}

--- a/components/form-builder/app/edit/elements/question/QuestionInput.tsx
+++ b/components/form-builder/app/edit/elements/question/QuestionInput.tsx
@@ -28,7 +28,6 @@ export const QuestionInput = ({
     if (!refs || !refs.current || !element) {
       return null;
     }
-
     return (refs.current[id as unknown as number] = element);
   };
 

--- a/components/form-builder/app/edit/elements/question/QuestionInput.tsx
+++ b/components/form-builder/app/edit/elements/question/QuestionInput.tsx
@@ -25,10 +25,11 @@ export const QuestionInput = ({
 
   const { refs } = useRefsContext();
   const getRef = (element: HTMLInputElement) => {
-    if (!refs || !refs.current || !element) {
-      return null;
+    if (!refs || !refs.current || !element || !id) {
+      return;
     }
-    return (refs.current[id as unknown as number] = element);
+
+    return (refs.current[id] = element);
   };
 
   const { getFocusInput, setFocusInput, translationLanguagePriority, getLocalizationAttribute } =

--- a/components/form-builder/app/edit/elements/question/QuestionInput.tsx
+++ b/components/form-builder/app/edit/elements/question/QuestionInput.tsx
@@ -5,24 +5,33 @@ import debounce from "lodash.debounce";
 import { Input } from "@formbuilder/app/shared";
 import { Language } from "@formbuilder/types";
 import { useTemplateStore } from "@formbuilder/store";
+import { useRefsContext } from "@formbuilder/app/edit/RefsContext";
 
 export const QuestionInput = ({
   index,
   id,
   initialValue,
   onQuestionChange,
-  questionInputRef,
   describedById,
 }: {
   index: number;
   id: number;
   initialValue: string;
   onQuestionChange: (itemIndex: number, val: string, lang: Language) => void;
-  questionInputRef: React.RefObject<HTMLInputElement>;
   describedById?: string;
 }) => {
   const { t } = useTranslation("form-builder");
   const [value, setValue] = useState(initialValue);
+
+  const { refs } = useRefsContext();
+  const getRef = (element: HTMLInputElement) => {
+    if (!refs || !refs.current || !element) {
+      return null;
+    }
+
+    return (refs.current[id as unknown as number] = element);
+  };
+
   const { getFocusInput, setFocusInput, translationLanguagePriority, getLocalizationAttribute } =
     useTemplateStore((s) => ({
       setFocusInput: s.setFocusInput,
@@ -33,11 +42,11 @@ export const QuestionInput = ({
 
   useEffect(() => {
     // see: https://github.com/cds-snc/platform-forms-client/pull/1194/commits/cf2d08676cb9dfa7bb500f713cc16cdf653c3e93
-    if (questionInputRef && questionInputRef.current && getFocusInput()) {
-      questionInputRef.current.focus();
+    if (refs && refs.current && getFocusInput()) {
+      refs.current[id].focus();
       setFocusInput(false);
     }
-  }, [getFocusInput, setFocusInput, questionInputRef]);
+  }, [getFocusInput, setFocusInput, id, refs]);
 
   useEffect(() => {
     setValue(initialValue);
@@ -65,7 +74,7 @@ export const QuestionInput = ({
 
   return (
     <Input
-      ref={questionInputRef}
+      ref={getRef}
       type="text"
       id={`item-${id}`}
       name={`item${index}`}


### PR DESCRIPTION
# Summary | Résumé

- Adds a provider / context  to handle keeping an array of question input refs
- Adds handle re-focus content after using the "more modal"
- Adds handle re-focus after moving items up / down

The allows us to focus question inputs by ID as needed

See issue details https://github.com/cds-snc/platform-forms-client/issues/1804

Fix - https://www.youtube.com/watch?v=nNC3HkXjx6k

Stand-alone demo https://mhtj61-5173.csb.app

https://github.com/timarney/input-refs-demo

# Test instructions | Instructions pour tester la modification

- Add 2 elements
- Open the more modal for one of the elements
- Press save
- Focus should be restored to the element 
- Move to the other element --- only on floating menu should appear.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
