### PR TITLE
Adds unknown error to profile dialog plus loader

### DIFF
--- a/components/admin/Profile/EditSecurityQuestionModal.tsx
+++ b/components/admin/Profile/EditSecurityQuestionModal.tsx
@@ -11,10 +11,6 @@ import { getCsrfToken } from "next-auth/react";
 import { useRouter } from "next/router";
 import debounce from "lodash.debounce";
 
-// TODO: Dialog component currently takes actions to control the dialog behavior. Would be nice to
-// be able to wire with a form element to work with onSubmit and button type=submit to get form
-// behaviors like keying enter in an input to submit the form.
-
 const updateSecurityQuestion = async (
   oldQuestionId: string,
   newQuestionId: string,
@@ -118,15 +114,6 @@ export const EditSecurityQuestionModal = ({
     }
   };
 
-  // TODO: ask design about content for a Dialog fail error
-  if (!questionNumber || !questionId || questions?.length <= 0) {
-    return (
-      <Dialog title={t("errorTodo")} dialogRef={dialog}>
-        <p>TODO missing dialog data</p>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog
       handleClose={handleClose}
@@ -139,7 +126,20 @@ export const EditSecurityQuestionModal = ({
       }
     >
       <>
-        {/* TODO: probably will not need the error since it can be removed programmatically */}
+        {(!questionNumber || !questionId || questions?.length <= 0) && (
+          <Attention
+            type={AttentionTypes.ERROR}
+            isAlert={true}
+            classes="mb-6"
+            heading={t("securityQuestionModal.errors.unknownError.title")}
+          >
+            <p className="text-sm text-[#26374a]">
+              {t("securityQuestionModal.errors.unknownError.content")}
+            </p>
+          </Attention>
+        )}
+
+        {/* TODO: probably will not need the error since already selected questions can be removed programmatically */}
         {isFormError && (
           <Attention
             type={AttentionTypes.ERROR}

--- a/components/admin/Profile/EditSecurityQuestionModal.tsx
+++ b/components/admin/Profile/EditSecurityQuestionModal.tsx
@@ -114,6 +114,23 @@ export const EditSecurityQuestionModal = ({
     }
   };
 
+  if (!questionNumber || !questionId || questions?.length <= 0) {
+    return (
+      <Dialog handleClose={handleClose} title={t("securityQuestionModal.title")} dialogRef={dialog}>
+        <Attention
+          type={AttentionTypes.ERROR}
+          isAlert={true}
+          classes="mb-6"
+          heading={t("securityQuestionModal.errors.unknownError.title")}
+        >
+          <p className="text-sm text-[#26374a]">
+            {t("securityQuestionModal.errors.unknownError.content")}
+          </p>
+        </Attention>
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog
       handleClose={handleClose}
@@ -126,19 +143,6 @@ export const EditSecurityQuestionModal = ({
       }
     >
       <>
-        {(!questionNumber || !questionId || questions?.length <= 0) && (
-          <Attention
-            type={AttentionTypes.ERROR}
-            isAlert={true}
-            classes="mb-6"
-            heading={t("securityQuestionModal.errors.unknownError.title")}
-          >
-            <p className="text-sm text-[#26374a]">
-              {t("securityQuestionModal.errors.unknownError.content")}
-            </p>
-          </Attention>
-        )}
-
         {/* TODO: probably will not need the error since already selected questions can be removed programmatically */}
         {isFormError && (
           <Attention

--- a/pages/auth/setup-security-questions.tsx
+++ b/pages/auth/setup-security-questions.tsx
@@ -88,6 +88,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
         }}
         onSubmit={async (values, { setSubmitting }) => {
           setFormError("");
+          setSubmitting(true);
           const data: Answer[] = [
             { questionId: values.question1, answer: values.answer1 },
             { questionId: values.question2, answer: values.answer2 },
@@ -98,10 +99,12 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
           // Fail, show an error
           if (result !== "success") {
             setFormError(result);
+          } else {
+            // Success, go to next step.
+            // Note: Await so async call will not auto resolve and "flash" the submit to enabled
+            // while loading.
+            await router.push({ pathname: `/${i18n.language}/myforms` });
           }
-
-          // Success, go to next step
-          router.push({ pathname: `/${i18n.language}/myforms` });
 
           setSubmitting(false);
         }}
@@ -109,7 +112,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
         validateOnBlur={false}
         validationSchema={validationSchema}
       >
-        {({ handleSubmit }) => (
+        {({ handleSubmit, isSubmitting }) => (
           <>
             {formError && (
               <Alert
@@ -257,7 +260,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
                 />
               </fieldset>
 
-              <Button theme="primary" type="submit" className="mr-4">
+              <Button theme="primary" type="submit" className="mr-4" disabled={isSubmitting}>
                 {t("continue")}
               </Button>
               <LinkButton.Secondary href={supportHref}>{t("contact")}</LinkButton.Secondary>

--- a/public/static/locales/en/profile.json
+++ b/public/static/locales/en/profile.json
@@ -31,7 +31,11 @@
         "title": "The security question has been changed",
         "content": "Would you like to save your changes?"
       },
-      "invalidInput": "Must be at least 4 characters."
+      "invalidInput": "Must be at least 4 characters.",
+      "unknownError": {
+        "title": "Unknown error",
+        "content": "An unknown error occurred and we could not process your request. Please try again later."
+      }
     }
   }
 }

--- a/public/static/locales/fr/profile.json
+++ b/public/static/locales/fr/profile.json
@@ -19,7 +19,7 @@
     "requirmentsList": {
       "title": "Votre réponse devrait être difficile à deviner:",
       "requirement1": "Au moins 4 caractères.",
-      "requirement2": "Aucune information d’identification personnelle."
+      "requirement2": "Aucune information d'identification personnelle."
     },
     "save": "Enregistrer",
     "errors": {
@@ -31,7 +31,11 @@
         "title": "Cette question de sécurité a été modifiée",
         "content": "Souhaitez-vous enregistrer vos modifications?"
       },
-      "invalidInput": "Doit être au moins 4 caractères."
+      "invalidInput": "Doit être au moins 4 caractères.",
+      "unknownError": {
+        "title": "Unknown error[FR]",
+        "content": "An unknown error occurred and we could not process your request. Please try again later.[FR]"
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Adds an "unknown error" to the profile dialog. 

Also adds the start of a "loader" for the create security questions page. I was noticing a small delay, even locally, when submitting the form. Currently this just disables the submit button as an indicator when submitting.

## Future work

Consider a "submitting" (previously called "loading") pattern for all/most of our forms.
