### PR TITLE
feat: allow more symbols to be used in passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated unauthenticated view on form builder tabs (publish and responses). [1869](https://github.com/cds-snc/platform-forms-client/issues/1869)
+- Allow more symbols to be used in passwords. [2095](https://github.com/cds-snc/platform-forms-client/issues/2095)
 
 ## [3.0.5] 2023-05-10
 

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -1,7 +1,12 @@
-import { validateOnSubmit, getErrorList, setFocusOnErrorMessage } from "../validation";
+import {
+  validateOnSubmit,
+  getErrorList,
+  setFocusOnErrorMessage,
+  isValidGovEmail,
+  containsSymbol,
+} from "@lib/validation";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { isValidGovEmail } from "@lib/validation";
 
 function getFormMetaData(type, textType, required = false, formElement = null) {
   return {
@@ -459,4 +464,54 @@ describe("Gov Email domain validator", () => {
   ])(`Should return true if email is valid (testing "%s")`, async (email, isValid) => {
     expect(isValidGovEmail(email)).toBe(isValid);
   });
+});
+
+describe("Test password symbol validation", () => {
+  it.each([
+    ["", false],
+    ["a", false],
+    ["^", true],
+    ["$", true],
+    ["*", true],
+    [".", true],
+    ["[", true],
+    ["]", true],
+    ["{", true],
+    ["}", true],
+    ["(", true],
+    [")", true],
+    ["?", true],
+    ['"', true],
+    ["!", true],
+    ["@", true],
+    ["#", true],
+    ["%", true],
+    ["&", true],
+    ["/", true],
+    ["\\", true],
+    [",", true],
+    [">", true],
+    ["<", true],
+    ["'", true],
+    [":", true],
+    [";", true],
+    ["|", true],
+    ["_", true],
+    ["~", true],
+    ["`", true],
+    ["=", true],
+    ["+", true],
+    ["-", true],
+    ["^^", true],
+    ["^$(", true],
+    ["⌘", false],
+    ["༄", false],
+    ["⌔", false],
+  ])(
+    `Should properly validate or not the use of symbols in password (symbol under test "%s")`,
+    async (symbol, isValid) => {
+      const password = "thisIsMyPassword" + symbol;
+      expect(containsSymbol(password)).toBe(isValid);
+    }
+  );
 });

--- a/lib/tests/validation.test.js
+++ b/lib/tests/validation.test.js
@@ -4,6 +4,9 @@ import {
   setFocusOnErrorMessage,
   isValidGovEmail,
   containsSymbol,
+  containsLowerCaseCharacter,
+  containsUpperCaseCharacter,
+  containsNumber,
 } from "@lib/validation";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -466,7 +469,58 @@ describe("Gov Email domain validator", () => {
   });
 });
 
