### PR TITLE
fix: update audit logs to be more unique

### DIFF
--- a/__tests__/api/id/form/submission/download.test.ts
+++ b/__tests__/api/id/form/submission/download.test.ts
@@ -177,9 +177,9 @@ describe("/api/id/[form]/[submission]/download", () => {
       expect(mockLogEvent).toHaveBeenNthCalledWith(
         2,
         "1",
-        { type: "Response" },
+        { type: "Response", id: "NAME#123456789" },
         "AccessDenied",
-        "Attemped to download response for submissionID 123456789"
+        "Attemped to download response"
       );
     });
 

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -18,6 +18,7 @@ export enum AuditLogEvent {
   ConfirmResponse = "ConfirmResponse",
   IdentifyProblemResponse = "IdentifyProblemResponse",
   ListResponses = "ListResponses",
+  DeleteResponses = "DeleteResponses",
   // User Events
   UserRegistration = "UserRegistration",
   UserSignIn = "UserSignIn",

--- a/lib/vault.ts
+++ b/lib/vault.ts
@@ -98,7 +98,10 @@ export async function listAllSubmissions(
     if (e instanceof AccessControlError)
       logEvent(
         ability.userID,
-        { type: "Response" },
+        {
+          type: "Form",
+          id: formID,
+        },
         "AccessDenied",
         `Attempted to list all responses for form ${formID}`
       );
@@ -171,7 +174,10 @@ export async function listAllSubmissions(
 
     logEvent(
       ability.userID,
-      { type: "Response" },
+      {
+        type: "Form",
+        id: formID,
+      },
       "ListResponses",
       `List all responses for form ${formID}`
     );
@@ -208,7 +214,7 @@ async function listAllSubmissionsAndConfirmations(
     if (e instanceof AccessControlError)
       logEvent(
         ability.userID,
-        { type: "Response" },
+        { type: "Form", id: formID },
         "AccessDenied",
         `Attempted to access all submissions and confirmations for form ${formID}`
       );
@@ -248,7 +254,7 @@ async function listAllSubmissionsAndConfirmations(
 
     logEvent(
       ability.userID,
-      { type: "Response" },
+      { type: "Form", id: formID },
       "ListResponses",
       `List all responses for form ${formID}`
     );
@@ -285,10 +291,10 @@ export async function numberOfUnprocessedSubmissions(
 }
 
 /**
- * This method deletes all responses for a given form
+ * This method deletes responses and confirmation codes
  * @param ability
  * @param dynamoDb - DynamoDB Document Client
- * @param formResponses - List of form submissions and confirmations
+ * @param formResponses - List of form submissions and confirmation codes
  * @param formID
  */
 export async function deleteResponses(
@@ -303,7 +309,7 @@ export async function deleteResponses(
     if (e instanceof AccessControlError)
       logEvent(
         ability.userID,
-        { type: "Response" },
+        { type: "Form", id: formID },
         "AccessDenied",
         `Attempted to delete all responses for form ${formID}`
       );
@@ -379,6 +385,12 @@ export async function deleteResponses(
       throw new Error(`Failed to delete form responses from DynamoDB.`);
     }
   }
+  logEvent(
+    ability.userID,
+    { type: "Form", id: formID },
+    "DeleteResponses",
+    `Deleted responses for form ${formID}`
+  );
   return { responsesDeleted };
 }
 

--- a/pages/api/id/[form]/[submission]/download.tsx
+++ b/pages/api/id/[form]/[submission]/download.tsx
@@ -167,9 +167,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
     if (error instanceof AccessControlError) {
       logEvent(
         ability.userID,
-        { type: "Response" },
+        { type: "Response", id: `NAME#${submissionName}` },
         "AccessDenied",
-        `Attemped to download response for submissionID ${submissionName}`
+        `Attemped to download response`
       );
       return res.status(403).json({ error: "Forbidden" });
     }

--- a/pages/api/id/[form]/submission/confirm.ts
+++ b/pages/api/id/[form]/submission/confirm.ts
@@ -47,7 +47,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
     if (e instanceof AccessControlError) {
       logEvent(
         ability.userID,
-        { type: "Response" },
+        { type: "Form", id: formId },
         "AccessDenied",
         `Attempted to confirm response without form ownership`
       );

--- a/pages/api/id/[form]/submission/report.ts
+++ b/pages/api/id/[form]/submission/report.ts
@@ -50,7 +50,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, props: Middlew
     if (e instanceof AccessControlError) {
       logEvent(
         ability.userID,
-        { type: "Response" },
+        { type: "Form", id: formId },
         "AccessDenied",
         `Attempted to identify response problem without form ownership`
       );


### PR DESCRIPTION
# Summary | Résumé
Some audit logs were being generated that had identical keys which were causing errors.

For general Response logs (for example get all responses for a form) the logs have been changed to instead reference the form ID.  Response subject and ID's are instead reserved for when dealing with a single response.

# Test instructions | Instructions pour tester la modification

Difficult to test...


# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
