### PR TITLE
Add redirect if missing security questions

### DIFF
--- a/lib/auth/securityQuestions.ts
+++ b/lib/auth/securityQuestions.ts
@@ -148,11 +148,18 @@ export async function retrieveUserSecurityQuestions({
   return userSecurityAnswers.map((answer) => answer.question);
 }
 
-export async function userHasSecurityQuestions(userId: string): Promise<boolean> {
+export async function userHasSecurityQuestions({
+  userId,
+  email,
+}: {
+  userId?: string;
+  email?: string;
+}): Promise<boolean> {
   const numberOfQuestions = await prisma.securityAnswer.count({
     where: {
       user: {
         id: userId,
+        email,
       },
     },
   });

--- a/lib/hooks/auth/useResetPassword.ts
+++ b/lib/hooks/auth/useResetPassword.ts
@@ -6,6 +6,7 @@ import { useTranslation } from "next-i18next";
 import { fetchWithCsrfToken } from "./fetchWithCsrfToken";
 import { useAuthErrors } from "./useAuthErrors";
 import { hasError } from "@lib/hasError";
+import axios from "axios";
 
 export const useResetPassword = ({
   onConfirmSecurityQuestions,
@@ -50,10 +51,15 @@ export const useResetPassword = ({
     authErrorsReset();
     try {
       await fetchWithCsrfToken("/api/auth/password-reset", { email });
-
       if (successCallback) successCallback();
     } catch (err) {
-      logMessage.error(err);
+      if (axios.isAxiosError(err)) {
+        if (err.response?.data.error === "Failed to send password reset link") {
+          await router.push("/auth/reset-failed");
+          if (failedCallback) failedCallback(err.response?.data.error);
+          return;
+        }
+      }
 
       if (hasError("InvalidParameterException", err) && failedCallback) {
         failedCallback("InvalidParameterException");

--- a/lib/hooks/auth/useResetPassword.ts
+++ b/lib/hooks/auth/useResetPassword.ts
@@ -53,6 +53,7 @@ export const useResetPassword = ({
       await fetchWithCsrfToken("/api/auth/password-reset", { email });
       if (successCallback) successCallback();
     } catch (err) {
+      logMessage.error(err);
       if (axios.isAxiosError(err)) {
         if (err.response?.data.error === "Failed to send password reset link") {
           await router.push("/auth/reset-failed");

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -136,7 +136,7 @@ export const authOptions: NextAuthOptions = {
 
       // Check if user has setup required Security Questions
       if (!token.hasSecurityQuestions) {
-        token.hasSecurityQuestions = await userHasSecurityQuestions(token.userId);
+        token.hasSecurityQuestions = await userHasSecurityQuestions({ userId: token.userId });
       }
 
       // Check if user has been deactivated

--- a/pages/auth/reset-failed.tsx
+++ b/pages/auth/reset-failed.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement } from "react";
+import { GetServerSideProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useTranslation } from "next-i18next";
+import Head from "next/head";
+
+import UserNavLayout from "@components/globals/layouts/UserNavLayout";
+import { LinkButton } from "@components/globals";
+import { BackArrowIcon } from "@components/form-builder/icons";
+
+export const ResetFailed = () => {
+  const { t, i18n } = useTranslation(["reset-password", "common"]);
+  const homeHref = `/${i18n.language}/auth/login`;
+  const supportHref = `/${i18n.language}/form-builder/support`;
+
+  return (
+    <>
+      <Head>
+        <title>{t("resetFailed.title")}</title>
+      </Head>
+      <div>
+        <h2 className="mb-6 mt-4 p-0" data-testid="session-expired">
+          {t("resetFailed.title")}
+        </h2>
+        <p className="mb-10">{t("resetFailed.description")}</p>
+        <div className="laptop:flex">
+          <LinkButton.Primary href={homeHref} className="mb-2 mr-3">
+            <span>
+              <BackArrowIcon className="mr-2 inline-block self-stretch fill-white" />
+              {t("account.actions.backToSignIn", { ns: "common" })}
+            </span>
+          </LinkButton.Primary>
+          <LinkButton.Secondary href={supportHref} className="mb-2">
+            {t("errorPanel.cta.support", { ns: "common" })}
+          </LinkButton.Secondary>
+        </div>
+      </div>
+    </>
+  );
+};
+
+ResetFailed.getLayout = (page: ReactElement) => {
+  return <UserNavLayout contentWidth="tablet:w-[768px] laptop:w-[850px]">{page}</UserNavLayout>;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    props: {
+      ...(context.locale &&
+        (await serverSideTranslations(context.locale, ["common", "reset-password"]))),
+    },
+  };
+};
+
+export default ResetFailed;

--- a/pages/auth/resetpassword.tsx
+++ b/pages/auth/resetpassword.tsx
@@ -600,6 +600,7 @@ ResetPassword.getLayout = (page: ReactElement) => {
 export const getServerSideProps: GetServerSideProps = async ({ query: { token }, locale }) => {
   // if the password reset feature flag is not enabled. Redirect to the login page
   const passwordResetEnabled = await checkOne("passwordReset");
+
   if (!passwordResetEnabled) {
     return {
       redirect: {
@@ -616,6 +617,15 @@ export const getServerSideProps: GetServerSideProps = async ({ query: { token },
     try {
       email = await getPasswordResetAuthenticatedUserEmailAddress(token as string);
       userSecurityQuestions = await retrieveUserSecurityQuestions({ email });
+
+      if (userSecurityQuestions.length === 0) {
+        return {
+          redirect: {
+            destination: `/${locale}/auth/reset-failed`,
+            permanent: false,
+          },
+        };
+      }
     } catch (e) {
       if (e instanceof PasswordResetExpiredLink) {
         return {

--- a/public/static/locales/en/reset-password.json
+++ b/public/static/locales/en/reset-password.json
@@ -53,5 +53,9 @@
   "expiredLink": {
     "title": "Your link expired",
     "description": "Try resetting again to generate a new link."
+  },
+  "resetFailed": {
+    "title": "Something went wrong",
+    "description": "Sorry, there was a problem and we lost you."
   }
 }

--- a/public/static/locales/fr/reset-password.json
+++ b/public/static/locales/fr/reset-password.json
@@ -40,8 +40,8 @@
   },
   "loading": "Chargement...",
   "errorPanel": {
-    "defaultTitle": "Something went wrong",
-    "defaultMessage": "Sorry, there was a problem and we lost you."
+    "defaultTitle": "[FR] Something went wrong",
+    "defaultMessage": "[FR] Sorry, there was a problem and we lost you."
   },
   "magicLink": {
     "title": "[FR] Check your email for a link",
@@ -53,5 +53,9 @@
   "expiredLink": {
     "title": "[FR] Your link expired",
     "description": "[FR]  Try resetting again to generate a new link."
+  },
+  "resetFailed": {
+    "defaultTitle": "[FR] Something went wrong",
+    "defaultMessage": "[FR] Sorry, there was a problem and we lost you."
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes #2502

Adds redirect to reset failed for 2 scenarios

1) via a reset magic link (this should never happen as the link shouldn't be generated) 
2) resetting with no security questions (added a check before sending the link)

<img width="500" alt="Screenshot 2023-08-09 at 3 21 30 PM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/8cdcea7e-d44e-4ded-ad61-0472c88dc1d5">

# Test instructions | Instructions pour tester la modification

- Test reset password without setting up security questions first

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
