### PR TITLE
chore: Remove password reset feature flag

### DIFF
--- a/flag_initialization/default_flag_settings.json
+++ b/flag_initialization/default_flag_settings.json
@@ -4,7 +4,6 @@
   "reCaptcha": false,
   "formTimer": false,
   "accountRegistration": true,
-  "passwordReset": false,
   "supportForms": false,
   "experimentalBlocks": false
 }

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -35,7 +35,6 @@ const LoginStep = ({
   const { t } = useTranslation(["login", "cognito-errors", "common"]);
 
   const { status: registrationOpen } = useFlag("accountRegistration");
-  const { status: passwordResetEnabled } = useFlag("passwordReset");
 
   const validationSchema = Yup.object().shape({
     username: Yup.string()
@@ -145,14 +144,11 @@ const LoginStep = ({
                   required
                 />
               </div>
-              {passwordResetEnabled && (
-                <p className="mb-10 -mt-6">
-                  <Link href={"/auth/resetpassword"} className="-mt-8 mb-10">
-                    {t("resetPasswordText")}
-                  </Link>
-                </p>
-              )}
-
+              <p className="mb-10 -mt-6">
+                <Link href={"/auth/resetpassword"} className="-mt-8 mb-10">
+                  {t("resetPasswordText")}
+                </Link>
+              </p>
               <Button theme="primary" type="submit">
                 {t("continueButton")}
               </Button>

--- a/pages/auth/resetpassword.tsx
+++ b/pages/auth/resetpassword.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "next-i18next";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import UserNavLayout from "@components/globals/layouts/UserNavLayout";
-import { checkOne } from "@lib/cache/flags";
 import Link from "next/link";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -598,18 +597,6 @@ ResetPassword.getLayout = (page: ReactElement) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async ({ query: { token }, locale }) => {
-  // if the password reset feature flag is not enabled. Redirect to the login page
-  const passwordResetEnabled = await checkOne("passwordReset");
-
-  if (!passwordResetEnabled) {
-    return {
-      redirect: {
-        destination: `/${locale}/auth/login`,
-        permanent: false,
-      },
-    };
-  }
-
   let userSecurityQuestions: SecurityQuestion[] = [];
   let email = "";
 

--- a/public/static/locales/en/admin-flags.json
+++ b/public/static/locales/en/admin-flags.json
@@ -34,10 +34,6 @@
       "title": "Account creation",
       "description": "Allow users to register for an account"
     },
-    "passwordReset": {
-      "title": "Allow password resets",
-      "description": "Allow users to reset their passwords"
-    },
     "supportForms": {
       "title": "Support forms",
       "description": "Whether or not support forms are enabled"

--- a/public/static/locales/fr/admin-flags.json
+++ b/public/static/locales/fr/admin-flags.json
@@ -34,10 +34,6 @@
       "title": "Création de compte",
       "description": "Permet aux utilisateurs de créer un compte"
     },
-    "passwordReset": {
-      "title": "Autoriser les réinitialisations de mot de passe",
-      "description": "Permet aux utilisateurs de réinitialiser leurs mots de passe"
-    },
     "supportForms": {
       "title": "Formulaires de support",
       "description": "Activation ou désactivation des formulaires de support"


### PR DESCRIPTION
# Summary | Résumé

Fixes https://github.com/cds-snc/platform-forms-client/issues/2508

Removes the feature flag to enable password reset form / link to show

# Test instructions | Instructions pour tester la modification

- Visit sign-in
- Reset link should be available by default now
- Visit + test reset password link

<hr>

- Visit admin + ensure the flag doesn't show



# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
