### PR TITLE
bugfix: Remove sub element parsing as it causes problems with long forms

### DIFF
--- a/components/form-builder/getPath.test.ts
+++ b/components/form-builder/getPath.test.ts
@@ -14,12 +14,12 @@ describe("Parse root ID", () => {
 });
 
 describe("Get array indexes for path by element ID", () => {
-  it("parses elIndex", () => {
+  it.skip("parses elIndex", () => {
     const elements = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 12 }];
     expect(getElementIndexes(1210, elements)).toEqual([3, null]);
   });
 
-  it("parses 3 digit elIndex and subIndex", () => {
+  it.skip("parses 3 digit elIndex and subIndex", () => {
     const elements = [
       { id: 1 },
       { id: 2, properties: { subElements: [{ id: 201 }, { id: 202 }, { id: 203 }] } },
@@ -31,7 +31,7 @@ describe("Get array indexes for path by element ID", () => {
     expect(subIndex).toEqual(0);
   });
 
-  it("parses 4 digit elIndex and subIndex", () => {
+  it.skip("parses 4 digit elIndex and subIndex", () => {
     const elements = [
       { id: 1 },
       { id: 2 },
@@ -71,7 +71,7 @@ describe("Get path string by id", () => {
     expect(path).toEqual("form.elements[1].properties");
   });
 
-  it("gets subPath", async () => {
+  it.skip("gets subPath", async () => {
     const elements = [
       { id: 1 },
       { id: 2 },
@@ -97,7 +97,7 @@ describe("Get path string by id", () => {
       expect(path).toEqual(form.elements[3]);
     });
 
-    it("gets sub element path", async () => {
+    it.skip("gets sub element path", async () => {
       const form = {
         elements: [
           { id: 1 },

--- a/components/form-builder/getPath.test.ts
+++ b/components/form-builder/getPath.test.ts
@@ -1,7 +1,7 @@
 import { parseRootId, getElementIndexes, indexesToPath, getPath, getPathString } from "./getPath";
 
 describe("Parse root ID", () => {
-  it("parses root id", () => {
+  it.skip("parses root id", () => {
     expect(parseRootId(1)).toEqual(1);
     expect(parseRootId(9)).toEqual(9);
     expect(parseRootId(12)).toEqual(12);

--- a/components/form-builder/getPath.ts
+++ b/components/form-builder/getPath.ts
@@ -1,10 +1,11 @@
 export const parseRootId = (id: number) => {
+  // @TODO: Revisit for sub elements. Note that the following will break if we have more than 99 sub elements
   // split 3 or 4 digit id into first 1 or 2 digits
-  const idStr = id.toString();
-  const sliceAt = idStr.length == 3 ? 1 : 2;
-  const idArr = idStr.split("");
-  const first = idArr.slice(0, sliceAt).join("");
-  return Number(first);
+  // const idStr = id.toString();
+  // const sliceAt = idStr.length == 3 ? 1 : 2;
+  // const idArr = idStr.split("");
+  // const first = idArr.slice(0, sliceAt).join("");
+  return Number(id);
 };
 
 interface Form {


### PR DESCRIPTION
# Summary | Résumé

The Root ID parsing code in the path helper breaks on forms with more than 99 elements. We currently do not support sub elements, so this parsing code is not needed at the moment, but is causing problems for large forms. Removing for now, to be revisited when we introduce sub element support.

# Test instructions | Instructions pour tester la modification

Sequential steps (1., 2., 3., ...) that describe how to test this change. You should include
anything outside the README that will help the developer access your changes and be able to test
them such as any environmental setup steps and/or any time-based elements that this requires.
This will help a developer test things out without too much detective work.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
