### PR TITLE
Refactor Responses Download button to component

### DIFF
--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -1,0 +1,120 @@
+import { TypeOmit, VaultSubmission } from "@lib/types";
+import { NextRouter } from "next/router";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "../shared";
+import axios from "axios";
+import { logMessage } from "@lib/logger";
+
+export const DownloadButton = ({
+  formId,
+  router,
+  errors,
+  setErrors,
+  tableItems,
+  responseDownloadLimit,
+}: {
+  formId: string;
+  router: NextRouter;
+  errors: {
+    downloadError: boolean;
+    maxItemsError: boolean;
+    noItemsError: boolean;
+  };
+  setErrors: React.Dispatch<
+    React.SetStateAction<{
+      downloadError: boolean;
+      maxItemsError: boolean;
+      noItemsError: boolean;
+    }>
+  >;
+  tableItems: {
+    checkedItems: Map<string, boolean>;
+    statusItems: Map<string, boolean>;
+    sortedItems: TypeOmit<
+      VaultSubmission,
+      "formSubmission" | "submissionID" | "confirmationCode"
+    >[];
+    numberOfOverdueResponses: number;
+  };
+  responseDownloadLimit: number;
+}) => {
+  const { t } = useTranslation("form-builder-responses");
+  const MAX_FILE_DOWNLOADS = responseDownloadLimit;
+
+  // NOTE: browsers have different limits for simultaneous downloads. May need to look into
+  // batching file downloads (e.g. 4 at a time) if edge cases/* come up.
+  const handleDownload = async () => {
+    // Reset any errors
+    if (errors.downloadError) {
+      setErrors({ ...errors, downloadError: false });
+    }
+
+    // Handle any errors and show them
+    if (tableItems.checkedItems.size === 0) {
+      if (!errors.noItemsError) {
+        setErrors({ ...errors, noItemsError: true });
+      }
+      return;
+    }
+    if (tableItems.checkedItems.size > MAX_FILE_DOWNLOADS) {
+      if (!errors.maxItemsError) {
+        setErrors({ ...errors, maxItemsError: true });
+      }
+      return;
+    }
+
+    toast.info(
+      t("downloadResponsesTable.notifications.downloadingXFiles", {
+        fileCount: tableItems.checkedItems.size,
+      })
+    );
+
+    const url = `/api/id/${formId}/submissions/download?format=html`;
+    const ids = Array.from(tableItems.checkedItems.keys());
+
+    axios({
+      url,
+      method: "POST",
+      data: {
+        ids: ids.join(","),
+      },
+    })
+      .then((response) => {
+        const interval = 200;
+        response.data.forEach((submission: { id: string; html: string }, i: number) => {
+          setTimeout(() => {
+            const fileName = `${submission.id}.html`;
+            const href = window.URL.createObjectURL(new Blob([submission.html]));
+            const anchorElement = document.createElement("a");
+            anchorElement.href = href;
+            anchorElement.download = fileName;
+            document.body.appendChild(anchorElement);
+            anchorElement.click();
+            document.body.removeChild(anchorElement);
+            window.URL.revokeObjectURL(href);
+          }, interval * i);
+        });
+        setTimeout(() => {
+          router.replace(router.asPath, undefined, { scroll: false });
+          toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
+        }, interval * response.data.length);
+      })
+      .catch((err) => {
+        logMessage.error(err as Error);
+        setErrors({ ...errors, downloadError: true });
+      });
+  };
+
+  return (
+    <button
+      className="gc-button--blue m-0 w-auto whitespace-nowrap"
+      aria-live="polite"
+      onClick={handleDownload}
+    >
+      {t("downloadResponsesTable.downloadXSelectedResponses", {
+        size: tableItems.checkedItems.size,
+      })}
+    </button>
+  );
+};

--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -1,4 +1,3 @@
-import { TypeOmit, VaultSubmission } from "@lib/types";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "../shared";

