### PR TITLE
fix: check user privileges when setting security questions

### DIFF
--- a/__utils__/permissions.ts
+++ b/__utils__/permissions.ts
@@ -15,6 +15,12 @@ export const Base: RawRuleOf<MongoAbility<Abilities>>[] = [
     conditions: { users: { $elemMatch: { id: "${user.id}" } } },
   },
   { action: "update", subject: "FormRecord", fields: ["isPublished"], inverted: true },
+  {
+    action: ["create", "view", "update"],
+    subject: "User",
+    fields: ["securityAnswers", "name"],
+    conditions: { id: "${user.id}" },
+  },
 ];
 
 export const PublishForms: RawRuleOf<MongoAbility<Abilities>>[] = [

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -23,7 +23,6 @@ export {
 export type {
   SecurityQuestionId,
   SecurityQuestion,
-  CreateSecurityAnswersCommand,
   UpdateSecurityAnswerCommand,
   ValidateSecurityAnswersCommand,
 } from "./securityQuestions";

--- a/lib/auth/securityQuestions.ts
+++ b/lib/auth/securityQuestions.ts
@@ -118,11 +118,12 @@ export async function updateSecurityAnswer(
       field: "securityAnswers",
     },
   ]);
-  const userSecurityAnswers = await _retrieveUserSecurityAnswers({ userId: ability.userID });
-  if (userSecurityAnswers.length === 0) throw new SecurityAnswersNotFound();
 
   const areQuestionIdsValidResult = await areQuestionIdsValid([command.newQuestionId]);
   if (!areQuestionIdsValidResult) throw new InvalidSecurityQuestionId();
