### PR TITLE
Add security questions check

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -63,6 +63,19 @@ export function requireAuthentication(
         };
       }
 
+      if (
+        !session.user.securityQuestions &&
+        !context.resolvedUrl?.startsWith("/auth/setup-security-questions")
+      ) {
+        // check if user has setup security questions setup
+        return {
+          redirect: {
+            destination: `/${context.locale}/auth/setup-security-questions`,
+            permanent: false,
+          },
+        };
+      }
+
       if (!session.user.acceptableUse && !context.resolvedUrl?.startsWith("/auth/policy")) {
         // If they haven't agreed to Acceptable Use redirect to policy page for acceptance
         // If already on the policy page don't redirect, aka endless redirect loop.
@@ -72,19 +85,6 @@ export function requireAuthentication(
             destination: `/${context.locale}/auth/policy?referer=${
               localPathRegEx.test(context.resolvedUrl || "") ? context.resolvedUrl : "/myforms"
             }`,
-            permanent: false,
-          },
-        };
-      }
-
-      if (
-        !session.user.securityQuestions &&
-        !context.resolvedUrl?.startsWith("/auth/setup-security-questions")
-      ) {
-        // check if user has setup security questions setup
-        return {
-          redirect: {
-            destination: `/${context.locale}/auth/setup-security-questions`,
             permanent: false,
           },
         };

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -77,6 +77,19 @@ export function requireAuthentication(
         };
       }
 
