### PR TITLE
chore: add ECS task definition delete workflow

### DIFF
--- a/.github/workflows/delete-ecs-task-defs.yml
+++ b/.github/workflows/delete-ecs-task-defs.yml
@@ -1,0 +1,39 @@
+name: Delete ECS task definitions
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ca-central-1
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  delete-ecs-task-definitions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
+      - name: Configure Staging AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+        with:
+          role-to-assume: arn:aws:iam::687401027353:role/platform-forms-client-apply
+          role-session-name: ECSTaskDefDelete
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Retrieves all ACTIVE task definitions except for the 5 most recent
+      - name: Get ECS task definitions
+        run: |
+            aws ecs list-task-definitions \
+                --sort ASC \
+                --status ACTIVE \
+                --region ${{ env.AWS_REGION }} \
+                --no-cli-pager \
+                | jq -r '(.taskDefinitionArns[:length-6])[]' > task-def-arns.txt
+
+      - name: Delete ECS task definitions
+        run: |
+          ./bin/delete-ecs-task-defs.sh task-def-arns.txt

--- a/bin/delete-ecs-task-defs.sh
+++ b/bin/delete-ecs-task-defs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# 
+# Deletes ECS task definitions in an AWS account.  It expects as input a
+# file path that contains a list of ECS task definition ARNs (one per line):
+#
+#   ./delete-ecs-task-defs.sh task-arns.txt
+#
+# This file can be created with the following command which will generate
+# a `task-arns.txt` file with all but the last 5 most recent task definitions:
+#
+#   aws ecs list-task-definitions \
+#     --sort ASC \
+#     --status ACTIVE \
+#     --region ca-central-1 \
+#     --no-cli-pager \
+#     | jq -r '(.taskDefinitionArns[:length-6])[]' > task-arns.txt
+#
+# The sleep commands in the script are to avoid API throttling issues.
+#
+
+TASK_ARNS="$1"
+AWS_REGION="ca-central-1"
+
+while read -r TASK_ARN
+do
+    echo  "🧹 Deleting: $TASK_ARN"
+
+    # Task definitions must be set to INACTIVE before they can be deleted
+    aws ecs deregister-task-definition \
+        --task-definition "$TASK_ARN" \
+        --region "$AWS_REGION" \
+        --no-cli-pager > /dev/null 2>&1
+    sleep 3
+
+    # Delete the INACTIVE task definition
+    aws ecs delete-task-definitions \
+        --task-definitions "$TASK_ARN" \
+        --region "$AWS_REGION" \
+        --no-cli-pager > /dev/null 2>&1
+    sleep 3
+done < "$TASK_ARNS"
+
+echo  "🎉 All done!"


### PR DESCRIPTION
# Summary | Résumé

Add a workflow that deletes old ECS task definitions from Staging.  The workflow is configured to delete all but the 5 most recent task definitions.

Once the workflow has been tested, it will be configured to run on a nightly schedule and Production task definitions steps will be added.

## ⚠️  Note
This workflow uses an OIDC role to retrieve temporary credentials rather than using a hard-coded AWS access key/secret.

# Test instructions | Instructions pour tester la modification

1. Once merged, manually run the workflow.
2. Expect that it will delete all ECS tasks in Staging except for the 5 most recent.

# Related
- https://github.com/cds-snc/platform-core-services/issues/441