### PR TITLE
Use translationLanguagePriority in Form Preview

### DIFF
--- a/components/form-builder/app/Preview.tsx
+++ b/components/form-builder/app/Preview.tsx
@@ -149,6 +149,7 @@ export const Preview = () => {
                   <Button
                     type="submit"
                     id="SubmitButton"
+                    className="mb-4"
                     onClick={(e) => {
                       if (status !== "authenticated") {
                         return preventSubmit(e);

--- a/components/form-builder/app/Preview.tsx
+++ b/components/form-builder/app/Preview.tsx
@@ -88,7 +88,7 @@ export const Preview = () => {
         {status !== "authenticated" ? (
           <div className="bg-purple-200 p-2 inline-block mb-1">
             <Markdown options={{ forceBlock: true }}>
-              {t("signInToTest", { ns: "form-builder" })}
+              {t("signInToTest", { ns: "form-builder", lng: language })}
             </Markdown>
           </div>
         ) : email ? (
@@ -155,7 +155,7 @@ export const Preview = () => {
                       }
                     }}
                   >
-                    {t("submitButton", { ns: "common" })}
+                    {t("submitButton", { ns: "common", lng: language })}
                   </Button>
                 </span>
                 {status !== "authenticated" && (
@@ -164,7 +164,7 @@ export const Preview = () => {
                     {...getLocalizationAttribute()}
                   >
                     <Markdown options={{ forceBlock: true }}>
-                      {t("signInToTest", { ns: "form-builder" })}
+                      {t("signInToTest", { ns: "form-builder", lng: language })}
                     </Markdown>
                   </div>
                 )}

--- a/components/forms/Label/Label.tsx
+++ b/components/forms/Label/Label.tsx
@@ -14,11 +14,23 @@ interface LabelProps {
   required?: boolean;
   validation?: ValidationProperties;
   group?: boolean;
+  lang?: string;
 }
 
 export const Label = (props: LabelProps): React.ReactElement => {
-  const { children, htmlFor, className, error, hint, srOnly, required, validation, id, group } =
-    props;
+  const {
+    children,
+    htmlFor,
+    className,
+    error,
+    hint,
+    srOnly,
+    required,
+    validation,
+    id,
+    group,
+    lang,
+  } = props;
 
   const classes = classnames(
     {
@@ -37,7 +49,7 @@ export const Label = (props: LabelProps): React.ReactElement => {
       {required && (
         <span data-testid="required" aria-hidden>
           {" "}
-          ({validation?.all ? t("all-required") : t("required")})
+          ({validation?.all ? t("all-required") : t("required", { lng: lang })})
         </span>
       )}
       {group && required && (

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -77,6 +77,7 @@ function _buildForm(element: FormElement, lang: string, t: TFunction): ReactElem
       required={isRequired}
       validation={element.properties.validation}
       group={["radio", "checkbox"].indexOf(element.type) !== -1}
+      lang={lang}
     >
       {labelText}
     </Label>


### PR DESCRIPTION
# Summary | Résumé

Fixes #1731 

Thought this was going to be more difficult, but it turns out we're already passing a language down through Preview/Form to the formBuilder which is responsible for rendering the Label which includes the (required) text. By adding a lang prop to the Label component, we can then pass that into the `t()` function that renders the (required) text.

For the Submit button, we pass that in for Preview, so that was pretty straightforward, along with the "Sign in to test..." text.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
