### PR TITLE
Add confirm button and dialog to the Downloaded Responses page

### DIFF
--- a/components/form-builder/app/responses/Dialogs/ConfirmDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/ConfirmDialog.tsx
@@ -170,11 +170,15 @@ export const ConfirmDialog = ({
               )}
             </div>
             <div className="py-4">
-              <p className="mt-2">{t("downloadResponsesModals.confirmReceiptDialog.findCode")}</p>
+              <h3>{t("downloadResponsesModals.confirmReceiptDialog.toDeleteHeading")}</h3>
+              <ol>
+                <li>{t("downloadResponsesModals.confirmReceiptDialog.toDelete1")}</li>
+                <li>{t("downloadResponsesModals.confirmReceiptDialog.toDelete2")}</li>
+                <li>{t("downloadResponsesModals.confirmReceiptDialog.toDelete3")}</li>
+                <li>{t("downloadResponsesModals.confirmReceiptDialog.toDelete4")}</li>
+              </ol>
               <p className="mb-2 mt-10 font-bold" id={confirmInstructionId}>
-                {t("downloadResponsesModals.confirmReceiptDialog.copyCode", {
-                  max: maxEntries,
-                })}
+                {t("downloadResponsesModals.confirmReceiptDialog.copyCode")}
               </p>
 
               <LineItemEntries
