### PR TITLE
ci: Update token on release generator

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -16,5 +16,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           command: manifest
+          token: ${{secrets.RELEASE_GENERATOR_TOKEN}}
           release-type: node
           default-branch: develop


### PR DESCRIPTION
# Summary | Résumé
Updates the token used on the Release Generator action to personal token so that CI tests and other actions downstream can run.  
See https://github.com/google-github-actions/release-please-action#github-credentials for details