### PR TITLE
fix: radio button on settings page

### DIFF
--- a/styles/_form-builder.scss
+++ b/styles/_form-builder.scss
@@ -81,7 +81,7 @@
     }
     input[type="radio"] + label::after {
       content: "";
-      border: 10px #64748B; // slate-500 
+      border: 10px solid #64748B; // slate-500 
       width: 0;
       height: 0;
       position: absolute;


### PR DESCRIPTION
# Summary | Résumé

Fixes: #2685

The `solid` prop for border was removed accidentally here https://github.com/cds-snc/platform-forms-client/pull/2654/files#diff-c66e3b7d15ceac3c4686d473ec1eb9c5174ee1ffc8a86d00ddf81975c38df32fR84

This PR brings it back.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="689" alt="Screenshot 2023-09-22 at 9 50 27 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/ed290cf5-9c0c-491d-9dcf-0e7164809a53"> | <img width="778" alt="Screenshot 2023-09-25 at 9 17 02 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/92fceb4f-a082-4cd1-a9c8-de9222fcdf93"> |

# Test instructions | Instructions pour tester la modification

Radio options on the Settings page.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
