### PR TITLE
chore: enable ECS task definition delete

### DIFF
--- a/.github/workflows/delete-ecs-task-defs.yml
+++ b/.github/workflows/delete-ecs-task-defs.yml
@@ -2,30 +2,37 @@ name: Delete ECS task definitions
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 0" # 5am Sunday UTC
 
 env:
   AWS_REGION: ca-central-1
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   delete-ecs-task-definitions:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - env: 'Staging'
+            secret_prefix: ''
+          - env: 'Production'
+            secret_prefix: 'PROD_'
+
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
-      - name: Configure Staging AWS credentials using OIDC
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
-          role-to-assume: arn:aws:iam::687401027353:role/platform-forms-client-apply
-          role-session-name: ECSTaskDefDelete
+          aws-access-key-id: ${{ secrets[format('{0}AWS_ACCESS_KEY_ID', matrix.secret_prefix)] }}
+          aws-secret-access-key: ${{ secrets[format('{0}AWS_SECRET_ACCESS_KEY', matrix.secret_prefix)] }}
           aws-region: ${{ env.AWS_REGION }}
 
       # Retrieves all ACTIVE task definitions except for the 5 most recent
-      - name: Get ECS task definitions
+      - name: Get ${{ matrix.env }} ECS task definitions
         run: |
             aws ecs list-task-definitions \
                 --sort ASC \
@@ -34,6 +41,6 @@ jobs:
                 --no-cli-pager \
                 | jq -r '(.taskDefinitionArns[:length-6])[]' > task-def-arns.txt
 
-      - name: Delete ECS task definitions
+      - name: Delete ${{ matrix.env }} ECS task definitions
         run: |
           ./bin/delete-ecs-task-defs.sh task-def-arns.txt

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -31,8 +31,8 @@ jobs:
         # v1 as of Jan 28 2021
         uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
# Summary
Update the ECS task definition to run once a week on Sunday.  Also include the Production ECS task deletion in the workflow and reverts to using AWS access keys.

Additionally, this fixes the Production deployment script to use the correct access keys.

# Related
- https://github.com/cds-snc/platform-core-services/issues/441