--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -7,22 +7,21 @@ import { logMessage } from "@lib/logger";
 export const DownloadButton = ({
   formId,
   onSuccessfulDownload,
+  canDownload,
   downloadError,
   setDownloadError,
   setNoSelectedItemsError,
   checkedItems,
-  responseDownloadLimit,
 }: {
   formId: string;
   onSuccessfulDownload: () => void;
+  canDownload: boolean;
   downloadError: boolean;
   setDownloadError: React.Dispatch<React.SetStateAction<boolean>>;
   setNoSelectedItemsError: React.Dispatch<React.SetStateAction<boolean>>;
   checkedItems: Map<string, boolean>;
-  responseDownloadLimit: number;
 }) => {
   const { t } = useTranslation("form-builder-responses");
-  const MAX_FILE_DOWNLOADS = responseDownloadLimit;
 
   const handleDownload = async () => {
     // Reset any errors
@@ -37,7 +36,7 @@ export const DownloadButton = ({
     }
 
     // Don't download if too many selected
-    if (checkedItems.size > MAX_FILE_DOWNLOADS) {
+    if (!canDownload) {
       return;
     }
 

--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -27,8 +27,6 @@ export const DownloadButton = ({
   const { t } = useTranslation("form-builder-responses");
   const MAX_FILE_DOWNLOADS = responseDownloadLimit;
 
-  // NOTE: browsers have different limits for simultaneous downloads. May need to look into
-  // batching file downloads (e.g. 4 at a time) if edge cases/* come up.
   const handleDownload = async () => {
     // Reset any errors
     if (downloadError) {

--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -12,7 +12,7 @@ export const DownloadButton = ({
   setDownloadError,
   noSelectedItemsError,
   setNoSelectedItemsError,
-  tableItems,
+  checkedItems,
   responseDownloadLimit,
 }: {
   formId: string;
@@ -21,15 +21,7 @@ export const DownloadButton = ({
   setDownloadError: React.Dispatch<React.SetStateAction<boolean>>;
   noSelectedItemsError: boolean;
   setNoSelectedItemsError: React.Dispatch<React.SetStateAction<boolean>>;
-  tableItems: {
-    checkedItems: Map<string, boolean>;
-    statusItems: Map<string, boolean>;
-    sortedItems: TypeOmit<
-      VaultSubmission,
-      "formSubmission" | "submissionID" | "confirmationCode"
-    >[];
-    numberOfOverdueResponses: number;
-  };
+  checkedItems: Map<string, boolean>;
   responseDownloadLimit: number;
 }) => {
   const { t } = useTranslation("form-builder-responses");
@@ -44,7 +36,7 @@ export const DownloadButton = ({
     }
 
     // Can't download if none selected
-    if (tableItems.checkedItems.size === 0) {
+    if (checkedItems.size === 0) {
       if (!noSelectedItemsError) {
         setNoSelectedItemsError(true);
       }
@@ -52,18 +44,18 @@ export const DownloadButton = ({
     }
 
     // Don't download if too many selected
-    if (tableItems.checkedItems.size > MAX_FILE_DOWNLOADS) {
+    if (checkedItems.size > MAX_FILE_DOWNLOADS) {
       return;
     }
 
     toast.info(
       t("downloadResponsesTable.notifications.downloadingXFiles", {
-        fileCount: tableItems.checkedItems.size,
+        fileCount: checkedItems.size,
       })
     );
 
     const url = `/api/id/${formId}/submissions/download?format=html`;
-    const ids = Array.from(tableItems.checkedItems.keys());
+    const ids = Array.from(checkedItems.keys());
 
     axios({
       url,
@@ -104,7 +96,7 @@ export const DownloadButton = ({
       onClick={handleDownload}
     >
       {t("downloadResponsesTable.downloadXSelectedResponses", {
-        size: tableItems.checkedItems.size,
+        size: checkedItems.size,
       })}
     </button>
   );

--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -9,7 +9,6 @@ export const DownloadButton = ({
   onSuccessfulDownload,
   downloadError,
   setDownloadError,
-  noSelectedItemsError,
   setNoSelectedItemsError,
   checkedItems,
   responseDownloadLimit,
@@ -18,7 +17,6 @@ export const DownloadButton = ({
   onSuccessfulDownload: () => void;
   downloadError: boolean;
   setDownloadError: React.Dispatch<React.SetStateAction<boolean>>;
-  noSelectedItemsError: boolean;
   setNoSelectedItemsError: React.Dispatch<React.SetStateAction<boolean>>;
   checkedItems: Map<string, boolean>;
   responseDownloadLimit: number;
@@ -34,9 +32,7 @@ export const DownloadButton = ({
 
     // Can't download if none selected
     if (checkedItems.size === 0) {
-      if (!noSelectedItemsError) {
-        setNoSelectedItemsError(true);
-      }
+      setNoSelectedItemsError(true);
       return;
     }
 

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -320,7 +320,6 @@ export const DownloadTable = ({
           formId={formId}
           downloadError={downloadError}
           setDownloadError={setDownloadError}
-          noSelectedItemsError={noSelectedItemsError}
           setNoSelectedItemsError={setNoSelectedItemsError}
           checkedItems={tableItems.checkedItems}
           responseDownloadLimit={MAX_FILE_DOWNLOADS}

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -322,7 +322,7 @@ export const DownloadTable = ({
           setDownloadError={setDownloadError}
           setNoSelectedItemsError={setNoSelectedItemsError}
           checkedItems={tableItems.checkedItems}
-          responseDownloadLimit={MAX_FILE_DOWNLOADS}
+          canDownload={tableItems.checkedItems.size <= MAX_FILE_DOWNLOADS}
           onSuccessfulDownload={() => {
             router.replace(router.asPath, undefined, { scroll: false });
             toast.success(t("downloadResponsesTable.notifications.downloadComplete"));

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -322,7 +322,7 @@ export const DownloadTable = ({
           setDownloadError={setDownloadError}
           noSelectedItemsError={noSelectedItemsError}
           setNoSelectedItemsError={setNoSelectedItemsError}
-          tableItems={tableItems}
+          checkedItems={tableItems.checkedItems}
           responseDownloadLimit={MAX_FILE_DOWNLOADS}
           onSuccessfulDownload={() => {
             router.replace(router.asPath, undefined, { scroll: false });

--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { DeleteIcon, DownloadIcon, MoreIcon } from "@components/form-builder/icons";
 import axios from "axios";
-import { toast } from "../shared/Toast";
 import { useTranslation } from "react-i18next";
-import { NextRouter } from "next/router";
 import { logMessage } from "@lib/logger";
 
 export const MoreMenu = ({

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -29,7 +29,7 @@ import { getAppSetting } from "@lib/appSettings";
 
 interface ResponsesProps {
   vaultSubmissions: VaultSubmissionList[];
-  formId?: string;
+  formId: string;
   nagwareResult: NagwareResult | null;
   responseDownloadLimit: number;
 }


### PR DESCRIPTION
# Summary | Résumé

Refactors the Download button and handler on the Responses page to its own component. There is no functional change here, just the button and handler have been moved out.

This is in preparation for future development where the download button will launch a Modal to handle the multiple download formats.
