### PR TITLE
chore: remove workflow trigger

### DIFF
--- a/.github/workflows/pr-review-sync-env-vars.yml
+++ b/.github/workflows/pr-review-sync-env-vars.yml
@@ -1,7 +1,6 @@
 name: PR review sync envionment variables
 
 on:
-  workflow_dispatch:
   workflow_run:
     workflows: ["Deploy to Staging"]
     types:


### PR DESCRIPTION
# Summary
Now that the PR review sync has been tested, the manual `workflow_dispatch` trigger is no longer needed.

# Related
- cds-snc/platform-core-services#385