### PR TITLE
Fixes myforms card email overflow problem

### DIFF
--- a/components/myforms/Card/Card.tsx
+++ b/components/myforms/Card/Card.tsx
@@ -143,10 +143,10 @@ export const Card = (props: CardProps): React.ReactElement => {
         </span>
         {/* Email delivery */}
         {deliveryOption && deliveryOption.emailAddress && (
-          <span className="mt-4 block text-sm">
+          <div className="mt-4 text-sm whitespace-nowrap text-ellipsis overflow-hidden">
             <EnvelopeIcon className="mr-2 inline-block" />
             {t("card.deliveryOption.email", { ns: "my-forms" })} {deliveryOption.emailAddress}
-          </span>
+          </div>
         )}
         {/* Vault delivery */}
         {deliveryOption && !deliveryOption.emailAddress && (


### PR DESCRIPTION
# Summary | Résumé

Stops long emails in a myforms card from breaking the design.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![Screenshot 2023-09-13 at 9 01 02 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/a74be756-4fc3-4b20-a260-3b2a6b668bca) | ![Screenshot 2023-09-13 at 9 00 12 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/82d3a174-3638-4a13-aa36-dbb096e36513) |



# Test instructions | Instructions pour tester la modification

Create a form and configure to have a long email and set the publishing option to email. Go back to the myforms screen and find the related card. The email line should be truncated
