### PR TITLE
feat: added new API to request new 2FA verification code

### DIFF
--- a/pages/api/auth/2fa/request-new-verification-code.ts
+++ b/pages/api/auth/2fa/request-new-verification-code.ts
@@ -1,0 +1,18 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { middleware, cors, csrfProtected } from "@lib/middleware";
+import { requestNew2FAVerificationCode } from "@lib/auth/cognito";
+
+const requestNewVerificationCode = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { email } = req.body;
+
+  if (!email) return res.status(400).json({ error: "Malformed request" });
+
+  await requestNew2FAVerificationCode(email);
+
+  return res.status(200).json({});
+};
+
+export default middleware(
+  [cors({ allowedMethods: ["POST"] }), csrfProtected(["POST"])],
+  requestNewVerificationCode
+);


### PR DESCRIPTION
# Summary | Résumé

- Added very basic API path to request new 2FA verification code. 

API path = `/api/auth/2fa/request-new-verification-code`
Request method = `POST`
Request body = `email: <user_email>`
Requires CSFR token