### PR TITLE
chore: Add to Cypress login test

### DIFF
--- a/cypress/e2e/login_page.cy.ts
+++ b/cypress/e2e/login_page.cy.ts
@@ -61,12 +61,26 @@ describe("Login Page", () => {
       cy.get("[type='submit']").click();
       cy.get("[id='errorMessagepassword']").should("not.exist");
     });
-
-    it("Sucessfully signs in", () => {
+  });
+  describe("User 2FA screen", () => {
+    beforeEach(() => {
+      cy.visitPage("/en/auth/login");
       cy.get("input[id='username']").type("test.user@cds-snc.ca");
       cy.get("input[id='password']").type("testTesttest");
       cy.get("[type='submit']").click();
-      cy.url().should("contain", "/auth/policy");
+    });
+    it("page renders", () => {
+      cy.get("[id='verificationCodeForm']").should("be.visible");
+      cy.get("[data-testid='textInput']").should("be.visible");
+    });
+    it("Displays an error message when submitting an empty form.", () => {
+      cy.get("button[type='submit']").click();
+      cy.get("[data-testid='errorMessage']").should("be.visible");
+    });
+    it("Sucessfully submits a code", () => {
+      cy.get("input[id='verificationCode']").type("123456");
+      cy.get("button[type='submit']").click();
+      cy.url().should("contain", "/en/auth/policy");
     });
   });
 });

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -108,6 +108,7 @@ Cypress.Commands.add("login", (acceptableUse = false) => {
     }).then((response) => {
       expect(response.body).to.have.property("status", "success");
       expect(response.body).to.have.property("challengeState", "MFA");
+      expect(response.body).to.have.property("authenticationFlowToken");
 
       cy.request({
         method: "POST",
@@ -116,6 +117,7 @@ Cypress.Commands.add("login", (acceptableUse = false) => {
         body: {
           username: "test.user@cds-snc.ca",
           verificationCode: "123456",
+          authenticationFlowToken: response.body.authenticationFlowToken,
           csrfToken,
           json: true,
         },

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -169,7 +169,11 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
       return res.status(400).json({ status: "error", error: "Missing username or password" });
 
     if (process.env.APP_ENV === "test") {
-      return res.status(200).json({ status: "success", challengeState: "MFA" });
+      return res.status(200).json({
+        status: "success",
+        challengeState: "MFA",
+        authenticationFlowToken: "0000-1111-2222-3333",
+      });
     }
 
     try {


### PR DESCRIPTION
# Summary | Résumé
- Updates the Cypress login page test to check for 2FA screen
- Updates the Cypress command 'login' to check and use `authenticationFlowToken`

# Test instructions | Instructions pour tester la modification

run Cypress test