### PR TITLE
fix: GC Notify callback API should only handle form submission type of email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- GC Notify callback API should only handle form submission type of email
+
 ## [v3.0.10] 2023-06-01
 
 ### Fixed

--- a/__tests__/api/notify-callbacks.test.js
+++ b/__tests__/api/notify-callbacks.test.js
@@ -4,8 +4,8 @@
 import { createMocks } from "node-mocks-http";
 import notifyCallback from "../../pages/api/notify-callback";
 import { SQSClient } from "@aws-sdk/client-sqs";
-
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { logMessage } from "@lib/logger";
 
 jest.mock("@aws-sdk/client-sqs");
 jest.mock("@aws-sdk/client-dynamodb");
@@ -14,6 +14,9 @@ jest.mock("@aws-sdk/lib-dynamodb");
 const dynamodbDocumentClient = {
   send: jest.fn(),
 };
+
+jest.mock("@lib/logger");
+const mockLogMessage = jest.mocked(logMessage, { shallow: true });
 
 describe("/api/notify-callbacks", () => {
   beforeAll(() => {
@@ -140,11 +143,15 @@ describe("/api/notify-callbacks", () => {
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res._getData())).toEqual(
-      expect.objectContaining({ status: "submission will not be reprocessed" })
+      expect.objectContaining({
+        status: "submission will not be reprocessed because the email was delivered",
+      })
     );
   });
 
   it("Should respond with code 200 if payload has a deliveryStatus equal to 'permanent-failure' value", async () => {
+    const sqsClientSpy = jest.spyOn(SQSClient.prototype, "send");
+
     const { req, res } = createMocks({
       method: "POST",
       headers: {
@@ -158,11 +165,24 @@ describe("/api/notify-callbacks", () => {
       },
     });
 
+    sqsClientSpy
+      .mockResolvedValueOnce({
+        QueueUrl: "http://queue_url",
+      })
+      .mockImplementation(() => Promise.resolve());
+
+    DynamoDBDocumentClient.from.mockReturnValue(dynamodbDocumentClient);
+
     await notifyCallback(req, res);
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res._getData())).toEqual(
-      expect.objectContaining({ status: "submission will not be reprocessed" })
+      expect.objectContaining({
+        status: "submission will not be reprocessed because the email will never be delivered",
+      })
+    );
+    expect(mockLogMessage.warn.mock.calls[0][0]).toBe(
+      "Form submission something will never be delivered because of a permanent failure (GC Notify)"
     );
   });
 
@@ -195,6 +215,30 @@ describe("/api/notify-callbacks", () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res._getData())).toEqual(
       expect.objectContaining({ status: "submission will be reprocessed" })
+    );
+  });
+
+  it("Should respond with code 200 if payload has a null reference value", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "http://localhost:3000",
+        authorization: `Bearer ${process.env.GC_NOTIFY_CALLBACK_BEARER_TOKEN}`,
+      },
+      body: {
+        reference: null,
+        status: "permanent-failure",
+      },
+    });
+
+    await notifyCallback(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual(
+      expect.objectContaining({
+        status: "submission will not be reprocessed because of missing submission ID",
+      })
     );
   });
 });


### PR DESCRIPTION
# Summary | Résumé

Our GC Notify callback API cannot differentiate between all the types of emails we are sending (form submission, account confirmation, share a form, etc...) with our GC Notify account.
The form submission email does have a reference (submission ID we are manually passing when sending a form submission) that can be sent back to us through the callback while the other emails do not have any (`null`) because it would be irrelevant.