### PR TITLE
fix: add noindex meta tag in Staging on all pages including root index

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -208,14 +208,17 @@ class StrictStaticCSP extends Head {
 // Actual main Document being rendered
 
 const CustomHead = process.env.NODE_ENV === "production" ? StrictStaticCSP : Head;
+
+const NoIndexMetaTag = process.env.NEXTAUTH_URL?.includes("staging") ? (
+  <meta name="robots" content="noindex,nofollow" />
+) : null;
+
 class MyDocument extends Document {
   render() {
     return (
       <Html>
         <CustomHead>
-          {process.env.NEXTAUTH_URL?.includes("staging") && (
-            <meta name="robots" content="noindex,nofollow" />
-          )}
+          {NoIndexMetaTag}
           <script async type="text/javascript" src="/static/scripts/form-polyfills.js"></script>
           {GoogleTagScript}
         </CustomHead>


### PR DESCRIPTION
# Summary | Résumé

- Attempting to fix `noindex` meta tag not being included on root index page