### PR TITLE
chore: added Bing ownership verification meta tag for staging env

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -210,7 +210,13 @@ class StrictStaticCSP extends Head {
 const CustomHead = process.env.NODE_ENV === "production" ? StrictStaticCSP : Head;
 
 const NoIndexMetaTag =
-  process.env.INDEX_SITE === "true" ? null : <meta name="robots" content="noindex,nofollow" />;
+  process.env.INDEX_SITE === "true" ? null : (
+    <>
+      {/* The msvalidate.01 meta tag is used to verify ownership of the website for Bing in order to get the staging URL out of search results.*/}
+      <meta name="msvalidate.01" content="90CA81AA34C5B1B1F53A42906A93992A" />
+      <meta name="robots" content="noindex,nofollow" />
+    </>
+  );
 
 class MyDocument extends Document {
   render() {

--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<users>
-	<user>90CA81AA34C5B1B1F53A42906A93992A</user>
-</users>


### PR DESCRIPTION
# Summary | Résumé

- The BingSiteAuth.xml file is blocked by our AWS firewall because it contains uppercase letters which cannot pass the AllowOnlyAppUrls rule unless we remove the instruction to lowercase the inspected URI. Since the meta tag works with Bing I decided to use that method to verify ownership of our staging website.