### PR TITLE
Adds initial work for restricting downloads

### DIFF
--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -41,6 +41,7 @@ export const DownloadTable = ({ vaultSubmissions, formId }: DownloadTableProps) 
   const accountEscalated = true; // TODO: get account exalated setting this is TEMP
 
   const { value: overdueAfter } = useSetting("nagwarePhaseEncouraged");
+  const { value: escalatedAfter } = useSetting("nagwarePhaseWarned");
   const [tableItems, tableItemsDispatch] = useReducer(reducerTableItems, {
     checkedItems: new Map(),
     statusItems: new Map(vaultSubmissions.map((submission) => [submission.name, false])),
@@ -213,6 +214,7 @@ export const DownloadTable = ({ vaultSubmissions, formId }: DownloadTableProps) 
               <p className="text-[#26374a] text-sm">
                 {t("downloadResponsesTable.errors.overdueAlert.description", {
                   numberOfOverdueResponses: tableItems.numberOfOverdueResponses,
+                  escalatedAfter,
                 })}
               </p>
             </Attention>

--- a/components/form-builder/app/responses/DownloadTableReducer.ts
+++ b/components/form-builder/app/responses/DownloadTableReducer.ts
@@ -59,7 +59,7 @@ export function isSubmissionOverdue({
   if (overdueAfter === undefined) return false;
   const overdueDays = parseInt(overdueAfter);
   if (isNaN(overdueDays)) return false;
-  const isOverdue = parseInt(overdueAfter) - getDaysPassed(createdAt) < 0;
+  const isOverdue = overdueDays - getDaysPassed(createdAt) < 0;
   // Download is overdue
   if (status === VaultStatus.NEW && isOverdue) return true;
   // Confirmed is overdue

--- a/components/form-builder/app/responses/DownloadTableReducer.ts
+++ b/components/form-builder/app/responses/DownloadTableReducer.ts
@@ -1,5 +1,5 @@
 import { getDaysPassed } from "@lib/clientHelpers";
-import { VaultSubmissionList, VaultStatus, VaultSubmission, TypeOmit } from "@lib/types";
+import { VaultSubmissionList, VaultStatus } from "@lib/types";
 
 export enum TableActions {
   UPDATE = "UPDATE",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -58,7 +58,11 @@
       "atLeastOneFile": "Try selecting at least one file to download.",
       "errorDownloadingFilesHeader": "Error downloading the selected files.",
       "errorDownloadingFiles": "Try again in a few minutes. If the problem persists, ",
-      "errorDownloadingFilesLink": "contact Support"
+      "errorDownloadingFilesLink": "contact Support",
+      "overdueAlert": {
+        "title": "Downloading is restricted for overdue responses until they are downloaded and confirmed",
+        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses 35 days overdue. Download and confirm all overdue responses before continuing."
+      }
     },
     "downloadXSelectedResponses": "Download {{size}} selected responses",
     "skipLink": "Skip the download table",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -61,7 +61,7 @@
       "errorDownloadingFilesLink": "contact Support",
       "overdueAlert": {
         "title": "Downloading is restricted for overdue responses until they are downloaded and confirmed",
-        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses 35 days overdue. Download and confirm all overdue responses before continuing."
+        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses {{escalatedAfter}} days overdue. Download and confirm all overdue responses before continuing."
       }
     },
     "downloadXSelectedResponses": "Download {{size}} selected responses",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -61,7 +61,7 @@
       "errorDownloadingFilesLink": "contactez Soutien",
       "overdueAlert": {
         "title": "Downloading is restricted for overdue responses until they are downloaded and confirmed",
-        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses 35 days overdue. Download and confirm all overdue responses before continuing."
+        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses {{escalatedAfter}} days overdue. Download and confirm all overdue responses before continuing."
       }
     },
     "downloadXSelectedResponses": "Télécharger {{size}} réponses sélectionnées",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -58,7 +58,11 @@
       "atLeastOneFile": "Essayez de sélectionner au moins un fichier à télécharger.",
       "errorDownloadingFilesHeader": "Erreur lors du téléchargement des fichiers sélectionnés.",
       "errorDownloadingFiles": "Réessayez dans quelques minutes. Si le problème persiste, ",
-      "errorDownloadingFilesLink": "contactez Soutien"
+      "errorDownloadingFilesLink": "contactez Soutien",
+      "overdueAlert": {
+        "title": "Downloading is restricted for overdue responses until they are downloaded and confirmed",
+        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses 35 days overdue. Download and confirm all overdue responses before continuing."
+      }
     },
     "downloadXSelectedResponses": "Télécharger {{size}} réponses sélectionnées",
     "skipLink": "Sauter le tableau de téléchargement",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -60,8 +60,8 @@
       "errorDownloadingFiles": "Réessayez dans quelques minutes. Si le problème persiste, ",
       "errorDownloadingFilesLink": "contactez Soutien",
       "overdueAlert": {
-        "title": "Downloading is restricted for overdue responses until they are downloaded and confirmed",
-        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses {{escalatedAfter}} days overdue. Download and confirm all overdue responses before continuing."
+        "title": "Downloading is restricted for overdue responses until they are downloaded and confirmed[FR]",
+        "description": "There are {{numberOfOverdueResponses}} unconfirmed responses {{escalatedAfter}} days overdue. Download and confirm all overdue responses before continuing.[FR]"
       }
     },
     "downloadXSelectedResponses": "Télécharger {{size}} réponses sélectionnées",

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -321,6 +321,11 @@
     &:focus + .gc-checkbox-label:after {
       background-image: url("../public/img/blue-checkmark.svg");
     }
+
+    &:disabled + .gc-checkbox-label {
+      pointer-events: none;
+      opacity: .5;
+    }
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

This work adds the Client side logic to restrict a download. A submission download is restricted if the user account is in a "escalated" state and the submission marked as new.

## Testing

IMPORTANT: because a placeholder value is use for "escalated" and set to true, the Download table will always show a warning and block any new downloads.

At this point I think the only thing that can be tested is whether non-new submissions are not blocked in the Client.

## Future Work

The warning text may need to be updated and eventually the French translation added.

This work relies on a placeholder value for the account "escalated" state. This will need to be done.

The download API should also use the account "escalated" state to block a submission download at the API level. This can be down once the variable is created (or now :).