### PR TITLE
refactor: default forms to "all" 

### DIFF
--- a/components/form-builder/app/navigation/SubNavLink.tsx
+++ b/components/form-builder/app/navigation/SubNavLink.tsx
@@ -35,8 +35,11 @@ export const SubNavLink = ({
       const langRegex = /\/(en|fr)\//;
       linkPathname = linkPathname.replace(langRegex, "/");
 
+      // Only one nav link can be active at a time
       if (linkPathname === activePathname) {
         setActive(true);
+      } else {
+        setActive(false);
       }
     }
   }, [asPath, isReady, href, setActive, activePathname]);

--- a/components/form-builder/app/navigation/SubNavLink.tsx
+++ b/components/form-builder/app/navigation/SubNavLink.tsx
@@ -8,11 +8,13 @@ export const SubNavLink = ({
   children,
   setAriaCurrent = false,
   id,
+  defaultActive = false,
 }: {
   children: ReactElement;
   href: string;
   setAriaCurrent?: boolean;
   id?: string;
+  defaultActive?: boolean;
 }) => {
   const baseClasses =
     "mb-4 mr-3 rounded-[100px] border-1 border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
@@ -23,7 +25,7 @@ export const SubNavLink = ({
     "bg-[#475569] !text-white [&_svg]:fill-white ${svgStroke} focus:text-white [&_svg]:focus:stroke-white";
 
   const { asPath, isReady, activePathname } = useActivePathname();
-  const [active, setActive] = useState(false);
+  const [active, setActive] = useState(defaultActive);
 
   useEffect(() => {
     // Check if the router fields are updated client-side
@@ -35,8 +37,6 @@ export const SubNavLink = ({
 
       if (linkPathname === activePathname) {
         setActive(true);
-      } else {
-        setActive(false);
       }
     }
   }, [asPath, isReady, href, setActive, activePathname]);

--- a/components/myforms/FilterNav/FilterNavigation.tsx
+++ b/components/myforms/FilterNav/FilterNavigation.tsx
@@ -12,7 +12,12 @@ export const FilterNavigation = () => {
 
   return (
     <nav className="flex flex-wrap laptop:mb-4" aria-label={t("navLabel")}>
-      <SubNavLink href={`/${i18n.language}/forms`} setAriaCurrent={true} id="tab-all">
+      <SubNavLink
+        href={`/${i18n.language}/forms`}
+        setAriaCurrent={true}
+        id="tab-all"
+        defaultActive={true}
+      >
         <>
           <FolderIcon className={iconClassname} />
           {t("nav.all")}

--- a/pages/forms/[[...path]].tsx
+++ b/pages/forms/[[...path]].tsx
@@ -102,7 +102,7 @@ const RenderMyForms: NextPageWithLayout<MyFormsProps> = ({ templates }: MyFormsP
           </StyledLink>
         </ResumeEditingForm>
 
-        <div>
+        <div aria-live="polite">
           <TabPanel id="tabpanel-drafts" labeledbyId="tab-drafts" isActive={path === "drafts"}>
             {templatesDrafts && templatesDrafts?.length > 0 ? (
               <CardGrid cards={templatesDrafts} gridType="drafts"></CardGrid>


### PR DESCRIPTION
# Summary | Résumé

Updates "forms" subnav to default highlight "all" as the selected sub nav item

**Before** 

The "all" sub nav highlighting happens "late" 

We know all will be highlighted so we can safely default to that item. 

<img width="400" src="https://github.com/cds-snc/platform-forms-client/assets/62242/5ec5aae8-0f1d-42e1-a753-fa221ecff1db">

# Test instructions | Instructions pour tester la modification

- Visit `/forms` note the sub nav highlights properly 
- Also visit the form builder as the Sub nav is also used there --- no updates but ensure it's working as current

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Noting -- for accounts with Manage All Forms / a large amount of cards we're still seeing a small "blip" but this PR updates will cover most use cases.

<img width="400" src="https://github.com/cds-snc/platform-forms-client/assets/62242/ee71d340-b24e-4ae5-91a9-6b513b48ee34">



# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