-describe("Test password symbol validation", () => {
+describe("Tests Password Validation", () => {
+  it.each([
+    ["", false],
+    ["ASDF", false],
+    ["asdf", true],
+    ["@@##", false],
+    ["1234", false],
+    ["ASDF1234", false],
+    ["asdf1234", true],
+    ["asdf1234!@#$", true],
+    ["asdf1234!@#$ASDF", true],
+    ["1234!@#$ASDF", false],
+  ])(
+    `Should return true if password contains lowercase (testing "%s")`,
+    async (password, isValid) => {
+      expect(containsLowerCaseCharacter(password)).toBe(isValid);
+    }
+  );
+  it.each([
+    ["", false],
+    ["ASDF", true],
+    ["asdf", false],
+    ["@@##", false],
+    ["1234", false],
+    ["ASDF1234", true],
+    ["asdf1234", false],
+    ["asdf1234!@#$", false],
+    ["asdf1234!@#$ASDF", true],
+    ["1234!@#$asdf", false],
+  ])(
+    `Should return true if password contains uppercase (testing "%s")`,
+    async (password, isValid) => {
+      expect(containsUpperCaseCharacter(password)).toBe(isValid);
+    }
+  );
+  it.each([
+    ["", false],
+    ["ASDF", false],
+    ["asdf", false],
+    ["@@##", false],
+    ["1234", true],
+    ["ASDF1234", true],
+    ["asdf1234", true],
+    ["asdf!@#$", false],
+    ["asdf1234!@#$ASDF", true],
+    ["ASDF!@#$asdf", false],
+  ])(
+    `Should return true if password contains a number (testing "%s")`,
+    async (password, isValid) => {
+      expect(containsNumber(password)).toBe(isValid);
+    }
+  );
   it.each([
     ["", false],
     ["a", false],

--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -310,7 +310,7 @@ export const isValidGovEmail = (email: string): boolean => {
  * @param field A string containing a lower case character
  * @returns {boolean} The validation result
  */
-export const isLowerCase = (field: string): boolean => {
+export const containsLowerCaseCharacter = (field: string): boolean => {
   const reg = new RegExp("^(?=.*?[a-z])");
   if (!field || !reg.test(field)) {
     return false;
@@ -323,7 +323,7 @@ export const isLowerCase = (field: string): boolean => {
  * @param field A string containing an uppwer case character
  * @returns {boolean} The validation result
  */
-export const isUpperCase = (field: string): boolean => {
+export const containsUpperCaseCharacter = (field: string): boolean => {
   const reg = new RegExp("^(?=.*?[A-Z])");
   if (!field || !reg.test(field)) {
     return false;
@@ -336,7 +336,7 @@ export const isUpperCase = (field: string): boolean => {
  * @param field A string containing a number
  * @returns {boolean} The validation result
  */
-export const isNumber = (field: string): boolean => {
+export const containsNumber = (field: string): boolean => {
   const reg = new RegExp("^(?=.*?[0-9])");
   if (!field || !reg.test(field)) {
     return false;
@@ -349,8 +349,9 @@ export const isNumber = (field: string): boolean => {
  * @param field A string containing a symbol character
  * @returns {boolean} The validation result
  */
-export const isSymbol = (field: string): boolean => {
-  const reg = new RegExp("^(?=.*?[#?!@$%^&*-])");
+export const containsSymbol = (field: string): boolean => {
+  // eslint-disable-next-line no-useless-escape
+  const reg = /^(?=.*?[\^\$\*\.\[\]\{\}\(\)\?\"\!\@\#\%\&\/\\\,\>\<\'\:\;\|\_\~\`\=\+\-])/;
   if (!field || !reg.test(field)) {
     return false;
   }

--- a/pages/auth/resetpassword.tsx
+++ b/pages/auth/resetpassword.tsx
@@ -12,7 +12,13 @@ import { checkOne } from "@lib/cache/flags";
 import Link from "next/link";
 import Head from "next/head";
 import * as Yup from "yup";
-import { isLowerCase, isNumber, isSymbol, isUpperCase, isValidGovEmail } from "@lib/validation";
+import {
+  containsLowerCaseCharacter,
+  containsNumber,
+  containsSymbol,
+  containsUpperCaseCharacter,
+  isValidGovEmail,
+} from "@lib/validation";
 import { ErrorStatus } from "@components/forms/Alert/Alert";
 
 const ResetPassword = () => {
@@ -59,22 +65,22 @@ const ResetPassword = () => {
       .test(
         "password-valid-lowerCase",
         t("resetPassword.fields.password.error.oneLowerCase"),
-        (password = "") => isLowerCase(password)
+        (password = "") => containsLowerCaseCharacter(password)
       )
       .test(
         "password-valid-upperCase",
         t("resetPassword.fields.password.error.oneUpperCase"),
-        (password = "") => isUpperCase(password)
+        (password = "") => containsUpperCaseCharacter(password)
       )
       .test(
         "password-valid-number",
         t("resetPassword.fields.password.error.oneNumber"),
-        (password = "") => isNumber(password)
+        (password = "") => containsNumber(password)
       )
       .test(
         "password-valid-symbol",
         t("resetPassword.fields.password.error.oneSymbol"),
-        (password = "") => isSymbol(password)
+        (password = "") => containsSymbol(password)
       ),
     passwordConfirmation: Yup.string()
       .required(t("input-validation.required", { ns: "common" }))

--- a/pages/signup/register.tsx
+++ b/pages/signup/register.tsx
@@ -8,7 +8,13 @@ import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Confirmation } from "@components/auth/Confirmation/Confirmation";
 import * as Yup from "yup";
-import { isValidGovEmail, isUpperCase, isLowerCase, isNumber, isSymbol } from "@lib/validation";
+import {
+  isValidGovEmail,
+  containsUpperCaseCharacter,
+  containsLowerCaseCharacter,
+  containsNumber,
+  containsSymbol,
+} from "@lib/validation";
 import UserNavLayout from "@components/globals/layouts/UserNavLayout";
 import Loader from "@components/globals/Loader";
 import { authOptions } from "@pages/api/auth/[...nextauth]";
@@ -52,22 +58,22 @@ const Register = () => {
       .test(
         "password-valid-lowerCase",
         t("signUpRegistration.fields.password.error.oneLowerCase"),
-        (password = "") => isLowerCase(password)
+        (password = "") => containsLowerCaseCharacter(password)
       )
       .test(
         "password-valid-upperCase",
         t("signUpRegistration.fields.password.error.oneUpperCase"),
-        (password = "") => isUpperCase(password)
+        (password = "") => containsUpperCaseCharacter(password)
       )
       .test(
         "password-valid-number",
         t("signUpRegistration.fields.password.error.oneNumber"),
-        (password = "") => isNumber(password)
+        (password = "") => containsNumber(password)
       )
       .test(
         "password-valid-symbol",
         t("signUpRegistration.fields.password.error.oneSymbol"),
-        (password = "") => isSymbol(password)
+        (password = "") => containsSymbol(password)
       ),
     passwordConfirmation: Yup.string()
       .required(t("input-validation.required", { ns: "common" }))


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/2095

- Allow more symbols to be used in passwords. (Set of special characters that is now being used can be found [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html))

# Test instructions | Instructions pour tester la modification

- The added unit test will take care of testing that change. 
- If you really want to test something, just create an account with a password that did not work ([see related issue](https://github.com/cds-snc/platform-forms-client/issues/2095)). Make sure you comment out line 122 in `register.tsx`

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
