### PR TITLE
chore: Enable Prod ECS task delete

### DIFF
--- a/.github/workflows/delete-ecs-task-defs.yml
+++ b/.github/workflows/delete-ecs-task-defs.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         include:
           - account: '687401027353'
+          - account: '957818836222'
 
     steps:
       - name: Checkout

--- a/bin/delete-ecs-task-defs.sh
+++ b/bin/delete-ecs-task-defs.sh
@@ -52,7 +52,7 @@ do
 
     # To delete a task, it must be deregistered first
     if [ "$ACTION" == "DEREGISTER" ] || [ "$ACTION" == "DELETE" ]; then
-        echo  "🗑️  Deregistering: $TASK_ARN"
+        echo  "🗑️ Deregistering: $TASK_ARN"
         aws ecs deregister-task-definition \
             --task-definition "$TASK_ARN" \
             --region "$AWS_REGION" \


### PR DESCRIPTION
# Summary | Résumé
Update the ECS task delete workflow to include production. Also fixes a minor spacing issue in the script output.

# Test instructions | Instructions pour tester la modification
Manually invoke the workflow once the PR merges and expect it to run against both Production and Staging accounts.

# Related
- Closes cds-snc/platform-core-services#464