### PR TITLE
chore: check session loading state on settings page

### DIFF
--- a/components/form-builder/app/LoggedOutTab.tsx
+++ b/components/form-builder/app/LoggedOutTab.tsx
@@ -20,7 +20,7 @@ export const LoggedOutTab = ({ tabName }: LoggedOutTabProps) => {
   const signInLink = `/${i18n.language}/auth/login`;
   const createAccountLink = `/${i18n.language}/signup/register`;
 
-  if (status === "authenticated") {
+  if (status === "authenticated" || status === "loading") {
     return null;
   }
 


### PR DESCRIPTION
# Summary | Résumé

Prior to this PR the settings page flashes the logged out screen prior to showing the correct page state.

This PR makes an update check the status of use session before showing content.




https://github.com/cds-snc/platform-forms-client/assets/62242/f6b7b241-055e-42ea-bca7-e2bfe2dba064
☝️ 
Current - we see a flash of the logged out screen

# Test instructions | Instructions pour tester la modification

- Throttle your network connection
- Note when logged in you should no longer see the logged out screen content.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
