### PR TITLE
Adds on blur behavior to security questions

### DIFF
--- a/components/globals/Input/Input.tsx
+++ b/components/globals/Input/Input.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import classnames from "classnames";
+import { useField } from "formik";
+import { ErrorMessage } from "@components/forms";
+import { InputFieldProps, CharacterCountMessages, HTMLTextInputTypeAttribute } from "@lib/types";
+
+/**
+ * Note: Copy+Past and edit from forms/Input. This is to allow us to customize inputs wihout worry
+ * of modifying the look and field of existing form-forms.
+ *
+ * TODO: clean up below, add a unit test, and then remove this and above comment :)
+ */
+
+export interface InputProps extends InputFieldProps {
+  type: HTMLTextInputTypeAttribute;
+  characterCountMessages?: CharacterCountMessages;
+  placeholder?: string;
+}
+
+export const Input = (props: InputProps & JSX.IntrinsicElements["input"]): React.ReactElement => {
+  const {
+    id,
+    type,
+    className,
+    required,
+    ariaDescribedBy,
+    placeholder,
+    autoComplete,
+    maxLength,
+    characterCountMessages,
+  } = props;
+  const [field, meta, helpers] = useField(props);
+  const classes = classnames("gc-input-text", className);
+
+  const [remainingCharacters, setRemainingCharacters] = useState(maxLength ?? 0);
+
+  const handleTextInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    helpers.setValue(event.target.value);
+    if (maxLength) {
+      setRemainingCharacters(maxLength - event.target.value.length);
+    }
+  };
+
+  const remainingCharactersMessage = characterCountMessages
+    ? characterCountMessages.part1 + " " + remainingCharacters + " " + characterCountMessages.part2
+    : "";
+
+  const tooManyCharactersMessage = characterCountMessages
+    ? characterCountMessages.part1Error +
+      " " +
+      remainingCharacters * -1 +
+      " " +
+      characterCountMessages.part2Error
+    : "";
+
+  const ariaDescribedByIds = () => {
+    const returnValue = [];
+    if (meta.error) returnValue.push("errorMessage" + id);
+    if (maxLength && (remainingCharacters < 0 || remainingCharacters < maxLength * 0.25))
+      returnValue.push("characterCountMessage" + id);
+    if (ariaDescribedBy) returnValue.push(ariaDescribedBy);
+    return returnValue.length > 0 ? { "aria-describedby": returnValue.join(" ") } : {};
+  };
+
+  return (
+    <>
+      {meta.touched && meta.error && (
+        <ErrorMessage id={"errorMessage" + id}>{meta.error}</ErrorMessage>
+      )}
+      <input
+        data-testid="textInput"
+        className={classes}
+        id={id}
+        type={type}
+        required={required}
+        autoComplete={autoComplete ? autoComplete : "off"}
+        placeholder={placeholder}
+        {...ariaDescribedByIds()}
+        {...field}
+        onChange={handleTextInputChange}
+      />
+      {characterCountMessages &&
+        maxLength &&
+        remainingCharacters < maxLength * 0.25 &&
+        remainingCharacters >= 0 && (
+          <div id={"characterCountMessage" + id} aria-live="polite">
+            {remainingCharactersMessage}
+          </div>
+        )}
+      {characterCountMessages && maxLength && remainingCharacters < 0 && (
+        <div id={"characterCountMessage" + id} className="gc-error-message" aria-live="polite">
+          {tooManyCharactersMessage}
+        </div>
+      )}
+    </>
+  );
+};

--- a/components/globals/Select/Select.tsx
+++ b/components/globals/Select/Select.tsx
@@ -23,7 +23,7 @@ export const Select = (props: SelectProps): React.ReactElement => {
   const [field, meta] = useField(props);
   return (
     <>
-      {meta.error && <ErrorMessage>{meta.error}</ErrorMessage>}
+      {meta.touched && meta.error && <ErrorMessage>{meta.error}</ErrorMessage>}
 
       <select
         id={id}

--- a/pages/auth/setup-security-questions.tsx
+++ b/pages/auth/setup-security-questions.tsx
@@ -4,12 +4,13 @@ import { useTranslation } from "next-i18next";
 import Head from "next/head";
 import { Formik, FormikProps } from "formik";
 import * as Yup from "yup";
-import { TextInput, Label, Alert } from "@components/forms";
+import { Label, Alert } from "@components/forms";
 import { requireAuthentication, retrievePoolOfSecurityQuestions } from "@lib/auth";
 import { checkPrivileges } from "@lib/privileges";
 import { Button, ErrorStatus } from "@components/globals";
 import UserNavLayout from "@components/globals/layouts/UserNavLayout";
 import { Select } from "@components/globals/Select/Select";
+import { Input } from "@components/globals/Input/Input";
 import { LinkButton } from "@components/globals";
 import { logMessage } from "@lib/logger";
 import { fetchWithCsrfToken } from "@lib/hooks/auth/fetchWithCsrfToken";
@@ -44,11 +45,6 @@ const updateSecurityQuestions = async (questionsAnswers: Answer[]): Promise<stri
     return "success";
   } catch (err) {
     logMessage.error(err);
-
-    // TODO may want to add "friendly" text or generalize error? Here are the response errors:
-    // e.g. "Malformed request", "All security questions must be different", "Failed to create..
-
-    // TODO typing if we stay with showing errors direct from the API
     const error = err as AxiosError;
     return error?.response && error?.response.data.error;
   }
@@ -109,7 +105,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
           setSubmitting(false);
         }}
         validateOnChange={false}
-        validateOnBlur={false}
+        validateOnBlur={true}
         validationSchema={validationSchema}
       >
         {({ handleSubmit, isSubmitting }) => (
@@ -169,7 +165,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
                 <Label id={"label-answer1"} htmlFor={"answer1"} className="required mt-6" required>
                   {t("answer")}
                 </Label>
-                <TextInput
+                <Input
                   className="gc-input-text w-full rounded"
                   type={"text"}
                   id={"answer1"}
@@ -210,7 +206,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
                 <Label id={"label-answer2"} htmlFor={"answer2"} className="required mt-6" required>
                   {t("answer")}
                 </Label>
-                <TextInput
+                <Input
                   className="gc-input-text w-full rounded"
                   type={"text"}
                   id={"answer2"}
@@ -251,7 +247,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
                 <Label id={"label-answer3"} htmlFor={"answer3"} className="required mt-6" required>
                   {t("answer")}
                 </Label>
-                <TextInput
+                <Input
                   className="gc-input-text w-full rounded"
                   type={"text"}
                   id={"answer3"}


### PR DESCRIPTION
# Summary | Résumé

Adds on blur behaviour to the Setup Security Questions form. Now validation will run when tabbing or clicking out of a field and only update the validation for that one field.

## Test

Go to the setup security form and try clicking on a select or input. Then click outside that field and only that field's validation should be updated.
![Screenshot 2023-08-02 at 8 42 52 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/2ab9f9ce-be2b-4c83-b98b-81d6b5510655)

