### PR TITLE
Update cypress.yml to use same cache as other workflows

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Cypress Tests
         uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
         with:
+          # we have already installed all dependencies above
+          install: false
           browser: chrome
           headed: false
           build: yarn build:test
@@ -73,6 +75,8 @@ jobs:
       - name: Cypress Component Tests
         uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
         with:
+          # we have already installed all dependencies above
+          install: false
           browser: chrome
           component: true
           headed: false


### PR DESCRIPTION
# Summary | Résumé

A single workflow was building and saving 2 different caches for yarn installations.
We now tell Cypress action that the caches have already been restored.