### PR TITLE
Experimental: Downloadable Formats API testing

### DIFF
--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -13,7 +13,6 @@ import { DownloadResponseStatus } from "./DownloadResponseStatus";
 import { RemovalStatus } from "./RemovalStatus";
 import { DownloadStatus } from "./DownloadStatus";
 import { useRouter } from "next/router";
-import { logMessage } from "@lib/logger";
 import axios from "axios";
 import { toast } from "../shared/Toast";
 import { useSetting } from "@lib/hooks/useSetting";
@@ -108,41 +107,35 @@ export const DownloadTable = ({ vaultSubmissions, formId, nagwareResult }: Downl
       })
     );
 
-    try {
-      const downloads = Array.from(tableItems.checkedItems, async ([submissionName]) => {
-        if (!submissionName) {
-          throw new Error("Error downloading file from Retrieval table. SubmissionId missing.");
-        }
-        const url = `/api/id/${formId}/${submissionName}/download`;
-        const fileName = `${submissionName}.html`;
-        return axios({
-          url,
-          method: "GET",
-          responseType: "blob",
-          timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
-        }).then((response) => {
-          const url = window.URL.createObjectURL(new Blob([response.data]));
-          const link = document.createElement("a");
-          link.href = url;
-          link.setAttribute("download", fileName);
-          document.body.appendChild(link);
-          link.click();
-        });
-      });
+    const url = `/api/id/${formId}/submissions/download?format=html`;
+    const ids = Array.from(tableItems.checkedItems.keys());
 
-      await Promise.all(downloads).then(() => {
-        // TODO: only occurs download more than one file at a time. Here is the issue to track
-        // https://github.com/cds-snc/platform-forms-client/issues/1744
+    axios({
+      url,
+      method: "POST",
+      data: {
+        ids: ids.join(","),
+      },
+    }).then((response) => {
+      const interval = 200;
+      response.data.forEach((submission: { id: string; html: string }, i: number) => {
         setTimeout(() => {
-          // Refreshes getServerSideProps data without a full page reload
-          router.replace(router.asPath, undefined, { scroll: false });
-          toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
-        }, 1000); // Increasing to 1 second to allow more time for prod - temp work around
+          const fileName = `${submission.id}.html`;
+          const href = window.URL.createObjectURL(new Blob([submission.html]));
+          const anchorElement = document.createElement("a");
+          anchorElement.href = href;
+          anchorElement.download = fileName;
+          document.body.appendChild(anchorElement);
+          anchorElement.click();
+          document.body.removeChild(anchorElement);
+          window.URL.revokeObjectURL(href);
+        }, interval * i);
       });
-    } catch (err) {
-      logMessage.error(err as Error);
-      setErrors({ ...errors, downloadError: true });
-    }
+      setTimeout(() => {
+        router.replace(router.asPath, undefined, { scroll: false });
+        toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
+      }, interval * response.data.length);
+    });
   };
 
   const blockDownload = (


### PR DESCRIPTION
# Summary | Résumé

This PR contains some early/experimental code related to #2793:
- ~~Wires up the Download button on the Responses page to the new Downloadable Formats API endpoint~~ #2829 
- Adds additional buttons for downloading other formats (csv, zip)
- Adds a prop to the handleDownload method to toggle between "html", "zip" and "csv" formats
- ~~Updates the response handler for HTML to loop over the json data, extract the html, and generate the rendered document for downloading~~ #2829 
- ~~Adds a 200ms delay to the above loop to make downloading large numbers of individual responses more consistent~~ #2829 