### PR TITLE
fix: responses page redirect to 404 page if form does not exist (deleted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Form submission timestamp is not reflecting current user timezone.[1860](https://github.com/cds-snc/platform-forms-client/issues/1860)
+- Responses page is not available if form does not exist (deleted). [2023](https://github.com/cds-snc/platform-forms-client/issues/2023)
 
 ## [3.0.1] 2023-04-25
 

--- a/pages/form-builder/index.tsx
+++ b/pages/form-builder/index.tsx
@@ -53,7 +53,20 @@ export const getServerSideProps: GetServerSideProps = async ({
   if (formID && session) {
     try {
       const ability = createAbility(session);
-      FormbuilderParams.initialForm = await getFullTemplateByID(ability, formID);
+
+      const initialForm = await getFullTemplateByID(ability, formID);
+
+      if (initialForm === null) {
+        return {
+          redirect: {
+            // We can redirect to a 'Form does not exist page' in the future
+            destination: `/${locale}/404`,
+            permanent: false,
+          },
+        };
+      }
+
+      FormbuilderParams.initialForm = initialForm;
     } catch (e) {
       if (e instanceof AccessControlError) {
         return {

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -311,10 +311,21 @@ export const getServerSideProps: GetServerSideProps = async ({
   if (formID && session) {
     try {
       const ability = createAbility(session);
-      const [initialForm, allSubmissions] = await Promise.all([
-        getFullTemplateByID(ability, formID),
-        listAllSubmissions(ability, formID),
-      ]);
+
+      const initialForm = await getFullTemplateByID(ability, formID);
+
+      if (initialForm === null) {
+        return {
+          redirect: {
+            // We can redirect to a 'Form does not exist page' in the future
+            destination: `/${locale}/404`,
+            permanent: false,
+          },
+        };
+      }
+
+      const allSubmissions = await listAllSubmissions(ability, formID);
+
       FormbuilderParams.initialForm = initialForm;
       vaultSubmissions.push(...allSubmissions.submissions);
 


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/2023

- Fixed issue where the responses page was still accessible even if the form was marked as deleted. It led to download of responses failing because of the logic behind that requires a form template to succeed.

# Test instructions | Instructions pour tester la modification

- Create a form
- Delete that new form
- Try to access the responses page for that form you just deleted `http://localhost:3000/form-builder/responses/<formId>`. It should redirect you to a 404 page.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
