### PR TITLE
chore: Remove demo request from contact us form

### DIFF
--- a/pages/form-builder/support/[[...supportType]].tsx
+++ b/pages/form-builder/support/[[...supportType]].tsx
@@ -234,15 +234,9 @@ export default function Contactus() {
                         required: true,
                       },
                       {
-                        id: "request-demo",
-                        name: "demo",
-                        label: t("contactus.request.option3"),
-                        required: true,
-                      },
-                      {
                         id: "request-other",
                         name: "other",
-                        label: t("contactus.request.option4"),
+                        label: t("contactus.request.option3"),
                         required: true,
                       },
                     ]}

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -214,10 +214,9 @@
 
     "needSupport": "Need help using GC Forms?",
     "request": {
-      "option1": "Request a product demo",
-      "option2": "Join the mailing list",
-      "option3": "Give feedback",
-      "option4": "Other",
+      "option1": "Join the mailing list",
+      "option2": "Give feedback",
+      "option3": "Other",
       "title": "Reason for reaching out"
     },
     "supportFormLink": "support form",
@@ -692,7 +691,7 @@
     "savedSuccessMessage": "Your changes have been saved.",
     "savedErrorMessage": "There was an error saving your changes. Please try again."
   },
-  "errorSavingForm":{
+  "errorSavingForm": {
     "title": "There was an error saving the form",
     "description": "Download a copy of the form and try again or",
     "supportLink": "contact Support",

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -214,10 +214,9 @@
 
     "needSupport": "Besoin d'aide pour l'utilisation de Formulaires GC?",
     "request": {
-      "option1": "Demander une démonstration du produit",
-      "option2": "S'inscrire à la liste de diffusion",
-      "option3": "Donner un avis",
-      "option4": "Autre",
+      "option1": "S'inscrire à la liste de diffusion",
+      "option2": "Donner un avis",
+      "option3": "Autre",
       "title": "Raison pour laquelle vous nous contactez"
     },
     "supportFormLink": "formulaire de soutien",
@@ -693,7 +692,7 @@
     "savedSuccessMessage": "Vos modifications ont été enregistrées.",
     "savedErrorMessage": "Une erreur s'est produite lors de l'enregistrement de vos modifications. Veuillez réessayer."
   },
-  "errorSavingForm":{
+  "errorSavingForm": {
     "title": "Une erreur s'est produite lors de l'enregistrement du formulaire",
     "description": "Veuillez télécharger une copie du formulaire et réessayer ou",
     "supportLink": "contacter l'équipe de soutien",


### PR DESCRIPTION
# Summary | Résumé

closes: #2735 
It removes the option to request a demo from the contact us page.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![Screenshot 2023-11-16 at 11 13 32 AM](https://github.com/cds-snc/platform-forms-client/assets/25329319/28086fcd-cf54-4982-aea8-9fd465649092) | ![Screenshot 2023-11-16 at 11 20 02 AM](https://github.com/cds-snc/platform-forms-client/assets/25329319/619af085-78ac-44c3-a3f8-5e988edf187d) |


# Test instructions | Instructions pour tester la modification

Visit the contact us page at `{host}/form-builder/support/contactus`
The request a demo option should no longer be visible.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
