### PR TITLE
Fixes missing translation key

### DIFF
--- a/components/form-builder/hooks/useElementOptions.tsx
+++ b/components/form-builder/hooks/useElementOptions.tsx
@@ -158,7 +158,7 @@ export const useElementOptions = (filterElements?: ElementOptionsFilter | undefi
     },
     {
       id: "address",
-      value: "Address",
+      value: t("addElementDialog.address.label"),
       icon: AddressIcon,
       description: Address,
       group: group.input,


### PR DESCRIPTION
# Summary | Résumé

Adds missing translation key for Address in the form-builder.

## Test

Try setting the language to French. Then in the form-builder menu dialog, the Address block label should be in French (Addresse)
