### PR TITLE
feat:  Immediate deactivation / logout

### DIFF
--- a/components/form-builder/app/Template.tsx
+++ b/components/form-builder/app/Template.tsx
@@ -67,7 +67,7 @@ export const PageTemplate = ({
     email: s.deliveryOption?.emailAddress,
   }));
 
-  // This will check to see if a user is deactivated and redirect them to the account deavtivated page
+  // This will check to see if a user is deactivated and redirect them to the account deactivated page
   useAccessControl();
 
   const locale = i18n.language as Language;

--- a/components/form-builder/app/Template.tsx
+++ b/components/form-builder/app/Template.tsx
@@ -11,6 +11,7 @@ import { Language } from "../types";
 import { TemplateApiProvider } from "../hooks";
 import { ToastContainer } from "./shared/Toast";
 import { RefStoreProvider } from "@lib/hooks/useRefStore";
+import { useAccessControl } from "@lib/hooks/useAccessControl";
 
 export const Template = ({
   page,
@@ -65,6 +66,9 @@ export const PageTemplate = ({
     setLang: s.setLang,
     email: s.deliveryOption?.emailAddress,
   }));
+
+  // This will check to see if a user is deactivated and redirect them to the account deavtivated page
+  useAccessControl();
 
   const locale = i18n.language as Language;
   useEffect(() => {

--- a/components/globals/layouts/AdminNavLayout.tsx
+++ b/components/globals/layouts/AdminNavLayout.tsx
@@ -8,6 +8,7 @@ import { User } from "next-auth";
 
 import { LeftNavigation } from "@components/admin/LeftNav/LeftNavigation";
 import { ToastContainer } from "@components/form-builder/app/shared/Toast";
+import { useAccessControl } from "@lib/hooks";
 
 interface AdminNavLayoutProps extends React.PropsWithChildren {
   user: User;
@@ -16,6 +17,8 @@ interface AdminNavLayoutProps extends React.PropsWithChildren {
 }
 
 const AdminNavLayout = ({ children, user, backLink, hideLeftNav }: AdminNavLayoutProps) => {
+  // This will check to see if a user is deactivated and redirect them to the account deavtivated page
+  useAccessControl();
   return (
     <div className={`flex h-full flex-col ${hideLeftNav && "bg-gray-50"}`}>
       <Head>

--- a/components/globals/layouts/AdminNavLayout.tsx
+++ b/components/globals/layouts/AdminNavLayout.tsx
@@ -17,7 +17,7 @@ interface AdminNavLayoutProps extends React.PropsWithChildren {
 }
 
 const AdminNavLayout = ({ children, user, backLink, hideLeftNav }: AdminNavLayoutProps) => {
-  // This will check to see if a user is deactivated and redirect them to the account deavtivated page
+  // This will check to see if a user is deactivated and redirect them to the account deactivated page
   useAccessControl();
   return (
     <div className={`flex h-full flex-col ${hideLeftNav && "bg-gray-50"}`}>

--- a/cypress/cypress.d.ts
+++ b/cypress/cypress.d.ts
@@ -8,7 +8,13 @@ declare global {
       useForm: (file: string) => Chainable<void>;
       visitForm: (formID: string) => Chainable<Window>;
       visitPage: (path: string) => Chainable<Window>;
-      login: (admin?: boolean, acceptableUse?: boolean) => Chainable<void>;
+      login: ({
+        admin,
+        acceptableUse,
+      }?: {
+        admin?: boolean;
+        acceptableUse?: boolean;
+      }) => Chainable<void>;
       logout: () => Chainable<void>;
       useFlag: (flagName: string, value: boolean, alreadyAuth?: boolean) => Chainable<void>;
       selection: (fn: (el: JQuery<HTMLElement>) => void) => Chainable<JQuery<HTMLElement>>;

--- a/cypress/e2e/accounts_page.cy.ts
+++ b/cypress/e2e/accounts_page.cy.ts
@@ -1,5 +1,5 @@
 describe("Accounts Page", () => {
-  const adminUserEmail = "testadmin.user@cds-snc.ca";
+  const adminUserEmail = "test.admin@cds-snc.ca";
   const testUserEmail = "test.user@cds-snc.ca";
   const deactivatedUserEmail = "test.deactivated@cds-snc.ca";
 

--- a/cypress/e2e/accounts_page.cy.ts
+++ b/cypress/e2e/accounts_page.cy.ts
@@ -4,7 +4,7 @@ describe("Accounts Page", () => {
   const deactivatedUserEmail = "test.deactivated@cds-snc.ca";
 
   beforeEach(() => {
-    cy.login(true, true);
+    cy.login({ admin: true, acceptableUse: true });
     cy.visitPage("/en/admin/accounts");
   });
 

--- a/cypress/e2e/form-builder/admin-menu.cy.ts
+++ b/cypress/e2e/form-builder/admin-menu.cy.ts
@@ -26,14 +26,14 @@ describe("Form ownership", () => {
   });
 
   it("Shows admin menu when logged in as Admin", () => {
-    cy.login(true, true);
+    cy.login({ admin: true, acceptableUse: true });
     cy.visit("/myforms");
 
     cy.get("nav[aria-label='Main']").should("contain", "Administration");
   });
 
   it("Does not show admin menu when logged in as non-Admin", () => {
-    cy.login(false, true);
+    cy.login({ acceptableUse: true });
     cy.visit("/myforms");
 
     cy.get("nav[aria-label='Main']").should("not.contain", "Administration");

--- a/cypress/e2e/form-builder/ownership.cy.ts
+++ b/cypress/e2e/form-builder/ownership.cy.ts
@@ -33,19 +33,19 @@ describe("Form ownership", () => {
   });
 
   it("Non-Admin cannot manage Form Ownership", () => {
-    cy.login(false, true);
+    cy.login({ acceptableUse: true });
     cy.visit(`/form-builder/settings/${formID}/form`);
     cy.get("h2").contains("Manage ownership").should("not.exist");
   });
 
   it("Admin can manage Form Ownership", () => {
-    cy.login(true, true);
+    cy.login({ admin: true, acceptableUse: true });
     cy.visit(`/form-builder/settings/${formID}/form`);
     cy.get("h2").contains("Manage ownership").should("exist");
   });
 
   it("Must have at least one owner", () => {
-    cy.login(true, true);
+    cy.login({ admin: true, acceptableUse: true });
     cy.visit(`/form-builder/settings/${formID}/form`);
     cy.get("h2").contains("Manage ownership").should("exist");
 

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -78,7 +78,7 @@ Cypress.Commands.add("useFlag", (flagName, value, alreadyAuth) => {
     url: `/api/flags/${flagName}/check`,
   }).then(({ body: { status } }) => {
     if (status !== value) {
-      !alreadyAuth && cy.login();
+      !alreadyAuth && cy.login({ admin: true });
       cy.request({
         method: "GET",
         url: `/api/flags/${flagName}/${value ? "enable" : "disable"}`,
@@ -92,7 +92,8 @@ Cypress.Commands.add("useFlag", (flagName, value, alreadyAuth) => {
  * Log the test user into the application
  */
 
-Cypress.Commands.add("login", (admin = false, acceptableUse = false) => {
+Cypress.Commands.add("login", (options?: { admin?: boolean; acceptableUse?: boolean }) => {
+  const { admin = false, acceptableUse = false } = options || {};
   cy.request({
     method: "GET",
     url: "/api/auth/csrf",
@@ -104,7 +105,7 @@ Cypress.Commands.add("login", (admin = false, acceptableUse = false) => {
       url: "/api/auth/signin/cognito",
       form: true,
       body: {
-        username: `test${admin ? "admin" : ""}.user@cds-snc.ca`,
+        username: `test.${admin ? "admin" : "user"}@cds-snc.ca`,
         password: "testing",
         csrfToken,
       },
@@ -118,7 +119,7 @@ Cypress.Commands.add("login", (admin = false, acceptableUse = false) => {
         url: "/api/auth/callback/cognito",
         form: true,
         body: {
-          username: `test${admin ? "admin" : ""}.user@cds-snc.ca`,
+          username: `test.${admin ? "admin" : "user"}@cds-snc.ca`,
           verificationCode: "123456",
           authenticationFlowToken: response.body.authenticationFlowToken,
           csrfToken,

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -34,7 +34,7 @@ Cypress.on("uncaught:exception", () => {
 before(() => {
   cy.task("db:teardown");
   cy.task("db:seed");
-  cy.login()
+  cy.login({ admin: true })
     .then(() => {
       Object.keys(flagsDefault).forEach((key) => {
         cy.useFlag(`${key}`, (flagsDefault as Record<string, boolean>)[key], true);

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -102,7 +102,7 @@ export const logEvent = async (
     // Only log the error in Production environment.
     // Development may be running without LocalStack setup
     if (process.env.NODE_ENV === "development" || process.env.APP_ENV === "test")
-      return logMessage.info(auditLog);
+      return logMessage.info(`AuditLog:${auditLog}`);
 
     logMessage.error("ERROR with Audit Logging");
     logMessage.error(e as Error);

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -22,6 +22,8 @@ export enum AuditLogEvent {
   UserRegistration = "UserRegistration",
   UserSignIn = "UserSignIn",
   UserSignOut = "UserSignOut",
+  UserActivated = "UserActivated",
+  UserDeactivated = "UserDeactivated",
   UserPasswordReset = "UserPasswordReset",
   UserTooManyFailedAttempts = "UserTooManyFailedAttempts",
   GrantPrivilege = "GrantPrivilege",

--- a/lib/auth/2fa.ts
+++ b/lib/auth/2fa.ts
@@ -9,6 +9,8 @@ export const generateVerificationCode = async () => generateTokenCode(5);
 
 export const sendVerificationCode = async (email: string, verificationCode: string) => {
   try {
+    // Don't try to send during tests
+    if (process.env.APP_ENV === "test") return;
     const notify = new NotifyClient("https://api.notification.canada.ca", NOTIFY_API_KEY);
 
     await notify.sendEmail(TEMPLATE_ID, email, {

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -54,6 +54,15 @@ export function requireAuthentication(
         };
       }
 
+      if (session.user.deactivated) {
+        return {
+          redirect: {
+            destination: `/${context.locale}/auth/account-deactivated`,
+            permanent: false,
+          },
+        };
+      }
+
       if (!session.user.acceptableUse && !context.resolvedUrl?.startsWith("/auth/policy")) {
         // If they haven't agreed to Acceptable Use redirect to policy page for acceptance
         // If already on the policy page don't redirect, aka endless redirect loop.

--- a/lib/cache/userActiveStatus.ts
+++ b/lib/cache/userActiveStatus.ts
@@ -1,0 +1,43 @@
+import { logMessage } from "@lib/logger";
+import { getRedisInstance } from "../integration/redisConnector";
+
+// If NODE_ENV is in test mode (Jest Tests) do not use the cache
+const cacheAvailable: boolean = process.env.APP_ENV !== "test" && Boolean(process.env.REDIS_URL);
+
+// Return a random number between 300 and 600  (5 - 10 minutes)
+const randomCacheExpiry = () => Math.floor(Math.random() * 300 + 300);
+
+export const activeStatusCheck = async (userID: string): Promise<boolean | null> => {
+  const checkParameter = `auth:active:${userID}`;
+
+  if (cacheAvailable) {
+    try {
+      const redis = await getRedisInstance();
+      const value = await redis.get(checkParameter);
+      if (value) {
+        logMessage.debug(`Using Cached User Status for ${checkParameter}`);
+        return value === "1";
+      }
+    } catch (e) {
+      logMessage.error(e as Error);
+      throw new Error("Could not connect to cache");
+    }
+  }
+
+  return null;
+};
+
+export const activeStatusUpdate = async (userID: string, status: boolean): Promise<void> => {
+  const modifyParameter = `auth:active:${userID}`;
+
+  if (!cacheAvailable) return;
+  try {
+    const redis = await getRedisInstance();
+
+    await redis.setex(modifyParameter, randomCacheExpiry(), status ? "1" : "0");
+    logMessage.debug(`Updating Cached User Status for ${modifyParameter}`);
+  } catch (e) {
+    logMessage.error(e as Error);
+    throw new Error("Could not connect to cache");
+  }
+};

--- a/lib/hooks/useAccessControl.tsx
+++ b/lib/hooks/useAccessControl.tsx
@@ -23,7 +23,7 @@ export const AccessControlProvider = ({ children }: { children: React.ReactNode 
         redirect: false,
         callbackUrl: "/auth/account-deactivated",
       });
-      // Not using useRouter() hook because it will cause unnecessary rerendering
+      // Not using useRouter() hook because it will cause unnecessary re-rendering
       Router.push(deactivated.url);
     }
     if (status === "authenticated" && session.user.privileges) {

--- a/lib/integration/prismaConnector.ts
+++ b/lib/integration/prismaConnector.ts
@@ -4,13 +4,12 @@ import { logMessage } from "@lib/logger";
 // See https://www.prisma.io/docs/support/help-articles/nextjs-prisma-client-dev-practices
 // Needed to ensure we only instantiate Prisma Client once
 
-interface CustomNodeJsGlobal {
-  prisma: PrismaClient;
-}
-declare const global: CustomNodeJsGlobal;
+export const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
 
 export const prisma =
-  global.prisma ||
+  globalForPrisma.prisma ??
   new PrismaClient({
     log:
       process.env.NODE_ENV === "development"
@@ -18,7 +17,7 @@ export const prisma =
         : ["info", "warn", "error"],
   });
 
-if (process.env.NODE_ENV !== "production") global.prisma = prisma;
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 
 /**
  * Filters Prisma Connection and DB errors

--- a/lib/middleware/sessionExists.ts
+++ b/lib/middleware/sessionExists.ts
@@ -21,7 +21,8 @@ export const sessionExists = (methods?: string[]) => {
   return async (req: NextApiRequest, res: NextApiResponse): Promise<MiddlewareReturn> => {
     const session = await isAuthenticated({ req, res });
 
-    if (useMethods(req, methods) && !session) {
+    // If user is not authenticated or has a deactivated account, return 401
+    if (useMethods(req, methods) && (!session || session.user.deactivated)) {
       res.status(401).json({ error: "Unauthorized" });
       return { next: false };
     }

--- a/lib/tests/auth.test.ts
+++ b/lib/tests/auth.test.ts
@@ -54,6 +54,47 @@ describe("Test Auth lib", () => {
         },
       });
     });
+    it("Redirects users with a deactivated account to the deactivated-account page", async () => {
+      const { req, res } = createMocks({
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      const mockSession = {
+        expires: "1",
+        user: {
+          email: "test@cds.ca",
+          name: "test",
+          image: "null",
+          id: "1",
+          privileges: mockUserPrivileges(Base, { user: { id: "1" } }),
+          acceptableUse: false,
+          deactivated: true,
+        },
+      };
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const context = {
+        req,
+        res,
+        query: {},
+        resolvedUrl: "",
+      };
+
+      const result = await requireAuthentication(async () => ({
+        props: {
+          test: "1",
+        },
+      }))(context);
+      expect(result).toEqual({
+        redirect: {
+          destination: "/undefined/auth/account-deactivated",
+          permanent: false,
+        },
+      });
+    });
     it("Redirects users to acceptable use page when not yet accepted", async () => {
       const { req, res } = createMocks({
         method: "GET",

--- a/lib/tests/sessionExists.test.js
+++ b/lib/tests/sessionExists.test.js
@@ -25,6 +25,27 @@ describe("Test a session middleware", () => {
     expect(JSON.parse(res._getData()).error).toEqual("Unauthorized");
     expect(res.statusCode).toBe(401);
   });
+  it("Shouldn't allow a request for a deactivated user", async () => {
+    const mockSession = {
+      expires: "1",
+      user: {
+        email: "test@cds.ca",
+        name: "Testing session middleware",
+        image: "null",
+        deactivated: true,
+      },
+    };
+    getServerSession.mockReturnValueOnce(mockSession);
+    const { req, res } = createMocks({
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    await sessionExists()(req, res);
+    expect(JSON.parse(res._getData()).error).toEqual("Unauthorized");
+    expect(res.statusCode).toBe(401);
+  });
 
   it("Should allow a request with a valid session", async () => {
     const mockSession = {

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -10,6 +10,7 @@ import { getAllTemplatesForUser } from "./templates";
 import { listAllSubmissions } from "./vault";
 import { detectOldUnprocessedSubmissions } from "./nagware";
 import { DBUser } from "./types/user-types";
+import { activeStatusUpdate } from "@lib/cache/userActiveStatus";
 
 /**
  * Get or Create a user if a record does not exist
@@ -233,6 +234,15 @@ export const updateActiveStatus = async (ability: UserAbility, userID: string, a
         email: true,
       },
     });
+
+    // Force update the cache with the new active value
+    await activeStatusUpdate(userID, active);
+    // Log the event
+    await logEvent(
+      userID,
+      { type: "User", id: userID },
+      active ? "UserActivated" : "UserDeactivated"
+    );
 
     if (!active && user.email) {
       sendDeactivationEmail(user.email);

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -241,7 +241,8 @@ export const updateActiveStatus = async (ability: UserAbility, userID: string, a
     await logEvent(
       userID,
       { type: "User", id: userID },
-      active ? "UserActivated" : "UserDeactivated"
+      active ? "UserActivated" : "UserDeactivated",
+      `User ${userID} was ${active ? "activated" : "deactivated"} by user ${ability.userID}`
     );
 
     if (!active && user.email) {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -37,36 +37,25 @@ export const authOptions: NextAuthOptions = {
       async authorize(credentials) {
         const { authenticationFlowToken, username, verificationCode } = credentials ?? {};
 
-        // Application is in test mode, return test user
-        if (process.env.APP_ENV === "test") {
-          if (
-            !username ||
-            ![
-              "test.user@cds-snc.ca",
-              "testadmin.user@cds-snc.ca",
-              "test.deactivated@cds-snc.ca",
-            ].includes(username)
-          ) {
-            throw new Error("Must use testing accounts when in test Mode");
-          }
+        // Check to ensure all required credentials were passed in
+        if (!authenticationFlowToken || !username || !verificationCode) return null;
 
-          // @todo - look into doing a local user lookup vs hardcoding the user
-
-          if (username === "test.deactivated@cds-snc.ca") {
-            return {
-              id: "100",
-              email: username,
-            };
-          }
+        // Check for test accounts being used
+        if (
+          ["test.user@cds-snc.ca", "test.admin@cds-snc.ca", "test.deactivated@cds-snc.ca"].includes(
+            username
+          )
+        ) {
+          // If we're not in test mode throw an error
+          if (process.env.APP_ENV !== "test")
+            throw new Error("Test accounts only available in testing mode");
 
           return {
-            id: "1",
+            // id is not used by the app, but is required by next-auth
+            id: "test",
             email: username,
           };
         }
-
-        // Check to ensure all required credentials were passed in
-        if (!authenticationFlowToken || !username || !verificationCode) return null;
 
         const validationResult = await validate2FAVerificationCode(
           authenticationFlowToken,
@@ -238,25 +227,19 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
 
     if (!username || !password)
       return res.status(400).json({ status: "error", error: "Missing username or password" });
-
-    if (process.env.APP_ENV === "test") {
-      if (username === "test.deactivated@cds-snc.ca") {
-        // -> return error that would be thrown by begin2FAAuthentication
-        return res.status(401).json({
-          status: "error",
-          error: "Cognito authentication failed",
-          reason: "AccountDeactivated",
+    try {
+      if (process.env.APP_ENV === "test") {
+        const authenticationFlowToken = await begin2FAAuthentication({
+          email: username,
+          token: "testCognitoToken",
+        });
+        return res.status(200).json({
+          status: "success",
+          challengeState: "MFA",
+          authenticationFlowToken: authenticationFlowToken,
         });
       }
 
-      return res.status(200).json({
-        status: "success",
-        challengeState: "MFA",
-        authenticationFlowToken: "0000-1111-2222-3333",
-      });
-    }
-
-    try {
       const cognitoToken = await initiateSignIn({
         username: username,
         password: password,

--- a/prisma/seeds/fixtures/users.ts
+++ b/prisma/seeds/fixtures/users.ts
@@ -1,0 +1,44 @@
+import { User } from "@prisma/client";
+
+type UserCollection = {
+  test: User[];
+  [key: string]: Array<User | { privileges: Record<string, unknown> }>;
+};
+
+const RegularUser: User | { privileges: Record<string, unknown> } = {
+  name: "Regular Test User",
+  email: "test.user@cds-snc.ca",
+  active: true,
+  privileges: {
+    connect: [{ nameEn: "Base" }, { nameEn: "PublishForms" }],
+  },
+};
+
+const AdminUser: User | { privileges: Record<string, unknown> } = {
+  name: "Admin Test User",
+  email: "test.admin@cds-snc.ca",
+  active: true,
+  privileges: {
+    connect: [
+      { nameEn: "Base" },
+      { nameEn: "PublishForms" },
+      { nameEn: "ManageApplicationSettings" },
+      { nameEn: "ManageUsers" },
+      { nameEn: "ManageForms" },
+      { nameEn: "ManagePrivileges" },
+    ],
+  },
+};
+
+const DeactivatedRegularUser: User | { privileges: Record<string, unknown> } = {
+  name: "Deactivated Test User",
+  email: "test.deactivated@cds-snc.ca",
+  active: false,
+  privileges: {
+    connect: [{ nameEn: "Base" }, { nameEn: "PublishForms" }],
+  },
+};
+
+export default {
+  test: [RegularUser, AdminUser, DeactivatedRegularUser],
+} as UserCollection;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,16 @@
 {
   "compilerOptions": {
-    "typeRoots": ["./types", "./node_modules/@types"],
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types"
+    ],
     "target": "es5",
     "downlevelIteration": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -17,21 +24,39 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@lib/*": ["lib/*"],
-      "@components/*": ["components/*"],
-      "@formbuilder/*": ["components/form-builder/*"],
-      "@pages/*": ["pages/*"],
-      "@jestFixtures/*": ["__fixtures__/*"],
-      "@jestUtils": ["__utils__"]
+      "@lib/*": [
+        "lib/*"
+      ],
+      "@components/*": [
+        "components/*"
+      ],
+      "@formbuilder/*": [
+        "components/form-builder/*"
+      ],
+      "@pages/*": [
+        "pages/*"
+      ],
+      "@jestFixtures/*": [
+        "__fixtures__/*"
+      ],
+      "@jestUtils": [
+        "__utils__"
+      ]
     },
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "types",
     "**/*.ts",
     "**/*.tsx",
-    "cypress/support/commands/selection-command.js"
+    "cypress/support/commands/selection-command.js",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/types/next_auth/index.d.ts
+++ b/types/next_auth/index.d.ts
@@ -15,6 +15,7 @@ declare module "next-auth" {
       email: string | null;
       image?: string | null;
       newlyRegistered?: boolean;
+      deactivated?: boolean;
     };
   }
 }
@@ -28,5 +29,6 @@ declare module "next-auth/jwt" {
     privileges: RawRuleOf<MongoAbility<Abilities>>[];
     acceptableUse: boolean;
     newlyRegistered?: boolean;
+    deactivated?: boolean;
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Implements immediate deactivation of a user by logging them out and redirecting them to the account deactivated page.

Closes #2347 

- Modifies the Next Auth JWT token and Session processing to add a 'deactivated' property to the Token and Session objects.
- Cache implemented to store the active status of a user to reduce calls to the database.
- `useAccessControl()` hook modified to check for user active status and if the user is deactivated to automatically sign the user out and redirect to `account-deactivated` page.
- `useSession` middleware that protects API endpoints updated to refuse access to deactivated accounts.
- `requireAuthentication` Page wrapper updated to redirect users to `account-deactivated` page when called Server Side
- Page layouts `Template.tsx` and `AdminNavLayout.tsx` use the `useAccessControl()` hook when rendered Client Side to ensure the User's active status is checked on pages that can have authenticated user interactions
- Audit log enum updated to include `UserActivated` and `UserDeactivated` events.
- Audit log event added to activation/deactivation of a user (who and by who)

TODO:
- Update Jest tests

| Admin                               | User                                      |
| ----------------------------------------------- | -------------------------------------------- |
| ![Admin deactivate account](https://github.com/cds-snc/platform-forms-client/assets/25329319/5b261062-a6d5-492e-87db-6120ee74e049) | ![Immediate deactivation](https://github.com/cds-snc/platform-forms-client/assets/25329319/56faad6b-9939-4150-806b-9bd8d286f197) |



# Test instructions | Instructions pour tester la modification

1. In one window log in as a user / In a second window log in as a user with the privileges required to deactivate a user.
2. In second window disable user in first window
3. In the first window navigate to any link in the app or refresh the page.
4. The user in the first window should be signed out and navigated to the account-deactivated page (it may take a few seconds).


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Will be difficult to create a test in Cypress since it requires an active session while the account is being disabled.


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
