### PR TITLE
Put back formTitle for Google Analytics and GTM

### DIFF
--- a/components/form-builder/app/shared/DownloadFileButton.tsx
+++ b/components/form-builder/app/shared/DownloadFileButton.tsx
@@ -98,11 +98,13 @@ export const DownloadFileButton = ({
   }, []);
 
   const downloadFileEvent = () => {
+    const formTitle = slugify(name ? name : i18n.language === "fr" ? form.titleFr : form.titleEn);
     const formId = form.id;
 
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({
       event: "form_download",
+      formTitle,
       formId,
       submitTime: getDate(true),
     });

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -104,6 +104,7 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
               window.dataLayer.push({
                 event: "form_submission_spam_trigger",
                 formID: formID,
+                formTitle: formTitle,
                 submitTime: formTimerState.remainingTime,
               });
 
@@ -319,6 +320,7 @@ export const Form = withFormik<FormProps, Responses>({
       window.dataLayer.push({
         event: "form_submission_trigger",
         formID: formikBag.props.formRecord.id,
+        formTitle: formikBag.props.formRecord.form.titleEn,
       });
 
       formikBag.setSubmitting(false);


### PR DESCRIPTION
# Summary | Résumé

Form titles are used for tracking success in google analytics
There's no other way to easily see this within the application, so putting it back as one of our data points in google analytics