### PR TITLE
chore: Add release manifest code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Users that are allowed to approve a release PR
+.release-please-manifest.json   @bryan-robitaille @dsamojlenko @timarney


### PR DESCRIPTION
# Summary | Résumé
Add a CODEOWNERS file that will be used with branch protection rules to ensure release PRs are only approved by one of the listed users.

# Test instructions | Instructions pour tester la modification
Once this has merged and the `develop` branch protection rules are updated, confirm that only one of the listed users is allowed to approve a release PR.

# Related
- https://github.com/cds-snc/platform-core-services/issues/466