### PR TITLE
Missing strings in Response HTML

### DIFF
--- a/components/myforms/HTMLDownload/ResponseSection.tsx
+++ b/components/myforms/HTMLDownload/ResponseSection.tsx
@@ -187,7 +187,7 @@ export const ResponseSection = ({
         // submissionID={submissionID}
         questionsAnswers={questionsAnswers}
         isRowTable={false}
-        lang={capitalizedLang}
+        lang={lang}
         data-clipboard-text=""
       />
 
@@ -217,7 +217,7 @@ export const ResponseSection = ({
         // submissionID={submissionID}
         questionsAnswers={questionsAnswers}
         isRowTable={true}
-        lang={capitalizedLang}
+        lang={lang}
       />
 
       <h3 id={`confirmReceipt${capitalizedLang}`} className="gc-h2 mt-20">


### PR DESCRIPTION
# Summary | Résumé

The html file downloads were not showing the table headers in French. The problem was a minor typo sending the language in the wrong case (le sigh...)


# Test instructions | Instructions pour tester la modification

Go to the responses page, download a submission and double check the French section table column headers are in French.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

This would be fun to refactor entirely but that can be fore another day

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