+      if (
+        !session.user.securityQuestions &&
+        !context.resolvedUrl?.startsWith("/auth/setup-security-questions")
+      ) {
+        // check if user has setup security questions setup
+        return {
+          redirect: {
+            destination: `/${context.locale}/auth/setup-security-questions`,
+            permanent: false,
+          },
+        };
+      }
+
       const innerFunctionProps = await innerFunction({
         user: { ...session.user, ability: createAbility(session) },
         ...context,

--- a/lib/cache/securityQuestionsStatus.ts
+++ b/lib/cache/securityQuestionsStatus.ts
@@ -1,0 +1,43 @@
+import { logMessage } from "@lib/logger";
+import { getRedisInstance } from "../integration/redisConnector";
+
+// If NODE_ENV is in test mode (Jest Tests) do not use the cache
+const cacheAvailable: boolean = process.env.APP_ENV !== "test" && Boolean(process.env.REDIS_URL);
+
+// Return a random number between 300 and 600  (5 - 10 minutes)
+const randomCacheExpiry = () => Math.floor(Math.random() * 300 + 300);
+
+export const securityQuestionsCheck = async (userID: string): Promise<boolean | null> => {
+  const checkParameter = `auth:active:${userID}`;
+
+  if (cacheAvailable) {
+    try {
+      const redis = await getRedisInstance();
+      const value = await redis.get(checkParameter);
+      if (value) {
+        logMessage.debug(`Using Cached User Status for ${checkParameter}`);
+        return value === "1";
+      }
+    } catch (e) {
+      logMessage.error(e as Error);
+      throw new Error("Could not connect to cache");
+    }
+  }
+
+  return null;
+};
+
+export const securityQuestionsStatusUpdate = async (userID: string, status: boolean): Promise<void> => {
+  const modifyParameter = `auth:active:${userID}`;
+
+  if (!cacheAvailable) return;
+  try {
+    const redis = await getRedisInstance();
+
+    await redis.setex(modifyParameter, randomCacheExpiry(), status ? "1" : "0");
+    logMessage.debug(`Updating Cached User Status for ${modifyParameter}`);
+  } catch (e) {
+    logMessage.error(e as Error);
+    throw new Error("Could not connect to cache");
+  }
+};

--- a/lib/cache/securityQuestionsStatus.ts
+++ b/lib/cache/securityQuestionsStatus.ts
@@ -8,14 +8,14 @@ const cacheAvailable: boolean = process.env.APP_ENV !== "test" && Boolean(proces
 const randomCacheExpiry = () => Math.floor(Math.random() * 300 + 300);
 
 export const securityQuestionsCheck = async (userID: string): Promise<boolean | null> => {
-  const checkParameter = `auth:active:${userID}`;
+  const checkParameter = `auth:securityquestions:${userID}`;
 
   if (cacheAvailable) {
     try {
       const redis = await getRedisInstance();
       const value = await redis.get(checkParameter);
       if (value) {
-        logMessage.debug(`Using Cached User Status for ${checkParameter}`);
+        logMessage.debug(`Using Cached Security Questions Status for ${checkParameter}`);
         return value === "1";
       }
     } catch (e) {
@@ -28,14 +28,14 @@ export const securityQuestionsCheck = async (userID: string): Promise<boolean | 
 };
 
 export const securityQuestionsStatusUpdate = async (userID: string, status: boolean): Promise<void> => {
-  const modifyParameter = `auth:active:${userID}`;
+  const modifyParameter = `auth:securityquestions:${userID}`;
 
   if (!cacheAvailable) return;
   try {
     const redis = await getRedisInstance();
 
     await redis.setex(modifyParameter, randomCacheExpiry(), status ? "1" : "0");
-    logMessage.debug(`Updating Cached User Status for ${modifyParameter}`);
+    logMessage.debug(`Updating Security Questions Status for ${modifyParameter}`);
   } catch (e) {
     logMessage.error(e as Error);
     throw new Error("Could not connect to cache");

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -237,7 +237,7 @@ const checkUserHasSecurityQuestions = async (userID: string): Promise<boolean> =
     return cachedStatus;
   }
 
-  // @todo add real check here
+  // @todo add real check here once security questions are implemented
   const hasSecurityQuestions = false;
 
   // Update cache with new value

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -238,7 +238,7 @@ const checkUserHasSecurityQuestions = async (userID: string): Promise<boolean> =
   }
 
   // @todo add real check here once security questions are implemented
-  const hasSecurityQuestions = false;
+  const hasSecurityQuestions = true;
 
   // Update cache with new value
   // Do not need to await promise.  This is an update only action that on fail will

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -15,7 +15,10 @@ import { getPrivilegeRulesForUser } from "@lib/privileges";
 import { logEvent } from "@lib/auditLogs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { activeStatusCheck, activeStatusUpdate } from "@lib/cache/userActiveStatus";
-import { securityQuestionsCheck, securityQuestionsStatusUpdate } from "@lib/cache/securityQuestionsCheck";
+import {
+  securityQuestionsCheck,
+  securityQuestionsStatusUpdate,
+} from "@lib/cache/securityQuestionsStatus";
 
 if (
   (!process.env.COGNITO_APP_CLIENT_ID ||
@@ -141,6 +144,10 @@ export const authOptions: NextAuthOptions = {
         token.deactivated = true;
       }
 
+      if (!token.securityQuestions) {
+        token.securityQuestions = await checkUserHasSecurityQuestions(token.userId as string);
+      }
+
       return token;
     },
     async session({ session, token }) {
@@ -150,6 +157,7 @@ export const authOptions: NextAuthOptions = {
         id: token.userId,
         lastLoginTime: token.lastLoginTime,
         acceptableUse: token.acceptableUse,
+        securityQuestions: token.securityQuestions as boolean,
         name: token.name ?? null,
         email: token.email ?? null,
         image: token.picture ?? null,

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -15,6 +15,7 @@ import { getPrivilegeRulesForUser } from "@lib/privileges";
 import { logEvent } from "@lib/auditLogs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { activeStatusCheck, activeStatusUpdate } from "@lib/cache/userActiveStatus";
+import { securityQuestionsCheck, securityQuestionsStatusUpdate } from "@lib/cache/securityQuestionsCheck";
 
 if (
   (!process.env.COGNITO_APP_CLIENT_ID ||
@@ -214,6 +215,29 @@ const checkUserActiveStatus = async (userID: string): Promise<boolean> => {
   activeStatusUpdate(userID, user?.active ?? false);
 
   return user?.active ?? false;
+};
+
+/**
+ * Check to ensure user has security questions setup using a cache strategy
+ * @param userID id of the user to check
+ * @returns boolean active status
+ */
+const checkUserHasSecurityQuestions = async (userID: string): Promise<boolean> => {
+  // Check cache first
+  const cachedStatus = await securityQuestionsCheck(userID);
+  if (cachedStatus !== null) {
+    return cachedStatus;
+  }
+
+  // @todo add real check here
+  const hasSecurityQuestions = false;
+
+  // Update cache with new value
+  // Do not need to await promise.  This is an update only action that on fail will
+  // force a recheck of the database on next call
+  securityQuestionsStatusUpdate(userID, hasSecurityQuestions ?? false);
+
+  return hasSecurityQuestions ?? false;
 };
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/auth/setup-security-questions.tsx
+++ b/pages/auth/setup-security-questions.tsx
@@ -1,0 +1,45 @@
+import React, { ReactElement } from "react";
+import { useTranslation } from "next-i18next";
+import Head from "next/head";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { GetServerSideProps } from "next";
+
+import UserNavLayout from "@components/globals/layouts/UserNavLayout";
+import { LinkButton } from "@components/globals";
+
+const SecurityQuestions = () => {
+  const { i18n, t } = useTranslation(["deactivated"]);
+  const supportHref = `/${i18n.language}/form-builder/support`;
+
+  return (
+    <>
+      <Head>
+        <title>Setup Security Questions</title>
+      </Head>
+      <div>
+        <h2 className="mt-4 mb-6 p-0">Setup Security Questions</h2>
+        <p className="mb-10">todo</p>
+        <div className="laptop:flex">
+          <LinkButton.Primary href={supportHref} className="mb-2">
+            {t("cta.label")}
+          </LinkButton.Primary>
+        </div>
+      </div>
+    </>
+  );
+};
+
+SecurityQuestions.getLayout = (page: ReactElement) => {
+  return <UserNavLayout>{page}</UserNavLayout>;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    props: {
+      ...(context.locale &&
+        (await serverSideTranslations(context.locale, ["common", "deactivated"]))),
+    },
+  };
+};
+
+export default SecurityQuestions;

--- a/pages/form-builder/index.tsx
+++ b/pages/form-builder/index.tsx
@@ -50,6 +50,16 @@ export const getServerSideProps: GetServerSideProps = async ({
     };
   }
 
+  if (session && !session.user.securityQuestions) {
+    // If they haven't setup security questions Use redirect to policy page for acceptance
+    return {
+      redirect: {
+        destination: `/${locale}/auth/setup-security-questions`,
+        permanent: false,
+      },
+    };
+  }
+
   if (formID && session) {
     try {
       const ability = createAbility(session);

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -315,6 +315,16 @@ export const getServerSideProps: GetServerSideProps = async ({
     };
   }
 
+  if (session && !session.user.securityQuestions) {
+    // If they haven't setup security questions Use redirect to policy page for acceptance
+    return {
+      redirect: {
+        destination: `/${locale}/auth/setup-security-questions`,
+        permanent: false,
+      },
+    };
+  }
+
   if (formID && session) {
     try {
       const ability = createAbility(session);

--- a/pages/form-builder/settings/branding-request.tsx
+++ b/pages/form-builder/settings/branding-request.tsx
@@ -39,6 +39,16 @@ export const getServerSideProps: GetServerSideProps = async ({ locale, req, res 
     };
   }
 
+  if (session && !session.user.securityQuestions) {
+    // If they haven't setup security questions Use redirect to policy page for acceptance
+    return {
+      redirect: {
+        destination: `/${locale}/auth/setup-security-questions`,
+        permanent: false,
+      },
+    };
+  }
+
   const brandingRequestFormSetting = await getAppSetting("brandingRequestForm");
 
   if (!brandingRequestFormSetting) {

--- a/pages/form-builder/settings/branding.tsx
+++ b/pages/form-builder/settings/branding.tsx
@@ -43,6 +43,16 @@ export const getServerSideProps: GetServerSideProps = async ({ locale, req, res 
     };
   }
 
+  if (session && !session.user.securityQuestions) {
+    // If they haven't setup security questions Use redirect to policy page for acceptance
+    return {
+      redirect: {
+        destination: `/${locale}/auth/setup-security-questions`,
+        permanent: false,
+      },
+    };
+  }
+
   const hasBrandingRequestForm = Boolean(await getAppSetting("brandingRequestForm"));
 
   return {

--- a/types/next_auth/index.d.ts
+++ b/types/next_auth/index.d.ts
@@ -31,5 +31,6 @@ declare module "next-auth/jwt" {
     acceptableUse: boolean;
     newlyRegistered?: boolean;
     deactivated?: boolean;
+    securityQuestions?: boolean;
   }
 }

--- a/types/next_auth/index.d.ts
+++ b/types/next_auth/index.d.ts
@@ -16,6 +16,7 @@ declare module "next-auth" {
       image?: string | null;
       newlyRegistered?: boolean;
       deactivated?: boolean;
+      securityQuestions?: boolean;
     };
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/2428

- Adds check to see if user has security questions setup and if not re-direct them to the setup page (temp page)

Will add tests in future PR just getting code in place to help unblock other PRs

Noting - check defaults to `true` as we need to do a real check still.

# Test instructions 

Update hardcoded value to equal `false` in [...nextauth].ts

which should in turn setup the redirect
```javascript
// @todo add real check here once security questions are implemented
  const hasSecurityQuestions = true;
```


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
