### PR TITLE
fix: update ECS task def delete to set inactive

### DIFF
--- a/.github/workflows/delete-ecs-task-defs.yml
+++ b/.github/workflows/delete-ecs-task-defs.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         include:
           - account: '687401027353'
-          - account: '957818836222'
 
     steps:
       - name: Checkout
@@ -34,15 +33,35 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       # Retrieves all ACTIVE task definitions except for the 5 most recent
-      - name: Get ECS task definitions
+      - name: Get ACTIVE ECS task definitions
+        env:
+          TASK_STATUS: ACTIVE
+          TASKS_TO_KEEP: 6 # 1 greater than number to keep
         run: |
             aws ecs list-task-definitions \
                 --sort ASC \
-                --status ACTIVE \
+                --status ${{ env.TASK_STATUS }} \
                 --region ${{ env.AWS_REGION }} \
                 --no-cli-pager \
-                | jq -r '(.taskDefinitionArns[:length-6])[]' > task-def-arns.txt
+                | jq -r '(.taskDefinitionArns[:length-${{ env.TASKS_TO_KEEP }}])[]' > task-def-active-arns.txt
 
-      - name: Delete ECS task definitions
+      - name: Set ECS tasks to INACTIVE
         run: |
-          ./bin/delete-ecs-task-defs.sh task-def-arns.txt
+          ./bin/delete-ecs-task-defs.sh DEREGISTER task-def-active-arns.txt
+
+      # Retrieves all INACTIVE task definitions except for the 100 most recent
+      - name: Get INACTIVE ECS task definitions
+        env:
+          TASK_STATUS: INACTIVE
+          TASKS_TO_KEEP: 101 # 1 greater than number to keep
+        run: |
+            aws ecs list-task-definitions \
+                --sort ASC \
+                --status ${{ env.TASK_STATUS }} \
+                --region ${{ env.AWS_REGION }} \
+                --no-cli-pager \
+                | jq -r '(.taskDefinitionArns[:length-${{ env.TASKS_TO_KEEP }}])[]' > task-def-inactive-arns.txt
+
+      - name: Delete INACTIVE ECS task definitions
+        run: |
+          ./bin/delete-ecs-task-defs.sh DELETE task-def-inactive-arns.txt          

--- a/bin/delete-ecs-task-defs.sh
+++ b/bin/delete-ecs-task-defs.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # 
-# Deletes ECS task definitions in an AWS account.  It expects as input a
-# file path that contains a list of ECS task definition ARNs (one per line):
+# Deregisters and deletes ECS task definitions in an AWS account.  It expects as 
+# input the action to perform (DEREGISTER or DELETE) and a file path that contains 
+# a list of ECS task definition ARNs (one per line):
 #
-#   ./delete-ecs-task-defs.sh task-arns.txt
+#   ./delete-ecs-task-defs.sh DEREGISTER task-arns.txt
 #
 # This file can be created with the following command which will generate
 # a `task-arns.txt` file with all but the last 5 most recent task definitions:
@@ -51,7 +52,7 @@ do
 
     # To delete a task, it must be deregistered first
     if [ "$ACTION" == "DEREGISTER" ] || [ "$ACTION" == "DELETE" ]; then
-        echo  "🗑️ Deregistering: $TASK_ARN"
+        echo  "🗑️  Deregistering: $TASK_ARN"
         aws ecs deregister-task-definition \
             --task-definition "$TASK_ARN" \
             --region "$AWS_REGION" \


### PR DESCRIPTION
# Summary | Résumé
Update the ECS task definition delete workflow to set `ACTIVE` tasks to `INACTIVE` and then to keep the 100 most recent `INACTIVE` task definitions.

This is being done because of how Terraform plan operations will fail if the Terraform state references an ECS task definition that no longer exists.  With this approach, the Terraform plan no longer fails.

Additionally, the Production ECS task delete is being temporarily removed until testing in Staging is complete.

# Test instructions | Instructions pour tester la modification

Once the PR merges, manually invoke the workflow and expect it to:

- Keep the 5 most recent `ACTIVE` ECS task definitions.
- Set the remaining ECS tasks to `INACTIVE`.

# Related
- cds-snc/platform-core-services#441
- https://github.com/cds-snc/platform-core-services/issues/464