### PR TITLE
chore: use SRE app token for Release Generator

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -13,9 +13,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@49ce228ea7cddec9f88dd09c5b7740dbac82d7ba # v1.2.1
+        id: sre_app_token
+        with:
+          app_id: ${{ secrets.SRE_APP_ID }}
+          private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+      
       - uses: google-github-actions/release-please-action@ca6063f4ed81b55db15b8c42d1b6f7925866342d # v3.7.11
         with:
           command: manifest
-          token: ${{secrets.RELEASE_GENERATOR_TOKEN}}
+          token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node
           default-branch: develop


### PR DESCRIPTION
# Summary | Résumé

Update the Release Generator workflow to use an SRE read/write GitHub app temporary token for authentication.

# Test instructions | Instructions pour tester la modification

Merge this PR and expect that Release Generator workflow runs without error.

# Related
- cds-snc/platform-core-services#441
- https://github.com/cds-snc/forms-terraform/pull/491
- https://github.com/cds-snc/forms-terraform/pull/495