### PR TITLE
Fix/add overlay for menu

### DIFF
--- a/components/globals/Overlay/Overlay.cy.tsx
+++ b/components/globals/Overlay/Overlay.cy.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Overlay } from "./Overlay";
+
+// see: https://on.cypress.io/mounting-react
+
+describe("<Ovleray />", () => {
+  it("Opens and closes as expected", () => {
+    cy.mount(<Overlay />);
+
+    cy.get(`[data-testid="overlay"]`).should("be.visible");
+  });
+
+  it("clicking executes the passed callback", () => {
+    let callbackCalled = false;
+    const callback = () => {
+      callbackCalled = true;
+    };
+
+    cy.mount(<Overlay callback={callback} />);
+
+    cy.get(`[data-testid="overlay"]`).should("be.visible");
+    cy.get(`[data-testid="overlay"]`).click();
+    cy.get(`[data-testid="overlay"]`).then(() => {
+      assert.isTrue(callbackCalled);
+    });
+  });
+});

--- a/components/globals/Overlay/Overlay.tsx
+++ b/components/globals/Overlay/Overlay.tsx
@@ -20,7 +20,8 @@ export const Overlay = ({
   hasOpacity?: boolean;
   hasCursor?: boolean;
 }) => {
-  function handleClose() {
+  // This will probably be used by the parent component to hide the overlay but can do anything
+  function handleCallback() {
     if (typeof callback === "function") {
       callback();
     }
@@ -29,7 +30,7 @@ export const Overlay = ({
   return (
     <div
       data-testid="overlay"
-      onClick={handleClose}
+      onClick={handleCallback}
       className={`z-40 w-screen h-screen fixed top-0 left-0${hasOpacity ? " bg-black/10" : ""}${
         hasCursor ? " cursor-pointer" : ""
       }`}

--- a/components/globals/Overlay/Overlay.tsx
+++ b/components/globals/Overlay/Overlay.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+/**
+ * Shows an overlay that acts to catch any clicks outside of a component to trigger "closing" the
+ * component.
+ *
+ * Note:  The overlay is set to a `z-index: 40`. The component that uses this must have a greater
+ * z-index, e.g. `z-index: 50`. Also any other components behind the overlay must be less than
+ * a z-index of 40.
+ *
+ * Future Thought: if this overlay is heavily used, it would make more sense to become a "singleton"
+ * at the App root level an shared among components using something like useContent + custom hook..
+ */
+export const Overlay = ({
+  callback,
+  hasOpacity = false,
+  hasCursor = false,
+}: {
+  callback?: () => void;
+  hasOpacity?: boolean;
+  hasCursor?: boolean;
+}) => {
+  function handleClose() {
+    if (typeof callback === "function") {
+      callback();
+    }
+  }
+
+  return (
+    <div
+      data-testid="overlay"
+      onClick={handleClose}
+      className={`z-40 w-screen h-screen fixed top-0 left-0${hasOpacity ? " bg-black/10" : ""}${
+        hasCursor ? " cursor-pointer" : ""
+      }`}
+      aria-hidden="true" // Not necessary but being ovious
+    />
+  );
+};

--- a/components/globals/Overlay/Overlay.tsx
+++ b/components/globals/Overlay/Overlay.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 /**
- * Shows an overlay that acts to catch any clicks outside of a component to trigger "closing" the
+ * Shows an overlay that acts to catch any clicks outside of a component to trigger closing/* the
  * component.
  *
  * Note:  The overlay is set to a `z-index: 40`. The component that uses this must have a greater
@@ -9,7 +9,7 @@ import React from "react";
  * a z-index of 40.
  *
  * Future Thought: if this overlay is heavily used, it would make more sense to become a "singleton"
- * at the App root level an shared among components using something like useContent + custom hook..
+ * at the App root level and shared among components using something like useContext + custom hook..
  */
 export const Overlay = ({
   callback,

--- a/components/myforms/MenuDropdown/Menu.ts
+++ b/components/myforms/MenuDropdown/Menu.ts
@@ -9,7 +9,6 @@ interface MenuProps {
 }
 
 // TODO: could also add character search on menu list in future
-// TODO: could add a layer mask to close on click outside, and or use "mouseout" event on container
 
 /**
  * Adds keybaord behavior for a HTML list element.

--- a/components/myforms/MenuDropdown/MenuDropdown.tsx
+++ b/components/myforms/MenuDropdown/MenuDropdown.tsx
@@ -41,7 +41,7 @@ export const MenuDropdown = (props: MenuDropdownProps): React.ReactElement => {
   }, []);
 
   const handleToggle = () => {
-    // Using an if-else to make sure the menu and overlay states stay in sync
+    // Using an if-else vs. single toggle, to make sure the menu and overlay states stay in sync
     if (menuDropdown.isOpen()) {
       menuDropdown?.close();
       setShowOverlay(false);

--- a/components/myforms/MenuDropdown/MenuDropdown.tsx
+++ b/components/myforms/MenuDropdown/MenuDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { Menu } from "./Menu";
+import { Overlay } from "@components/globals/Overlay/Overlay";
 
 export interface MenuDropdownItemCallback {
   message: string;
@@ -26,6 +27,7 @@ export const MenuDropdown = (props: MenuDropdownProps): React.ReactElement => {
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuListRef = useRef<HTMLUListElement>(null);
   const [menuDropdown, setMenuDropdown] = useState({} as Menu);
+  const [showOverlay, setShowOverlay] = useState(false);
 
   useEffect(() => {
     if (menuButtonRef.current && menuListRef.current) {
@@ -38,92 +40,104 @@ export const MenuDropdown = (props: MenuDropdownProps): React.ReactElement => {
     }
   }, []);
 
+  const handleToggle = () => {
+    // Using an if-else to make sure the menu and overlay states stay in sync
+    if (menuDropdown.isOpen()) {
+      menuDropdown?.close();
+      setShowOverlay(false);
+    } else {
+      menuDropdown?.open();
+      setShowOverlay(true);
+    }
+  };
+
   return (
-    <div className="relative">
-      <button
-        onClick={() => {
-          menuDropdown?.toggle();
-        }}
-        onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
-          // Note: Avoiding sending as React.KeyboardEvent.. keeps the menu more generic
-          menuDropdown?.onMenuButtonKey(e as unknown as KeyboardEvent);
-        }}
-        type="button"
-        id={`button-${id}`}
-        className="flex border border-2 border-white-default py-1 pr-1 pl-0 aria-expanded:border-black-default"
-        aria-haspopup="true"
-        aria-controls={`menu-${id}`}
-        ref={menuButtonRef}
-      >
-        {children}
-      </button>
-      <ul
-        id={`menu-${id}`}
-        className={
-          "hidden absolute z-10 -left-[1rem] m-0 p-0 bg-white-default border border-1 border-black-default list-none" +
-          (direction === "up" ? " -top-[13rem]" : "")
-        }
-        role="menu"
-        tabIndex={-1}
-        aria-labelledby={`button-${id}`}
-        aria-activedescendant={`mi-${id}-0`}
-        ref={menuListRef}
-        onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
-          menuDropdown?.onMenuListKeydown(e as unknown as KeyboardEvent);
-        }}
-      >
-        {items &&
-          items?.length > 0 &&
-          items.map((item: MenuDropdownItemI, index: number) => {
-            return (
-              <li
-                id={`mi-${id}-${index}`}
-                role="menuitem"
-                key={`mo-${id}-${index}`}
-                className={`px-4 py-2 first:pt-4 last:pb-4 ${item?.callback ? "relative" : ""}`}
-              >
-                {item.callback ? (
-                  <>
-                    <button
-                      className="action gc-button-link no-underline hover:underline whitespace-nowrap"
-                      onClick={(e) => {
-                        // Shows a success or error status message from a callback
-                        if (!item || !item.callback) {
-                          return;
-                        }
-                        const result = item.callback();
-                        const el = (e.target as HTMLElement).nextElementSibling;
-                        if (el && result?.message) {
-                          el.classList.remove("hidden");
-                          el.textContent = `${result.isError ? t("error") + ": " : ""} ${
-                            result.message
-                          }`;
-                          if (result.isError) {
-                            el.classList.remove("text-green-default");
-                            el.classList.add("text-red-default");
+    <>
+      <div className="relative">
+        <button
+          onClick={handleToggle}
+          onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
+            // Note: Avoiding sending as React.KeyboardEvent.. keeps the menu more generic
+            menuDropdown?.onMenuButtonKey(e as unknown as KeyboardEvent);
+          }}
+          type="button"
+          id={`button-${id}`}
+          className="flex border border-2 border-white-default py-1 pr-1 pl-0 aria-expanded:border-black-default"
+          aria-haspopup="true"
+          aria-controls={`menu-${id}`}
+          ref={menuButtonRef}
+        >
+          {children}
+        </button>
+        <ul
+          id={`menu-${id}`}
+          className={
+            "hidden absolute z-50 -left-[1rem] m-0 p-0 bg-white-default border border-1 border-black-default list-none" +
+            (direction === "up" ? " -top-[13rem]" : "")
+          }
+          role="menu"
+          tabIndex={-1}
+          aria-labelledby={`button-${id}`}
+          aria-activedescendant={`mi-${id}-0`}
+          ref={menuListRef}
+          onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
+            menuDropdown?.onMenuListKeydown(e as unknown as KeyboardEvent);
+          }}
+        >
+          {items &&
+            items?.length > 0 &&
+            items.map((item: MenuDropdownItemI, index: number) => {
+              return (
+                <li
+                  id={`mi-${id}-${index}`}
+                  role="menuitem"
+                  key={`mo-${id}-${index}`}
+                  className={`px-4 py-2 first:pt-4 last:pb-4 ${item?.callback ? "relative" : ""}`}
+                >
+                  {item.callback ? (
+                    <>
+                      <button
+                        className="action gc-button-link no-underline hover:underline whitespace-nowrap"
+                        onClick={(e) => {
+                          // Shows a success or error status message from a callback
+                          if (!item || !item.callback) {
+                            return;
                           }
-                        }
-                      }}
+                          const result = item.callback();
+                          const el = (e.target as HTMLElement).nextElementSibling;
+                          if (el && result?.message) {
+                            el.classList.remove("hidden");
+                            el.textContent = `${result.isError ? t("error") + ": " : ""} ${
+                              result.message
+                            }`;
+                            if (result.isError) {
+                              el.classList.remove("text-green-default");
+                              el.classList.add("text-red-default");
+                            }
+                          }
+                        }}
+                      >
+                        {item.title}
+                      </button>
+                      <div
+                        aria-live="polite"
+                        className="hidden line-clamp-1 absolute top-8 text-[.7rem] text-green-default"
+                      ></div>
+                    </>
+                  ) : (
+                    <a
+                      href={item.url}
+                      className="action no-underline whitespace-nowrap hover:underline active:underline"
                     >
                       {item.title}
-                    </button>
-                    <div
-                      aria-live="polite"
-                      className="hidden line-clamp-1 absolute top-8 text-[.7rem] text-green-default"
-                    ></div>
-                  </>
-                ) : (
-                  <a
-                    href={item.url}
-                    className="action no-underline whitespace-nowrap hover:underline active:underline"
-                  >
-                    {item.title}
-                  </a>
-                )}
-              </li>
-            );
-          })}
-      </ul>
-    </div>
+                    </a>
+                  )}
+                </li>
+              );
+            })}
+        </ul>
+      </div>
+      {showOverlay && <Overlay callback={handleToggle} />}
+    </>
   );
 };


### PR DESCRIPTION
# Summary | Résumé

Adds an overlay component to help with components like the Menu component. It allows an overlay on top of the UI to act as a page wide click area. For the Menu component this helps by giving an area outside the Menu that when clicked will close the menu.

Test by going to the myforms screen. Try opening a menu. Move your mouse around the screen, only the menu links should change the cursor. Clicking outside the menu should close the menu. 