### PR TITLE
Fixes ErrorPannel home link depending on auth status

### DIFF
--- a/components/globals/ErrorPanel.tsx
+++ b/components/globals/ErrorPanel.tsx
@@ -23,7 +23,11 @@ export const ErrorPanel = ({
 
   // links
   const homeHref =
-    status === "authenticated" ? `/${i18n.language}/myforms` : `/${i18n.language}/form-builder`;
+    status === "authenticated"
+      ? `/${i18n.language}/myforms`
+      : `https://articles.alpha.canada.ca/forms-formulaires/${
+          String(i18n.language).toLowerCase() === "fr" ? "fr/" : ""
+        }`;
 
   const homeText =
     status === "authenticated" ? t("errorPanel.cta.yourForms") : t("errorPanel.cta.home");


### PR DESCRIPTION
# Summary | Résumé

Updates the error pages (ErrorPannel) home link depending on auth status. 

If the user is authenticated then the home link should be to the form builder, otherwise the link should be to the public forms site.