### PR TITLE
Added unit tests for new 2FA code

### DIFF
--- a/lib/auth/2fa.ts
+++ b/lib/auth/2fa.ts
@@ -4,7 +4,7 @@ import crypto from "crypto";
 const TEMPLATE_ID = process.env.TEMPLATE_ID;
 const NOTIFY_API_KEY = process.env.NOTIFY_API_KEY;
 
-export const generateVerificationCode = async () => {
+export const generateVerificationCode = () => {
   // Temporary - for testing purposes
   // Will create more robust code generation in the future
   return crypto.randomBytes(5).toString("hex");

--- a/lib/auth/2faLockout.ts
+++ b/lib/auth/2faLockout.ts
@@ -7,7 +7,7 @@ export interface Lockout2FAResponse {
 }
 
 const LOCKOUT_KEY = "auth:2fa:failed";
-const MAX_FAILED_ATTEMPTS_ALLOWED = 10;
+const MAX_FAILED_ATTEMPTS_ALLOWED = 3;
 
 export async function registerFailed2FAAttempt(email: string): Promise<Lockout2FAResponse> {
   const redis = await getRedisInstance();
@@ -15,7 +15,7 @@ export async function registerFailed2FAAttempt(email: string): Promise<Lockout2F
 
   const isLockedOut = incrementedNumberOfFailedLoginAttempts >= MAX_FAILED_ATTEMPTS_ALLOWED;
 
-  isLockedOut && log2FALockoutEvent(email);
+  if (isLockedOut) logMessage.warn(`2FA session was locked out for user: ${email}`);
 
   return {
     isLockedOut,
@@ -29,8 +29,4 @@ export async function registerFailed2FAAttempt(email: string): Promise<Lockout2F
 export async function clear2FALockout(email: string): Promise<void> {
   const redis = await getRedisInstance();
   await redis.del(`${LOCKOUT_KEY}:${email}`);
-}
-
-async function log2FALockoutEvent(email: string): Promise<void> {
-  logMessage.warn(`2FA session was locked out for user: ${email}`);
 }

--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -124,7 +124,7 @@ export const begin2FAAuthentication = async ({
   email,
   token,
 }: CognitoToken): Promise<AuthenticationFlowToken> => {
-  const verificationCode = await generateVerificationCode();
+  const verificationCode = generateVerificationCode();
 
   const dateIn15Minutes = new Date(Date.now() + 900000); // 15 minutes (= 900000 ms)
 
@@ -154,7 +154,7 @@ export const requestNew2FAVerificationCode = async (
   authenticationFlowToken: AuthenticationFlowToken,
   email: string
 ): Promise<void> => {
-  const verificationCode = await generateVerificationCode();
+  const verificationCode = generateVerificationCode();
 
   try {
     await prisma.cognitoCustom2FA.update({
@@ -181,6 +181,14 @@ export const validate2FAVerificationCode = async (
   email: string,
   verificationCode: string
 ): Promise<Validate2FAVerificationCodeResult> => {
+  const delete2FAVerificationCode = async () => {
+    await prisma.cognitoCustom2FA.deleteMany({
+      where: {
+        email: email,
+      },
+    });
+  };
+
   // Verify if the verification code is valid
   const mfaEntry = await prisma.cognitoCustom2FA.findUnique({
     where: {
@@ -195,11 +203,7 @@ export const validate2FAVerificationCode = async (
   if (mfaEntry === null || mfaEntry.verificationCode !== verificationCode) {
     const lockoutResponse = await registerFailed2FAAttempt(email);
     if (lockoutResponse.isLockedOut) {
-      await prisma.cognitoCustom2FA.deleteMany({
-        where: {
-          email: email,
-        },
-      });
+      await delete2FAVerificationCode();
       await clear2FALockout(email);
       return { status: Validate2FAVerificationCodeResultStatus.LOCKED_OUT };
     } else {
@@ -209,20 +213,13 @@ export const validate2FAVerificationCode = async (
 
   // If the verification code is expired remove it from the database
   if (mfaEntry.expires.getTime() < new Date().getTime()) {
-    await prisma.cognitoCustom2FA.deleteMany({
-      where: {
-        email: email,
-      },
-    });
+    await delete2FAVerificationCode();
+    await clear2FALockout(email);
     return { status: Validate2FAVerificationCodeResultStatus.EXPIRED };
   }
 
   // 2FA is valid, remove the verification code from the database and return user info
-  await prisma.cognitoCustom2FA.deleteMany({
-    where: {
-      email: email,
-    },
-  });
+  await delete2FAVerificationCode();
 
   await clear2FALockout(email);
 

--- a/lib/tests/auth/2fa.test.ts
+++ b/lib/tests/auth/2fa.test.ts
@@ -7,7 +7,7 @@ import { containsLowerCaseCharacter } from "@lib/validation";
 
 describe("Test 2FA library", () => {
   it("Should generate a valid and complex verification code", async () => {
-    const generatedCode = await generateVerificationCode();
+    const generatedCode = generateVerificationCode();
 
     expect(containsLowerCaseCharacter(generatedCode)).toBe(true);
   });

--- a/lib/tests/auth/2fa.test.ts
+++ b/lib/tests/auth/2fa.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
+import { generateVerificationCode } from "@lib/auth/2fa";
+import { containsLowerCaseCharacter } from "@lib/validation";
+
+describe("Test 2FA library", () => {
+  it("Should generate a valid and complex verification code", async () => {
+    const generatedCode = await generateVerificationCode();
+
+    expect(containsLowerCaseCharacter(generatedCode)).toBe(true);
+  });
+});

--- a/lib/tests/auth/2faLockout.test.ts
+++ b/lib/tests/auth/2faLockout.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+
+import Redis from "ioredis-mock";
+import { registerFailed2FAAttempt, clear2FALockout } from "@lib/auth/2faLockout";
+import { logMessage } from "@lib/logger";
+
+const redis = new Redis();
+
+jest.mock("@lib/integration/redisConnector", () => ({
+  getRedisInstance: jest.fn(() => redis),
+}));
+
+jest.mock("@lib/logger");
+
+const mockLogMessage = jest.mocked(logMessage, { shallow: false });
+
+const TEST_EMAIL = "myEmail@email.com";
+
+const registerPreviousFailedAttempts = async (attempts: number) => {
+  const failedAttemps = [];
+  for (let i = 0; i < attempts; i++) {
+    failedAttemps.push(registerFailed2FAAttempt(TEST_EMAIL));
+  }
+
+  await Promise.all(failedAttemps);
+};
+
+describe("Test 2FA lockout library", () => {
+  beforeEach(() => {
+    redis.flushall();
+  });
+
+  it("Should not lock user out even after 2 failed attempts", async () => {
+    await registerPreviousFailedAttempts(1);
+
+    const response = await registerFailed2FAAttempt(TEST_EMAIL);
+
+    expect(response.isLockedOut).toBe(false);
+  });
+
+  it("Should lock user out after 3 failed attempts", async () => {
+    await registerPreviousFailedAttempts(2);
+
+    const response = await registerFailed2FAAttempt(TEST_EMAIL);
+
+    expect(response.isLockedOut).toBe(true);
+    expect(mockLogMessage.warn).toHaveBeenCalledWith(
+      `2FA session was locked out for user: ${TEST_EMAIL}`
+    );
+  });
+
+  it("registerFailed2FAAttempt should return information on remaining number of attempts before lockout", async () => {
+    for (let i = 1; i < 3; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const lockoutResponse = await registerFailed2FAAttempt(TEST_EMAIL);
+      expect(lockoutResponse.isLockedOut).toBe(false);
+      expect(lockoutResponse.remainingNumberOfAttemptsBeforeLockout).toBe(3 - i);
+    }
+  });
+
+  it("Should unlock user if its associated lockout entry was cleared because a new validation code was generated", async () => {
+    await registerPreviousFailedAttempts(1);
+
+    const firstResponse = await registerFailed2FAAttempt(TEST_EMAIL);
+
+    expect(firstResponse.isLockedOut).toBe(false);
+
+    await clear2FALockout(TEST_EMAIL);
+
+    await registerPreviousFailedAttempts(1);
+
+    const secondResponse = await registerFailed2FAAttempt(TEST_EMAIL);
+
+    expect(secondResponse.isLockedOut).toBe(false);
+  });
+});

--- a/lib/tests/auth/cognito.test.ts
+++ b/lib/tests/auth/cognito.test.ts
@@ -1,0 +1,307 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import Redis from "ioredis-mock";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  CognitoIdentityProviderClient,
+  AdminInitiateAuthCommand,
+  AdminInitiateAuthResponse,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { prismaMock } from "@jestUtils";
+import {
+  initiateSignIn,
+  begin2FAAuthentication,
+  requestNew2FAVerificationCode,
+  validate2FAVerificationCode,
+  Validate2FAVerificationCodeResultStatus,
+} from "@lib/auth/cognito";
+import { Base } from "__utils__/permissions";
+import { generateVerificationCode, sendVerificationCode } from "@lib/auth/2fa";
+import { registerFailed2FAAttempt, clear2FALockout } from "@lib/auth/2faLockout";
+
+const redis = new Redis();
+jest.mock("@lib/integration/redisConnector", () => ({
+  getRedisInstance: jest.fn(() => redis),
+}));
+
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+
+jest.mock("@lib/auth/2fa");
+const mockGenerateVerificationCode = jest.mocked(generateVerificationCode, {
+  shallow: true,
+});
+const mockSendVerificationCode = jest.mocked(sendVerificationCode, {
+  shallow: true,
+});
+
+jest.mock("@lib/auth/2faLockout");
+const mockRegisterFailed2FAAttempt = jest.mocked(registerFailed2FAAttempt, {
+  shallow: true,
+});
+const mockClear2FALockout = jest.mocked(clear2FALockout, {
+  shallow: true,
+});
+
+/*
+JWT token including:
+{
+  "sub": "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67",
+  "name": "Test User",
+  "email": "test@test.com"
+}
+*/
+const mockedCognitoToken =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmNGY3Y2VkYi0wZjBiLTQzOTAtOTFhMi02OWU4YzhhMjlmNjciLCJuYW1lIjoiVGVzdCBVc2VyIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIn0.7BofsW0I0SRMb1BWgDuRV_CupOttdsOJXE4JV6kYhyc";
+
+describe("Test Cognito library", () => {
+  beforeEach(() => {
+    redis.flushall();
+  });
+
+  describe("initiateSignIn", () => {
+    it("Should return email with token if Cognito was able to authenticate the user", async () => {
+      (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        id: "3",
+        name: "user_1",
+        email: "fads@asdf.ca",
+        privileges: Base,
+      });
+
+      const cognitoMockedResponse: AdminInitiateAuthResponse = {
+        AuthenticationResult: {
+          IdToken: mockedCognitoToken,
+        },
+      };
+
+      cognitoMock.on(AdminInitiateAuthCommand).resolves(cognitoMockedResponse);
+
+      const signInResponse = await initiateSignIn({
+        username: "test@test.com",
+        password: "testtest",
+      });
+
+      expect(signInResponse?.email).toEqual("test@test.com");
+      expect(signInResponse?.token).toEqual(mockedCognitoToken);
+    });
+
+    it("Should return null if Cognito was not able to authenticate the user", async () => {
+      (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        id: "3",
+        name: "user_1",
+        email: "fads@asdf.ca",
+        privileges: Base,
+      });
+
+      const cognitoMockedResponse: AdminInitiateAuthResponse = {
+        AuthenticationResult: {
+          IdToken: undefined,
+        },
+      };
+
+      cognitoMock.on(AdminInitiateAuthCommand).resolves(cognitoMockedResponse);
+
+      const signInResponse = await initiateSignIn({
+        username: "test@test.com",
+        password: "testtest",
+      });
+
+      expect(signInResponse).toBeNull();
+    });
+  });
+
+  describe("begin2FAAuthentication", () => {
+    it("Should generate a verification code and save it in the database", async () => {
+      const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
+
+      (prismaMock.cognitoCustom2FA.create as jest.MockedFunction<any>).mockResolvedValue({
+        id: mockedId,
+      });
+
+      mockGenerateVerificationCode.mockReturnValueOnce("a1é3_8");
+
+      const begin2FAAuthenticationResponse = await begin2FAAuthentication({
+        email: "test@test.com",
+        token: mockedCognitoToken,
+      });
+
+      expect(prismaMock.cognitoCustom2FA.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: "test@test.com",
+          cognitoToken: mockedCognitoToken,
+          verificationCode: "a1é3_8",
+        }),
+        select: {
+          id: true,
+        },
+      });
+
+      expect(mockSendVerificationCode).toHaveBeenCalled();
+
+      expect(begin2FAAuthenticationResponse).toEqual(mockedId);
+    });
+  });
+
+  describe("requestNew2FAVerificationCode", () => {
+    it("Should generate a new verification code and update the database entry associated to the email address", async () => {
+      const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
+
+      mockGenerateVerificationCode.mockReturnValueOnce("a1é3_8");
+
+      await requestNew2FAVerificationCode(mockedId, "test@test.com");
+
+      expect(prismaMock.cognitoCustom2FA.update).toHaveBeenCalledWith({
+        where: {
+          id_email: {
+            id: mockedId,
+            email: "test@test.com",
+          },
+        },
+        data: {
+          verificationCode: "a1é3_8",
+        },
+      });
+
+      expect(mockSendVerificationCode).toHaveBeenCalled();
+    });
+  });
+
+  describe("validate2FAVerificationCode", () => {
+    it("Should return VALID if email and verification code are both correct", async () => {
+      const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
+      const mockedVerificationCode = "a1é3_8";
+
+      (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        cognitoToken: mockedCognitoToken,
+        verificationCode: mockedVerificationCode,
+        expires: new Date(Date.now() + 10000),
+      });
+
+      const validate2FAVerificationCodeResponse = await validate2FAVerificationCode(
+        mockedId,
+        "test@test.com",
+        mockedVerificationCode
+      );
+
+      expect(validate2FAVerificationCodeResponse).toEqual({
+        status: Validate2FAVerificationCodeResultStatus.VALID,
+        decodedCognitoToken: {
+          id: "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67",
+          name: "Test User",
+          email: "test@test.com",
+        },
+      });
+
+      expect(prismaMock.cognitoCustom2FA.deleteMany).toHaveBeenCalledWith({
+        where: {
+          email: "test@test.com",
+        },
+      });
+
+      expect(mockClear2FALockout).toHaveBeenCalled();
+    });
+
+    it("Should return INVALID if email and/or authentication flow token code are invalid and number of attempts is below 3", async () => {
+      (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      mockRegisterFailed2FAAttempt.mockResolvedValueOnce({
+        isLockedOut: false,
+        remainingNumberOfAttemptsBeforeLockout: 1,
+      });
+
+      const validate2FAVerificationCodeResponse = await validate2FAVerificationCode(
+        "fakeId",
+        "test@test.com",
+        "fakeVerificationCode"
+      );
+
+      expect(validate2FAVerificationCodeResponse).toEqual({
+        status: Validate2FAVerificationCodeResultStatus.INVALID,
+      });
+    });
+
+    it("Should return INVALID if verification code is incorrect and number of attempts is below 3", async () => {
+      const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
+      const mockedVerificationCode = "a1é3_8";
+
+      (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        cognitoToken: mockedCognitoToken,
+        verificationCode: mockedVerificationCode,
+        expires: new Date(Date.now() + 10000),
+      });
+
+      mockRegisterFailed2FAAttempt.mockResolvedValueOnce({
+        isLockedOut: false,
+        remainingNumberOfAttemptsBeforeLockout: 1,
+      });
+
+      const validate2FAVerificationCodeResponse = await validate2FAVerificationCode(
+        mockedId,
+        "test@test.com",
+        "wrongVerificationCode"
+      );
+
+      expect(validate2FAVerificationCodeResponse).toEqual({
+        status: Validate2FAVerificationCodeResultStatus.INVALID,
+      });
+    });
+
+    it("Should return LOCKED_OUT if email and/or verification code are incorrect and number of attempts is 3 or more", async () => {
+      (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      mockRegisterFailed2FAAttempt.mockResolvedValueOnce({
+        isLockedOut: true,
+        remainingNumberOfAttemptsBeforeLockout: 0,
+      });
+
+      const validate2FAVerificationCodeResponse = await validate2FAVerificationCode(
+        "fakeId",
+        "test@test.com",
+        "fakeVerificationCode"
+      );
+
+      expect(validate2FAVerificationCodeResponse).toEqual({
+        status: Validate2FAVerificationCodeResultStatus.LOCKED_OUT,
+      });
+
+      expect(prismaMock.cognitoCustom2FA.deleteMany).toHaveBeenCalledWith({
+        where: {
+          email: "test@test.com",
+        },
+      });
+
+      expect(mockClear2FALockout).toHaveBeenCalled();
+    });
+
+    it("Should return EXPIRED if verification code has expired (2FA session is no longer valid)", async () => {
+      const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
+      const mockedVerificationCode = "a1é3_8";
+
+      (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+        cognitoToken: mockedCognitoToken,
+        verificationCode: mockedVerificationCode,
+        expires: new Date(Date.now() - 10000),
+      });
+
+      const validate2FAVerificationCodeResponse = await validate2FAVerificationCode(
+        mockedId,
+        "test@test.com",
+        mockedVerificationCode
+      );
+
+      expect(validate2FAVerificationCodeResponse).toEqual({
+        status: Validate2FAVerificationCodeResultStatus.EXPIRED,
+      });
+
+      expect(prismaMock.cognitoCustom2FA.deleteMany).toHaveBeenCalledWith({
+        where: {
+          email: "test@test.com",
+        },
+      });
+
+      expect(mockClear2FALockout).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

- Reduced number of allowed attempts from 10 to 3 for 2FA validation mechanism
- Added unit tests for new 2FA code