### PR TITLE
chore: Add Get Support link to Answer Security Questions

### DIFF
--- a/pages/auth/resetpassword.tsx
+++ b/pages/auth/resetpassword.tsx
@@ -331,7 +331,7 @@ const Step2 = ({
                   {t("securityQuestions.resetPasswordButton")}
                 </Button>
 
-                <LinkButton.Secondary href="/form-builder/support/contactus">
+                <LinkButton.Secondary href="/form-builder/support">
                   {t("securityQuestions.support")}
                 </LinkButton.Secondary>
               </div>

--- a/pages/auth/setup-security-questions.tsx
+++ b/pages/auth/setup-security-questions.tsx
@@ -270,7 +270,7 @@ const SetupSecurityQuestions = ({ questions = [] }: { questions: Question[] }) =
               <Button theme="primary" type="submit" className="mr-4" disabled={isSubmitting}>
                 {t("continue")}
               </Button>
-              <LinkButton.Secondary href={supportHref}>{t("contact")}</LinkButton.Secondary>
+              <LinkButton.Secondary href={supportHref}>{t("support")}</LinkButton.Secondary>
             </form>
           </>
         )}

--- a/public/static/locales/en/reset-password.json
+++ b/public/static/locales/en/reset-password.json
@@ -28,7 +28,7 @@
     "title": "Answer security questions",
     "description": "You don’t need to worry about capital letters, punctuation, or accents in your answers.",
     "resetPasswordButton": "Continue",
-    "support": "Contact us",
+    "support": "Get support",
     "inputValidation": {
       "required": "Cannot be empty",
       "questionLength": "Must be at least 4 characters.",

--- a/public/static/locales/en/setup-security-questions.json
+++ b/public/static/locales/en/setup-security-questions.json
@@ -11,7 +11,7 @@
   "thirdQuestion": "Enter the third security qestion and answer[FR]",
   "questionPlaceholder": "Select question",
   "continue": "Continue",
-  "contact": "Contact us",
+  "support": "Get support",
   "errors": {
     "serverError": {
       "title": "An error occurred"

--- a/public/static/locales/fr/reset-password.json
+++ b/public/static/locales/fr/reset-password.json
@@ -28,7 +28,7 @@
     "title": "Répondez aux questions de sécurité",
     "description": "Vous n’avez pas à vous soucier des majuscules, de la ponctuation ou des accents dans vos réponses.",
     "resetPasswordButton": "Continuer",
-    "support": "Contactez-nous",
+    "support": "Obtenir du soutien",
     "inputValidation": {
       "required": "Ne peut pas être vide",
       "questionLength": "Doit comporter au moins 4 caractères.",

--- a/public/static/locales/fr/setup-security-questions.json
+++ b/public/static/locales/fr/setup-security-questions.json
@@ -11,7 +11,7 @@
   "thirdQuestion": "Enter the third security qestion and answer[FR]",
   "questionPlaceholder": "Sélectionner une question",
   "continue": "Continuer",
-  "contact": "Nous contacter",
+  "support": "Obtenir du soutien",
   "errors": {
     "serverError": {
       "title": "An error occurred[FR]"


### PR DESCRIPTION
# Summary | Résumé

fixes: #2515

Updates support link + text on security questions page

<img width="400" alt="reset" src="https://github.com/cds-snc/platform-forms-client/assets/62242/cd5fd663-b992-466d-8de9-e40ebb7b6558"> <img width="400" alt="setup" src="https://github.com/cds-snc/platform-forms-client/assets/62242/41f3a3e9-5ea2-401d-991c-cbde49868718">




# Test instructions | Instructions pour tester la modification

- Test support "Get support" link form security questions password reset flow

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
