### PR TITLE
chore: Add automated production ECS task deploy

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -61,17 +61,22 @@ jobs:
           CONTAINER_NAME=${{ steps.download-taskdef-form-viewer.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' form_viewer.json | cut -f 1-6 -d "/"`
           jq --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port' config/infrastructure/aws/appspec-template.json > form-viewer-appspec.json
+          
+      - name: Sanity test appspec and form viewer task definition
+        run: |
+          aws s3 cp ${{ github.workspace }}/form-viewer-appspec.json s3://forms-production-vault-file-storage/${{ github.run_id }}/form-viewer-appspec.json
+          aws s3 cp ${{ steps.taskdef-form-viewer.outputs.task-definition }} s3://forms-production-vault-file-storage/${{ github.run_id }}/form-viewer-task-def.json
 
-      - name: Deploy image for Form Viewer
-        timeout-minutes: 10
-        # v1.4.11
-        uses: aws-actions/amazon-ecs-deploy-task-definition@37ec59d6c3e314c12279ab3e75395e72da65f1c6
-        with:
-          task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
-          service: form-viewer
-          cluster: Forms
-          wait-for-service-stability: true
-          codedeploy-appspec: ${{ github.workspace }}/form-viewer-appspec.json
+      # - name: Deploy image for Form Viewer
+      #   timeout-minutes: 10
+      #   # v1.4.11
+      #   uses: aws-actions/amazon-ecs-deploy-task-definition@37ec59d6c3e314c12279ab3e75395e72da65f1c6
+      #   with:
+      #     task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
+      #     service: form-viewer
+      #     cluster: Forms
+      #     wait-for-service-stability: true
+      #     codedeploy-appspec: ${{ github.workspace }}/form-viewer-appspec.json
 
       - name: Logout of Amazon ECR
         if: always()

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -76,3 +76,12 @@ jobs:
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Report deployment to Sentinel
+        if: always()
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          input_data: '{"product": "articles", "sha": "${{ github.sha }}", "version": "${{ github.event.workflow_run.head_branch }}", "repository": "${{ github.repository }}", "environment": "production", "status": "${{ job.status }}"}'
+          log_type: CDS_Product_Deployment_Data
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy to Staging
+name: Deploy to Production
 
 on:
   workflow_run:
-    workflows: ["Staging — Push container to ECR"]
+    workflows: ["Production — Push container to ECR"]
     types:
       - completed
 
@@ -16,9 +16,9 @@ jobs:
           WORKFLOW_URL: "${{ github.event.workflow_run.html_url }}"
           WORKFLOW_NAME: "${{ github.event.workflow_run.name }}"
         run: |
-          json='{"channel":"#forms-staging-events", "blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failure: <${{ env.WORKFLOW_URL }}|${{ env.WORKFLOW_NAME }}>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.STAGING_SLACK_WEBHOOK }}
-          exit 1
+          json='{"channel":"#forms-production-events", "blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failure: <${{ env.WORKFLOW_URL }}|${{ env.WORKFLOW_NAME }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+          exit 1   
 
   deploy-form-viewer-service:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -40,11 +40,6 @@ jobs:
         # v1 as of Jan 28 2021
         uses: aws-actions/amazon-ecr-login@865664b3240e20b35d3528593d496632704f48af
 
-      - name: Get Cluster Name
-        id: cluster
-        run: |
-          echo "##[set-output name=name;]$(aws ecs list-clusters | jq -r '.clusterArns[0]' | cut -f 2 -d "/" )"
-
       - name: Download Form Viewer task definition
         id: download-taskdef-form-viewer
         run: |
@@ -58,14 +53,14 @@ jobs:
         with:
           task-definition: form_viewer.json
           container-name: ${{ steps.download-taskdef-form-viewer.outputs.container_name }}
-          image: ${{ steps.login-ecr.outputs.registry }}/form_viewer_staging:${{ github.event.workflow_run.head_sha }}
+          image: ${{ steps.login-ecr.outputs.registry }}/form_viewer_production:${{ github.event.workflow_run.head_branch }}
 
       - name: Render appspec for form viewer service
         run: |
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' form_viewer.json`
           CONTAINER_NAME=${{ steps.download-taskdef-form-viewer.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' form_viewer.json | cut -f 1-6 -d "/"`
-          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port' config/infrastructure/aws/appspec-template.json > form-viewer-appspec.json
+          jq --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port' config/infrastructure/aws/appspec-template.json > form-viewer-appspec.json
 
       - name: Deploy image for Form Viewer
         timeout-minutes: 10
@@ -74,7 +69,7 @@ jobs:
         with:
           task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
           service: form-viewer
-          cluster: ${{ steps.cluster.outputs.name }}
+          cluster: Forms
           wait-for-service-stability: true
           codedeploy-appspec: ${{ github.workspace }}/form-viewer-appspec.json
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -40,11 +40,6 @@ jobs:
         # v1 as of Jan 28 2021
         uses: aws-actions/amazon-ecr-login@865664b3240e20b35d3528593d496632704f48af
 
-      - name: Get Cluster Name
-        id: cluster
-        run: |
-          echo "##[set-output name=name;]$(aws ecs list-clusters | jq -r '.clusterArns[0]' | cut -f 2 -d "/" )"
-
       - name: Download Form Viewer task definition
         id: download-taskdef-form-viewer
         run: |
@@ -74,7 +69,7 @@ jobs:
         with:
           task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
           service: form-viewer
-          cluster: ${{ steps.cluster.outputs.name }}
+          cluster: Forms
           wait-for-service-stability: true
           codedeploy-appspec: ${{ github.workspace }}/form-viewer-appspec.json
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,3 +81,12 @@ jobs:
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Report deployment to Sentinel
+        if: always()
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          input_data: '{"product": "articles", "sha": "${{ github.sha }}", "version": "${{ github.sha }}", "repository": "${{ github.repository }}", "environment": "staging", "status": "${{ job.status }}"}'
+          log_type: CDS_Product_Deployment_Data
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}


### PR DESCRIPTION
# Summary | Résumé

Add a GitHub workflow to automatically update the production ECS task when a new release is published.  This workflow will wait for the production Docker image build/push before starting.

Additionally, this reports the Staging and Production deployments to Sentinel to help with the capture of [DORA metrics](https://www.leanix.net/en/wiki/vsm/dora-metrics). 

# Test instructions | Instructions pour tester la modification

## Staging 
1. Merge a non-release PR and confirm that the ECS task deployment still works as expected.

## Production
1. Merge a release PR.
2. Once the Production Docker image build and push workflow finishes, the Production deploy workflow should start.
3. Validate the rendered appsec and task definitions templates in the `forms-production-vault-file-storage` S3 buckets.

Once we've confirmed that the templates are correct, a subsequent PR will enable the automated ECS task deployment.

# Related
- https://github.com/cds-snc/platform-core-services/issues/441
