### PR TITLE
fix: data classification in HTML response does not match form settings

### DIFF
--- a/components/myforms/HTMLDownload/ProtectedWarning.tsx
+++ b/components/myforms/HTMLDownload/ProtectedWarning.tsx
@@ -3,20 +3,35 @@ import { useTranslation } from "next-i18next";
 
 // Note: use lang prop if you want to force a specific language e.g. HTMLDownload component
 interface ProtectedWarningProps {
+  securityAttribute: string;
   lang?: string;
 }
 
 export const ProtectedWarning = (props: ProtectedWarningProps) => {
   const { t, i18n } = useTranslation(["my-forms"]);
   const { lang = i18n.language } = props;
+
+  const renderSecurityAttribute = () => {
+    switch (props.securityAttribute) {
+      case "Unclassified":
+        return t("dataClassification.unclassified", { lng: lang });
+      case "Protected A":
+        return t("dataClassification.protectedA", { lng: lang });
+      case "Protected B":
+        return t("dataClassification.protectedB", { lng: lang });
+      default:
+        throw new Error(`Unsupported security attribute ${props.securityAttribute}`);
+    }
+  };
+
   return (
     <div className="flex p-4 justify-between items-center bg-gray-200 border border-gray-300 text-sm">
       <div className="flex flex-col">
-        <p className="font-bold">{t("protectedBWarning.officialRecord", { lng: lang })}</p>
-        <p>{t("protectedBWarning.retainCopy", { lng: lang })}</p>
+        <p className="font-bold">{t("dataClassification.officialRecord", { lng: lang })}</p>
+        <p>{t("dataClassification.retainCopy", { lng: lang })}</p>
       </div>
       <div className="px-4 py-2 bg-white-default font-bold border border-gray-300">
-        {t("protectedBWarning.protectedB", { lng: lang })}
+        {renderSecurityAttribute()}
       </div>
     </div>
   );

--- a/components/myforms/HTMLDownload/ProtectedWarning.tsx
+++ b/components/myforms/HTMLDownload/ProtectedWarning.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useTranslation } from "next-i18next";
+import { SecurityAttribute } from "@lib/types";
 
 // Note: use lang prop if you want to force a specific language e.g. HTMLDownload component
 interface ProtectedWarningProps {
-  securityAttribute: string;
+  securityAttribute: SecurityAttribute;
   lang?: string;
 }
 
@@ -19,8 +20,6 @@ export const ProtectedWarning = (props: ProtectedWarningProps) => {
         return t("dataClassification.protectedA", { lng: lang });
       case "Protected B":
         return t("dataClassification.protectedB", { lng: lang });
-      default:
-        throw new Error(`Unsupported security attribute ${props.securityAttribute}`);
     }
   };
 

--- a/components/myforms/HTMLDownload/index.tsx
+++ b/components/myforms/HTMLDownload/index.tsx
@@ -14,6 +14,7 @@ interface HTMLDownloadProps {
   // submissionID: string;
   responseID: string;
   createdAt: number;
+  securityAttribute: string;
 }
 
 // Note: copy-text-to-clipboard is a very simple and clean lib and works in all browsers but
