### PR TITLE
chore: add google site verification meta tag

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -210,7 +210,13 @@ class StrictStaticCSP extends Head {
 const CustomHead = process.env.NODE_ENV === "production" ? StrictStaticCSP : Head;
 
 const NoIndexMetaTag =
-  process.env.INDEX_SITE === "true" ? null : <meta name="robots" content="noindex,nofollow" />;
+  process.env.INDEX_SITE === "true" ? null : (
+    <>
+      <meta name="robots" content="noindex,nofollow" />
+      {/* The google-site-verification meta tag is used to accelerate the removal of our staging website from Google search results.*/}
+      <meta name="google-site-verification" content="bdK-TPSaVF-l967L-5AN5ZTUPFZz2mUYwBusMM7P6J0" />
+    </>
+  );
 
 class MyDocument extends Document {
   render() {


### PR DESCRIPTION
# Summary | Résumé

- To accelerate the removal of our staging website from Google search results we need to verify the ownership of the URL in order to have robots come and see the new `noindex` tag.