+
+  const userSecurityAnswers = await _retrieveUserSecurityAnswers({ userId: ability.userID });
+  if (userSecurityAnswers.length === 0) throw new SecurityAnswersNotFound();
 
   const oldAnswer = userSecurityAnswers.find(
     (answer) => answer.question.id === command.oldQuestionId

--- a/lib/privileges.ts
+++ b/lib/privileges.ts
@@ -328,7 +328,7 @@ export const checkPrivileges = (
   rules: {
     action: Action;
     subject: Subject | ForcedSubjectType;
-    field?: string;
+    field?: string | string[];
   }[],
   logic: "all" | "one" = "all"
 ): void => {
@@ -336,6 +336,17 @@ export const checkPrivileges = (
   try {
     const result = rules.map(({ action, subject, field }) => {
       let ruleResult = false;
+      if (Array.isArray(field)) {
+        field.forEach((f) => {
+          try {
+            checkPrivileges(ability, [{ action, subject, field: f }], logic);
+            ruleResult = true;
+          } catch (error) {
+            ruleResult = false;
+          }
+        });
+        return ruleResult;
+      }
       if (_isForceTyping(subject)) {
         ruleResult = ability.can(action, setSubjectType(subject.type, subject.object), field);
         logMessage.debug(

--- a/lib/tests/securityQuestions.test.ts
+++ b/lib/tests/securityQuestions.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { prismaMock } from "@jestUtils";
+import {
+  createSecurityAnswers,
+  updateSecurityAnswer,
+  AlreadyHasSecurityAnswers,
+  InvalidSecurityQuestionId,
+  DuplicatedQuestionsNotAllowed,
+  SecurityAnswersNotFound,
+} from "@lib/auth";
+import { createAbility } from "@lib/privileges";
+import { Base, mockUserPrivileges } from "__utils__/permissions";
+import { Session } from "next-auth";
+
+describe("Create Security Questions", () => {
+  it("Allows a user to create their security questions", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const userUpdate = (prismaMock.user.update as jest.MockedFunction<any>).mockResolvedValue({});
+
+    await createSecurityAnswers(ability, [{ questionId: "10", answer: "answer" }]);
+    expect(userUpdate).toBeCalledTimes(1);
+    expect(userUpdate).toBeCalledWith({
+      where: { id: "1" },
+      data: {
+        securityAnswers: {
+          create: [
+            {
+              question: { connect: { id: "10" } },
+              answer: expect.any(String),
+            },
+          ],
+        },
+      },
+    });
+  });
+  it("Throws an error if the user already has security questions", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [
+        {
+          id: "1",
+          answer: "answer",
+          question: { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+        },
+      ],
+    });
+    await expect(async () => {
+      await createSecurityAnswers(ability, [{ questionId: "10", answer: "answer" }]);
+    }).rejects.toThrowError(new AlreadyHasSecurityAnswers());
+  });
+  it("Throws an error if the user tries to create security questions with invalid question ids", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "9", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const userUpdate = (prismaMock.user.update as jest.MockedFunction<any>).mockResolvedValue({});
+    await expect(async () => {
+      await createSecurityAnswers(ability, [{ questionId: "10", answer: "answer" }]);
+    }).rejects.toThrowError(new InvalidSecurityQuestionId());
+
+    expect(userUpdate).toBeCalledTimes(0);
+  });
+  it("Throws and error if the user tries to create security questions with duplicated question ids", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const userUpdate = (prismaMock.user.update as jest.MockedFunction<any>).mockResolvedValue({});
+    await expect(async () => {
+      await createSecurityAnswers(ability, [
+        { questionId: "10", answer: "answer" },
+        { questionId: "10", answer: "answer" },
+      ]);
+    }).rejects.toThrowError(new DuplicatedQuestionsNotAllowed());
+    expect(userUpdate).toBeCalledTimes(0);
+  });
+});
+describe("Update Security Questions", () => {
+  it("Allows a user to update their security questions", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [
+        {
+          id: "1",
+          answer: "answer",
+          question: { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+        },
+      ],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const securityAnswerUpdate = (
+      prismaMock.securityAnswer.update as jest.MockedFunction<any>
+    ).mockResolvedValue({});
+
+    await updateSecurityAnswer(ability, {
+      oldQuestionId: "10",
+      newQuestionId: "10",
+      newAnswer: "answer",
+    });
+    expect(securityAnswerUpdate).toBeCalledTimes(1);
+    expect(securityAnswerUpdate).toBeCalledWith({
+      where: { id: "1" },
+      data: {
+        question: { connect: { id: "10" } },
+        answer: expect.any(String),
+      },
+    });
+  });
+  it("Allows a user to change their security questions", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [
+        {
+          id: "1",
+          answer: "answer",
+          question: { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+        },
+      ],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+      { id: "9", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const securityAnswerUpdate = (
+      prismaMock.securityAnswer.update as jest.MockedFunction<any>
+    ).mockResolvedValue({});
+
+    await updateSecurityAnswer(ability, {
+      oldQuestionId: "10",
+      newQuestionId: "9",
+      newAnswer: "answer",
+    });
+    expect(securityAnswerUpdate).toBeCalledTimes(1);
+    expect(securityAnswerUpdate).toBeCalledWith({
+      where: { id: "1" },
+      data: {
+        question: { connect: { id: "9" } },
+        answer: expect.any(String),
+      },
+    });
+  });
+  it("Throws an error if securityQuestions are not yet set", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const userUpdate = (
+      prismaMock.securityAnswer.update as jest.MockedFunction<any>
+    ).mockResolvedValue({});
+
+    await expect(async () => {
+      await updateSecurityAnswer(ability, {
+        oldQuestionId: "10",
+        newQuestionId: "10",
+        newAnswer: "answer",
+      });
+    }).rejects.toThrowError(new SecurityAnswersNotFound());
+    expect(userUpdate).toBeCalledTimes(0);
+  });
+  it("Throws an error if the user tries to update security questions with invalid question ids", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [
+        {
+          id: "1",
+          answer: "answer",
+          question: { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+        },
+      ],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+      { id: "9", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    await expect(async () => {
+      await updateSecurityAnswer(ability, {
+        oldQuestionId: "9",
+        newQuestionId: "6",
+        newAnswer: "answer",
+      });
+    }).rejects.toThrowError(new InvalidSecurityQuestionId());
+  });
+  it("Throws an error if the user tries to create security questions with duplicated question ids", async () => {
+    const fakeSession = {
+      user: { id: "1", privileges: mockUserPrivileges(Base, { user: { id: "1" } }) },
+    };
+    const ability = createAbility(fakeSession as Session);
+
+    //_retrieveUserSecurityAnswers
+    (prismaMock.user.findUnique as jest.MockedFunction<any>).mockResolvedValue({
+      securityAnswers: [
+        {
+          id: "1",
+          answer: "answer",
+          question: { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+        },
+      ],
+    });
+
+    // retrivePoolOfSecurityQuestions
+    (prismaMock.securityQuestion.findMany as jest.MockedFunction<any>).mockResolvedValue([
+      { id: "10", questionEn: "question", questionFr: "question", deprecated: false },
+      { id: "9", questionEn: "question", questionFr: "question", deprecated: false },
+    ]);
+
+    const userUpdate = (prismaMock.user.update as jest.MockedFunction<any>).mockResolvedValue({});
+    await expect(async () => {
+      await updateSecurityAnswer(ability, {
+        oldQuestionId: "9",
+        newQuestionId: "10",
+        newAnswer: "answer",
+      });
+    }).rejects.toThrowError(new DuplicatedQuestionsNotAllowed());
+    expect(userUpdate).toBeCalledTimes(0);
+  });
+});

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -178,7 +178,16 @@ interface SelectedUser
  */
 export const getUsers = async (ability: UserAbility): Promise<SelectedUser[] | never[]> => {
   try {
-    checkPrivileges(ability, [{ action: "view", subject: "User" }]);
+    checkPrivileges(ability, [
+      {
+        action: "view",
+        subject: {
+          type: "User",
+          // Empty object to force the ability to check for any user
+          object: {},
+        },
+      },
+    ]);
 
     const users = await prisma.user
       .findMany({

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/api/account/security-questions/index.ts
+++ b/pages/api/account/security-questions/index.ts
@@ -11,11 +11,11 @@ import {
   updateSecurityAnswer,
 } from "@lib/auth";
 import securityQuestionsWithAssociatedAnswersSchema from "@lib/middleware/schemas/security-questions-with-associated-answers.schema.json";
-import { MiddlewareProps, WithRequired } from "@lib/types";
+import { MiddlewareProps, UserAbility, WithRequired } from "@lib/types";
 import { createAbility } from "@lib/privileges";
 
 async function saveUserSecurityAnswers(
-  userId: string,
+  ability: UserAbility,
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
@@ -26,7 +26,7 @@ async function saveUserSecurityAnswers(
       return res.status(400).json({ error: "Malformed request" });
     }
 
-    await createSecurityAnswers({ userId, questionsWithAssociatedAnswers });
+    await createSecurityAnswers(ability, questionsWithAssociatedAnswers);
     return res.status(200).json({});
   } catch (error) {
     if (error instanceof AlreadyHasSecurityAnswers) {
@@ -44,7 +44,7 @@ async function saveUserSecurityAnswers(
 }
 
 async function updateUserSecurityAnswer(
-  userId: string,
+  ability: UserAbility,
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
@@ -62,7 +62,11 @@ async function updateUserSecurityAnswer(
       return res.status(400).json({ error: "Malformed request" });
     }
 
-    await updateSecurityAnswer({ userId, oldQuestionId, newQuestionId, newAnswer });
+    await updateSecurityAnswer(ability, {
+      oldQuestionId,
+      newQuestionId,
+      newAnswer,
+    });
     return res.status(200).json({});
   } catch (error) {
     if (error instanceof SecurityAnswersNotFound) {
@@ -91,11 +95,11 @@ const apiHandler = async (req: NextApiRequest, res: NextApiResponse, props: Midd
 
     switch (req.method) {
       case "POST": {
-        await saveUserSecurityAnswers(ability.userID, req, res);
+        await saveUserSecurityAnswers(ability, req, res);
         break;
       }
       case "PUT": {
-        await updateUserSecurityAnswer(ability.userID, req, res);
+        await updateUserSecurityAnswer(ability, req, res);
         break;
       }
     }

--- a/prisma/seeds/fixtures/privileges.ts
+++ b/prisma/seeds/fixtures/privileges.ts
@@ -20,6 +20,12 @@ const Base: PrivilegeSeed = {
       conditions: { users: { $elemMatch: { id: "${user.id}" } } },
     },
     { action: "update", subject: "FormRecord", fields: ["isPublished"], inverted: true },
+    {
+      action: ["view", "update"],
+      subject: "User",
+      fields: ["securityAnswers", "name"],
+      conditions: { id: "${user.id}" },
+    },
   ],
   priority: 0,
 };


### PR DESCRIPTION
# Summary | Résumé

 - Extends the 'Base' privilege to allow a user to access and modify their Security Questions and Name (future implementation)
 - Security Question Create and Update functions explicitly get the userID from the current session and not a passed argument.
 - Implements a new function that only gets the Security Questions without the answers in the query.  Slightly duplicates the code but from a security perspective, it separates the concerns.
 - Marked `retrieveUserSecurityAnswers` as an internal module function by adding an `_`.  Now renamed `_retrieveUserSecurityAnswers`

# Test instructions | Instructions pour tester la modification

Create / Modify Security Questions

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