@@ -188,9 +192,15 @@ export const ConfirmDialog = ({
                 setStatus={setStatus}
               ></LineItemEntries>
 
-              <p className="mt-8">
-                {t("downloadResponsesModals.confirmReceiptDialog.responsesAvailableFor")}
-              </p>
+              <Alert.Warning className="my-4">
+                <Alert.Title headingTag="h4">
+                  {t("downloadResponsesModals.confirmReceiptDialog.warningTitle")}
+                </Alert.Title>
+                <Alert.Body>
+                  {t("downloadResponsesModals.confirmReceiptDialog.warningBody")}
+                </Alert.Body>
+              </Alert.Warning>
+
               <div className="mt-4 flex">
                 <Button
                   className="mr-4"

--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export const DownloadDialog = () => {
-  return <div>DownloadDialog</div>;
-};

--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const DownloadDialog = () => {
+  return <div>DownloadDialog</div>;
+};

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -137,7 +137,7 @@ export const DownloadTable = ({
           <caption className="sr-only">{t("downloadResponsesTable.header.tableTitle")}</caption>
           <thead className="border-b-2 border-[#6a6d7b]">
             <tr>
-              <th className="p-4 text-center">
+              <th className="py-4 pr-3 text-center">
                 <CheckAll
                   tableItems={tableItems}
                   tableItemsDispatch={tableItemsDispatch}

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -133,7 +133,7 @@ export const DownloadTable = ({
             </Alert.Danger>
           )}
         </div>
-        <table className="text-sm" aria-live="polite">
+        <table className="w-full text-sm" aria-live="polite">
           <caption className="sr-only">{t("downloadResponsesTable.header.tableTitle")}</caption>
           <thead className="border-b-2 border-[#6a6d7b]">
             <tr>

--- a/components/form-builder/app/responses/tests/DownloadTable.cy.tsx
+++ b/components/form-builder/app/responses/tests/DownloadTable.cy.tsx
@@ -151,7 +151,14 @@ describe("<DownloadTable />", () => {
     };
 
     cy.viewport(1050, 550);
-    cy.mount(<DownloadTable vaultSubmissions={vaultSubmissions} nagwareResult={nagwareResult} />);
+    cy.mount(
+      <DownloadTable
+        formId=""
+        responseDownloadLimit={50}
+        vaultSubmissions={vaultSubmissions}
+        nagwareResult={nagwareResult}
+      />
+    );
 
     // The -35 overdue causes the rest to be blocked
     cy.get("tbody tr:nth-child(1)").should("have.attr", "class").and("contain", "opacity-50");
@@ -231,7 +238,14 @@ describe("<DownloadTable />", () => {
     };
 
     cy.viewport(1050, 550);
-    cy.mount(<DownloadTable vaultSubmissions={vaultSubmissions} nagwareResult={nagwareResult} />);
+    cy.mount(
+      <DownloadTable
+        formId=""
+        responseDownloadLimit={50}
+        vaultSubmissions={vaultSubmissions}
+        nagwareResult={nagwareResult}
+      />
+    );
 
     cy.get("tbody tr:nth-child(1)").should("have.attr", "class").and("not.contain", "opacity-50");
     cy.get("tbody tr:nth-child(2)").should("have.attr", "class").and("not.contain", "opacity-50");

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -39,7 +39,6 @@ interface ResponsesProps {
 }
 
 // TODO: move to an app setting variable
-const MAX_CONFIRMATION_COUNT = 20;
 const MAX_REPORT_COUNT = 20;
 
 const Responses: NextPageWithLayout<ResponsesProps> = ({
@@ -240,7 +239,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         isShow={isShowConfirmReceiptDialog}
         setIsShow={setIsShowConfirmReceiptDialog}
         apiUrl={`/api/id/${formId}/submission/confirm`}
-        maxEntries={MAX_CONFIRMATION_COUNT}
+        maxEntries={responseDownloadLimit}
       />
 
       <ReportDialog

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -23,7 +23,7 @@ import { useTemplateStore } from "@components/form-builder/store";
 import { LoggedOutTabName, LoggedOutTab } from "@components/form-builder/app/LoggedOutTab";
 import Head from "next/head";
 import { FormBuilderLayout } from "@components/globals/layouts/FormBuilderLayout";
-import { ErrorPanel } from "@components/globals";
+import { Button, ErrorPanel } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
 import { DeleteIcon, FolderIcon, InboxIcon } from "@components/form-builder/icons";
@@ -136,7 +136,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         {isAuthenticated ? t("responses.title") : t("responses.unauthenticated.title")}
       </h1>
 
-      <nav className="my-8 flex flex-wrap" aria-label={t("responses.navLabel")}>
+      <nav className="my-8 flex relative" aria-label={t("responses.navLabel")}>
         <SubNavLink
           id="new-responses"
           defaultActive={statusQuery === "new"}
@@ -165,6 +165,18 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             <DeleteIcon className="inline-block h-7 w-7" /> {t("responses.status.deleted")}
           </span>
         </SubNavLink>
+        <div className="absolute right-0">
+          {isAuthenticated && statusQuery === "downloaded" && (
+            <Button
+              onClick={() => setIsShowConfirmReceiptDialog(true)}
+              theme="destructive"
+              className="float-right"
+              disabled={status !== "authenticated"}
+            >
+              {t("responses.confirmReceipt")}
+            </Button>
+          )}
+        </div>
       </nav>
 
       {nagwareResult && <Nagware nagwareResult={nagwareResult} />}

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -26,7 +26,7 @@ import { FormBuilderLayout } from "@components/globals/layouts/FormBuilderLayout
 import { Button, ErrorPanel } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
-import { DeleteIcon, FolderIcon, InboxIcon } from "@components/form-builder/icons";
+import { Close, DeleteIcon, FolderIcon, InboxIcon } from "@components/form-builder/icons";
 import { SubNavLink } from "@components/form-builder/app/navigation/SubNavLink";
 import { useRouter } from "next/router";
 import Image from "next/image";
@@ -172,6 +172,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
               theme="destructive"
               className="float-right"
               disabled={status !== "authenticated"}
+              icon={<Close className="fill-white" />}
             >
               {t("responses.confirmReceipt")}
             </Button>

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -1,7 +1,7 @@
 {
   "responses": {
     "changeSetup": "Change settings",
-    "confirmReceipt": "Confirm receipt",
+    "confirmReceipt": "Confirm and delete",
     "navLabel": "Responses",
     "reportProblems": "Report a problem",
     "title": "Responses",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -85,10 +85,15 @@
   },
   "downloadResponsesModals": {
     "confirmReceiptDialog": {
-      "title": "Confirm receipt of responses",
-      "findCode": "Find the confirmation code on the bottom of the downloaded form response. It looks like: c0c42c90-b816-49da-a69a-80bfd8ba15db.",
-      "copyCode": "Copy and paste up to {{max}} confirmation codes, one per line.",
-      "responsesAvailableFor": "After you confirm receipt, responses will be available for 30 days then automatically removed from our database.",
+      "title": "Confirm and delete responses",
+      "toDeleteHeading": "To delete responses:",
+      "toDelete1": "Confirm you have a copy of each response.",
+      "toDelete2": "Open the downloaded HTML response file.",
+      "toDelete3": "Ensure the responses show up as expected.",
+      "toDelete4": "Use the button in the HTML response file to copy and paste confirmation codes into the space below.",
+      "copyCode": "Enter the confirmation codes of responses to be deleted:",
+      "warningTitle": "Deleting cannot be undone.",
+      "warningBody": "Responses will be moved to “Deleted” and permanently removed from GC Forms in 30 days.",
       "confirmReceipt": "Confirm receipt",
       "errors": {
         "minEntries": {

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -85,10 +85,15 @@
   },
   "downloadResponsesModals": {
     "confirmReceiptDialog": {
-      "title": "Confirmer la réception de réponses",
-      "findCode": "Trouvez le code de confirmation au bas des réponses de formulaires téléchargées. Ces codes ressemblent à : c0c42c90-b816-49da-a69a-80bfd8ba15db.",
-      "copyCode": "Copiez et collez jusqu'à 20 codes de confirmation, un par ligne.",
-      "responsesAvailableFor": "Une fois que vous aurez confirmé la réception des réponses, celles-ci seront disponibles pendant 30 jours, puis, ensuite automatiquement retirées de notre base de données.",
+      "title": "Confirmer et supprimer les réponses",
+      "toDeleteHeading": "Pour supprimer les réponses :",
+      "toDelete1": "Confirmer que vous disposez d’une copie de chaque réponse.",
+      "toDelete2": "Ouvrir le fichier de réponse en format HTML téléchargé.",
+      "toDelete3": "S’assurer que les réponses s’affichent comme prévu.",
+      "toDelete4": "Copier et coller les codes de confirmation ci-bas.",
+      "copyCode": "Entrez les codes de confirmation des réponses à supprimer :",
+      "warningTitle": "La suppression ne peut être annulée.",
+      "warningBody": "Les réponses seront déplacées vers « Supprimés » et retirées du système après 30 jours.",
       "confirmReceipt": "Confirmer la réception",
       "errors": {
         "minEntries": {

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -1,7 +1,7 @@
 {
   "responses": {
     "changeSetup": "Modifier les paramètres",
-    "confirmReceipt": "Confirmer la réception",
+    "confirmReceipt": "Confirmer et supprimer",
     "navLabel": "Réponses",
     "reportProblems": "Signaler un problème",
     "title": "Réponses",


### PR DESCRIPTION
# Summary | Résumé

Restores the Confirm dialog and button to the Downloaded Responses page and updates the content of the dialog. Also uses responseDownloadLimit for the maximum number of codes to input. This may need its own setting eventually.

<img width="1581" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/69f34d08-3dca-40d7-9251-46d90e4d86a3">

<img width="1584" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/9d1c64d1-ed43-496a-84df-6eff2ed3fa8a">

