### PR TITLE
Fixes minor a11y issue with a missing label

### DIFF
--- a/components/form-builder/app/navigation/FileName.tsx
+++ b/components/form-builder/app/navigation/FileName.tsx
@@ -102,6 +102,7 @@ export const FileNameInput = () => {
           setIsEditing(false);
         }}
         onChange={(e) => setContent(e.target.value)}
+        aria-label={t("formName", { ns: "form-builder" })}
       />
     </div>
   );

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -598,6 +598,7 @@
   "unlockPublishing": "Unlock publishing",
   "unlockPublishingDescription": "To unlock publishing, provide the contact information of the person you report to.",
   "unnamedForm": "Unnamed form file",
+  "formName": "Form name", 
   "responsesNavLabel": "Responses",
   "nagware": {
     "restrictedDownloadAfter35Days": "Downloading will be restricted if unconfirmed responses are older than 35 days.",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -599,6 +599,7 @@
   "unlockPublishing": "Soumettre",
   "unlockPublishingDescription": "Pour déverrouiller la publication, fournissez les coordonnées de la personne de qui vous relevez. ",
   "unnamedForm": "Formulaire sans titre",
+  "formName": "Form name[FR]",
   "responsesNavLabel": "Réponses",
   "nagware": {
     "restrictedDownloadAfter35Days": "Le téléchargement sera limité si les réponses non confirmées ont plus de 35 jours de retard.",


### PR DESCRIPTION
# Summary | Résumé

Adds a hidden label for the form name on the Settings screen. 

## Test

Go to the settings screen. Start VoiceOver and tab to the Form name input. The content in the input should be announced along with the label "Form name". 
