### PR TITLE
chore: use OIDC roles for ECS task def delete

### DIFF
--- a/.github/workflows/delete-ecs-task-defs.yml
+++ b/.github/workflows/delete-ecs-task-defs.yml
@@ -8,6 +8,10 @@ on:
 env:
   AWS_REGION: ca-central-1
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   delete-ecs-task-definitions:
     runs-on: ubuntu-latest
@@ -15,24 +19,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - env: 'Staging'
-            secret_prefix: ''
-          - env: 'Production'
-            secret_prefix: 'PROD_'
+          - account: '687401027353'
+          - account: '957818836222'
 
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
-          aws-access-key-id: ${{ secrets[format('{0}AWS_ACCESS_KEY_ID', matrix.secret_prefix)] }}
-          aws-secret-access-key: ${{ secrets[format('{0}AWS_SECRET_ACCESS_KEY', matrix.secret_prefix)] }}
+          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/platform-forms-client-apply
+          role-session-name: ECSTaskDefDelete
           aws-region: ${{ env.AWS_REGION }}
 
       # Retrieves all ACTIVE task definitions except for the 5 most recent
-      - name: Get ${{ matrix.env }} ECS task definitions
+      - name: Get ECS task definitions
         run: |
             aws ecs list-task-definitions \
                 --sort ASC \
@@ -41,6 +43,6 @@ jobs:
                 --no-cli-pager \
                 | jq -r '(.taskDefinitionArns[:length-6])[]' > task-def-arns.txt
 
-      - name: Delete ${{ matrix.env }} ECS task definitions
+      - name: Delete ECS task definitions
         run: |
           ./bin/delete-ecs-task-defs.sh task-def-arns.txt


### PR DESCRIPTION
# Summary | Résumé
Update the ECS task definition delete workflow to use OIDC roles now that the claim policy has been updated with the correct default branch.

# Test instructions | Instructions pour tester la modification

Manually run the workflow and expect that it deletes the old ECS task definitions successfully in the Staging and Production accounts.

# Related
- https://github.com/cds-snc/platform-core-services/issues/441
- https://github.com/cds-snc/aft-global-customizations/pull/42
- https://github.com/cds-snc/aft-account-request/pull/134