### PR TITLE
Feature/account lock publishing

### DIFF
--- a/pages/admin/accounts/index.tsx
+++ b/pages/admin/accounts/index.tsx
@@ -102,38 +102,40 @@ const Users = ({
                     <h2 className="pb-6 text-base">{user.name}</h2>
                     <p className="mb-4">{user.email}</p>
                     <div className="">
-                      {/* {canManageUsers && !isCurrentUser(user) && !user.active && ( */}
-                      <Button
-                        theme={"secondary"}
-                        className="mr-2"
-                        onClick={async () => {
-                          // TODO: Actions enum?
-                          //
-                          const action = hasPrivilege({
+                      {canManageUsers && (
+                        <Button
+                          theme={"secondary"}
+                          className="mr-2"
+                          onClick={async () => {
+                            // TODO: Actions enum? (remove, add)
+                            //
+                            const action = hasPrivilege({
+                              privileges: user.privileges,
+                              privilegeName: "PublishForms",
+                            })
+                              ? "remove"
+                              : "add";
+                            await updatePrivilege(user.id, [{ id: publishFormsId, action }]);
+                            await refreshData();
+                          }}
+                        >
+                          {hasPrivilege({
                             privileges: user.privileges,
                             privilegeName: "PublishForms",
                           })
-                            ? "remove"
-                            : "add";
-                          await updatePrivilege(user.id, [{ id: publishFormsId, action }]);
-                          await refreshData();
-                        }}
-                      >
-                        {hasPrivilege({
-                          privileges: user.privileges,
-                          privilegeName: "PublishForms",
-                        })
-                          ? "Lock Publishing"
-                          : "Unlock Publishing"}
-                      </Button>
-                      {/* )} */}
+                            ? t("lockPublishing")
+                            : t("unlockPublishing")}
+                        </Button>
+                      )}
 
-                      <LinkButton.Secondary
-                        href={`/admin/accounts/${user.id}/manage-forms`}
-                        className="mb-2 mr-3"
-                      >
-                        {t("manageForms")}
-                      </LinkButton.Secondary>
+                      {canManageUsers && (
+                        <LinkButton.Secondary
+                          href={`/admin/accounts/${user.id}/manage-forms`}
+                          className="mb-2 mr-3"
+                        >
+                          {t("manageForms")}
+                        </LinkButton.Secondary>
+                      )}
 
                       {canManageUsers && !isCurrentUser(user) && !user.active && (
                         <Button
@@ -203,7 +205,7 @@ export const getServerSideProps = requireAuthentication(async ({ user: { ability
     })
   );
 
-  // TODO: Perhaps the Privileges e.g. "PublishForms" could be stored in an enum?
+  // TODO: Perhaps the Privileges e.g. "PublishForms" etc. could be stored in an enum?
   //
   // Convenience for features, lock/unlock publishing that may or may not have the related ID
   const publishFormsId = allPrivileges.find((privilege) => privilege.nameEn === "PublishForms")?.id;

--- a/pages/admin/accounts/index.tsx
+++ b/pages/admin/accounts/index.tsx
@@ -18,6 +18,7 @@ import { Dropdown } from "@components/admin/Users/Dropdown";
 import { ConfirmDeactivate } from "@components/admin/Users/ConfirmDeactivate";
 import { Button, themes, LinkButton } from "@components/globals";
 import { DBUser } from "@lib/types/user-types";
+import { Privilege } from "@prisma/client";
 
 export const updateActiveStatus = async (userID: string, active: boolean) => {
   try {
@@ -35,7 +36,32 @@ export const updateActiveStatus = async (userID: string, active: boolean) => {
   }
 };
 
-const Users = ({ allUsers }: { allUsers: DBUser[] }): React.ReactElement => {
+const updatePrivilege = async (
+  userID: string,
+  privileges: { id: string; action: "add" | "remove" }[]
+) => {
+  try {
+    return await axios({
+      url: `/api/users`,
+      method: "PUT",
+      data: {
+        userID,
+        privileges,
+      },
+      timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
+    });
+  } catch (e) {
+    logMessage.error(e);
+  }
+};
+
+const Users = ({
+  allUsers,
+  publishFormsId,
+}: {
+  allUsers: DBUser[];
+  publishFormsId: string;
+}): React.ReactElement => {
   const { t } = useTranslation("admin-users");
   const { ability } = useAccessControl();
   const canManageUsers = ability?.can("update", "User") ?? false;
@@ -44,6 +70,16 @@ const Users = ({ allUsers }: { allUsers: DBUser[] }): React.ReactElement => {
   const router = useRouter();
   const isCurrentUser = (user: DBUser) => {
     return user.id === session?.user?.id;
+  };
+
+  const hasPrivilege = ({
+    privileges,
+    privilegeName,
+  }: {
+    privileges: Privilege[];
+    privilegeName: string;
+  }): boolean => {
+    return Boolean(privileges?.find((privilege) => privilege.nameEn === privilegeName)?.id);
   };
 
   return (
@@ -66,6 +102,32 @@ const Users = ({ allUsers }: { allUsers: DBUser[] }): React.ReactElement => {
                     <h2 className="pb-6 text-base">{user.name}</h2>
                     <p className="mb-4">{user.email}</p>
                     <div className="">
+                      {/* {canManageUsers && !isCurrentUser(user) && !user.active && ( */}
+                      <Button
+                        theme={"secondary"}
+                        className="mr-2"
+                        onClick={async () => {
+                          // TODO: Actions enum?
+                          //
+                          const action = hasPrivilege({
+                            privileges: user.privileges,
+                            privilegeName: "PublishForms",
+                          })
+                            ? "remove"
+                            : "add";
+                          await updatePrivilege(user.id, [{ id: publishFormsId, action }]);
+                          await refreshData();
+                        }}
+                      >
+                        {hasPrivilege({
+                          privileges: user.privileges,
+                          privilegeName: "PublishForms",
+                        })
+                          ? "Lock Publishing"
+                          : "Unlock Publishing"}
+                      </Button>
+                      {/* )} */}
+
                       <LinkButton.Secondary
                         href={`/admin/accounts/${user.id}/manage-forms`}
                         className="mb-2 mr-3"
@@ -141,6 +203,11 @@ export const getServerSideProps = requireAuthentication(async ({ user: { ability
     })
   );
 
+  // TODO: Perhaps the Privileges e.g. "PublishForms" could be stored in an enum?
+  //
+  // Convenience for features, lock/unlock publishing that may or may not have the related ID
+  const publishFormsId = allPrivileges.find((privilege) => privilege.nameEn === "PublishForms")?.id;
+
   return {
     props: {
       ...(locale &&
@@ -148,6 +215,7 @@ export const getServerSideProps = requireAuthentication(async ({ user: { ability
 
       allUsers,
       allPrivileges,
+      publishFormsId,
     },
   };
 });

--- a/public/static/locales/en/admin-users.json
+++ b/public/static/locales/en/admin-users.json
@@ -34,5 +34,7 @@
     "title": "Error",
     "message": "Something went wrong."
   },
-  "backToAccounts": "Back to Accounts"
+  "backToAccounts": "Back to Accounts",
+  "lockPublishing": "Lock publishing",
+  "unlockPublishing" : "Unlock publishing"
 }

--- a/public/static/locales/fr/admin-users.json
+++ b/public/static/locales/fr/admin-users.json
@@ -34,5 +34,7 @@
     "title": "Erreur",
     "message": "Quelque chose a mal tourné."
   },
-  "backToAccounts": "Retourner à Comptes"
+  "backToAccounts": "Retourner à Comptes",
+  "lockPublishing": "Lock publishing[FR]",
+  "unlockPublishing" : "Unlock publishing[FR]"
 }


### PR DESCRIPTION
# Summary | Résumé

Adds a lock/unlock publishing button on the account page for convenience. 

## Test

Test by clicking the "lock publishing" button. The button text should change to "unlock publishing". (Or vice versa)
You can also check the networking tab to see if the api call to "user" success/fail, or look in Prisma, or try a few places in the app that require publishing
