### PR TITLE
fix: removed space in bulleted list for Markdown rendered pages

### DIFF
--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -95,6 +95,7 @@
 .gc-richText {
   p {
     @extend .gc-p;
+    @apply mb-0;
   }
   h4 {
     @extend .gc-section-header;

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -105,6 +105,14 @@
     @apply mb-10;
   }
 
+  ul,
+  ol {
+    ul,
+    ol {
+      @apply mb-0;
+    }
+  }
+
   ol {
     @apply list-inside;
   }
@@ -207,7 +215,7 @@
   &:active {
     @apply text-white-default top-0.5;
   }
- 
+
   &:visited {
     @apply text-white-default top-0.5;
   }

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -95,10 +95,14 @@
 .gc-richText {
   p {
     @extend .gc-p;
-    @apply mb-0;
   }
+
   h4 {
     @extend .gc-section-header;
+  }
+
+  p:has(+ ul, + ol) {
+    @apply mb-0;
   }
 
   ul,


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/1933

- Removed space in bulleted list for Markdown renderer content