### PR TITLE
fix: Do not list all ID's when not required in audit logs

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -339,6 +339,16 @@ export async function getAllTemplatesForUser(
 ): Promise<Array<FormRecord>> {
   try {
     checkPrivileges(ability, [{ action: "view", subject: "FormRecord" }]);
+    const canUserAccessAllTemplates = checkPrivilegesAsBoolean(ability, [
+      {
+        action: "view",
+        subject: {
+          type: "FormRecord",
+          // Passing an empty object here just to force CASL evaluate the condition part of a permission.
+          object: {},
+        },
+      },
+    ]);
 
     const templates = await prisma.template
       .findMany({
@@ -370,7 +380,11 @@ export async function getAllTemplatesForUser(
         ability.userID,
         { type: "Form" },
         "ReadForm",
-        `Accessed Forms: ${templates.map((template) => template.id).toString()}`
+        `Accessed Forms: ${
+          canUserAccessAllTemplates
+            ? "All System Forms"
+            : templates.map((template) => template.id).toString()
+        }`
       );
 
     return templates.map((template) => _parseTemplate(template));


### PR DESCRIPTION
# Summary | Résumé
When a user has access to all forms do not list all system form id's in the audit log.