### PR TITLE
feat: introducing authentication flow token

### DIFF
--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -25,6 +25,8 @@ type DecodedCognitoToken = {
   email: string;
 };
 
+export type AuthenticationFlowToken = string;
+
 export enum Validate2FAVerificationCodeResultStatus {
   VALID,
   INVALID,
@@ -112,34 +114,49 @@ export const initiateSignIn = async ({
   }
 };
 
-export const begin2FAAuthentication = async ({ email, token }: CognitoToken): Promise<void> => {
+export const begin2FAAuthentication = async ({
+  email,
+  token,
+}: CognitoToken): Promise<AuthenticationFlowToken> => {
   const verificationCode = await generateVerificationCode();
 
   const dateIn15Minutes = new Date(Date.now() + 900000); // 15 minutes (= 900000 ms)
 
   try {
-    await prisma.cognitoCustom2FA.create({
+    const result = await prisma.cognitoCustom2FA.create({
       data: {
         email: email,
         cognitoToken: token,
         verificationCode: verificationCode,
         expires: dateIn15Minutes,
       },
+      select: {
+        id: true,
+      },
     });
 
     await sendVerificationCode(email, verificationCode);
+
+    return result.id;
   } catch (error) {
     // handle error if hitting unique constraint
+    throw new Error("begin2FAAuthentication > failure");
   }
 };
 
-export const requestNew2FAVerificationCode = async (email: string): Promise<void> => {
+export const requestNew2FAVerificationCode = async (
+  authenticationFlowToken: AuthenticationFlowToken,
+  email: string
+): Promise<void> => {
   const verificationCode = await generateVerificationCode();
 
   try {
     await prisma.cognitoCustom2FA.update({
       where: {
-        email: email,
+        id_email: {
+          id: authenticationFlowToken,
+          email: email,
+        },
       },
       data: {
         verificationCode: verificationCode,
@@ -149,17 +166,22 @@ export const requestNew2FAVerificationCode = async (email: string): Promise<void
     await sendVerificationCode(email, verificationCode);
   } catch (error) {
     // handle error if hitting unique constraint
+    throw new Error("requestNew2FAVerificationCode > failure");
   }
 };
 
 export const validate2FAVerificationCode = async (
+  authenticationFlowToken: AuthenticationFlowToken,
   email: string,
   verificationCode: string
 ): Promise<Validate2FAVerificationCodeResult> => {
   // Verify if the verification code is valid
   const mfaEntry = await prisma.cognitoCustom2FA.findUnique({
     where: {
-      email: email,
+      id_email: {
+        id: authenticationFlowToken,
+        email: email,
+      },
     },
   });
 

--- a/pages/api/auth/2fa/request-new-verification-code.ts
+++ b/pages/api/auth/2fa/request-new-verification-code.ts
@@ -3,13 +3,18 @@ import { middleware, cors, csrfProtected } from "@lib/middleware";
 import { requestNew2FAVerificationCode } from "@lib/auth/cognito";
 
 const requestNewVerificationCode = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { email } = req.body;
+  const { authenticationFlowToken, email } = req.body;
 
-  if (!email) return res.status(400).json({ error: "Malformed request" });
+  if (!authenticationFlowToken || !email)
+    return res.status(400).json({ error: "Malformed request" });
 
-  await requestNew2FAVerificationCode(email);
-
-  return res.status(200).json({});
+  try {
+    await requestNew2FAVerificationCode(authenticationFlowToken, email);
+    return res.status(200).json({});
+  } catch (error) {
+    // TODO: Proper error handling
+    return res.status(400).json({});
+  }
 };
 
 export default middleware(

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -40,6 +40,7 @@ export const authOptions: NextAuthOptions = {
       id: "cognito",
       name: "CognitoLogin",
       credentials: {
+        authenticationFlowToken: { label: "Authentication flow token", type: "text" },
         username: { label: "Username", type: "text" },
         verificationCode: { label: "Verification Code", type: "text" },
       },
@@ -53,12 +54,16 @@ export const authOptions: NextAuthOptions = {
           };
         }
 
-        const { username, verificationCode } = credentials ?? {};
+        const { authenticationFlowToken, username, verificationCode } = credentials ?? {};
 
         // Check to ensure all required credentials were passed in
-        if (!username || !verificationCode) return null;
+        if (!authenticationFlowToken || !username || !verificationCode) return null;
 
-        const validationResult = await validate2FAVerificationCode(username, verificationCode);
+        const validationResult = await validate2FAVerificationCode(
+          authenticationFlowToken,
+          username,
+          verificationCode
+        );
 
         switch (validationResult.status) {
           case Validate2FAVerificationCodeResultStatus.VALID: {
@@ -201,8 +206,12 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
       });
 
       if (cognitoToken) {
-        await begin2FAAuthentication(cognitoToken);
-        return res.status(200).json({ status: "success", challengeState: "MFA" });
+        const authenticationFlowToken = await begin2FAAuthentication(cognitoToken);
+        return res.status(200).json({
+          status: "success",
+          challengeState: "MFA",
+          authenticationFlowToken: authenticationFlowToken,
+        });
       } else {
         return res.status(400).json({
           status: "error",
@@ -211,7 +220,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
         });
       }
     } catch (error) {
-      return res.status(400).json({
+      return res.status(401).json({
         status: "error",
         error: "Cognito authentication failed",
         reason: (error as Error).message,

--- a/pages/auth/test_2fa.tsx
+++ b/pages/auth/test_2fa.tsx
@@ -13,8 +13,9 @@ const Login = () => {
   return (
     <>
       <Formik
-        initialValues={{ username: "", verificationCode: "" }}
+        initialValues={{ authenticationFlowToken: "", username: "", verificationCode: "" }}
         onSubmit={async (values) => {
+          values.authenticationFlowToken;
           values.username;
           values.verificationCode;
           const { data } = await axios({
@@ -24,6 +25,7 @@ const Login = () => {
               "Content-Type": "application/x-www-form-urlencoded",
             },
             data: new URLSearchParams({
+              authenticationFlowToken: values.authenticationFlowToken,
               username: values.username,
               verificationCode: values.verificationCode,
               csrfToken: (await getCsrfToken()) ?? "noToken",
@@ -39,6 +41,23 @@ const Login = () => {
         {({ handleSubmit }) => (
           <>
             <form id="login" method="POST" onSubmit={handleSubmit} noValidate>
+              <div className="focus-group">
+                <Label
+                  id={"label-authenticationFlowToken"}
+                  htmlFor={"authenticationFlowToken"}
+                  className="required"
+                  required
+                >
+                  {"fields.authenticationFlowToken.label"}
+                </Label>
+                <TextInput
+                  className="h-10 w-full max-w-lg rounded"
+                  type={"text"}
+                  id={"authenticationFlowToken"}
+                  name={"authenticationFlowToken"}
+                  required
+                />
+              </div>
               <div className="focus-group">
                 <Label id={"label-username"} htmlFor={"username"} className="required" required>
                   {"fields.username.label"}

--- a/prisma/migrations/20230523174152_add_cognito_custom_2fa/migration.sql
+++ b/prisma/migrations/20230523174152_add_cognito_custom_2fa/migration.sql
@@ -1,9 +1,12 @@
 -- CreateTable
 CREATE TABLE "CognitoCustom2FA" (
+    "id" TEXT NOT NULL,
     "email" TEXT NOT NULL,
     "cognitoToken" TEXT NOT NULL,
     "verificationCode" TEXT NOT NULL,
-    "expires" TIMESTAMP(3) NOT NULL
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CognitoCustom2FA_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
@@ -11,3 +14,6 @@ CREATE UNIQUE INDEX "CognitoCustom2FA_email_key" ON "CognitoCustom2FA"("email");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "CognitoCustom2FA_verificationCode_key" ON "CognitoCustom2FA"("verificationCode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CognitoCustom2FA_id_email_key" ON "CognitoCustom2FA"("id", "email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,8 +113,11 @@ model Setting {
 }
 
 model CognitoCustom2FA {
+  id                String    @id @default(cuid())
   email             String    @unique
   cognitoToken      String
   verificationCode  String    @unique
   expires           DateTime
+
+  @@unique([id, email])
 }


### PR DESCRIPTION
# Summary | Résumé

- Introducing authentication flow token as an extra layer of security to our authentication APIs (especially the one that can request a new 2FA verification token)