### PR TITLE
fix: do not load recaptcha in form builder preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v3.0.10] 2023-06-05
+### Fixed
+
+- ReCaptcha should not be loaded in form builder preview mode
+
+## [v3.0.11] 2023-06-05
 
 ### Fixed
 

--- a/components/form-builder/app/Preview.tsx
+++ b/components/form-builder/app/Preview.tsx
@@ -122,6 +122,7 @@ export const Preview = () => {
         ) : (
           <Form
             formRecord={formRecord}
+            isPreview={true}
             language={language}
             router={router}
             t={t}

--- a/components/forms/Form/Form.tsx
+++ b/components/forms/Form/Form.tsx
@@ -135,6 +135,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
     handleSubmit,
     status,
     formRecord: { id: formID, reCaptchaID, form },
+    isPreview = false,
   }: InnerFormProps = props;
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(-1);
@@ -147,10 +148,11 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const formStatusError = props.status === "Error" ? t("server-error") : null;
 
   const { status: isReCaptchaEnableOnSite } = useFlag("reCaptcha");
+  const shouldUseRecaptcha = isPreview ? false : isReCaptchaEnableOnSite;
 
   useExternalScript(
     `https://www.google.com/recaptcha/api.js?render=${reCaptchaID}`,
-    isReCaptchaEnableOnSite
+    shouldUseRecaptcha
   );
 
   const handleSubmitReCaptcha = (evt: React.FormEvent<HTMLFormElement>) => {
@@ -245,7 +247,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
             onSubmit={(e) => {
               e.preventDefault();
 
-              if (isReCaptchaEnableOnSite) {
+              if (shouldUseRecaptcha) {
                 handleSubmitReCaptcha(e);
               } else {
                 handleSubmit(e);


### PR DESCRIPTION
# Summary | Résumé

- ReCaptcha will not load in form builder preview mode. 

@anikbrazeau found that the submit button of the form builder preview tab was not working anymore. We broke it when we enabled (recently) Google ReCaptcha in Staging (it is not enabled in Production). This is due to the preview feature not passing the ReCaptcha secret key (the frond end does not have access to that information) to the form component. I decided to take advantage of the `isPreview` parameter to decide whether we should load ReCaptcha or not.

# Test instructions | Instructions pour tester la modification

- Make sure you have enabled ReCaptcha in the Feature flags
- Create a form and try to submit a response through the Preview tab

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
