### PR TITLE
use hasError

### DIFF
--- a/lib/hooks/auth/useLogin.ts
+++ b/lib/hooks/auth/useLogin.ts
@@ -4,6 +4,7 @@ import { signIn } from "next-auth/react";
 import { FormikHelpers } from "formik";
 import { logMessage } from "@lib/logger";
 import { useAuthErrors } from "@lib/hooks/auth/useAuthErrors";
+import { hasError } from "@lib/hasError";
 
 export const useLogin = () => {
   const router = useRouter();
@@ -32,21 +33,18 @@ export const useLogin = () => {
       });
 
       if (response?.error) {
-        const responseErrorMessage = response.error;
+        const error = response.error;
         setSubmitting(false);
-        if (responseErrorMessage.includes("UserNotConfirmedException")) {
+        if (hasError("UserNotConfirmedException", error)) {
           setNeedsConfirmation(true);
-        } else if (
-          responseErrorMessage.includes("UserNotFoundException") ||
-          responseErrorMessage.includes("NotAuthorizedException")
-        ) {
+        } else if (hasError(["UserNotFoundException", "NotAuthorizedException"], error)) {
           handleErrorById("UsernameOrPasswordIncorrect");
-        } else if (responseErrorMessage.includes("GoogleCredentialsExist")) {
+        } else if (hasError("GoogleCredentialsExist", error)) {
           await router.push("/admin/login");
-        } else if (responseErrorMessage.includes("PasswordResetRequiredException")) {
+        } else if (hasError("PasswordResetRequiredException", error)) {
           await router.push("/auth/resetpassword");
         } else {
-          throw Error(responseErrorMessage);
+          throw Error(error);
         }
       } else if (response?.ok) {
         if (didConfirm.current) {

--- a/lib/hooks/auth/useRegister.ts
+++ b/lib/hooks/auth/useRegister.ts
@@ -1,11 +1,11 @@
 import { useRef } from "react";
-import { AxiosError } from "axios";
 import { FormikHelpers } from "formik";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
 import { fetchWithCsrfToken } from "./fetchWithCsrfToken";
 import { useAuthErrors } from "@lib/hooks/auth/useAuthErrors";
 import { logMessage } from "@lib/logger";
+import { hasError } from "@lib/hasError";
 
 export const useRegister = () => {
   const { t } = useTranslation("cognito-errors");
@@ -35,10 +35,8 @@ export const useRegister = () => {
       });
       setNeedsConfirmation(true);
     } catch (err) {
-      const e = err as AxiosError;
-      logMessage.error(e);
-      const message = e.response?.data?.message;
-      if (message?.includes("UsernameExistsException")) {
+      logMessage.error(err);
+      if (hasError("UsernameExistsException", err)) {
         handleErrorById("UsernameExistsException");
         return;
       }


### PR DESCRIPTION
# Summary | Résumé

Follow-up to https://github.com/cds-snc/platform-forms-client/pull/2117 to use re-factor to use hasError

This cuts down on the repeated code to parse Axios error messages

```javascript
const e = err as AxiosError;
const message = e.response?.data?.message;
```

and makes the `includes` lookup easier but adding the ability to pass strings as an array vs multiple str `includes` 

# Test instructions | Instructions pour tester la modification

- signup / register flow

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
