### PR TITLE
fix: download API can only change status for new responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- Download API will not override a response status that is different than `New`. [2052](https://github.com/cds-snc/platform-forms-client/issues/2052)
+
 ## [3.0.4] 2023-05-05
 
 ### Fixed

--- a/__tests__/api/id/form/submission/download.test.ts
+++ b/__tests__/api/id/form/submission/download.test.ts
@@ -13,6 +13,8 @@ import { mockClient } from "aws-sdk-client-mock";
 import { EventEmitter } from "events";
 import testFormConfig from "../../../../../__fixtures__/accessibilityTestForm.json";
 import { logEvent } from "@lib/auditLogs";
+import { renderToStaticNodeStream } from "react-dom/server";
+import { Readable } from "node:stream";
 
 jest.mock("next-auth/next");
 jest.mock("@lib/auditLogs");
@@ -26,14 +28,20 @@ jest.mock("next-i18next", () => ({
   },
 }));
 
+jest.mock("react-dom/server");
+
+const mockRenderToStaticNodeStream = jest.mocked(renderToStaticNodeStream, { shallow: true });
+
 //Needed in the typescript version of the test so types are inferred correctly
 const mockGetSession = jest.mocked(getServerSession, { shallow: true });
 const mockLogEvent = jest.mocked(logEvent, { shallow: true });
+
 const testFormTemplate = {
   id: "testForm",
   form: testFormConfig,
   isPublished: true,
 };
