### PR TITLE
ci: add back github sha for docker image arg

### DIFF
--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   ECR_REPOSITORY: form_viewer_production
+  GITHUB_SHA: ${{ github.sha }}
   TAG_VERSION: ${{ github.ref }}
   COGNITO_APP_CLIENT_ID: ${{secrets.PRODUCTION_COGNITO_APP_CLIENT_ID}}
   COGNITO_USER_POOL_ID: ${{ secrets.PRODUCTION_COGNITO_USER_POOL_ID}}


### PR DESCRIPTION
# Summary | Résumé
Add back the GitHub SHA variable that is used in the docker image arg.
Future check to possibly remove the argument from docker files.