### PR TITLE
chore: Fix support form duplicate word

### DIFF
--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -579,7 +579,7 @@
     "text2": "Réponses"
   },
   "support": {
-    "contactUs": "le formulaire de contact",
+    "contactUs": "formulaire de contact",
     "description": {
       "description": "Fournissez plus de contexte autour du problème que vous rencontrez.",
       "title": "Dites-nous en plus"


### PR DESCRIPTION
Word "le" shows up twice on FR Support form
<img width="1202" alt="Screenshot 2023-09-26 at 12 53 29 PM" src="https://github.com/cds-snc/platform-forms-client/assets/38330843/e064baab-a046-4f13-9b68-699f678e48c4">
