### PR TITLE
Hide delete on confirmed

### DIFF
--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -20,7 +20,7 @@ export const MoreMenu = ({
   const { t } = useTranslation("form-builder-responses");
 
   const router = useRouter();
-  const [, statusQuery = "new"] = router.query.params || [];
+  const [, statusQuery = "new"] = router.query?.params || [];
 
   const handleDownload = () => {
     const url = `/api/id/${formId}/submission/download?format=html`;

--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -4,6 +4,7 @@ import { DeleteIcon, DownloadIcon, MoreIcon } from "@components/form-builder/ico
 import axios from "axios";
 import { useTranslation } from "react-i18next";
 import { logMessage } from "@lib/logger";
+import { useRouter } from "next/router";
 
 export const MoreMenu = ({
   formId,
@@ -17,6 +18,9 @@ export const MoreMenu = ({
   onDownloadSuccess: () => void;
 }) => {
   const { t } = useTranslation("form-builder-responses");
+
+  const router = useRouter();
+  const [, statusQuery = "new"] = router.query.params || [];
 
   const handleDownload = () => {
     const url = `/api/id/${formId}/submission/download?format=html`;
@@ -75,13 +79,15 @@ export const MoreMenu = ({
               <DownloadIcon className="scale-50" />
               {t("downloadResponsesTable.download")}
             </DropdownMenu.Item>
-            <DropdownMenu.Item
-              onClick={handleDelete}
-              className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
-            >
-              <DeleteIcon className="scale-50" />
-              {t("downloadResponsesTable.delete")}
-            </DropdownMenu.Item>
+            {statusQuery !== "confirmed" && (
+              <DropdownMenu.Item
+                onClick={handleDelete}
+                className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
+              >
+                <DeleteIcon className="scale-50" />
+                {t("downloadResponsesTable.delete")}
+              </DropdownMenu.Item>
+            )}
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>

--- a/components/form-builder/app/responses/tests/DownloadTable.cy.tsx
+++ b/components/form-builder/app/responses/tests/DownloadTable.cy.tsx
@@ -151,7 +151,14 @@ describe("<DownloadTable />", () => {
     };
 
     cy.viewport(1050, 550);
-    cy.mount(<DownloadTable vaultSubmissions={vaultSubmissions} nagwareResult={nagwareResult} />);
+    cy.mount(
+      <DownloadTable
+        formId=""
+        responseDownloadLimit={50}
+        vaultSubmissions={vaultSubmissions}
+        nagwareResult={nagwareResult}
+      />
+    );
 
     // The -35 overdue causes the rest to be blocked
     cy.get("tbody tr:nth-child(1)").should("have.attr", "class").and("contain", "opacity-50");
@@ -231,7 +238,14 @@ describe("<DownloadTable />", () => {
     };
 
     cy.viewport(1050, 550);
-    cy.mount(<DownloadTable vaultSubmissions={vaultSubmissions} nagwareResult={nagwareResult} />);
+    cy.mount(
+      <DownloadTable
+        formId=""
+        responseDownloadLimit={50}
+        vaultSubmissions={vaultSubmissions}
+        nagwareResult={nagwareResult}
+      />
+    );
 
     cy.get("tbody tr:nth-child(1)").should("have.attr", "class").and("not.contain", "opacity-50");
     cy.get("tbody tr:nth-child(2)").should("have.attr", "class").and("not.contain", "opacity-50");


### PR DESCRIPTION
# Summary | Résumé

Hides the inline Delete option on the More menu on the Confirmed Responses screen.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="1359" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/ae41475a-91b8-4e23-b57c-e0cdef3e9192"> | <img width="1388" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/9ab3261c-64ff-4980-9510-563ee62ac02d"> |