@@ -31,6 +32,7 @@ const HTMLDownload: NextPageWithLayout<HTMLDownloadProps> = ({
   // submissionID,
   responseID,
   createdAt,
+  securityAttribute,
 }: HTMLDownloadProps) => {
   const CopyToClipboardScript = React.createElement("script", {
     dangerouslySetInnerHTML: {
@@ -75,7 +77,7 @@ const HTMLDownload: NextPageWithLayout<HTMLDownloadProps> = ({
     <>
       <h1 className="sr-only">{`${formTemplate.titleEn} - ${formTemplate.titleFr}`}</h1>
       <div className="mt-14" />
-      <ProtectedWarning lang="en" />
+      <ProtectedWarning securityAttribute={securityAttribute} lang="en" />
       <Fip language="en" />
       <div className="mt-14" />
       <ResponseSection
@@ -88,7 +90,7 @@ const HTMLDownload: NextPageWithLayout<HTMLDownloadProps> = ({
         formResponse={formResponse}
       />
       <div className="mt-20" />
-      <ProtectedWarning lang="fr" />
+      <ProtectedWarning securityAttribute={securityAttribute} lang="fr" />
       <Fip language="fr" />
       <div className="mt-14" />
       <ResponseSection

--- a/components/myforms/HTMLDownload/index.tsx
+++ b/components/myforms/HTMLDownload/index.tsx
@@ -5,7 +5,7 @@ import Fip from "./Fip";
 import { NextPageWithLayout } from "@pages/_app";
 import SkipLink from "@components/globals/SkipLink";
 import Footer from "./Footer";
-import { FormProperties, Responses } from "@lib/types";
+import { FormProperties, Responses, SecurityAttribute } from "@lib/types";
 
 interface HTMLDownloadProps {
   formTemplate: FormProperties;
@@ -14,7 +14,7 @@ interface HTMLDownloadProps {
   // submissionID: string;
   responseID: string;
   createdAt: number;
-  securityAttribute: string;
+  securityAttribute: SecurityAttribute;
 }
 
 // Note: copy-text-to-clipboard is a very simple and clean lib and works in all browsers but

--- a/pages/api/id/[form]/[submission]/download.tsx
+++ b/pages/api/id/[form]/[submission]/download.tsx
@@ -8,7 +8,7 @@ import {
   UpdateCommand,
   UpdateCommandInput,
 } from "@aws-sdk/lib-dynamodb";
-import { MiddlewareProps, WithRequired, Responses } from "@lib/types";
+import { MiddlewareProps, WithRequired, Responses, SecurityAttribute } from "@lib/types";
 import { AccessControlError, createAbility } from "@lib/privileges";
 import React from "react";
 import { renderToStaticNodeStream } from "react-dom/server";
@@ -87,7 +87,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
       confirmReceiptCode: string;
       responseID: string;
       submissionID: string;
-      securityAttribute: string;
+      securityAttribute: SecurityAttribute;
     } => {
       return {
         formResponse: JSON.parse(vaultResult.FormSubmission),

--- a/pages/api/id/[form]/[submission]/download.tsx
+++ b/pages/api/id/[form]/[submission]/download.tsx
@@ -61,8 +61,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
       ExpressionAttributeNames: {
         "#Name": "Name",
       },
-      ProjectionExpression: "SubmissionID,FormSubmission,ConfirmationCode,#Name,CreatedAt",
+      ProjectionExpression:
+        "SubmissionID,FormSubmission,ConfirmationCode,#Name,CreatedAt,SecurityAttribute",
     };
+
     const queryCommand = new GetCommand(getItemsDbParams);
 
     const response = await documentClient.send(queryCommand);
@@ -70,7 +72,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
     // If the SubmissionID does not exist return a 404
     if (response.Item === undefined) return res.status(404).json({ error: "Submission not Found" });
 
-    const { formResponse, createdAt, confirmReceiptCode, responseID, submissionID } = ((
+    const {
+      formResponse,
+      createdAt,
+      confirmReceiptCode,
+      responseID,
+      submissionID,
+      securityAttribute,
+    } = ((
       vaultResult
     ): {
       formResponse: Responses;
@@ -78,6 +87,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
       confirmReceiptCode: string;
       responseID: string;
       submissionID: string;
+      securityAttribute: string;
     } => {
       return {
         formResponse: JSON.parse(vaultResult.FormSubmission),
@@ -87,6 +97,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words
         responseID: vaultResult.Name,
         submissionID: vaultResult.SubmissionID,
+        securityAttribute: vaultResult.SecurityAttribute,
       };
     })(response.Item);
 
@@ -97,6 +108,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
       // submissionID,
       responseID,
       createdAt,
+      securityAttribute,
       pathname: "/",
       query: {},
       ...(await serverSideTranslations("en", ["my-forms", "common"], null, ["fr"])),

--- a/public/static/locales/en/my-forms.json
+++ b/public/static/locales/en/my-forms.json
@@ -58,9 +58,11 @@
     "submissionID": "Submission ID",
     "copyResponse": "Copy answer row to clipboard"
   },
-  "protectedBWarning": {
+  "dataClassification": {
     "officialRecord": "This is an official record",
     "retainCopy": "Retain this copy in accordance to your retention policy.",
+    "unclassified": "UNCLASSIFIED",
+    "protectedA": "PROTECTED A",
     "protectedB": "PROTECTED B"
   }
 }

--- a/public/static/locales/fr/my-forms.json
+++ b/public/static/locales/fr/my-forms.json
@@ -58,9 +58,11 @@
     "submissionID": "Identifiant de la soumission",
     "copyResponse": "Copier la ligne de réponse dans le presse-papiers"
   },
-  "protectedBWarning": {
+  "dataClassification": {
     "officialRecord": "Ceci est un document officiel",
     "retainCopy": "Conservez cette copie conformément à votre politique de conservation.",
+    "unclassified": "NON CLASSIFIÉ",
+    "protectedA": "PROTÉGÉ A",
     "protectedB": "PROTÉGÉ B"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/1934

- Fixed issue where data classification was not properly set in the HTML response. It was static but now relies on the `SecurityAttribute` retrieved from the database.