### PR TITLE
chore: add verification files instead of meta tags for Google and Bing search engines inspection tools

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -210,13 +210,7 @@ class StrictStaticCSP extends Head {
 const CustomHead = process.env.NODE_ENV === "production" ? StrictStaticCSP : Head;
 
 const NoIndexMetaTag =
-  process.env.INDEX_SITE === "true" ? null : (
-    <>
-      <meta name="robots" content="noindex,nofollow" />
-      {/* The google-site-verification meta tag is used to accelerate the removal of our staging website from Google search results.*/}
-      <meta name="google-site-verification" content="bdK-TPSaVF-l967L-5AN5ZTUPFZz2mUYwBusMM7P6J0" />
-    </>
-  );
+  process.env.INDEX_SITE === "true" ? null : <meta name="robots" content="noindex,nofollow" />;
 
 class MyDocument extends Document {
   render() {

--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>90CA81AA34C5B1B1F53A42906A93992A</user>
+</users>

--- a/public/googlef34bd8c094c26cb0.html
+++ b/public/googlef34bd8c094c26cb0.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef34bd8c094c26cb0.html


### PR DESCRIPTION
# Summary | Résumé

- Replaced `google-site-verification` meta tag with a public file used to identify our https://forms-staging.cdssandbox.xyz/ URL in Google Inspection Tool. A file is unique and tied to a specific URL address.
- Also added a file for Bing as they both use the same verification method

PS: I was able to test the verification process with the PR environment URL and it worked fine. Bing was also able to see the meta tag but Google could not so after multiple tests I decided to go with the file method.