### PR TITLE
fix: remove AWS cli output for PR review envs

### DIFF
--- a/.github/workflows/pr-review-client-delete-unused.yml
+++ b/.github/workflows/pr-review-client-delete-unused.yml
@@ -37,9 +37,9 @@ jobs:
               if [ $LAST_MODIFIED_EPOCH -lt $DELETE_DATE_EPOCH ]; then
                   echo "Deleting $FUNCTION_NAME"
                   PR_NUMBER="${FUNCTION_NAME##*-}"
-                  aws lambda delete-function-url-config --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
-                  aws lambda delete-function --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
-                  aws logs delete-log-group --log-group-name /aws/lambda/${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
-                  aws ecr batch-delete-image --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER
+                  aws lambda delete-function-url-config --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER > /dev/null 2>&1
+                  aws lambda delete-function --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER > /dev/null 2>&1
+                  aws logs delete-log-group --log-group-name /aws/lambda/${{ env.FUNCTION_PREFIX }}-$PR_NUMBER > /dev/null 2>&1
+                  aws ecr batch-delete-image --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER > /dev/null 2>&1
               fi
           done

--- a/.github/workflows/pr-review-client-deploy.yml
+++ b/.github/workflows/pr-review-client-deploy.yml
@@ -120,7 +120,7 @@ jobs:
           aws lambda wait function-updated --function-name $FUNCTION_NAME-$PR_NUMBER
           aws lambda put-function-concurrency \
             --function-name $FUNCTION_NAME-$PR_NUMBER \
-            --reserved-concurrent-executions 10
+            --reserved-concurrent-executions 10 > /dev/null 2>&1
 
       - name: Update PR
         if: env.URL != ''

--- a/.github/workflows/pr-review-client-remove.yml
+++ b/.github/workflows/pr-review-client-remove.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Delete lambda function resources
         run: |
-          aws lambda wait function-active --function-name $FUNCTION_NAME-$PR_NUMBER
-          aws lambda delete-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER
-          aws lambda delete-function --function-name $FUNCTION_NAME-$PR_NUMBER
-          aws logs delete-log-group --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER
-          aws ecr batch-delete-image --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER
+          aws lambda wait function-active --function-name $FUNCTION_NAME-$PR_NUMBER > /dev/null 2>&1
+          aws lambda delete-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER > /dev/null 2>&1
+          aws lambda delete-function --function-name $FUNCTION_NAME-$PR_NUMBER > /dev/null 2>&1
+          aws logs delete-log-group --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER > /dev/null 2>&1
+          aws ecr batch-delete-image --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER > /dev/null 2>&1

--- a/Dockerfile.pr
+++ b/Dockerfile.pr
@@ -53,7 +53,9 @@ COPY bin/pr-review-entrypoint.sh ./entrypoint.sh
 RUN apt-get update && apt-get install -y awscli
 
 # Lambda web adapter: https://github.com/awslabs/aws-lambda-web-adapter
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.7.0 /lambda-adapter /opt/extensions/lambda-adapter
+# The public.ecr.aws/awsguru/aws-lambda-adapter:0.7.0 image reference in the docs has
+# been pushed to the public CDS ECR to avoid rate limiting when pulling the image.
+COPY --from=public.ecr.aws/cds-snc/aws-lambda-adapter:0.7.0 /lambda-adapter /opt/extensions/lambda-adapter
 RUN ln -s /tmp ./.next/cache
 
 EXPOSE 3000


### PR DESCRIPTION
# Summary
Update the PR review env workflow to remove all AWS cli output.

Also updates the `Dockerfile.pr` to pull the AWS web adapter Docker image from the CDS public ECR to avoid rate limiting issues.

# Related
- Closes cds-snc/platform-core-services#387