### PR TITLE
Fix - #2092

### DIFF
--- a/components/form-builder/__tests__/useTemplateStore.test.tsx
+++ b/components/form-builder/__tests__/useTemplateStore.test.tsx
@@ -195,7 +195,7 @@ describe("TemplateStore", () => {
     expect(result.current.form.elements).toHaveLength(3);
 
     act(() => {
-      result.current.duplicateElement(1);
+      result.current.duplicateElement(2);
     });
 
     expect(result.current.form.elements).toHaveLength(4);

--- a/components/form-builder/app/edit/Edit.tsx
+++ b/components/form-builder/app/edit/Edit.tsx
@@ -53,8 +53,10 @@ export const Edit = () => {
     100
   );
 
+  const sortedElements = sortByLayout({ layout, elements: [...elements] });
+
   // grab only the data we need to render the question number
-  const elementTypes = sortByLayout({ layout, elements: [...elements] }).map((element) => ({
+  const elementTypes = sortedElements.map((element) => ({
     id: element.id,
     type: element.type,
   }));
@@ -116,14 +118,16 @@ export const Edit = () => {
         ariaLabel={t("richTextIntroTitle")}
       />
       <RefsProvider>
-        {layout.map((id, index) => {
-          const element = elements.find((element) => element.id === id);
-          if (element) {
-            const questionNumber = getQuestionNumber(element, elementTypes);
-            const item = { ...element, index, questionNumber };
-            return <ElementPanel elements={elements} item={item} key={item.id} />;
-          }
-        })}
+        {layout.length >= 1 &&
+          layout.map((id, index) => {
+            const element = sortedElements.find((element) => element.id === id);
+
+            if (element) {
+              const questionNumber = getQuestionNumber(element, elementTypes);
+              const item = { ...element, index, questionNumber };
+              return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
+            }
+          })}
       </RefsProvider>
       <>
         <RichTextLocked

--- a/components/form-builder/app/edit/ElementPanel.tsx
+++ b/components/form-builder/app/edit/ElementPanel.tsx
@@ -145,7 +145,7 @@ export const ElementPanel = ({
         }}
         handleDuplicate={() => {
           setFocusInput(true);
-          duplicateElement(item.index);
+          duplicateElement(item.id);
         }}
         {...moreButton}
       />

--- a/components/form-builder/app/edit/ElementRequired.tsx
+++ b/components/form-builder/app/edit/ElementRequired.tsx
@@ -9,7 +9,7 @@ export const ElementRequired = ({
   onRequiredChange,
 }: {
   item: FormElementWithIndex;
-  onRequiredChange: (itemIndex: number, checked: boolean) => void;
+  onRequiredChange: (itemId: number, checked: boolean) => void;
 }) => {
   const { t } = useTranslation("form-builder");
   const allRequired = item.properties.validation?.all;
@@ -25,7 +25,7 @@ export const ElementRequired = ({
             return;
           }
 
-          onRequiredChange(item.index, e.target.checked);
+          onRequiredChange(item.id, e.target.checked);
         }}
         label={allRequired ? t("allRequired") : t("required")}
       />

--- a/components/form-builder/app/edit/PanelBody.tsx
+++ b/components/form-builder/app/edit/PanelBody.tsx
@@ -15,8 +15,8 @@ export const PanelBody = ({
 }: {
   item: FormElementWithIndex;
   elIndex?: number;
-  onQuestionChange: (itemIndex: number, val: string, lang: Language) => void;
-  onRequiredChange: (itemIndex: number, checked: boolean) => void;
+  onQuestionChange: (itemId: number, val: string, lang: Language) => void;
+  onRequiredChange: (itemId: number, checked: boolean) => void;
 }) => {
   const { t } = useTranslation("form-builder");
   const isRichText = item.type === "richText";

--- a/components/form-builder/app/edit/PanelBodyRoot.tsx
+++ b/components/form-builder/app/edit/PanelBodyRoot.tsx
@@ -5,7 +5,8 @@ import { FormElementWithIndex, Language, LocalizedElementProperties } from "../.
 import { useTemplateStore } from "../../store";
 
 export const PanelBodyRoot = ({ item }: { item: FormElementWithIndex }) => {
-  const { localizeField, updateField } = useTemplateStore((s) => ({
+  const { updateField, propertyPath } = useTemplateStore((s) => ({
+    propertyPath: s.propertyPath,
     localizeField: s.localizeField,
     updateField: s.updateField,
   }));
@@ -17,18 +18,12 @@ export const PanelBodyRoot = ({ item }: { item: FormElementWithIndex }) => {
   // the `panel body` should be the ony thing that knows about the store
   // and the only thing that should be able to update the store
 
-  const onQuestionChange = (itemIndex: number, val: string, lang: Language) => {
-    updateField(
-      `form.elements[${itemIndex}].properties.${localizeField(
-        LocalizedElementProperties.TITLE,
-        lang
-      )}`,
-      val
-    );
+  const onQuestionChange = (itemId: number, val: string, lang: Language) => {
+    updateField(propertyPath(itemId, LocalizedElementProperties.TITLE, lang), val);
   };
 
-  const onRequiredChange = (itemIndex: number, checked: boolean) => {
-    updateField(`form.elements[${itemIndex}].properties.validation.required`, checked);
+  const onRequiredChange = (itemId: number, checked: boolean) => {
+    updateField(propertyPath(itemId, "validation.required"), checked);
   };
 
   return (

--- a/components/form-builder/app/edit/PanelBodySub.tsx
+++ b/components/form-builder/app/edit/PanelBodySub.tsx
@@ -11,19 +11,15 @@ export const PanelBodySub = ({
 }: {
   item: FormElementWithIndex;
   elIndex: number;
-  onQuestionChange: (elIndex: number, subIndex: number, val: string, lang: Language) => void;
+  onQuestionChange: (itemId: number, val: string, lang: Language) => void;
   onRequiredChange: (subIndex: number, val: boolean) => void;
 }) => {
-  const onQuestionChangeSub = (subIndex: number, val: string, lang: Language) => {
-    onQuestionChange(elIndex, subIndex, val, lang);
-  };
-
   return (
     <div className="py-5">
       <PanelBody
         elIndex={elIndex}
         item={item}
-        onQuestionChange={onQuestionChangeSub}
+        onQuestionChange={onQuestionChange}
         onRequiredChange={onRequiredChange}
       />
     </div>

--- a/components/form-builder/app/edit/elements/Options.tsx
+++ b/components/form-builder/app/edit/elements/Options.tsx
@@ -65,27 +65,27 @@ export const Options = ({
     translationLanguagePriority: s.translationLanguagePriority,
   }));
 
-  const index = item.index;
+  const parentIndex = elements.findIndex((element) => element.id === item.id);
+  const element = elements.find((element) => element.id === item.id);
 
-  if (!elements[index]?.properties) {
+  if (!element?.properties) {
     return null;
   }
-  const { choices } = elements[index].properties;
+  const { choices } = element.properties;
 
   if (!choices) {
-    return <AddOptions index={index} />;
+    return <AddOptions index={parentIndex} />;
   }
 
   const options = choices.map((child, index) => {
     if (!child || !item) return null;
 
-    const initialValue =
-      elements[item.index].properties.choices?.[index][translationLanguagePriority] ?? "";
+    const initialValue = element.properties.choices?.[index][translationLanguagePriority] ?? "";
 
     return (
       <Option
         renderIcon={renderIcon}
-        parentIndex={item.index}
+        parentIndex={parentIndex}
         key={`child-${item.id}-${index}`}
         id={item.id}
         index={index}
@@ -97,7 +97,7 @@ export const Options = ({
   return (
     <div className="mt-5">
       {options}
-      <AddOptions index={index} />
+      <AddOptions index={parentIndex} />
     </div>
   );
 };

--- a/components/form-builder/app/edit/elements/question/Question.tsx
+++ b/components/form-builder/app/edit/elements/question/Question.tsx
@@ -9,7 +9,7 @@ export const Question = ({
   describedById,
 }: {
   item: FormElementWithIndex;
-  onQuestionChange: (itemIndex: number, val: string, lang: Language) => void;
+  onQuestionChange: (itemId: number, val: string, lang: Language) => void;
   describedById?: string;
 }) => {
   const { localizeField, translationLanguagePriority } = useTemplateStore((s) => ({

--- a/components/form-builder/app/edit/elements/question/QuestionInput.tsx
+++ b/components/form-builder/app/edit/elements/question/QuestionInput.tsx
@@ -17,7 +17,7 @@ export const QuestionInput = ({
   index: number;
   id: number;
   initialValue: string;
-  onQuestionChange: (itemIndex: number, val: string, lang: Language) => void;
+  onQuestionChange: (itemId: number, val: string, lang: Language) => void;
   describedById?: string;
 }) => {
   const { t } = useTranslation("form-builder");
@@ -54,8 +54,8 @@ export const QuestionInput = ({
 
   const _debounced = debounce(
     useCallback(
-      (index: number, value: string, lang: Language) => {
-        onQuestionChange(index, value, lang);
+      (id: number, value: string, lang: Language) => {
+        onQuestionChange(id, value, lang);
       },
       [onQuestionChange]
     ),
@@ -63,9 +63,9 @@ export const QuestionInput = ({
   );
 
   const updateValue = useCallback(
-    (index: number, value: string) => {
+    (id: number, value: string) => {
       setValue(value);
-      _debounced(index, value, translationLanguagePriority);
+      _debounced(id, value, translationLanguagePriority);
     },
     // exclude _debounced from the dependency array
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -83,7 +83,7 @@ export const QuestionInput = ({
       className="font-bold text-base"
       value={value}
       describedBy={describedById ?? undefined}
-      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => updateValue(index, e.target.value)}
+      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => updateValue(id, e.target.value)}
       {...getLocalizationAttribute()}
     />
   );

--- a/components/form-builder/app/edit/elements/sub-elements/SubElement.tsx
+++ b/components/form-builder/app/edit/elements/sub-elements/SubElement.tsx
@@ -26,6 +26,7 @@ export const SubElement = ({ item, elIndex, ...props }: { item: FormElement; elI
     localizeField,
     translationLanguagePriority,
     getLocalizationAttribute,
+    propertyPath,
   } = useTemplateStore((s) => ({
     updateField: s.updateField,
     subMoveUp: s.subMoveUp,
@@ -36,6 +37,7 @@ export const SubElement = ({ item, elIndex, ...props }: { item: FormElement; elI
     localizeField: s.localizeField,
     translationLanguagePriority: s.translationLanguagePriority,
     getLocalizationAttribute: s.getLocalizationAttribute,
+    propertyPath: s.propertyPath,
   }));
 
   const { handleAddSubElement } = useHandleAdd();
@@ -51,21 +53,12 @@ export const SubElement = ({ item, elIndex, ...props }: { item: FormElement; elI
     [updateField, localizeField, translationLanguagePriority]
   );
 
-  const onQuestionChange = (elIndex: number, subIndex: number, val: string, lang: Language) => {
-    updateField(
-      `form.elements[${elIndex}].properties.subElements[${subIndex}].properties.${localizeField(
-        LocalizedElementProperties.TITLE,
-        lang
-      )}`,
-      val
-    );
+  const onQuestionChange = (itemId: number, val: string, lang: Language) => {
+    updateField(propertyPath(itemId, LocalizedElementProperties.TITLE, lang), val);
   };
 
-  const onRequiredChange = (elIndex: number, subIndex: number, checked: boolean) => {
-    updateField(
-      `form.elements[${elIndex}].properties.subElements[${subIndex}].properties.validation.required`,
-      checked
-    );
+  const onRequiredChange = (itemId: number, checked: boolean) => {
+    updateField(propertyPath(itemId, "validation.required"), checked);
   };
 
   const elementFilter: ElementOptionsFilter = (elements) => {
@@ -136,9 +129,7 @@ export const SubElement = ({ item, elIndex, ...props }: { item: FormElement; elI
                 elIndex={elIndex}
                 item={item}
                 onQuestionChange={onQuestionChange}
-                onRequiredChange={(subIndex, checked) => {
-                  onRequiredChange(elIndex, subIndex, checked);
-                }}
+                onRequiredChange={onRequiredChange}
               />
             </PanelHightLight>
           </div>

--- a/components/form-builder/app/edit/elements/tests/Question.test.js
+++ b/components/form-builder/app/edit/elements/tests/Question.test.js
@@ -4,6 +4,7 @@ import { Question } from "../question/Question";
 import { useTemplateStore } from "@formbuilder/store";
 import { defaultStore as store, Providers, localStorageMock } from "@formbuilder/test-utils";
 import userEvent from "@testing-library/user-event";
+import { LocalizedElementProperties } from "../../../../types";
 
 // Mock sessionStorage
 Object.defineProperty(window, "sessionStorage", {
@@ -60,13 +61,14 @@ describe("Question", () => {
     const user = userEvent.setup();
 
     const Container = () => {
-      const { elements, updateField } = useTemplateStore((s) => ({
+      const { elements, updateField, propertyPath } = useTemplateStore((s) => ({
         elements: s.form.elements,
         updateField: s.updateField,
+        propertyPath: s.propertyPath,
       }));
 
-      const onQuestionChange = (itemIndex, val) => {
-        updateField(`form.elements[${itemIndex}].properties.titleEn`, val);
+      const onQuestionChange = (itemId, val) => {
+        updateField(propertyPath(itemId, LocalizedElementProperties.TITLE, "en"), val);
       };
 
       const item = { id: 1, index: 0, ...elements[0] };

--- a/components/form-builder/store/useModalStore.tsx
+++ b/components/form-builder/store/useModalStore.tsx
@@ -33,7 +33,9 @@ export const useModalStore = create<ModalStore>()(
       }),
     updateModalProperties: (id, properties) =>
       set((state) => {
-        state.modals[id] = properties;
+        if (id !== -1) {
+          state.modals[id] = properties;
+        }
       }),
     unsetModalField: (path) =>
       set((state) => {

--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -133,7 +133,7 @@ export interface TemplateStoreState extends TemplateStoreProps {
   updateSecurityAttribute: (value: SecurityAttribute) => void;
   propertyPath: (id: number, field: string, lang?: Language) => string;
   unsetField: (path: string) => void;
-  duplicateElement: (elIndex: number) => void;
+  duplicateElement: (id: number) => void;
   subDuplicateElement: (elIndex: number, subIndex: number) => void;
   importTemplate: (jsonConfig: FormProperties) => void;
   getSchema: () => string;
@@ -340,7 +340,8 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
                   subIndex
                 ].properties.choices?.splice(choiceIndex, 1);
               }),
-            duplicateElement: (elIndex) => {
+            duplicateElement: (itemId) => {
+              const elIndex = get().form.elements.findIndex((el) => el.id === itemId);
               set((state) => {
                 const id = incrementElementId(state.form.elements);
                 // deep copy the element


### PR DESCRIPTION
# Summary | Résumé

Per issue #2092 element updates we're happening to the wrong elements after moving elements up / down etc...

This PR makes use of the `propertyPath` helper which takes an `id` to look up the element path vs relying on the index which started breaking when we moved to use the layout array for element ordering.
 
Fixes: #2092

# Test instructions | Instructions pour tester la modification

See "steps to re-create" https://github.com/cds-snc/platform-forms-client/issues/2092

Also:

- Insert at least 3 elements. Be sure 2 of these elements contain "choices" i.e. Radio, Checkboxes, Dropdown
- Enter text into the elements
- Move the items up / down etc...
- Update the text in each --- ensure the text updated is for the correct element
- Test duplicating items


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
