### PR TITLE
Add "Select all" header icon to DownloadTable

### DIFF
--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -275,7 +275,7 @@ export const DownloadTable = ({
         <caption className="sr-only">{t("downloadResponsesTable.header.tableTitle")}</caption>
         <thead className="border-b-2 border-[#6a6d7b]">
           <tr>
-            <th className="p-4 text-center" onClick={handleCheckAll}>
+            <th className="p-4 text-center">
               <span
                 className="cursor-pointer"
                 role="checkbox"
@@ -286,6 +286,13 @@ export const DownloadTable = ({
                     ? "mixed"
                     : "false"
                 }
+                tabIndex={0}
+                onClick={handleCheckAll}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    handleCheckAll();
+                  }
+                }}
               >
                 {checkAllStatus() === allCheckedState.ALL && (
                   <CheckAllIcon

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -276,24 +276,35 @@ export const DownloadTable = ({
         <thead className="border-b-2 border-[#6a6d7b]">
           <tr>
             <th className="p-4 text-center" onClick={handleCheckAll}>
-              {checkAllStatus() === allCheckedState.ALL && (
-                <CheckAllIcon
-                  title={t("downloadResponsesTable.header.deselectAll")}
-                  className="m-auto h-6 w-6 cursor-pointer"
-                />
-              )}
-              {checkAllStatus() === allCheckedState.SOME && (
-                <CheckIndeterminateIcon
-                  title={t("downloadResponsesTable.header.deselectAll")}
-                  className="m-auto h-6 w-6 cursor-pointer"
-                />
-              )}
-              {checkAllStatus() === allCheckedState.NONE && (
-                <CheckBoxEmptyIcon
-                  title={t("downloadResponsesTable.header.selectAll")}
-                  className="m-auto h-6 w-6 cursor-pointer"
-                />
-              )}
+              <span
+                role="checkbox"
+                aria-checked={
+                  checkAllStatus() === allCheckedState.ALL
+                    ? "true"
+                    : checkAllStatus() === allCheckedState.SOME
+                    ? "mixed"
+                    : "false"
+                }
+              >
+                {checkAllStatus() === allCheckedState.ALL && (
+                  <CheckAllIcon
+                    title={t("downloadResponsesTable.header.deselectAll")}
+                    className="m-auto h-6 w-6 cursor-pointer"
+                  />
+                )}
+                {checkAllStatus() === allCheckedState.SOME && (
+                  <CheckIndeterminateIcon
+                    title={t("downloadResponsesTable.header.deselectAll")}
+                    className="m-auto h-6 w-6 cursor-pointer"
+                  />
+                )}
+                {checkAllStatus() === allCheckedState.NONE && (
+                  <CheckBoxEmptyIcon
+                    title={t("downloadResponsesTable.header.selectAll")}
+                    className="m-auto h-6 w-6 cursor-pointer"
+                  />
+                )}
+              </span>
             </th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.number")}</th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.status")}</th>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -265,7 +265,7 @@ export const DownloadTable = ({
                   (isBlocked ? " opacity-50" : "")
                 }
               >
-                <td className="flex whitespace-nowrap pb-2 pl-8 pr-4">
+                <td className="flex whitespace-nowrap pb-2 pl-9 pr-4">
                   <div className="gc-input-checkbox">
                     <input
                       id={submission.name}

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -70,25 +70,41 @@ export const DownloadTable = ({
 
   const MAX_FILE_DOWNLOADS = responseDownloadLimit;
 
-  const allCheckedState = () => {
+  enum allCheckedState {
+    NONE = "NONE",
+    SOME = "SOME",
+    ALL = "ALL",
+  }
+
+  const checkAllChecked = () => {
     if (tableItems.checkedItems.size === 0) {
-      return 0;
+      return allCheckedState.NONE; // none checked
     }
     if (tableItems.checkedItems.size < tableItems.sortedItems.length) {
-      return 1;
+      return allCheckedState.SOME; // some checked
     }
     if (tableItems.checkedItems.size === tableItems.sortedItems.length) {
-      return 2;
+      return allCheckedState.ALL; // all checked
     }
+    return allCheckedState.NONE;
   };
 
   const handleCheckAll = () => {
-    vaultSubmissions.forEach((submission) => {
-      tableItemsDispatch({
-        type: TableActions.UPDATE,
-        payload: { item: { name: submission.name, checked: true } },
+    if (checkAllChecked() === allCheckedState.NONE) {
+      vaultSubmissions.forEach((submission) => {
+        tableItemsDispatch({
+          type: TableActions.UPDATE,
+          payload: { item: { name: submission.name, checked: true } },
+        });
       });
-    });
+    } else {
+      tableItems.checkedItems.forEach((_, key) => {
+        tableItemsDispatch({
+          type: TableActions.UPDATE,
+          payload: { item: { name: key, checked: false } },
+        });
+      });
+    }
 
     // Show or hide errors depending
     if (tableItems.checkedItems.size > MAX_FILE_DOWNLOADS && !errors.maxItemsError) {
@@ -256,13 +272,13 @@ export const DownloadTable = ({
         <thead className="border-b-2 border-[#6a6d7b]">
           <tr>
             <th className="p-4 text-center" onClick={handleCheckAll}>
-              {allCheckedState() === 2 && (
+              {checkAllChecked() === allCheckedState.ALL && (
                 <CheckAllIcon className="m-auto h-6 w-6 cursor-pointer" />
               )}
-              {allCheckedState() === 1 && (
+              {checkAllChecked() === allCheckedState.SOME && (
                 <CheckIndeterminateIcon className="m-auto h-6 w-6 cursor-pointer" />
               )}
-              {allCheckedState() === 0 && (
+              {checkAllChecked() === allCheckedState.NONE && (
                 <CheckBoxEmptyIcon className="m-auto h-6 w-6 cursor-pointer" />
               )}
             </th>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -26,6 +26,7 @@ import {
 import { getDaysPassed } from "@lib/clientHelpers";
 import { Alert } from "@components/globals";
 import { logMessage } from "@lib/logger";
+import { CheckAllIcon } from "../../icons/CheckAllIcon";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -64,6 +65,25 @@ export const DownloadTable = ({
   });
 
   const MAX_FILE_DOWNLOADS = responseDownloadLimit;
+
+  const handleCheckAll = () => {
+    vaultSubmissions.forEach((submission) => {
+      tableItemsDispatch({
+        type: TableActions.UPDATE,
+        payload: { item: { name: submission.name, checked: true } },
+      });
+    });
+
+    // Show or hide errors depending
+    if (tableItems.checkedItems.size > MAX_FILE_DOWNLOADS && !errors.maxItemsError) {
+      setErrors({ ...errors, maxItemsError: true });
+    } else if (errors.maxItemsError) {
+      setErrors({ ...errors, maxItemsError: false });
+    }
+    if (tableItems.checkedItems.size > 0 && errors.noItemsError) {
+      setErrors({ ...errors, noItemsError: false });
+    }
+  };
 
   const handleChecked = (e: React.ChangeEvent<HTMLInputElement>) => {
     const name = e.target.id;
@@ -219,7 +239,12 @@ export const DownloadTable = ({
         <caption className="sr-only">{t("downloadResponsesTable.header.tableTitle")}</caption>
         <thead className="border-b-2 border-[#6a6d7b]">
           <tr>
-            <th className="p-4 text-center">{t("downloadResponsesTable.header.select")}</th>
+            <th className="p-4 text-center" onClick={handleCheckAll}>
+              <CheckAllIcon
+                className="m-auto h-6 w-6"
+                title={t("downloadResponsesTable.header.select")}
+              />
+            </th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.number")}</th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.status")}</th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.downloadResponse")}</th>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -76,21 +76,21 @@ export const DownloadTable = ({
     ALL = "ALL",
   }
 
-  const checkAllChecked = () => {
+  const checkAllStatus = () => {
     if (tableItems.checkedItems.size === 0) {
-      return allCheckedState.NONE; // none checked
+      return allCheckedState.NONE;
     }
     if (tableItems.checkedItems.size < tableItems.sortedItems.length) {
-      return allCheckedState.SOME; // some checked
+      return allCheckedState.SOME;
     }
     if (tableItems.checkedItems.size === tableItems.sortedItems.length) {
-      return allCheckedState.ALL; // all checked
+      return allCheckedState.ALL;
     }
     return allCheckedState.NONE;
   };
 
   const handleCheckAll = () => {
-    if (checkAllChecked() === allCheckedState.NONE) {
+    if (checkAllStatus() === allCheckedState.NONE) {
       vaultSubmissions.forEach((submission) => {
         tableItemsDispatch({
           type: TableActions.UPDATE,
@@ -272,13 +272,13 @@ export const DownloadTable = ({
         <thead className="border-b-2 border-[#6a6d7b]">
           <tr>
             <th className="p-4 text-center" onClick={handleCheckAll}>
-              {checkAllChecked() === allCheckedState.ALL && (
+              {checkAllStatus() === allCheckedState.ALL && (
                 <CheckAllIcon className="m-auto h-6 w-6 cursor-pointer" />
               )}
-              {checkAllChecked() === allCheckedState.SOME && (
+              {checkAllStatus() === allCheckedState.SOME && (
                 <CheckIndeterminateIcon className="m-auto h-6 w-6 cursor-pointer" />
               )}
-              {checkAllChecked() === allCheckedState.NONE && (
+              {checkAllStatus() === allCheckedState.NONE && (
                 <CheckBoxEmptyIcon className="m-auto h-6 w-6 cursor-pointer" />
               )}
             </th>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -76,19 +76,23 @@ export const DownloadTable = ({
     ALL = "ALL",
   }
 
+  /**
+   * Are all items checked, some items checked, or no items checked?
+   * @returns {allCheckedState} The current state of the checked items.
+   */
   const checkAllStatus = () => {
     if (tableItems.checkedItems.size === 0) {
       return allCheckedState.NONE;
     }
-    if (tableItems.checkedItems.size < tableItems.sortedItems.length) {
-      return allCheckedState.SOME;
-    }
     if (tableItems.checkedItems.size === tableItems.sortedItems.length) {
       return allCheckedState.ALL;
     }
-    return allCheckedState.NONE;
+    return allCheckedState.SOME;
   };
 
+  /**
+   * Check all items if none are checked, otherwise uncheck all items.
+   */
   const handleCheckAll = () => {
     if (checkAllStatus() === allCheckedState.NONE) {
       vaultSubmissions.forEach((submission) => {

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -277,13 +277,22 @@ export const DownloadTable = ({
           <tr>
             <th className="p-4 text-center" onClick={handleCheckAll}>
               {checkAllStatus() === allCheckedState.ALL && (
-                <CheckAllIcon className="m-auto h-6 w-6 cursor-pointer" />
+                <CheckAllIcon
+                  title={t("downloadResponsesTable.header.deselectAll")}
+                  className="m-auto h-6 w-6 cursor-pointer"
+                />
               )}
               {checkAllStatus() === allCheckedState.SOME && (
-                <CheckIndeterminateIcon className="m-auto h-6 w-6 cursor-pointer" />
+                <CheckIndeterminateIcon
+                  title={t("downloadResponsesTable.header.deselectAll")}
+                  className="m-auto h-6 w-6 cursor-pointer"
+                />
               )}
               {checkAllStatus() === allCheckedState.NONE && (
-                <CheckBoxEmptyIcon className="m-auto h-6 w-6 cursor-pointer" />
+                <CheckBoxEmptyIcon
+                  title={t("downloadResponsesTable.header.selectAll")}
+                  className="m-auto h-6 w-6 cursor-pointer"
+                />
               )}
             </th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.number")}</th>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -277,6 +277,7 @@ export const DownloadTable = ({
           <tr>
             <th className="p-4 text-center" onClick={handleCheckAll}>
               <span
+                className="cursor-pointer"
                 role="checkbox"
                 aria-checked={
                   checkAllStatus() === allCheckedState.ALL
@@ -289,19 +290,19 @@ export const DownloadTable = ({
                 {checkAllStatus() === allCheckedState.ALL && (
                   <CheckAllIcon
                     title={t("downloadResponsesTable.header.deselectAll")}
-                    className="m-auto h-6 w-6 cursor-pointer"
+                    className="m-auto h-6 w-6"
                   />
                 )}
                 {checkAllStatus() === allCheckedState.SOME && (
                   <CheckIndeterminateIcon
                     title={t("downloadResponsesTable.header.deselectAll")}
-                    className="m-auto h-6 w-6 cursor-pointer"
+                    className="m-auto h-6 w-6"
                   />
                 )}
                 {checkAllStatus() === allCheckedState.NONE && (
                   <CheckBoxEmptyIcon
                     title={t("downloadResponsesTable.header.selectAll")}
-                    className="m-auto h-6 w-6 cursor-pointer"
+                    className="m-auto h-6 w-6"
                   />
                 )}
               </span>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -26,7 +26,11 @@ import {
 import { getDaysPassed } from "@lib/clientHelpers";
 import { Alert } from "@components/globals";
 import { logMessage } from "@lib/logger";
-import { CheckAllIcon } from "../../icons/CheckAllIcon";
+import {
+  CheckAllIcon,
+  CheckBoxEmptyIcon,
+  CheckIndeterminateIcon,
+} from "@components/form-builder/icons";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -65,6 +69,18 @@ export const DownloadTable = ({
   });
 
   const MAX_FILE_DOWNLOADS = responseDownloadLimit;
+
+  const allCheckedState = () => {
+    if (tableItems.checkedItems.size === 0) {
+      return 0;
+    }
+    if (tableItems.checkedItems.size < tableItems.sortedItems.length) {
+      return 1;
+    }
+    if (tableItems.checkedItems.size === tableItems.sortedItems.length) {
+      return 2;
+    }
+  };
 
   const handleCheckAll = () => {
     vaultSubmissions.forEach((submission) => {
@@ -240,10 +256,15 @@ export const DownloadTable = ({
         <thead className="border-b-2 border-[#6a6d7b]">
           <tr>
             <th className="p-4 text-center" onClick={handleCheckAll}>
-              <CheckAllIcon
-                className="m-auto h-6 w-6"
-                title={t("downloadResponsesTable.header.select")}
-              />
+              {allCheckedState() === 2 && (
+                <CheckAllIcon className="m-auto h-6 w-6 cursor-pointer" />
+              )}
+              {allCheckedState() === 1 && (
+                <CheckIndeterminateIcon className="m-auto h-6 w-6 cursor-pointer" />
+              )}
+              {allCheckedState() === 0 && (
+                <CheckBoxEmptyIcon className="m-auto h-6 w-6 cursor-pointer" />
+              )}
             </th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.number")}</th>
             <th className="p-4 text-left">{t("downloadResponsesTable.header.status")}</th>

--- a/components/form-builder/icons/CheckAllIcon.tsx
+++ b/components/form-builder/icons/CheckAllIcon.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+export const CheckAllIcon = ({ className, title }: { className?: string; title?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="48"
+    width="48"
+    className={className}
+    viewBox="0 -960 960 960"
+    focusable="false"
+    aria-hidden={title ? false : true}
+    role={title ? "img" : "presentation"}
+  >
+    {title && <title>{title}</title>}
+    <path d="M180-120q-24.75 0-42.375-17.625T120-180v-600q0-24.75 17.625-42.375T180-840h600q14 0 25.5 6t18.5 14l-44 44v-4H180v600h600v-343l60-60v403q0 24.75-17.625 42.375T780-120H180Zm281-168L239-510l42-42 180 180 382-382 42 42-424 424Z" />
+  </svg>
+);

--- a/components/form-builder/icons/CheckIndeterminateIcon.tsx
+++ b/components/form-builder/icons/CheckIndeterminateIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+export const CheckIndeterminateIcon = ({
+  className,
+  title,
+}: {
+  className?: string;
+  title?: string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="48"
+    width="48"
+    className={className}
+    viewBox="0 -960 960 960"
+    focusable="false"
+    aria-hidden={title ? false : true}
+    role={title ? "img" : "presentation"}
+  >
+    {title && <title>{title}</title>}
+    <path d="M250-452h461v-60H250v60Zm-70 332q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h600q24 0 42 18t18 42v600q0 24-18 42t-42 18H180Zm0-60h600v-600H180v600Zm0-600v600-600Z" />
+  </svg>
+);

--- a/components/form-builder/icons/index.ts
+++ b/components/form-builder/icons/index.ts
@@ -68,3 +68,5 @@ export { EditIcon } from "./EditIcon";
 export { ProtectedIcon } from "./ProtectedIcon";
 export { BrandingIcon } from "./BrandingIcon";
 export { ClosedFormIcon } from "./ClosedFormIcon";
+export { CheckIndeterminateIcon } from "./CheckIndeterminateIcon";
+export { CheckAllIcon } from "./CheckAllIcon";

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -23,6 +23,8 @@
     "header": {
       "tableTitle": "Download responses table",
       "select": "Select",
+      "selectAll": "Select all",
+      "deselectAll": "Deselect all",
       "number": "Submission",
       "status": "Status",
       "downloadResponse": "Download window",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -23,6 +23,8 @@
     "header": {
       "tableTitle": "Tableau des réponses à télécharger",
       "select": "Sélection",
+      "selectAll": "[FR] Select all",
+      "deselectAll": "[FR] Deselect all",
       "number": "Soumission",
       "status": "État",
       "downloadResponse": "Période de téléchargement",


### PR DESCRIPTION
# Summary | Résumé

Adds an icon to the header of DownloadTable to enable selecting all visible records.
Icon toggles between 3 states:
- All selected
- None selected
- Indeterminate (some selected)

![Screen Recording 2023-11-09 at 4 12 30 PM](https://github.com/cds-snc/platform-forms-client/assets/1187115/415caba8-048d-4bce-b2ef-b1c14917211e)
