### PR TITLE
fix: draft/publish button in view-templates admin page is not working because of API implementation

### DIFF
--- a/pages/api/templates/[formID].ts
+++ b/pages/api/templates/[formID].ts
@@ -103,7 +103,7 @@ const templateCRUD = async ({
           deliveryOption: deliveryOption,
           securityAttribute: securityAttribute,
         });
-      } else if (formID && isPublished) {
+      } else if (formID && isPublished !== undefined) {
         return await updateIsPublishedForTemplate(ability, formID, isPublished);
       } else if (formID && users) {
         return await updateAssignedUsersForTemplate(ability, formID, users);


### PR DESCRIPTION
# Summary | Résumé

- Fixes issue with `isPublished` API not able to unpublish a form