### PR TITLE
chore: enable automated Production ECS deploy

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -67,22 +67,17 @@ jobs:
           CONTAINER_NAME=${{ steps.download-taskdef-form-viewer.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' form_viewer.json | cut -f 1-6 -d "/"`
           jq --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port' config/infrastructure/aws/appspec-template.json > form-viewer-appspec.json
-          
-      - name: Sanity test appspec and form viewer task definition
-        run: |
-          aws s3 cp ${{ github.workspace }}/form-viewer-appspec.json s3://forms-production-vault-file-storage/${{ github.run_id }}/form-viewer-appspec.json
-          aws s3 cp ${{ steps.taskdef-form-viewer.outputs.task-definition }} s3://forms-production-vault-file-storage/${{ github.run_id }}/form-viewer-task-def.json
 
-      # - name: Deploy image for Form Viewer
-      #   timeout-minutes: 10
-      #   # v1.4.11
-      #   uses: aws-actions/amazon-ecs-deploy-task-definition@37ec59d6c3e314c12279ab3e75395e72da65f1c6
-      #   with:
-      #     task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
-      #     service: form-viewer
-      #     cluster: Forms
-      #     wait-for-service-stability: true
-      #     codedeploy-appspec: ${{ github.workspace }}/form-viewer-appspec.json
+      - name: Deploy image for Form Viewer
+        timeout-minutes: 10
+        # v1.4.11
+        uses: aws-actions/amazon-ecs-deploy-task-definition@37ec59d6c3e314c12279ab3e75395e72da65f1c6
+        with:
+          task-definition: ${{ steps.taskdef-form-viewer.outputs.task-definition }}
+          service: form-viewer
+          cluster: Forms
+          wait-for-service-stability: true
+          codedeploy-appspec: ${{ github.workspace }}/form-viewer-appspec.json
 
       - name: Logout of Amazon ECR
         if: always()

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -6,6 +6,13 @@ on:
     types:
       - completed
 
+env:
+  AWS_REGION: ca-central-1
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   unable-to-deploy:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
@@ -27,13 +34,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - name: Configure AWS credentials
-        # v1 as of Jan 28 2021
-        uses: aws-actions/configure-aws-credentials@fbaaea849082b09c6da098c397edb77cf7d2875a
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::687401027353:role/platform-forms-client-apply
+          role-session-name: ECSDeploy
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
# Summary | Résumé

Update the Production deploy workflow to perform the ECS task update and deploy.

Update the Staging deploy workflow to use OIDC roles for AWS authentication so it is consistent with the Production deploy workflow.

# Verification

The ECS task definition and app spec template generated from [yesterday's `v3.4.5` release](https://github.com/cds-snc/platform-forms-client/actions/runs/6240260581) was compared to the ECS task definition and app spec template used to deploy in the AWS console.

The only major difference was that the v3.4.5 release template used the expected Docker image tag.  The `diff` of the files is shown below.

## ECS task definition template
```diff
❯ diff form-viewer-task-def-github.json form-viewer-task-def-aws.json
6c6
<       "image": "957818836222.dkr.ecr.ca-central-1.amazonaws.com/form_viewer_production:v3.4.5",
---
>       "image": "957818836222.dkr.ecr.ca-central-1.amazonaws.com/form_viewer_production",
173,174c173,184
<   "registeredAt": "2023-09-19T18:58:17.308000+00:00",
<   "registeredBy": "REDACTED_IAM_USER_ARN"
---
>   "registeredAt": "2023-09-19T18:58:17.308Z",
>   "registeredBy": "REDACTED_IAM_USER_ARN",
>   "tags": [
>     {
>       "key": "Terraform",
>       "value": "true"
>     },
>     {
>       "key": "CostCentre",
>       "value": "forms-platform-production"
>     }
>   ]
```


## App spec template
```diff
❯ diff form-viewer-appspec-github.json form-viewer-appspec-aws.json
2c2
<   "version": 0,
---
>   "version": 1,
8d7
<           "PlatformVersion": "1.4.0",
13c12,13
<           }
---
>           },
>           "PlatformVersion": "1.4.0"
17,18c17,19
<   ]
< }
---
>   ],
>   "Hooks": []
> }

```

# Test instructions | Instructions pour tester la modification

Merge a release PR and expect that the Production ECS task is updated with the release's tagged Docker image.

# Related
- cds-snc/platform-core-services#441