### PR TITLE
fix: manually handle logout redirect for PR Review environments

### DIFF
--- a/components/auth/LoginMenu.tsx
+++ b/components/auth/LoginMenu.tsx
@@ -14,7 +14,7 @@ const LoginMenu = ({ isAuthenticated }: LoginMenuProp) => {
   const handleClick = () => {
     clearTemplateStore();
     signOut({ redirect: false, callbackUrl: "/" });
-    window.location.href = "/${i18n.language}/auth/logout";
+    window.location.href = `/${i18n.language}/auth/logout`;
   };
 
   return (

--- a/components/auth/LoginMenu.tsx
+++ b/components/auth/LoginMenu.tsx
@@ -13,8 +13,7 @@ const LoginMenu = ({ isAuthenticated }: LoginMenuProp) => {
   const { i18n, t } = useTranslation("common");
   const handleClick = () => {
     clearTemplateStore();
-    signOut({ redirect: false, callbackUrl: "/" });
-    window.location.href = `/${i18n.language}/auth/logout`;
+    signOut({ callbackUrl: `/${i18n.language}/auth/logout` });
   };
 
   return (

--- a/components/auth/LoginMenu.tsx
+++ b/components/auth/LoginMenu.tsx
@@ -14,7 +14,7 @@ const LoginMenu = ({ isAuthenticated }: LoginMenuProp) => {
   const handleClick = () => {
     clearTemplateStore();
     signOut({ redirect: false, callbackUrl: "/" });
-    window.location.href = "/en/auth/logout";
+    window.location.href = "/${i18n.language}/auth/logout";
   };
 
   return (

--- a/components/auth/LoginMenu.tsx
+++ b/components/auth/LoginMenu.tsx
@@ -13,7 +13,8 @@ const LoginMenu = ({ isAuthenticated }: LoginMenuProp) => {
   const { i18n, t } = useTranslation("common");
   const handleClick = () => {
     clearTemplateStore();
-    signOut({ callbackUrl: `/${i18n.language}/auth/logout` });
+    signOut({ redirect: false, callbackUrl: "/" });
+    window.location.href = "/en/auth/logout";
   };
 
   return (

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -136,6 +136,13 @@ export const authOptions: NextAuthOptions = {
 
       return session;
     },
+    async redirect({ url, baseUrl }) {
+      // Allows relative callback URLs
+      if (url.startsWith("/")) return `${url}`;
+      // Allows callback URLs on the same origin
+      else if (new URL(url).origin === baseUrl) return url;
+      return baseUrl;
+    },
   },
 };
 


### PR DESCRIPTION
# Summary | Résumé

To save ourselves from having to add all PR Review environment URLs to Cognito as allowed Callback URLs dynamically, we just use the Staging URL for the NEXTAUTH_URL in the Review environments. 

For the most part, this doesn't affect anything visibly until you try to Logout, when NextAuth will redirect you using the NEXTAUTH_URL from the environment as the baseUrl, which would be the Staging URL.

This PR modifies the NextAuth `redirects` callback to return a relative path without baseUrl, so it will work in any environment.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [x] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
