### PR TITLE
Terms of Use - precise number of days

### DIFF
--- a/public/static/content/en/terms-of-use.md
+++ b/public/static/content/en/terms-of-use.md
@@ -30,7 +30,7 @@ You are responsible for:
 
 You are responsible for:
 - Adhering to your departmental guidance for acceptable device and network use.
-- Saving a copy and confirming receipt of your form responses within 46 days of receiving a submission.
+- Saving a copy and confirming receipt of your form responses within 45 days of receiving a submission.
 - Reporting any problems with saved form responses.
 - Handling and saving form responses in accordance with your retention and disposition schedule. 
 - Accepting [GC Notify's terms of use](https://notification.canada.ca/terms). 

--- a/public/static/content/fr/terms-of-use.md
+++ b/public/static/content/fr/terms-of-use.md
@@ -30,7 +30,7 @@ Vous avez pour responsabilité :
 
 Vous avez pour responsabilité :
 - d’adhérer aux directives ministérielles concernant la bonne utilisation des appareils et des réseaux.
-- d’accuser réception des réponses au formulaire et d’en enregistrer une copie dans les 46 jours suivant la réception d’une réponse.
+- d’accuser réception des réponses au formulaire et d’en enregistrer une copie dans les 45 jours suivant la réception d’une réponse.
 - de signaler tout problème lié aux réponses enregistrées.
 - de traiter et d’enregistrer les réponses aux formulaires conformément à votre calendrier de conservation et d’élimination.
 - d’accepter [les conditions d’utilisation de Notification GC](https://notification.canada.ca/conditions-dutilisation). 


### PR DESCRIPTION
Clients need to confirm receipt within 45 days.