### PR TITLE
useConfirm bug issue #2196

### DIFF
--- a/components/auth/Confirmation/Confirmation.tsx
+++ b/components/auth/Confirmation/Confirmation.tsx
@@ -20,7 +20,10 @@ export const Confirmation = ({
   confirmationCallback,
   shouldSignIn = true,
 }: ConfirmationProps): ReactElement => {
-  const { confirm, resendConfirmationCode, authErrorsState, authErrorsReset } = useConfirm();
+  const { confirm, resendConfirmationCode, authErrorsState, authErrorsReset } = useConfirm({
+    username,
+    password,
+  });
   const [showSentReconfirmationToast, setShowSentReconfirmationToast] = useState(false);
   const { t } = useTranslation(["signup", "cognito-errors", "common"]);
 

--- a/lib/hooks/auth/useConfirm.ts
+++ b/lib/hooks/auth/useConfirm.ts
@@ -8,11 +8,9 @@ import { fetchWithCsrfToken } from "./fetchWithCsrfToken";
 import { useAuthErrors } from "./useAuthErrors";
 import { hasError } from "@lib/hasError";
 
-export const useConfirm = () => {
+export const useConfirm = ({ username, password }: { username: string; password: string }) => {
   const router = useRouter();
   const { t } = useTranslation("cognito-errors");
-  const username = useRef("");
-  const password = useRef("");
   const [authErrorsState, { authErrorsReset, handleErrorById }] = useAuthErrors();
 
   const confirm = async (

--- a/lib/hooks/auth/useConfirm.ts
+++ b/lib/hooks/auth/useConfirm.ts
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { useRouter } from "next/router";
 import { signIn } from "next-auth/react";
 import { FormikHelpers } from "formik";


### PR DESCRIPTION
# Summary | Résumé

Updates use confirm to accept props coming from login vs creating new refs.

Fixes #2196

# Test instructions | Instructions pour tester la modification
- To test you'll need an account that `hasn't been confirmed` yet + a local connection to staging for the user pool

- Using an account that hasn't been confirmed try to login 
- Once you receive the email verification code ... enter it 
- You should now be signed in 


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