+
 const testFormResponse = JSON.stringify({
   2: "Jane Doe",
   3: "English",
@@ -73,6 +81,7 @@ describe("/api/id/[form]/[submission]/download", () => {
       expect(res.statusCode).toBe(401);
       expect(JSON.parse(res._getData())).toMatchObject({ error: "Unauthorized" });
     });
+
     test.each(["POST", "DELETE", "PATCH"])(
       "Shouldn't allow an unaccepted method",
       async (httpVerb) => {
@@ -92,6 +101,7 @@ describe("/api/id/[form]/[submission]/download", () => {
       }
     );
   });
+
   describe("Download form submission as a html file", () => {
     beforeEach(() => {
       const mockSession: Session = {
@@ -110,6 +120,7 @@ describe("/api/id/[form]/[submission]/download", () => {
       mockGetSession.mockReset();
       ddbMock.reset();
     });
+
     test.each([
       { form: "a" },
       { submission: "a" },
@@ -132,6 +143,7 @@ describe("/api/id/[form]/[submission]/download", () => {
       expect(res.statusCode).toBe(400);
       expect(JSON.parse(res._getData())).toMatchObject({ error: "Bad Request" });
     });
+
     test("User can only access form responses that a user is associated to", async () => {
       (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
         id: "formTestID",
@@ -169,8 +181,8 @@ describe("/api/id/[form]/[submission]/download", () => {
         "Attemped to download response for submissionID 123456789"
       );
     });
-    test.skip("Renders a HTML file", async () => {
-      // Data mocks
+
+    test("Renders a HTML file", async () => {
       (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
         id: "formTestID",
         jsonConfig: testFormTemplate,
@@ -186,8 +198,18 @@ describe("/api/id/[form]/[submission]/download", () => {
           SecurityAttribute: "Protected B",
         },
       };
+
       ddbMock.on(GetCommand).resolves(dynamodbExpectedResponse);
       ddbMock.on(UpdateCommand).resolves;
+
+      mockRenderToStaticNodeStream.mockReturnValueOnce(
+        new Readable({
+          objectMode: true,
+          read: function () {
+            this.push(null);
+          },
+        })
+      );
 
       const { req, res } = createMocks(
         {
@@ -205,6 +227,7 @@ describe("/api/id/[form]/[submission]/download", () => {
           eventEmitter: EventEmitter,
         }
       );
+
       await download(req, res);
 
       expect(res.statusCode).toBe(200);
@@ -225,6 +248,121 @@ describe("/api/id/[form]/[submission]/download", () => {
       expect(res._getHeaders()).toMatchObject({
         "content-disposition": "attachment; filename=123-test.html",
       });
+    });
+
+    test("When downloading a response with a status equal to New the API should update that status to Downloaded", async () => {
+      (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        id: "formTestID",
+        jsonConfig: testFormTemplate,
+        users: [{ id: "1" }],
+      });
+
+      const dynamodbExpectedResponse = {
+        Item: {
+          FormID: "formTestID",
+          Name: "123-test",
+          SubmissionID: "12",
+          FormSubmission: testFormResponse,
+          SecurityAttribute: "Protected B",
+          Status: "New",
+        },
+      };
+
+      ddbMock.on(GetCommand).resolves(dynamodbExpectedResponse);
+      ddbMock.on(UpdateCommand).resolves;
+
+      mockRenderToStaticNodeStream.mockReturnValueOnce(
+        new Readable({
+          objectMode: true,
+          read: function () {
+            this.push(null);
+          },
+        })
+      );
+
+      const { req, res } = createMocks(
+        {
+          method: "GET",
+          query: {
+            form: "formtestID",
+            submission: "12",
+          },
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+        },
+        {
+          eventEmitter: EventEmitter,
+        }
+      );
+
+      await download(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(
+        ddbMock.commandCalls(UpdateCommand, {
+          UpdateExpression:
+            "SET LastDownloadedBy = :email, DownloadedAt = :downloadedAt, #status = :statusUpdate",
+        }).length
+      ).toBe(1);
+    });
+
+    test("When downloading a response with a status not equal to New the API should not update that status", async () => {
+      (prismaMock.template.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        id: "formTestID",
+        jsonConfig: testFormTemplate,
+        users: [{ id: "1" }],
+      });
+
+      const dynamodbExpectedResponse = {
+        Item: {
+          FormID: "formTestID",
+          Name: "123-test",
+          SubmissionID: "12",
+          FormSubmission: testFormResponse,
+          SecurityAttribute: "Protected B",
+          Status: "Confirmed",
+        },
+      };
+
+      ddbMock.on(GetCommand).resolves(dynamodbExpectedResponse);
+      ddbMock.on(UpdateCommand).resolves;
+
+      mockRenderToStaticNodeStream.mockReturnValueOnce(
+        new Readable({
+          objectMode: true,
+          read: function () {
+            this.push(null);
+          },
+        })
+      );
+
+      const { req, res } = createMocks(
+        {
+          method: "GET",
+          query: {
+            form: "formtestID",
+            submission: "12",
+          },
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:3000",
+          },
+        },
+        {
+          eventEmitter: EventEmitter,
+        }
+      );
+
+      await download(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(
+        ddbMock.commandCalls(UpdateCommand, {
+          UpdateExpression: "SET LastDownloadedBy = :email, DownloadedAt = :downloadedAt",
+        }).length
+      ).toBe(1);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "add": "^2.0.6",
     "autoprefixer": "^10.4.4",
-    "aws-sdk-client-mock": "^0.6.2",
+    "aws-sdk-client-mock": "^2.1.1",
     "axe-core": "^4.5.2",
     "babel-loader": "^8.2.4",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,7 +3607,7 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
 
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
+"@sinonjs/commons@^1.7.0":
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
   integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
@@ -3628,19 +3628,26 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
-"@sinonjs/fake-timers@^7.1.0", "@sinonjs/fake-timers@^7.1.2":
+"@sinonjs/fake-timers@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
   integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sinonjs/samsam@^6.0.2":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.3.tgz#4e30bcd4700336363302a7d72cbec9b9ab87b104"
-  integrity sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==
+"@sinonjs/fake-timers@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
-    "@sinonjs/commons" "^1.6.0"
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/samsam@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-7.0.1.tgz#5b5fa31c554636f78308439d220986b9523fc51f"
+  integrity sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
     lodash.get "^4.4.2"
     type-detect "^4.0.8"
 
@@ -4013,7 +4020,7 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
-"@types/sinon@10.0.10":
+"@types/sinon@^10.0.10":
   version "10.0.10"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.10.tgz#f8acd72fbc2e87c4679f3e2c1ab3530dff1ab6e2"
   integrity sha512-US5E539UfeL2DiWALzCyk0c4zKh6sCv86V/0lpda/afMJJ0oEm2SrKgedH5optvFWstnJ8e1MNYhLmPhAy4rvQ==
@@ -4634,13 +4641,13 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-sdk-client-mock@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/aws-sdk-client-mock/-/aws-sdk-client-mock-0.6.2.tgz#2880d7a7a7e9fcaaf7abdfc01a0f6f22551bc654"
-  integrity sha512-0kH1cyfqGogp69vJitzVducx9q691vGOwg7wEG+DUegGlepjaeskp6YG4SJI0y5Vwh3vi+fP27YQTcWllv4GlQ==
+aws-sdk-client-mock@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/aws-sdk-client-mock/-/aws-sdk-client-mock-2.1.1.tgz#52e5e580fd5654492f9b477153928e373034798e"
+  integrity sha512-UuxXmICU4nmXTRm2BzLZdXmnyI+5NEBb5McRDkObasXVxXChvLm0Ci/PGENh4sCD+Es64SJiz70mtY48JROk0A==
   dependencies:
-    "@types/sinon" "10.0.10"
-    sinon "^11.1.1"
+    "@types/sinon" "^10.0.10"
+    sinon "^14.0.2"
     tslib "^2.1.0"
 
 aws-sign2@~0.7.0:
@@ -8587,7 +8594,7 @@ next@13.2.3:
     "@next/swc-win32-ia32-msvc" "13.2.3"
     "@next/swc-win32-x64-msvc" "13.2.3"
 
-nise@^5.1.0:
+nise@^5.1.2:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
   integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
@@ -10083,16 +10090,16 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-sinon@^11.1.1:
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-11.1.2.tgz#9e78850c747241d5c59d1614d8f9cbe8840e8674"
-  integrity sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==
+sinon@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-14.0.2.tgz#585a81a3c7b22cf950762ac4e7c28eb8b151c46f"
+  integrity sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==
   dependencies:
-    "@sinonjs/commons" "^1.8.3"
-    "@sinonjs/fake-timers" "^7.1.2"
-    "@sinonjs/samsam" "^6.0.2"
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "^9.1.2"
+    "@sinonjs/samsam" "^7.0.1"
     diff "^5.0.0"
-    nise "^5.1.0"
+    nise "^5.1.2"
     supports-color "^7.2.0"
 
 sisteransi@^1.0.5:


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/2052

- Fixed issue where the download API would override the `Status` of a response from `Confirmed` to `Downloaded`. Now it can only update it if it is a `New` response.
- Re enable `Renders a HTML file` unit test. It was only missing a mock for the `renderToStaticNodeStream` function
- Added `aws-sdk-client-mock-jest` package for new download API unit tests
- Upgraded `aws-sdk-client-mock` to version 2.1.1

# Test instructions | Instructions pour tester la modification

- Get yourself in a state where a new response is available for download
- Download the response (status should be updated to Downloaded)
- Confirm the response (status should be update to Confirmed)
- Download the response once again (status SHOULD NOT be updated to Downloaded)

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
