### PR TITLE
fix: disables input field for form name on published forms

### DIFF
--- a/components/form-builder/app/navigation/FileName.tsx
+++ b/components/form-builder/app/navigation/FileName.tsx
@@ -7,12 +7,14 @@ import { LocalizedFormProperties } from "@formbuilder/types";
 
 export const FileNameInput = () => {
   const { t } = useTranslation(["form-builder"]);
-  const { updateField, getName } = useTemplateStore((s) => ({
+  const { updateField, getName, getIsPublished } = useTemplateStore((s) => ({
     getName: s.getName,
     updateField: s.updateField,
+    getIsPublished: s.getIsPublished,
   }));
 
   const fileName = getName();
+  const isPublished = getIsPublished();
 
   const [content, setContent] = useState(fileName);
   const [isEditing, setIsEditing] = useState(false);
@@ -103,6 +105,7 @@ export const FileNameInput = () => {
         }}
         onChange={(e) => setContent(e.target.value)}
         aria-label={t("formName", { ns: "form-builder" })}
+        disabled={isPublished && true}
       />
     </div>
   );


### PR DESCRIPTION
# Summary | Résumé
The form name component appears to be editable after publishing even though it doesn't update or save

The easiest way to fix this is by simply disabling the input field when a form is published


| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
|![Screenshot 2023-08-09 at 4 21 18 PM](https://github.com/cds-snc/platform-forms-client/assets/916044/f9cfd2b7-04c1-40a9-847b-ce16a03bfc21) |![Screenshot 2023-08-09 at 4 21 36 PM](https://github.com/cds-snc/platform-forms-client/assets/916044/a5961100-f0ed-4393-ba93-cb183002e58a) |

# Test instructions | Instructions pour tester la modification

1. Publish a form
2. Go to the settings of the form
3. Click on the form name. It should not be editable.

1. Go to an unpublished form
2. Click on the form name. It should still be editable and saves on "Save on draft" or by clicking on another page.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
