### PR TITLE
fix: make security questions unique in database schema

### DIFF
--- a/prisma/migrations/20230811140652_make_security_questions_unique/migration.sql
+++ b/prisma/migrations/20230811140652_make_security_questions_unique/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[questionEn]` on the table `SecurityQuestion` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[questionFr]` on the table `SecurityQuestion` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "SecurityQuestion_questionEn_key" ON "SecurityQuestion"("questionEn");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SecurityQuestion_questionFr_key" ON "SecurityQuestion"("questionFr");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,8 +126,8 @@ model CognitoCustom2FA {
 
 model SecurityQuestion {
   id             String           @id @default(cuid())
-  questionEn     String
-  questionFr     String
+  questionEn     String           @unique
+  questionFr     String           @unique
   deprecated     Boolean          @default(false)
   securityAnswer SecurityAnswer[]
 }


### PR DESCRIPTION
# Delete all existing security questions (`SecurityQuestion`) and security answers (`SecurityAnswer`) from the staging database just before merging it

# Summary | Résumé

- Adds uniqueness to security questions in Prisma schema to avoid duplication when starting the application.

# Test instructions | Instructions pour tester la modification

- Delete all existing security questions (`SecurityQuestion`) and security answers (`SecurityAnswer`) from your database
- Run multiple `yarn prisma:deploy`
- Check the `SecurityQuestion` database table. There should not be any duplicate.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
