### PR TITLE
chore: refactor delete responses on publish

### DIFF
--- a/lib/types/retrieval-types.ts
+++ b/lib/types/retrieval-types.ts
@@ -36,12 +36,6 @@ export type VaultSubmissionList = TypeOmit<
   "formSubmission" | "submissionID" | "confirmationCode"
 >;
 
-export type VaultSubmissionAndConfirmationList = {
-  formID: string;
-  confirmationCode: string;
-  name: string;
-};
-
 export enum VaultStatus {
   NEW = "New",
   DOWNLOADED = "Downloaded",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,9 +1,5 @@
-import { VaultSubmissionAndConfirmationList } from "@lib/types/retrieval-types";
-
-export const chunkArray = (
-  arr: NonNullable<VaultSubmissionAndConfirmationList>[] | [],
-  size: number
-) =>
-  Array.from({ length: Math.ceil(arr.length / size) }, (v, i) =>
+export function chunkArray<T>(arr: T[], size: number): T[][] {
+  return Array.from({ length: Math.ceil(arr.length / size) }, (v, i) =>
     arr.slice(i * size, i * size + size)
   );
+}

--- a/lib/vault.ts
+++ b/lib/vault.ts
@@ -1,4 +1,4 @@
-import { QueryCommand, QueryCommandInput, DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { QueryCommand, QueryCommandInput } from "@aws-sdk/lib-dynamodb";
 import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
 import { VaultSubmissionList, UserAbility, VaultStatus } from "@lib/types";
 import { logEvent } from "./auditLogs";

--- a/pages/form-builder/settings/[formId]/form.tsx
+++ b/pages/form-builder/settings/[formId]/form.tsx
@@ -7,7 +7,7 @@ import { SettingsNavigation } from "@components/form-builder/app/navigation/Sett
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { getTemplateWithAssociatedUsers } from "@lib/templates";
 import { requireAuthentication } from "@lib/auth";
-import { checkPrivileges, checkPrivilegesAsBoolean } from "@lib/privileges";
+import { checkPrivilegesAsBoolean } from "@lib/privileges";
 import { getUsers } from "@lib/users";
 import { User } from "@prisma/client";
 import { FormRecord } from "@lib/types";


### PR DESCRIPTION
# Summary | Résumé
Tweaks to enhance performance and fix a few issues
- Simplify the call to get the entries related to the form ID in the vault.
- Ensure that if DynamoDB needs to paginate due to a large number of responses the code can handle the use case
- Build a promise array of the batched delete request and allow them to begin while continuing to generate the promise array.
- Fix privileges and ability in tests where the privileges were modified instead of the user ID.
- Modify util `chunkArray` to use a generic type so that it is easier for other functions to leverage it.

# Test instructions | Instructions pour tester la modification
- Create a draft form
- Send multiple form responses
- Check responses page that responses are available
- Publish form
- Check responses page that responses are gone

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
