### PR TITLE
feat: renew 2FA verification code when beginning 2FA auth session even if one already exists

### DIFF
--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -129,8 +129,16 @@ export const begin2FAAuthentication = async ({
   const dateIn15Minutes = new Date(Date.now() + 900000); // 15 minutes (= 900000 ms)
 
   try {
-    const result = await prisma.cognitoCustom2FA.create({
-      data: {
+    const result = await prisma.cognitoCustom2FA.upsert({
+      where: {
+        email: email,
+      },
+      update: {
+        cognitoToken: token,
+        verificationCode: verificationCode,
+        expires: dateIn15Minutes,
+      },
+      create: {
         email: email,
         cognitoToken: token,
         verificationCode: verificationCode,
@@ -140,6 +148,8 @@ export const begin2FAAuthentication = async ({
         id: true,
       },
     });
+
+    await clear2FALockout(email);
 
     await sendVerificationCode(email, verificationCode);
 

--- a/lib/tests/auth/cognito.test.ts
+++ b/lib/tests/auth/cognito.test.ts
@@ -116,7 +116,7 @@ describe("Test Cognito library", () => {
     it("Should generate a verification code and save it in the database", async () => {
       const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
 
-      (prismaMock.cognitoCustom2FA.create as jest.MockedFunction<any>).mockResolvedValue({
+      (prismaMock.cognitoCustom2FA.upsert as jest.MockedFunction<any>).mockResolvedValue({
         id: mockedId,
       });
 
@@ -127,8 +127,15 @@ describe("Test Cognito library", () => {
         token: mockedCognitoToken,
       });
 
-      expect(prismaMock.cognitoCustom2FA.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      expect(prismaMock.cognitoCustom2FA.upsert).toHaveBeenCalledWith({
+        where: {
+          email: "test@test.com",
+        },
+        update: expect.objectContaining({
+          cognitoToken: mockedCognitoToken,
+          verificationCode: "a1é3_8",
+        }),
+        create: expect.objectContaining({
           email: "test@test.com",
           cognitoToken: mockedCognitoToken,
           verificationCode: "a1é3_8",
@@ -137,6 +144,8 @@ describe("Test Cognito library", () => {
           id: true,
         },
       });
+
+      expect(mockClear2FALockout).toHaveBeenCalled();
 
       expect(mockSendVerificationCode).toHaveBeenCalled();
 


### PR DESCRIPTION
# Summary | Résumé

- New verification code is being generated and saved when calling `begin2FAAuthentication` even if a code already exists.