### PR TITLE
Add Download/Confirm panel to Responses

### DIFF
--- a/components/form-builder/app/responses/ActionsPanel.tsx
+++ b/components/form-builder/app/responses/ActionsPanel.tsx
@@ -6,7 +6,7 @@ const handleDelete = () => {
   alert("Not yet implemented");
 };
 
-export const BottomActionsPanel = ({ children }: { children: React.ReactNode }) => {
+export const ActionsPanel = ({ children }: { children: React.ReactNode }) => {
   const { t } = useTranslation("form-builder-responses");
   return (
     <section className="fixed bottom-0 left-0 h-32 w-full border-t-2 border-black bg-white py-8">

--- a/components/form-builder/app/responses/BottomActionsPanel.tsx
+++ b/components/form-builder/app/responses/BottomActionsPanel.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@components/globals";
+import React from "react";
+
+export const BottomActionsPanel = () => {
+  return (
+    <section className="fixed bottom-0 left-0 h-32 w-full border-t-2 border-black bg-white py-8">
+      <div className="mx-4 laptop:mx-32 desktop:mx-64">
+        <div className="ml-[210px] flex gap-4">
+          <Button theme="primary">Download selected</Button>
+          <Button theme="destructive">Delete selected</Button>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/form-builder/app/responses/BottomActionsPanel.tsx
+++ b/components/form-builder/app/responses/BottomActionsPanel.tsx
@@ -1,13 +1,21 @@
 import { Button } from "@components/globals";
 import React from "react";
+import { useTranslation } from "react-i18next";
 
-export const BottomActionsPanel = () => {
+const handleDelete = () => {
+  alert("Not yet implemented");
+};
+
+export const BottomActionsPanel = ({ children }: { children: React.ReactNode }) => {
+  const { t } = useTranslation("form-builder-responses");
   return (
     <section className="fixed bottom-0 left-0 h-32 w-full border-t-2 border-black bg-white py-8">
       <div className="mx-4 laptop:mx-32 desktop:mx-64">
         <div className="ml-[210px] flex gap-4">
-          <Button theme="primary">Download selected</Button>
-          <Button theme="destructive">Delete selected</Button>
+          {children}
+          <Button theme="destructive" onClick={handleDelete}>
+            {t("downloadResponsesTable.deleteSelectedResponses")}
+          </Button>
         </div>
       </div>
     </section>

--- a/components/form-builder/app/responses/DownloadButton.tsx
+++ b/components/form-builder/app/responses/DownloadButton.tsx
@@ -88,9 +88,7 @@ export const DownloadButton = ({
       aria-live="polite"
       onClick={handleDownload}
     >
-      {t("downloadResponsesTable.downloadXSelectedResponses", {
-        size: checkedItems.size,
-      })}
+      {t("downloadResponsesTable.downloadSelectedResponses")}
     </button>
   );
 };

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -22,7 +22,7 @@ import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
 import { MoreMenu } from "./MoreMenu";
-import { BottomActionsPanel } from "./BottomActionsPanel";
+import { ActionsPanel } from "./ActionsPanel";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -275,7 +275,7 @@ export const DownloadTable = ({
       </section>
 
       {tableItems.checkedItems.size > 0 && (
-        <BottomActionsPanel>
+        <ActionsPanel>
           <DownloadButton
             formId={formId}
             downloadError={downloadError}
@@ -288,7 +288,7 @@ export const DownloadTable = ({
               toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
             }}
           />
-        </BottomActionsPanel>
+        </ActionsPanel>
       )}
     </>
   );

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -83,8 +83,7 @@ export const DownloadTable = ({
   };
 
   useEffect(() => {
-    // NOTE: Table not updating when it should? May need to be more explicit in telling react
-    // what has changed in the array (e.g. a status). For now, this seems to work well.
+    // Reset tableItems when vaultSubmissions changes (ie, when switching between Status tabs)
     const dispatchAction = { type: TableActions.RESET, payload: { vaultSubmissions } };
     tableItemsDispatch(dispatchAction);
   }, [vaultSubmissions]);

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -27,7 +27,6 @@ import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
 import { MoreMenu } from "./MoreMenu";
-import { logMessage } from "@lib/logger";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -64,6 +63,7 @@ export const DownloadTable = ({
         overdueAfter,
       })
     ).length,
+    overdueAfter,
   });
 
   const MAX_FILE_DOWNLOADS = responseDownloadLimit;
@@ -103,7 +103,7 @@ export const DownloadTable = ({
   useEffect(() => {
     // NOTE: Table not updating when it should? May need to be more explicit in telling react
     // what has changed in the array (e.g. a status). For now, this seems to work well.
-    const dispatchAction = { type: TableActions.SORT, payload: { vaultSubmissions } };
+    const dispatchAction = { type: TableActions.RESET, payload: { vaultSubmissions } };
     tableItemsDispatch(dispatchAction);
   }, [vaultSubmissions]);
 

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -27,12 +27,14 @@ import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
 import { MoreMenu } from "./MoreMenu";
+import { logMessage } from "@lib/logger";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
   formId: string;
   nagwareResult: NagwareResult | null;
   responseDownloadLimit: number;
+  setShowBottomPanel: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const DownloadTable = ({
@@ -40,6 +42,7 @@ export const DownloadTable = ({
   formId,
   nagwareResult,
   responseDownloadLimit,
+  setShowBottomPanel,
 }: DownloadTableProps) => {
   const { t } = useTranslation("form-builder-responses");
   const router = useRouter();
@@ -74,9 +77,11 @@ export const DownloadTable = ({
     // Needed because of how useReducer updates state on the next render vs. inside this function..
     const nextState = reducerTableItems(tableItems, dispatchAction);
 
-    // Show or hide errors depending
-    if (nextState.checkedItems.size > 0 && noSelectedItemsError) {
+    if (nextState.checkedItems.size > 0) {
       setNoSelectedItemsError(false);
+      setShowBottomPanel(true);
+    } else {
+      setShowBottomPanel(false);
     }
   };
 

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -235,19 +235,6 @@ export const DownloadTable = ({
           </tbody>
         </table>
         <div className="mt-8 flex">
-          <DownloadButton
-            formId={formId}
-            downloadError={downloadError}
-            setDownloadError={setDownloadError}
-            setNoSelectedItemsError={setNoSelectedItemsError}
-            checkedItems={tableItems.checkedItems}
-            canDownload={tableItems.checkedItems.size <= MAX_FILE_DOWNLOADS}
-            onSuccessfulDownload={() => {
-              router.replace(router.asPath, undefined, { scroll: false });
-              toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
-            }}
-          />
-
           <div id="notificationsBottom" className="ml-4">
             {tableItems.checkedItems.size > MAX_FILE_DOWNLOADS && (
               <Alert.Danger icon={false}>
@@ -287,7 +274,22 @@ export const DownloadTable = ({
         </div>
       </section>
 
-      {tableItems.checkedItems.size > 0 && <BottomActionsPanel />}
+      {tableItems.checkedItems.size > 0 && (
+        <BottomActionsPanel>
+          <DownloadButton
+            formId={formId}
+            downloadError={downloadError}
+            setDownloadError={setDownloadError}
+            setNoSelectedItemsError={setNoSelectedItemsError}
+            checkedItems={tableItems.checkedItems}
+            canDownload={tableItems.checkedItems.size <= MAX_FILE_DOWNLOADS}
+            onSuccessfulDownload={() => {
+              router.replace(router.asPath, undefined, { scroll: false });
+              toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
+            }}
+          />
+        </BottomActionsPanel>
+      )}
     </>
   );
 };

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -15,25 +15,20 @@ import { DownloadStatus } from "./DownloadStatus";
 import { useRouter } from "next/router";
 import { useSetting } from "@lib/hooks/useSetting";
 import Link from "next/link";
-import {
-  TableActions,
-  isSubmissionOverdue,
-  reducerTableItems,
-  sortVaultSubmission,
-} from "./DownloadTableReducer";
+import { TableActions, initialTableItemsState, reducerTableItems } from "./DownloadTableReducer";
 import { getDaysPassed } from "@lib/clientHelpers";
 import { Alert } from "@components/globals";
 import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
 import { MoreMenu } from "./MoreMenu";
+import { BottomActionsPanel } from "./BottomActionsPanel";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
   formId: string;
   nagwareResult: NagwareResult | null;
   responseDownloadLimit: number;
-  setShowBottomPanel: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const DownloadTable = ({
@@ -41,7 +36,6 @@ export const DownloadTable = ({
   formId,
   nagwareResult,
   responseDownloadLimit,
-  setShowBottomPanel,
 }: DownloadTableProps) => {
   const { t } = useTranslation("form-builder-responses");
   const router = useRouter();
@@ -52,19 +46,10 @@ export const DownloadTable = ({
   const accountEscalated = nagwareResult && nagwareResult.level > 2;
 
   const { value: overdueAfter } = useSetting("nagwarePhaseEncouraged");
-  const [tableItems, tableItemsDispatch] = useReducer(reducerTableItems, {
-    checkedItems: new Map(),
-    statusItems: new Map(vaultSubmissions.map((submission) => [submission.name, false])),
-    sortedItems: sortVaultSubmission(vaultSubmissions),
-    numberOfOverdueResponses: vaultSubmissions.filter((submission) =>
-      isSubmissionOverdue({
-        status: submission.status,
-        createdAt: submission.createdAt,
-        overdueAfter,
-      })
-    ).length,
-    overdueAfter,
-  });
+  const [tableItems, tableItemsDispatch] = useReducer(
+    reducerTableItems,
+    initialTableItemsState(vaultSubmissions, overdueAfter)
+  );
 
   const MAX_FILE_DOWNLOADS = responseDownloadLimit;
 
@@ -79,9 +64,6 @@ export const DownloadTable = ({
 
     if (nextState.checkedItems.size > 0) {
       setNoSelectedItemsError(false);
-      setShowBottomPanel(true);
-    } else {
-      setShowBottomPanel(false);
     }
   };
 
@@ -108,165 +90,21 @@ export const DownloadTable = ({
   }, [vaultSubmissions]);
 
   return (
-    <section>
-      <SkipLinkReusable
-        text={t("downloadResponsesTable.skipLink")}
-        anchor="#downloadTableButtonId"
-      />
-      <div id="notificationsTop">
-        {tableItems.checkedItems.size > MAX_FILE_DOWNLOADS && (
-          <Alert.Danger>
-            <Alert.Title>
-              {t("downloadResponsesTable.errors.trySelectingLessFilesHeader", {
-                max: MAX_FILE_DOWNLOADS,
-              })}
-            </Alert.Title>
-            <p className="text-sm text-[#26374a]">
-              {t("downloadResponsesTable.errors.trySelectingLessFiles", {
-                max: MAX_FILE_DOWNLOADS,
-              })}
-            </p>
-          </Alert.Danger>
-        )}
-        {noSelectedItemsError && (
-          <Alert.Danger>
-            <Alert.Title>{t("downloadResponsesTable.errors.atLeastOneFileHeader")}</Alert.Title>
-            <p className="text-sm text-[#26374a]">
-              {t("downloadResponsesTable.errors.atLeastOneFile")}
-            </p>
-          </Alert.Danger>
-        )}
-        {downloadError && (
-          <Alert.Danger>
-            <Alert.Title>
-              {t("downloadResponsesTable.errors.errorDownloadingFilesHeader")}
-            </Alert.Title>
-            <p className="mb-2 text-sm text-[#26374a]">
-              {t("downloadResponsesTable.errors.errorDownloadingFiles")}
-              <Link href="/form-builder/support">
-                {t("downloadResponsesTable.errors.errorDownloadingFilesLink")}
-              </Link>
-              .
-            </p>
-          </Alert.Danger>
-        )}
-      </div>
-      <table className="text-sm" aria-live="polite">
-        <caption className="sr-only">{t("downloadResponsesTable.header.tableTitle")}</caption>
-        <thead className="border-b-2 border-[#6a6d7b]">
-          <tr>
-            <th className="p-4 text-center">
-              <CheckAll
-                tableItems={tableItems}
-                tableItemsDispatch={tableItemsDispatch}
-                noSelectedItemsError={noSelectedItemsError}
-                setNoSelectedItemsError={setNoSelectedItemsError}
-              />
-            </th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.number")}</th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.status")}</th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.downloadResponse")}</th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.lastDownloadedBy")}</th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.confirmReceipt")}</th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.removal")}</th>
-            <th className="p-4 text-left">{t("downloadResponsesTable.header.more")}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {tableItems.sortedItems.map((submission) => {
-            const isBlocked = blockDownload(submission);
-            return (
-              <tr
-                key={submission.name}
-                className={
-                  "border-b-2 border-grey" +
-                  (tableItems.statusItems.get(submission.name) ? " bg-[#fffbf3]" : "") +
-                  (isBlocked ? " opacity-50" : "")
-                }
-              >
-                <td className="flex whitespace-nowrap pb-2 pl-9 pr-4">
-                  <div className="gc-input-checkbox">
-                    <input
-                      id={submission.name}
-                      className="gc-input-checkbox__input"
-                      name="responses"
-                      type="checkbox"
-                      checked={tableItems.statusItems.get(submission.name)}
-                      onChange={handleChecked}
-                      {...(isBlocked && { disabled: true })}
-                    />
-                    <label className="gc-checkbox-label" htmlFor={submission.name}>
-                      <span className="sr-only">{submission.name}</span>
-                    </label>
-                  </div>
-                </td>
-                <td className="whitespace-nowrap px-4">{submission.name}</td>
-                <td className="whitespace-nowrap px-4">
-                  <DownloadStatus vaultStatus={submission.status} />
-                </td>
-                <td className="whitespace-nowrap px-4">
-                  <DownloadResponseStatus
-                    vaultStatus={submission.status}
-                    createdAt={submission.createdAt}
-                    downloadedAt={submission.downloadedAt}
-                    overdueAfter={overdueAfter ? parseInt(overdueAfter) : undefined}
-                  />
-                </td>
-                <td className="whitespace-nowrap px-4">
-                  <div className="w-40 truncate">
-                    {submission.lastDownloadedBy ||
-                      t("downloadResponsesTable.status.notDownloaded")}
-                  </div>
-                </td>
-                <td className="whitespace-nowrap px-4">
-                  <ConfirmReceiptStatus
-                    vaultStatus={submission.status}
-                    createdAtDate={submission.createdAt}
-                    overdueAfter={overdueAfter ? parseInt(overdueAfter) : undefined}
-                  />
-                </td>
-                <td className="whitespace-nowrap px-4">
-                  <RemovalStatus vaultStatus={submission.status} removalAt={submission.removedAt} />
-                </td>
-                <td className="px-4">
-                  <MoreMenu
-                    formId={submission.formID}
-                    responseId={submission.name}
-                    onDownloadSuccess={() => {
-                      router.replace(router.asPath, undefined, { scroll: false });
-                      toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
-                    }}
-                    setDownloadError={setDownloadError}
-                  />
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-      <div className="mt-8 flex">
-        <DownloadButton
-          formId={formId}
-          downloadError={downloadError}
-          setDownloadError={setDownloadError}
-          setNoSelectedItemsError={setNoSelectedItemsError}
-          checkedItems={tableItems.checkedItems}
-          canDownload={tableItems.checkedItems.size <= MAX_FILE_DOWNLOADS}
-          onSuccessfulDownload={() => {
-            router.replace(router.asPath, undefined, { scroll: false });
-            toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
-          }}
+    <>
+      <section>
+        <SkipLinkReusable
+          text={t("downloadResponsesTable.skipLink")}
+          anchor="#downloadTableButtonId"
         />
-
-        <div id="notificationsBottom" className="ml-4">
+        <div id="notificationsTop">
           {tableItems.checkedItems.size > MAX_FILE_DOWNLOADS && (
-            <Alert.Danger icon={false}>
-              <Alert.Title headingTag="h3">
+            <Alert.Danger>
+              <Alert.Title>
                 {t("downloadResponsesTable.errors.trySelectingLessFilesHeader", {
                   max: MAX_FILE_DOWNLOADS,
                 })}
               </Alert.Title>
-              <p className="text-sm text-black">
+              <p className="text-sm text-[#26374a]">
                 {t("downloadResponsesTable.errors.trySelectingLessFiles", {
                   max: MAX_FILE_DOWNLOADS,
                 })}
@@ -274,27 +112,182 @@ export const DownloadTable = ({
             </Alert.Danger>
           )}
           {noSelectedItemsError && (
-            <Alert.Danger icon={false}>
-              <Alert.Title headingTag="h3">
-                {t("downloadResponsesTable.errors.atLeastOneFileHeader")}
-              </Alert.Title>
-              <p className="text-sm text-black">
+            <Alert.Danger>
+              <Alert.Title>{t("downloadResponsesTable.errors.atLeastOneFileHeader")}</Alert.Title>
+              <p className="text-sm text-[#26374a]">
                 {t("downloadResponsesTable.errors.atLeastOneFile")}
               </p>
             </Alert.Danger>
           )}
           {downloadError && (
-            <Alert.Danger icon={false}>
-              <Alert.Title headingTag="h3">
+            <Alert.Danger>
+              <Alert.Title>
                 {t("downloadResponsesTable.errors.errorDownloadingFilesHeader")}
               </Alert.Title>
-              <p className="text-sm text-black">
+              <p className="mb-2 text-sm text-[#26374a]">
                 {t("downloadResponsesTable.errors.errorDownloadingFiles")}
+                <Link href="/form-builder/support">
+                  {t("downloadResponsesTable.errors.errorDownloadingFilesLink")}
+                </Link>
+                .
               </p>
             </Alert.Danger>
           )}
         </div>
-      </div>
-    </section>
+        <table className="text-sm" aria-live="polite">
+          <caption className="sr-only">{t("downloadResponsesTable.header.tableTitle")}</caption>
+          <thead className="border-b-2 border-[#6a6d7b]">
+            <tr>
+              <th className="p-4 text-center">
+                <CheckAll
+                  tableItems={tableItems}
+                  tableItemsDispatch={tableItemsDispatch}
+                  noSelectedItemsError={noSelectedItemsError}
+                  setNoSelectedItemsError={setNoSelectedItemsError}
+                />
+              </th>
+              <th className="p-4 text-left">{t("downloadResponsesTable.header.number")}</th>
+              <th className="p-4 text-left">{t("downloadResponsesTable.header.status")}</th>
+              <th className="p-4 text-left">
+                {t("downloadResponsesTable.header.downloadResponse")}
+              </th>
+              <th className="p-4 text-left">
+                {t("downloadResponsesTable.header.lastDownloadedBy")}
+              </th>
+              <th className="p-4 text-left">{t("downloadResponsesTable.header.confirmReceipt")}</th>
+              <th className="p-4 text-left">{t("downloadResponsesTable.header.removal")}</th>
+              <th className="p-4 text-left">{t("downloadResponsesTable.header.more")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tableItems.sortedItems.map((submission) => {
+              const isBlocked = blockDownload(submission);
+              return (
+                <tr
+                  key={submission.name}
+                  className={
+                    "border-b-2 border-grey" +
+                    (tableItems.statusItems.get(submission.name) ? " bg-[#fffbf3]" : "") +
+                    (isBlocked ? " opacity-50" : "")
+                  }
+                >
+                  <td className="flex whitespace-nowrap pb-2 pl-9 pr-4">
+                    <div className="gc-input-checkbox">
+                      <input
+                        id={submission.name}
+                        className="gc-input-checkbox__input"
+                        name="responses"
+                        type="checkbox"
+                        checked={tableItems.statusItems.get(submission.name)}
+                        onChange={handleChecked}
+                        {...(isBlocked && { disabled: true })}
+                      />
+                      <label className="gc-checkbox-label" htmlFor={submission.name}>
+                        <span className="sr-only">{submission.name}</span>
+                      </label>
+                    </div>
+                  </td>
+                  <td className="whitespace-nowrap px-4">{submission.name}</td>
+                  <td className="whitespace-nowrap px-4">
+                    <DownloadStatus vaultStatus={submission.status} />
+                  </td>
+                  <td className="whitespace-nowrap px-4">
+                    <DownloadResponseStatus
+                      vaultStatus={submission.status}
+                      createdAt={submission.createdAt}
+                      downloadedAt={submission.downloadedAt}
+                      overdueAfter={overdueAfter ? parseInt(overdueAfter) : undefined}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-4">
+                    <div className="w-40 truncate">
+                      {submission.lastDownloadedBy ||
+                        t("downloadResponsesTable.status.notDownloaded")}
+                    </div>
+                  </td>
+                  <td className="whitespace-nowrap px-4">
+                    <ConfirmReceiptStatus
+                      vaultStatus={submission.status}
+                      createdAtDate={submission.createdAt}
+                      overdueAfter={overdueAfter ? parseInt(overdueAfter) : undefined}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-4">
+                    <RemovalStatus
+                      vaultStatus={submission.status}
+                      removalAt={submission.removedAt}
+                    />
+                  </td>
+                  <td className="px-4">
+                    <MoreMenu
+                      formId={submission.formID}
+                      responseId={submission.name}
+                      onDownloadSuccess={() => {
+                        router.replace(router.asPath, undefined, { scroll: false });
+                        toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
+                      }}
+                      setDownloadError={setDownloadError}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        <div className="mt-8 flex">
+          <DownloadButton
+            formId={formId}
+            downloadError={downloadError}
+            setDownloadError={setDownloadError}
+            setNoSelectedItemsError={setNoSelectedItemsError}
+            checkedItems={tableItems.checkedItems}
+            canDownload={tableItems.checkedItems.size <= MAX_FILE_DOWNLOADS}
+            onSuccessfulDownload={() => {
+              router.replace(router.asPath, undefined, { scroll: false });
+              toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
+            }}
+          />
+
+          <div id="notificationsBottom" className="ml-4">
+            {tableItems.checkedItems.size > MAX_FILE_DOWNLOADS && (
+              <Alert.Danger icon={false}>
+                <Alert.Title headingTag="h3">
+                  {t("downloadResponsesTable.errors.trySelectingLessFilesHeader", {
+                    max: MAX_FILE_DOWNLOADS,
+                  })}
+                </Alert.Title>
+                <p className="text-sm text-black">
+                  {t("downloadResponsesTable.errors.trySelectingLessFiles", {
+                    max: MAX_FILE_DOWNLOADS,
+                  })}
+                </p>
+              </Alert.Danger>
+            )}
+            {noSelectedItemsError && (
+              <Alert.Danger icon={false}>
+                <Alert.Title headingTag="h3">
+                  {t("downloadResponsesTable.errors.atLeastOneFileHeader")}
+                </Alert.Title>
+                <p className="text-sm text-black">
+                  {t("downloadResponsesTable.errors.atLeastOneFile")}
+                </p>
+              </Alert.Danger>
+            )}
+            {downloadError && (
+              <Alert.Danger icon={false}>
+                <Alert.Title headingTag="h3">
+                  {t("downloadResponsesTable.errors.errorDownloadingFilesHeader")}
+                </Alert.Title>
+                <p className="text-sm text-black">
+                  {t("downloadResponsesTable.errors.errorDownloadingFiles")}
+                </p>
+              </Alert.Danger>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {tableItems.checkedItems.size > 0 && <BottomActionsPanel />}
+    </>
   );
 };

--- a/components/form-builder/app/responses/DownloadTableReducer.ts
+++ b/components/form-builder/app/responses/DownloadTableReducer.ts
@@ -4,6 +4,7 @@ import { VaultSubmissionList, VaultStatus } from "@lib/types";
 export enum TableActions {
   UPDATE = "UPDATE",
   SORT = "SORT",
+  RESET = "RESET",
 }
 
 interface ReducerTableItemsState {
@@ -11,6 +12,7 @@ interface ReducerTableItemsState {
   checkedItems: Map<string, boolean>;
   sortedItems: VaultSubmissionList[];
   numberOfOverdueResponses: number;
+  overdueAfter: string | undefined;
 }
 
 export interface ReducerTableItemsActions {
@@ -95,6 +97,8 @@ export const reducerTableItems = (
           newCheckedItems.set(name, true);
         }
       });
+
+
       return {
         ...state,
         checkedItems: newCheckedItems,
@@ -108,6 +112,27 @@ export const reducerTableItems = (
       return {
         ...state,
         sortedItems: sortVaultSubmission(payload.vaultSubmissions),
+      };
+    }
+
+    case "RESET": {
+      if (!payload.vaultSubmissions) {
+        throw Error("Table sort dispatch missing vaultSubmissions");
+      }
+      return {
+        ...state,
+        checkedItems: new Map(),
+        statusItems: new Map(
+          payload.vaultSubmissions.map((submission) => [submission.name, false])
+        ),
+        sortedItems: sortVaultSubmission(payload.vaultSubmissions),
+        numberOfOverdueResponses: payload.vaultSubmissions.filter((submission) =>
+          isSubmissionOverdue({
+            status: submission.status,
+            createdAt: submission.createdAt,
+            overdueAfter: state.overdueAfter,
+          })
+        ).length,
       };
     }
     default:

--- a/components/form-builder/app/responses/DownloadTableReducer.ts
+++ b/components/form-builder/app/responses/DownloadTableReducer.ts
@@ -26,6 +26,25 @@ export interface ReducerTableItemsActions {
   };
 }
 
+export const initialTableItemsState = (
+  vaultSubmissions: VaultSubmissionList[],
+  overdueAfter: string | undefined
+) => {
+  return {
+    checkedItems: new Map(),
+    statusItems: new Map(vaultSubmissions.map((submission) => [submission.name, false])),
+    sortedItems: sortVaultSubmission(vaultSubmissions),
+    numberOfOverdueResponses: vaultSubmissions.filter((submission) =>
+      isSubmissionOverdue({
+        status: submission.status,
+        createdAt: submission.createdAt,
+        overdueAfter,
+      })
+    ).length,
+    overdueAfter,
+  };
+};
+
 // Sort submissions by created date first but prioritize New submissions to the top of the list.
 // Note: This can probably be done more efficiently but the sorting behavior has not been fully
 // defined yet and for now this simple way works.
@@ -98,7 +117,6 @@ export const reducerTableItems = (
         }
       });
 
-
       return {
         ...state,
         checkedItems: newCheckedItems,
@@ -119,21 +137,7 @@ export const reducerTableItems = (
       if (!payload.vaultSubmissions) {
         throw Error("Table sort dispatch missing vaultSubmissions");
       }
-      return {
-        ...state,
-        checkedItems: new Map(),
-        statusItems: new Map(
-          payload.vaultSubmissions.map((submission) => [submission.name, false])
-        ),
-        sortedItems: sortVaultSubmission(payload.vaultSubmissions),
-        numberOfOverdueResponses: payload.vaultSubmissions.filter((submission) =>
-          isSubmissionOverdue({
-            status: submission.status,
-            createdAt: submission.createdAt,
-            overdueAfter: state.overdueAfter,
-          })
-        ).length,
-      };
+      return initialTableItemsState(payload.vaultSubmissions, state.overdueAfter);
     }
     default:
       throw Error("Unknown action: " + action.type);

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -23,7 +23,7 @@ import { useTemplateStore } from "@components/form-builder/store";
 import { LoggedOutTabName, LoggedOutTab } from "@components/form-builder/app/LoggedOutTab";
 import Head from "next/head";
 import { FormBuilderLayout } from "@components/globals/layouts/FormBuilderLayout";
-import { Button, ErrorPanel } from "@components/globals";
+import { ErrorPanel } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
 import { DeleteIcon, FolderIcon, InboxIcon } from "@components/form-builder/icons";

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -53,7 +53,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
   const isAuthenticated = status === "authenticated";
   const [isShowConfirmReceiptDialog, setIsShowConfirmReceiptDialog] = useState(false);
   const [isShowReportProblemsDialog, setIsShowReportProblemsDialog] = useState(false);
-  const [showBottomPanel, setShowBottomPanel] = useState(false);
 
   const [isServerError, setIsServerError] = useState(false);
 
@@ -180,7 +179,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
                 formId={formId}
                 nagwareResult={nagwareResult}
                 responseDownloadLimit={responseDownloadLimit}
-                setShowBottomPanel={setShowBottomPanel}
               />
             )}
 
@@ -239,17 +237,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         apiUrl={`/api/id/${formId}/submission/report`}
         maxEntries={MAX_REPORT_COUNT}
       />
-
-      {showBottomPanel && (
-        <section className="fixed bottom-0 left-0 h-32 w-full border-t-2 border-black bg-white py-8">
-          <div className="mx-4 laptop:mx-32 desktop:mx-64">
-            <div className="ml-[210px] flex gap-4">
-              <Button theme="primary">Download selected</Button>
-              <Button theme="destructive">Delete selected</Button>
-            </div>
-          </div>
-        </section>
-      )}
     </>
   );
 };

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -23,7 +23,7 @@ import { useTemplateStore } from "@components/form-builder/store";
 import { LoggedOutTabName, LoggedOutTab } from "@components/form-builder/app/LoggedOutTab";
 import Head from "next/head";
 import { FormBuilderLayout } from "@components/globals/layouts/FormBuilderLayout";
-import { ErrorPanel } from "@components/globals";
+import { Button, ErrorPanel } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
 import { DeleteIcon, FolderIcon, InboxIcon } from "@components/form-builder/icons";
@@ -53,6 +53,8 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
   const isAuthenticated = status === "authenticated";
   const [isShowConfirmReceiptDialog, setIsShowConfirmReceiptDialog] = useState(false);
   const [isShowReportProblemsDialog, setIsShowReportProblemsDialog] = useState(false);
+  const [showBottomPanel, setShowBottomPanel] = useState(false);
+
   const [isServerError, setIsServerError] = useState(false);
 
   const router = useRouter();
@@ -178,6 +180,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
                 formId={formId}
                 nagwareResult={nagwareResult}
                 responseDownloadLimit={responseDownloadLimit}
+                setShowBottomPanel={setShowBottomPanel}
               />
             )}
 
@@ -236,6 +239,17 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         apiUrl={`/api/id/${formId}/submission/report`}
         maxEntries={MAX_REPORT_COUNT}
       />
+
+      {showBottomPanel && (
+        <section className="fixed bottom-0 left-0 h-32 w-full border-t-2 border-black bg-white py-8">
+          <div className="mx-4 laptop:mx-32 desktop:mx-64">
+            <div className="ml-[210px] flex gap-4">
+              <Button theme="primary">Download selected</Button>
+              <Button theme="destructive">Delete selected</Button>
+            </div>
+          </div>
+        </section>
+      )}
     </>
   );
 };

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -78,7 +78,8 @@
         "description": "There are {{numberOfOverdueResponses}} unconfirmed responses that are {{escalatedAfter}} days old. Download and confirm all overdue responses to remove this restriction."
       }
     },
-    "downloadXSelectedResponses": "Download {{size}} selected responses",
+    "downloadSelectedResponses": "Download selected",
+    "deleteSelectedResponses": "Delete selected",
     "skipLink": "Skip the download table",
     "unknown": "Unknown"
   },

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -78,7 +78,8 @@
         "description": "Il y a {{numberOfOverdueResponses}} réponses qui datent de {{escalatedAfter}} jours. Téléchargez et confirmez toutes les réponses en retard pour enlever cette restriction."
       }
     },
-    "downloadXSelectedResponses": "Télécharger {{size}} réponses sélectionnées",
+    "downloadSelectedResponses": "Télécharger les réponses sélectionnées",
+    "deleteSelectedResponses": "Supprimer les réponses sélectionnées",
     "skipLink": "Sauter le tableau de téléchargement",
     "unknown": "Inconnu"
   },


### PR DESCRIPTION
# Summary | Résumé

Adds the Download/Confirm panel to the bottom of the Responses screen and adds a RESET action to the Reducer to handle when switching Status filter.

This PR just adds the panel and uses the existing Download/Delete buttons and actions.

![Screen Recording 2023-11-16 at 11 46 02 AM](https://github.com/cds-snc/platform-forms-client/assets/1187115/f3907936-1fe4-41a0-8e67-71e9c818d017)

