### PR TITLE
Feature/2fa audit logs

### DIFF
--- a/lib/auth/2faLockout.ts
+++ b/lib/auth/2faLockout.ts
@@ -7,7 +7,7 @@ export interface Lockout2FAResponse {
 }
 
 const LOCKOUT_KEY = "auth:2fa:failed";
-const MAX_FAILED_ATTEMPTS_ALLOWED = 3;
+const MAX_FAILED_ATTEMPTS_ALLOWED = 5;
 
 export async function registerFailed2FAAttempt(email: string): Promise<Lockout2FAResponse> {
   const redis = await getRedisInstance();

--- a/lib/auth/2faLockout.ts
+++ b/lib/auth/2faLockout.ts
@@ -1,5 +1,4 @@
 import { getRedisInstance } from "@lib/integration/redisConnector";
-import { logMessage } from "@lib/logger";
 
 export interface Lockout2FAResponse {
   isLockedOut: boolean;
@@ -14,8 +13,6 @@ export async function registerFailed2FAAttempt(email: string): Promise<Lockout2F
   const incrementedNumberOfFailedLoginAttempts = await redis.incr(`${LOCKOUT_KEY}:${email}`);
 
   const isLockedOut = incrementedNumberOfFailedLoginAttempts >= MAX_FAILED_ATTEMPTS_ALLOWED;
-
-  if (isLockedOut) logMessage.warn(`2FA session was locked out for user: ${email}`);
 
   return {
     isLockedOut,

--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -8,6 +8,7 @@ import { logEvent } from "@lib/auditLogs";
 import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
 import { generateVerificationCode, sendVerificationCode } from "./2fa";
 import { registerFailed2FAAttempt, clear2FALockout } from "./2faLockout";
+import { logMessage } from "@lib/logger";
 
 type Credentials = {
   username: string;
@@ -114,6 +115,8 @@ export const initiateSignIn = async ({
         "UserTooManyFailedAttempts",
         `Password attempts exceeded for ${username}`
       );
+
+      logMessage.warn("Cognito Lockout: Password attempts exceeded");
     }
 
     // throw new Error with cognito error converted to string so as to include the exception name
@@ -234,6 +237,8 @@ export const validate2FAVerificationCode = async (
         "UserTooManyFailedAttempts",
         `2FA attempts exceeded for ${email}`
       );
+
+      logMessage.warn("2FA Lockout: Verification code attempts exceeded");
 
       return { status: Validate2FAVerificationCodeResultStatus.LOCKED_OUT };
     } else {

--- a/lib/tests/auth/2faLockout.test.ts
+++ b/lib/tests/auth/2faLockout.test.ts
@@ -4,17 +4,12 @@
 
 import Redis from "ioredis-mock";
 import { registerFailed2FAAttempt, clear2FALockout } from "@lib/auth";
-import { logMessage } from "@lib/logger";
 
 const redis = new Redis();
 
 jest.mock("@lib/integration/redisConnector", () => ({
   getRedisInstance: jest.fn(() => redis),
 }));
-
-jest.mock("@lib/logger");
-
-const mockLogMessage = jest.mocked(logMessage, { shallow: false });
 
 const TEST_EMAIL = "myEmail@email.com";
 
@@ -46,9 +41,6 @@ describe("Test 2FA lockout library", () => {
     const response = await registerFailed2FAAttempt(TEST_EMAIL);
 
     expect(response.isLockedOut).toBe(true);
-    expect(mockLogMessage.warn).toHaveBeenCalledWith(
-      `2FA session was locked out for user: ${TEST_EMAIL}`
-    );
   });
 
   it("registerFailed2FAAttempt should return information on remaining number of attempts before lockout", async () => {

--- a/lib/tests/auth/2faLockout.test.ts
+++ b/lib/tests/auth/2faLockout.test.ts
@@ -32,16 +32,16 @@ describe("Test 2FA lockout library", () => {
     redis.flushall();
   });
 
-  it("Should not lock user out even after 2 failed attempts", async () => {
-    await registerPreviousFailedAttempts(1);
+  it("Should not lock user out if below maximum number of failed attempts", async () => {
+    await registerPreviousFailedAttempts(3);
 
     const response = await registerFailed2FAAttempt(TEST_EMAIL);
 
     expect(response.isLockedOut).toBe(false);
   });
 
-  it("Should lock user out after 3 failed attempts", async () => {
-    await registerPreviousFailedAttempts(2);
+  it("Should lock user out after maximum number of failed attempts", async () => {
+    await registerPreviousFailedAttempts(4);
 
     const response = await registerFailed2FAAttempt(TEST_EMAIL);
 
@@ -52,11 +52,11 @@ describe("Test 2FA lockout library", () => {
   });
 
   it("registerFailed2FAAttempt should return information on remaining number of attempts before lockout", async () => {
-    for (let i = 1; i < 3; i++) {
+    for (let i = 1; i < 5; i++) {
       // eslint-disable-next-line no-await-in-loop
       const lockoutResponse = await registerFailed2FAAttempt(TEST_EMAIL);
       expect(lockoutResponse.isLockedOut).toBe(false);
-      expect(lockoutResponse.remainingNumberOfAttemptsBeforeLockout).toBe(3 - i);
+      expect(lockoutResponse.remainingNumberOfAttemptsBeforeLockout).toEqual(5 - i);
     }
   });
 

--- a/lib/tests/auth/cognito.test.ts
+++ b/lib/tests/auth/cognito.test.ts
@@ -23,6 +23,7 @@ import { Base } from "__utils__/permissions";
 import { generateVerificationCode, sendVerificationCode } from "@lib/auth/2fa";
 import { registerFailed2FAAttempt, clear2FALockout } from "@lib/auth/2faLockout";
 import { logEvent } from "@lib/auditLogs";
+import { logMessage } from "@lib/logger";
 
 const redis = new Redis();
 jest.mock("@lib/integration/redisConnector", () => ({
@@ -49,6 +50,9 @@ const mockClear2FALockout = jest.mocked(clear2FALockout, {
 
 jest.mock("@lib/auditLogs");
 const mockLogEvent = jest.mocked(logEvent, { shallow: true });
+
+jest.mock("@lib/logger");
+const mockLogMessage = jest.mocked(logMessage, { shallow: false });
 
 /*
 JWT token including:
@@ -131,6 +135,10 @@ describe("Test Cognito library", () => {
         { id: "3", type: "User" },
         "UserTooManyFailedAttempts",
         "Password attempts exceeded for test@test.com"
+      );
+
+      expect(mockLogMessage.warn).toHaveBeenCalledWith(
+        `Cognito Lockout: Password attempts exceeded`
       );
     });
   });
@@ -320,6 +328,10 @@ describe("Test Cognito library", () => {
         { id: "3", type: "User" },
         "UserTooManyFailedAttempts",
         "2FA attempts exceeded for test@test.com"
+      );
+
+      expect(mockLogMessage.warn).toHaveBeenCalledWith(
+        `2FA Lockout: Verification code attempts exceeded`
       );
     });
 

--- a/lib/tests/auth/cognito.test.ts
+++ b/lib/tests/auth/cognito.test.ts
@@ -214,7 +214,7 @@ describe("Test Cognito library", () => {
       expect(mockClear2FALockout).toHaveBeenCalled();
     });
 
-    it("Should return INVALID if email and/or authentication flow token code are invalid and number of attempts is below 3", async () => {
+    it("Should return INVALID if email and/or authentication flow token code are invalid and number of attempts is below maximum allowed", async () => {
       (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue(null);
 
       mockRegisterFailed2FAAttempt.mockResolvedValueOnce({
@@ -233,7 +233,7 @@ describe("Test Cognito library", () => {
       });
     });
 
-    it("Should return INVALID if verification code is incorrect and number of attempts is below 3", async () => {
+    it("Should return INVALID if verification code is incorrect and number of attempts is below maximum allowed", async () => {
       const mockedId = "f4f7cedb-0f0b-4390-91a2-69e8c8a29f67";
       const mockedVerificationCode = "a1é3_8";
 
@@ -259,7 +259,7 @@ describe("Test Cognito library", () => {
       });
     });
 
-    it("Should return LOCKED_OUT if email and/or verification code are incorrect and number of attempts is 3 or more", async () => {
+    it("Should return LOCKED_OUT if email and/or verification code are incorrect and number of attempts is equal or greater than maximum allowed", async () => {
       (prismaMock.cognitoCustom2FA.findUnique as jest.MockedFunction<any>).mockResolvedValue(null);
 
       mockRegisterFailed2FAAttempt.mockResolvedValueOnce({

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -109,12 +109,14 @@ describe("Template CRUD functions", () => {
       },
     });
 
-    expect(newTemplate).toEqual({
-      id: "formtestID",
-      form: formConfiguration,
-      isPublished: false,
-      securityAttribute: "Unclassified",
-    });
+    expect(newTemplate).toEqual(
+      expect.objectContaining({
+        id: "formtestID",
+        form: formConfiguration,
+        isPublished: false,
+        securityAttribute: "Unclassified",
+      })
+    );
 
     expect(mockedLogEvent).toHaveBeenCalledWith(
       fakeSession.user.id,
@@ -137,18 +139,18 @@ describe("Template CRUD functions", () => {
     const templates = await getAllTemplates(ability, "1");
 
     expect(templates).toEqual([
-      {
+      expect.objectContaining({
         id: "formtestID",
         form: formConfiguration,
         isPublished: false,
         securityAttribute: "Unclassified",
-      },
-      {
+      }),
+      expect.objectContaining({
         id: "formtestID2",
         form: formConfiguration,
         isPublished: false,
         securityAttribute: "Unclassified",
-      },
+      }),
     ]);
     if (
       // Can manage all forms
@@ -293,12 +295,14 @@ describe("Template CRUD functions", () => {
       },
     });
 
-    expect(template).toEqual({
-      id: "formtestID",
-      form: formConfiguration,
-      isPublished: false,
-      securityAttribute: "Unclassified",
-    });
+    expect(template).toEqual(
+      expect.objectContaining({
+        id: "formtestID",
+        form: formConfiguration,
+        isPublished: false,
+        securityAttribute: "Unclassified",
+      })
+    );
     expect(mockedLogEvent).toHaveBeenCalledTimes(0);
   });
 
@@ -338,12 +342,14 @@ describe("Template CRUD functions", () => {
       },
     });
 
-    expect(template).toEqual({
-      id: "formtestID",
-      form: formConfiguration,
-      isPublished: false,
-      securityAttribute: "Unclassified",
-    });
+    expect(template).toEqual(
+      expect.objectContaining({
+        id: "formtestID",
+        form: formConfiguration,
+        isPublished: false,
+        securityAttribute: "Unclassified",
+      })
+    );
     expect(mockedLogEvent).toHaveBeenCalledWith(
       fakeSession.user.id,
       { type: "Form", id: "formTestID" },
@@ -458,12 +464,14 @@ describe("Template CRUD functions", () => {
       },
     });
 
-    expect(updatedTemplate).toEqual({
-      id: "test1",
-      form: updatedFormConfig,
-      isPublished: true,
-      securityAttribute: "Unclassified",
-    });
+    expect(updatedTemplate).toEqual(
+      expect.objectContaining({
+        id: "test1",
+        form: updatedFormConfig,
+        isPublished: true,
+        securityAttribute: "Unclassified",
+      })
+    );
     expect(mockedLogEvent).toHaveBeenCalledWith(
       fakeSession.user.id,
       { id: "test1", type: "Form" },
@@ -511,12 +519,14 @@ describe("Template CRUD functions", () => {
       },
     });
 
-    expect(updatedTemplate).toEqual({
-      id: "formtestID",
-      form: formConfiguration,
-      isPublished: true,
-      securityAttribute: "Unclassified",
-    });
+    expect(updatedTemplate).toEqual(
+      expect.objectContaining({
+        id: "formtestID",
+        form: formConfiguration,
+        isPublished: true,
+        securityAttribute: "Unclassified",
+      })
+    );
     expect(mockedLogEvent).toHaveBeenCalledWith(
       fakeSession.user.id,
       { id: "formtestID", type: "Form" },
@@ -720,12 +730,14 @@ describe("Template CRUD functions", () => {
         })
       );
 
-      expect(updatedTemplate).toEqual({
-        id: "formtestID",
-        form: formConfiguration,
-        isPublished: false,
-        securityAttribute: "Unclassified",
-      });
+      expect(updatedTemplate).toEqual(
+        expect.objectContaining({
+          id: "formtestID",
+          form: formConfiguration,
+          isPublished: false,
+          securityAttribute: "Unclassified",
+        })
+      );
       expect(mockedLogEvent).toHaveBeenCalledWith(
         fakeSession.user.id,
         { id: "formtestID", type: "Form" },
@@ -775,12 +787,14 @@ describe("Template CRUD functions", () => {
       })
     );
 
-    expect(deletedTemplate).toEqual({
-      id: "formtestID",
-      form: formConfiguration,
-      isPublished: false,
-      securityAttribute: "Unclassified",
-    });
+    expect(deletedTemplate).toEqual(
+      expect.objectContaining({
+        id: "formtestID",
+        form: formConfiguration,
+        isPublished: false,
+        securityAttribute: "Unclassified",
+      })
+    );
 
     expect(mockedLogEvent).toHaveBeenCalledWith(
       fakeSession.user.id,


### PR DESCRIPTION
# Summary | Résumé

Related to https://github.com/cds-snc/platform-forms-client/issues/2150
Goes with https://github.com/cds-snc/forms-terraform/pull/400

- Increased maximum number of allowed 2FA failed attempts from 3 to 5
- Added an audit log for when a user is locked out of 2FA validation session
- Added warn logs for upcoming CloudWatch alarms

# Test instructions | Instructions pour tester la modification

- Get into a 2FA validation session (you are on the 2FA verification code page)
- Enter 5 invalid codes in a row
- Look into your DynamoDB `AuditLogs` table to see if a new log was published. Here is how to do it within your terraform folder:
     - `cd aws/app/lambda`
     - `./invoke_audit_logs.sh`
     - `aws dynamodb scan --table-name AuditLogs --endpoint http://localhost:4566`

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
