### PR TITLE
chore: Remove section-header default styling on h4 and add margin

### DIFF
--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -97,10 +97,6 @@
     @extend .gc-p;
   }
 
-  h4 {
-    @extend .gc-section-header;
-  }
-
   p:has(+ ul, + ol) {
     @apply mb-0;
   }

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -47,7 +47,7 @@
     }
 
     h4, .gc-h4 {
-      @apply text-[22px];
+      @apply mb-4 text-[22px];
     }
 
     h5, .gc-h5 {


### PR DESCRIPTION
# Summary | Résumé

H4 had some odd default styling.
<img width="833" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/4530da1f-3eca-4b38-9d03-91e559315680">

This PR removes that and adds a bit of padding to it for better H4s.
<img width="281" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/0a57a7cf-ff9d-4147-a4c6-b3fdc6345efa">