### PR TITLE
CheckAll Tooltip and small refactor

### DIFF
--- a/components/form-builder/app/responses/CheckAll.tsx
+++ b/components/form-builder/app/responses/CheckAll.tsx
@@ -3,10 +3,11 @@ import {
   CheckBoxEmptyIcon,
   CheckIndeterminateIcon,
 } from "@components/form-builder/icons";
-import { TypeOmit, VaultSubmission } from "@lib/types";
+import { VaultSubmissionList } from "@lib/types";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { ReducerTableItemsActions, TableActions } from "./DownloadTableReducer";
+import { Tooltip } from "../shared/Tooltip";
 
 export const CheckAll = ({
   tableItems,
@@ -17,10 +18,7 @@ export const CheckAll = ({
   tableItems: {
     checkedItems: Map<string, boolean>;
     statusItems: Map<string, boolean>;
-    sortedItems: TypeOmit<
-      VaultSubmission,
-      "formSubmission" | "submissionID" | "confirmationCode"
-    >[];
+    sortedItems: VaultSubmissionList[];
     numberOfOverdueResponses: number;
   };
   tableItemsDispatch: React.Dispatch<ReducerTableItemsActions>;
@@ -35,25 +33,19 @@ export const CheckAll = ({
     ALL = "ALL",
   }
 
-  /**
-   * Are all items checked, some items checked, or no items checked?
-   * @returns {allCheckedState} The current state of the checked items.
-   */
-  const checkAllStatus = () => {
-    if (tableItems.checkedItems.size === 0) {
-      return allCheckedState.NONE;
-    }
-    if (tableItems.checkedItems.size === tableItems.sortedItems.length) {
-      return allCheckedState.ALL;
-    }
-    return allCheckedState.SOME;
-  };
+  // Are all items checked, some items checked, or no items checked?
+  const checkAllStatus =
+    tableItems.checkedItems.size === 0
+      ? allCheckedState.NONE
+      : tableItems.checkedItems.size === tableItems.sortedItems.length
+      ? allCheckedState.ALL
+      : allCheckedState.SOME;
 
   /**
    * Check all items if none are checked, otherwise uncheck all items.
    */
   const handleCheckAll = () => {
-    if (checkAllStatus() === allCheckedState.NONE) {
+    if (checkAllStatus === allCheckedState.NONE) {
       tableItems.sortedItems.forEach((submission) => {
         tableItemsDispatch({
           type: TableActions.UPDATE,
@@ -73,43 +65,41 @@ export const CheckAll = ({
     }
   };
 
+  const tooltip =
+    checkAllStatus === allCheckedState.NONE
+      ? t("downloadResponsesTable.header.selectAll")
+      : t("downloadResponsesTable.header.deselectAll");
+
   return (
-    <span
-      className="cursor-pointer"
-      role="checkbox"
-      aria-checked={
-        checkAllStatus() === allCheckedState.ALL
-          ? "true"
-          : checkAllStatus() === allCheckedState.SOME
-          ? "mixed"
-          : "false"
-      }
-      tabIndex={0}
-      onClick={handleCheckAll}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          handleCheckAll();
+    <Tooltip text={tooltip} side="top">
+      <span
+        className="m-auto inline-block cursor-pointer"
+        role="checkbox"
+        aria-checked={
+          checkAllStatus === allCheckedState.ALL
+            ? "true"
+            : checkAllStatus === allCheckedState.SOME
+            ? "mixed"
+            : "false"
         }
-      }}
-    >
-      {checkAllStatus() === allCheckedState.ALL && (
-        <CheckAllIcon
-          title={t("downloadResponsesTable.header.deselectAll")}
-          className="m-auto h-6 w-6"
-        />
-      )}
-      {checkAllStatus() === allCheckedState.SOME && (
-        <CheckIndeterminateIcon
-          title={t("downloadResponsesTable.header.deselectAll")}
-          className="m-auto h-6 w-6"
-        />
-      )}
-      {checkAllStatus() === allCheckedState.NONE && (
-        <CheckBoxEmptyIcon
-          title={t("downloadResponsesTable.header.selectAll")}
-          className="m-auto h-6 w-6"
-        />
-      )}
-    </span>
+        tabIndex={0}
+        onClick={handleCheckAll}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            handleCheckAll();
+          }
+        }}
+      >
+        {checkAllStatus === allCheckedState.ALL && (
+          <CheckAllIcon title={tooltip} className="h-6 w-6" />
+        )}
+        {checkAllStatus === allCheckedState.SOME && (
+          <CheckIndeterminateIcon title={tooltip} className="h-6 w-6" />
+        )}
+        {checkAllStatus === allCheckedState.NONE && (
+          <CheckBoxEmptyIcon title={tooltip} className="h-6 w-6" />
+        )}
+      </span>
+    </Tooltip>
   );
 };

--- a/components/form-builder/app/responses/CheckAll.tsx
+++ b/components/form-builder/app/responses/CheckAll.tsx
@@ -33,11 +33,16 @@ export const CheckAll = ({
     ALL = "ALL",
   }
 
+  const { checkedItems, sortedItems } = tableItems;
+
+  const checkedItemsCount = checkedItems.size;
+  const sortedItemsCount = sortedItems.length;
+
   // Are all items checked, some items checked, or no items checked?
   const checkAllStatus =
-    tableItems.checkedItems.size === 0
+    checkedItemsCount === 0
       ? allCheckedState.NONE
-      : tableItems.checkedItems.size === tableItems.sortedItems.length
+      : checkedItemsCount === sortedItemsCount
       ? allCheckedState.ALL
       : allCheckedState.SOME;
 
@@ -46,7 +51,7 @@ export const CheckAll = ({
    */
   const handleCheckAll = () => {
     if (checkAllStatus === allCheckedState.NONE) {
-      tableItems.sortedItems.forEach((submission) => {
+      sortedItems.forEach((submission) => {
         tableItemsDispatch({
           type: TableActions.UPDATE,
           payload: { item: { name: submission.name, checked: true } },
@@ -56,7 +61,7 @@ export const CheckAll = ({
         setNoSelectedItemsError(false);
       }
     } else {
-      tableItems.checkedItems.forEach((_, key) => {
+      checkedItems.forEach((_, key) => {
         tableItemsDispatch({
           type: TableActions.UPDATE,
           payload: { item: { name: key, checked: false } },

--- a/components/form-builder/app/shared/Tooltip.tsx
+++ b/components/form-builder/app/shared/Tooltip.tsx
@@ -5,7 +5,7 @@ import { cn } from "@lib/utils";
 interface TooltipProps {
   text: string;
   className?: string;
-  children: React.ReactNode;
+  children: React.ReactNode | string;
   side?: "left" | "right" | "top" | "bottom";
 }
 
@@ -13,7 +13,9 @@ export const Tooltip = ({ text, children, className = "", side = "left" }: Toolt
   return (
     <TooltipPrimitive.Provider>
       <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Trigger asChild>
+          <span>{children}</span>
+        </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Content
           sideOffset={4}
           side={side}

--- a/components/form-builder/app/shared/Tooltip.tsx
+++ b/components/form-builder/app/shared/Tooltip.tsx
@@ -6,16 +6,17 @@ interface TooltipProps {
   text: string;
   className?: string;
   children: React.ReactNode;
+  side?: "left" | "right" | "top" | "bottom";
 }
 
-export const Tooltip = ({ text, children, className = "" }: TooltipProps) => {
+export const Tooltip = ({ text, children, className = "", side = "left" }: TooltipProps) => {
   return (
     <TooltipPrimitive.Provider>
       <TooltipPrimitive.Root>
         <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
         <TooltipPrimitive.Content
           sideOffset={4}
-          side="left"
+          side={side}
           className={cn("inline-flex items-center rounded-md px-4 py-2 bg-slate-800", className)}
         >
           <TooltipPrimitive.Arrow className="fill-current" />


### PR DESCRIPTION
# Summary | Résumé

Adds a Tooltip to the CheckAll component.
Simplifies a type on the CheckAll component by using an existing one.
Adds "side" prop to Tooltip component

<img width="361" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/d67ba0fa-d698-489b-ad64-25298e8bbb86">

