### PR TITLE
Add a configurable responseDownloadLimit Setting

### DIFF
--- a/prisma/seeds/fixtures/settings.ts
+++ b/prisma/seeds/fixtures/settings.ts
@@ -57,12 +57,22 @@ const nagwarePhaseEscalated: Setting = {
   value: "46",
 };
 
+const responseDownloadLimit: Setting = {
+  internalId: "responseDownloadLimit",
+  nameEn: "Limit the number of responses that can be downloaded at once",
+  nameFr: "[FR] Limit the number of responses that can be downloaded at once",
+  descriptionEn: null,
+  descriptionFr: null,
+  value: "20",
+};
+
 const allSettings = [
   brandingRequestFormSetting,
   nagwarePhaseEncouraged,
   nagwarePhasePrompted,
   nagwarePhaseWarned,
   nagwarePhaseEscalated,
+  responseDownloadLimit,
 ];
 
 export default {


### PR DESCRIPTION
# Summary | Résumé

Adds a setting to configure the responseDownloadLimit.
This affects the Responses screen and limits the number of responses you can download at once.
Adding this setting to be merged to develop so that we can experiment with it on #2831 
(currently PR review environments can't make db changes)
