### PR TITLE
Update More Modal to use item ids

### DIFF
--- a/components/form-builder/app/edit/ModalForm.tsx
+++ b/components/form-builder/app/edit/ModalForm.tsx
@@ -72,6 +72,7 @@ export const ModalForm = ({
         <TextArea
           id={`description--modal--${item.index}`}
           placeholder={t("inputDescription")}
+          testId="description-input"
           className="w-11/12"
           onChange={(e) => {
             const description = e.target.value.replace(/[\r\n]/gm, "");

--- a/components/form-builder/app/edit/ModalForm.tsx
+++ b/components/form-builder/app/edit/ModalForm.tsx
@@ -28,7 +28,7 @@ export const ModalForm = ({
 }: {
   item: FormElementWithIndex;
   properties: ElementProperties;
-  updateModalProperties: (index: number, properties: ElementProperties) => void;
+  updateModalProperties: (id: number, properties: ElementProperties) => void;
   unsetModalField: (path: string) => void;
 }) => {
   const { t } = useTranslation("form-builder");
@@ -56,7 +56,7 @@ export const ModalForm = ({
           }
           className="w-11/12"
           onChange={(e) =>
-            updateModalProperties(item.index, {
+            updateModalProperties(item.id, {
               ...properties,
               ...{
                 [localizeField(LocalizedElementProperties.TITLE, translationLanguagePriority)]:
@@ -75,7 +75,7 @@ export const ModalForm = ({
           className="w-11/12"
           onChange={(e) => {
             const description = e.target.value.replace(/[\r\n]/gm, "");
-            updateModalProperties(item.index, {
+            updateModalProperties(item.id, {
               ...properties,
               ...{
                 [localizeField(
@@ -105,7 +105,7 @@ export const ModalForm = ({
             const validation = Object.assign({}, properties.validation, {
               required: e.target.checked,
             });
-            updateModalProperties(item.index, {
+            updateModalProperties(item.id, {
               ...properties,
               ...{ validation },
             });
@@ -133,13 +133,13 @@ export const ModalForm = ({
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               // if value is "", unset the field
               if (e.target.value === "") {
-                unsetModalField(`modals[${item.index}].properties.maxNumberOfRows`);
+                unsetModalField(`modals[${item.id}].properties.maxNumberOfRows`);
                 return;
               }
 
               const value = parseInt(e.target.value);
               if (!isNaN(value) && value >= 1) {
-                updateModalProperties(item.index, {
+                updateModalProperties(item.id, {
                   ...properties,
                   maxNumberOfRows: value,
                 });
@@ -157,7 +157,7 @@ export const ModalForm = ({
             <AutocompleteDropdown
               handleChange={(e) => {
                 const autoComplete = e.target.value;
-                updateModalProperties(item.index, {
+                updateModalProperties(item.id, {
                   ...properties,
                   ...{ autoComplete },
                 });
@@ -196,7 +196,7 @@ export const ModalForm = ({
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     // if value is "", unset the field
                     if (e.target.value === "") {
-                      unsetModalField(`modals[${item.index}].validation.maxLength`);
+                      unsetModalField(`modals[${item.id}].validation.maxLength`);
                       return;
                     }
 
@@ -206,7 +206,7 @@ export const ModalForm = ({
                       const validation = Object.assign({}, properties.validation, {
                         maxLength: value,
                       });
-                      updateModalProperties(item.index, {
+                      updateModalProperties(item.id, {
                         ...properties,
                         ...{ validation },
                       });

--- a/components/form-builder/app/edit/MoreModal.tsx
+++ b/components/form-builder/app/edit/MoreModal.tsx
@@ -30,9 +30,9 @@ export const MoreModal = ({
 
   useEffect(() => {
     if (item.type != "richText") {
-      const index = getElementIndexes(item.id, elements);
-      if (!index || !index[0]) return;
-      updateModalProperties(item.id, elements[index[0]].properties);
+      const indexes = getElementIndexes(item.id, elements);
+      if (!indexes || indexes[0] === null || indexes[0] === undefined) return;
+      updateModalProperties(item.id, elements[indexes[0]].properties);
     }
   }, [item, isOpen, isRichText, elements, updateModalProperties]);
 

--- a/components/form-builder/app/edit/MoreModal.tsx
+++ b/components/form-builder/app/edit/MoreModal.tsx
@@ -7,6 +7,7 @@ import { Button } from "../shared";
 import { Modal } from "./index";
 import { ModalButton, ModalForm } from "./index";
 import { useRefsContext } from "@formbuilder/app/edit/RefsContext";
+import { getPathString, getElementIndexes } from "@formbuilder/getPath";
 
 export const MoreModal = ({
   item,
@@ -29,7 +30,9 @@ export const MoreModal = ({
 
   useEffect(() => {
     if (item.type != "richText") {
-      updateModalProperties(item.index, elements[item.index].properties);
+      const index = getElementIndexes(item.id, elements);
+      if (!index || !index[0]) return;
+      updateModalProperties(item.id, elements[index[0]].properties);
     }
   }, [item, isOpen, isRichText, elements, updateModalProperties]);
 
@@ -38,15 +41,15 @@ export const MoreModal = ({
     return (e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault();
       // replace all of "properties" with the new properties set in the ModalForm
-      updateField(`form.elements[${item.index}].properties`, properties);
+      updateField(getPathString(item.id, elements), properties);
     };
   };
 
   const renderSaveButton = () => {
     return (
       <ModalButton isOpenButton={false}>
-        {modals[item.index] && (
-          <Button className="mr-4" onClick={handleSubmit({ item, properties: modals[item.index] })}>
+        {modals[item.id] && (
+          <Button className="mr-4" onClick={handleSubmit({ item, properties: modals[item.id] })}>
             {t("save")}
           </Button>
         )}
@@ -63,10 +66,10 @@ export const MoreModal = ({
         refs && refs.current && refs.current[item.id] && refs.current[item.id].focus();
       }}
     >
-      {!isRichText && modals[item.index] && (
+      {!isRichText && modals[item.id] && (
         <ModalForm
           item={item}
-          properties={modals[item.index]}
+          properties={modals[item.id]}
           updateModalProperties={updateModalProperties}
           unsetModalField={unsetModalField}
         />

--- a/components/form-builder/app/shared/TextArea.tsx
+++ b/components/form-builder/app/shared/TextArea.tsx
@@ -10,6 +10,7 @@ export const TextArea = ({
   className,
   placeholder,
   lang,
+  testId,
 }: {
   id: string;
   name?: string;
@@ -20,10 +21,12 @@ export const TextArea = ({
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   className?: string;
   lang?: string;
+  testId?: string;
 }) => {
   return (
     <textarea
       id={id}
+      data-testid={testId}
       name={name}
       aria-describedby={describedBy}
       className={`${className} py-2 px-3 my-2 rounded border-1.5 border-black-default border-solid focus:outline-2 focus:outline-blue-focus focus:outline focus:border-blue-focus`}

--- a/components/form-builder/store/useModalStore.tsx
+++ b/components/form-builder/store/useModalStore.tsx
@@ -7,7 +7,7 @@ type ModalStore = {
   isOpen: boolean;
   modals: ElementProperties[];
   updateIsOpen: (isOpen: boolean) => void;
-  updateModalProperties: (index: number, properties: ElementProperties) => void;
+  updateModalProperties: (id: number, properties: ElementProperties) => void;
   unsetModalField: (path: string) => void;
   initialize: () => void;
 };
@@ -31,9 +31,9 @@ export const useModalStore = create<ModalStore>()(
       set((state) => {
         state.isOpen = isOpen;
       }),
-    updateModalProperties: (index, properties) =>
+    updateModalProperties: (id, properties) =>
       set((state) => {
-        state.modals[index] = properties;
+        state.modals[id] = properties;
       }),
     unsetModalField: (path) =>
       set((state) => {

--- a/cypress/e2e/form-builder/form-builder-modal-description.cy.js
+++ b/cypress/e2e/form-builder/form-builder-modal-description.cy.js
@@ -1,0 +1,61 @@
+describe("Form builder modal description", () => {
+  beforeEach(() => {
+    cy.visit("/form-builder/edit", {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        let nextData;
+        Object.defineProperty(win, "__NEXT_DATA__", {
+          set(serverSideProps) {
+            serverSideProps.context = {
+              user: {
+                acceptableUse: false,
+                name: null,
+                userId: "testId",
+              },
+            };
+            nextData = serverSideProps;
+          },
+          get() {
+            return nextData;
+          },
+        });
+      },
+    });
+  });
+
+  it("Renders matching element description in more modal", () => {
+    // see https://github.com/cds-snc/platform-forms-client/issues/2017
+
+    cy.get("button").contains("Add").click();
+    cy.get('[data-testid="date"]').click();
+    cy.get("button").contains("Select block").click();
+    cy.get(".description-text").should("exist").contains("Enter a date. For example: mm/dd/yyyy");
+    cy.get(".example-text").should("exist").contains("mm/dd/yyyy");
+
+    cy.get('#element-1 [data-testid="more"]').click();
+    cy.get('[data-testid="description-input"]').contains("mm/dd/yyyy");
+    cy.get("button").contains("Close").click();
+
+    cy.get("button").contains("Add").click();
+    cy.get('[data-testid="number"]').click();
+    cy.get("button").contains("Select block").click();
+    cy.get(".description-text").should("exist").contains("Only enter numbers");
+    cy.get(".example-text").should("exist").contains("0123456789");
+
+    cy.get('#element-2 [data-testid="more"]').click();
+    cy.get('[data-testid="description-input"]').contains("Only enter numbers");
+    cy.get("button").contains("Close").click();
+
+    // rearrange the first element
+    cy.get('#element-1 [data-testid="moveDown"]').click();
+
+    // check that the descriptions are still correct
+    cy.get('#element-1 [data-testid="more"]').click();
+    cy.get('[data-testid="description-input"]').contains("mm/dd/yyyy");
+    cy.get("button").contains("Close").click();
+
+    cy.get('#element-2 [data-testid="more"]').click();
+    cy.get('[data-testid="description-input"]').contains("Only enter numbers");
+    cy.get("button").contains("Close").click();
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

Fixes: #2017

With the move to use the layout array (https://github.com/cds-snc/platform-forms-client/pull/1956) for element ordering a bug was introduced with the More modal which was based on element indexes.

This PR updates the code to use item.id for the More modal.

# Test instructions | Instructions pour tester la modification

- Add a multiple form elements
- Use the `more` modal to add descriptions 
- Move the elements `up` or `down`
- Ensure the item descriptions match the element



# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
