### PR TITLE
Confirm delete new responses dialog

### DIFF
--- a/components/form-builder/app/responses/ActionsPanel.tsx
+++ b/components/form-builder/app/responses/ActionsPanel.tsx
@@ -1,22 +1,10 @@
-import { Button } from "@components/globals";
 import React from "react";
-import { useTranslation } from "react-i18next";
-
-const handleDelete = () => {
-  alert("Not yet implemented");
-};
 
 export const ActionsPanel = ({ children }: { children: React.ReactNode }) => {
-  const { t } = useTranslation("form-builder-responses");
   return (
     <section className="fixed bottom-0 left-0 h-32 w-full border-t-2 border-black bg-white py-8">
       <div className="mx-4 laptop:mx-32 desktop:mx-64">
-        <div className="ml-[210px] flex gap-4">
-          {children}
-          <Button theme="destructive" onClick={handleDelete}>
-            {t("downloadResponsesTable.deleteSelectedResponses")}
-          </Button>
-        </div>
+        <div className="ml-[210px] flex gap-4">{children}</div>
       </div>
     </section>
   );

--- a/components/form-builder/app/responses/DeleteButton.tsx
+++ b/components/form-builder/app/responses/DeleteButton.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@components/globals";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export const DeleteButton = ({
+  setShowConfirmNewDialog,
+}: {
+  setShowConfirmNewDialog: (showConfirmNewDialog: boolean) => void;
+}) => {
+  const { t } = useTranslation("form-builder-responses");
+
+  const handleDelete = () => {
+    setShowConfirmNewDialog(true);
+  };
+
+  return (
+    <>
+      <Button theme="destructive" onClick={handleDelete}>
+        {t("downloadResponsesTable.deleteSelectedResponses")}
+      </Button>
+    </>
+  );
+};

--- a/components/form-builder/app/responses/Dialogs/ConfirmDeleteNewDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/ConfirmDeleteNewDialog.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { Dialog, useDialogRef } from "../../shared";
+import { Alert, Button } from "@components/globals";
+import { useTranslation } from "react-i18next";
+
+export const ConfirmDeleteNewDialog = ({
+  isVisible,
+  setIsVisible,
+}: {
+  isVisible: boolean;
+  setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  const dialogRef = useDialogRef();
+  const [deleteDisabled, setDeleteDisabled] = React.useState(true);
+  const { t } = useTranslation("form-builder-responses");
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setDeleteDisabled(true);
+    dialogRef.current?.close();
+  };
+
+  const handleSubmit = () => {
+    alert("not yet implemented");
+  };
+
+  const checkDeleteInput = (value: string) => {
+    if (value === t("downloadResponsesModals.confirmDeleteNewDialog.deleteConfirmationString")) {
+      setDeleteDisabled(false);
+    } else {
+      setDeleteDisabled(true);
+    }
+  };
+
+  return (
+    <>
+      {isVisible && (
+        <Dialog
+          title={t("downloadResponsesModals.confirmDeleteNewDialog.confirmAndDelete")}
+          dialogRef={dialogRef}
+          handleClose={handleClose}
+        >
+          <div className="p-4">
+            <Alert.Danger>
+              <Alert.Title>
+                {t("downloadResponsesModals.confirmDeleteNewDialog.responsesNotYetDownloaded")}
+              </Alert.Title>
+              <Alert.Body>
+                {t("downloadResponsesModals.confirmDeleteNewDialog.alertBody")}
+              </Alert.Body>
+            </Alert.Danger>
+
+            <label htmlFor="confirmDelete" className="my-4 block font-semibold">
+              {t("downloadResponsesModals.confirmDeleteNewDialog.deletePrompt")}
+              <span className="ml-2 text-red">
+                ({t("downloadResponsesModals.confirmDeleteNewDialog.required")})
+              </span>
+            </label>
+            <input
+              type="text"
+              name="confirmDelete"
+              placeholder={t(
+                "downloadResponsesModals.confirmDeleteNewDialog.deleteConfirmationString"
+              )}
+              className="gc-input-text w-full"
+              onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>) =>
+                checkDeleteInput(e.currentTarget.value)
+              }
+            />
+
+            <div className="mt-8 flex gap-4">
+              <Button theme="secondary" onClick={handleClose}>
+                {t("downloadResponsesModals.confirmDeleteNewDialog.cancel")}
+              </Button>
+              <Button
+                theme="destructive"
+                className="mr-4"
+                onClick={handleSubmit}
+                disabled={deleteDisabled}
+              >
+                {t("downloadResponsesModals.confirmDeleteNewDialog.delete")}
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      )}
+    </>
+  );
+};

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -23,6 +23,8 @@ import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
 import { MoreMenu } from "./MoreMenu";
 import { ActionsPanel } from "./ActionsPanel";
+import { DeleteButton } from "./DeleteButton";
+import { ConfirmDeleteNewDialog } from "./Dialogs/ConfirmDeleteNewDialog";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -39,9 +41,11 @@ export const DownloadTable = ({
 }: DownloadTableProps) => {
   const { t } = useTranslation("form-builder-responses");
   const router = useRouter();
+  const [, statusQuery = "new"] = router.query?.params || [];
 
   const [downloadError, setDownloadError] = useState(false);
   const [noSelectedItemsError, setNoSelectedItemsError] = useState(false);
+  const [showConfirmNewtDialog, setShowConfirmNewDialog] = useState(false);
 
   const accountEscalated = nagwareResult && nagwareResult.level > 2;
 
@@ -226,6 +230,7 @@ export const DownloadTable = ({
                         toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
                       }}
                       setDownloadError={setDownloadError}
+                      setShowConfirmNewDialog={setShowConfirmNewDialog}
                     />
                   </td>
                 </tr>
@@ -287,8 +292,16 @@ export const DownloadTable = ({
               toast.success(t("downloadResponsesTable.notifications.downloadComplete"));
             }}
           />
+          {statusQuery === "new" && (
+            <DeleteButton setShowConfirmNewDialog={setShowConfirmNewDialog} />
+          )}
         </ActionsPanel>
       )}
+
+      <ConfirmDeleteNewDialog
+        isVisible={showConfirmNewtDialog}
+        setIsVisible={setShowConfirmNewDialog}
+      />
     </>
   );
 };

--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -11,11 +11,13 @@ export const MoreMenu = ({
   responseId,
   setDownloadError,
   onDownloadSuccess,
+  setShowConfirmNewDialog,
 }: {
   formId: string;
   responseId: string;
   setDownloadError: (downloadError: boolean) => void;
   onDownloadSuccess: () => void;
+  setShowConfirmNewDialog: (showConfirmNewDialog: boolean) => void;
 }) => {
   const { t } = useTranslation("form-builder-responses");
 
@@ -56,7 +58,7 @@ export const MoreMenu = ({
   };
 
   const handleDelete = () => {
-    alert("Not implemented yet");
+    setShowConfirmNewDialog(true);
   };
 
   return (

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -84,6 +84,16 @@
     "unknown": "Unknown"
   },
   "downloadResponsesModals": {
+    "confirmDeleteNewDialog": {
+      "confirmAndDelete": "Confirm and delete new responses",
+      "responsesNotYetDownloaded": "Responses not yet downloaded",
+      "alertBody": "You’ve not downloaded the responses you’re about to delete. If you delete these responses, they will be removed permanently from GC Forms after 30 days.",
+      "deletePrompt": "To proceed with deleting non-downloaded responses enter the word “DELETE” below.",
+      "required": "Required",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "deleteConfirmationString": "DELETE"
+    },
     "confirmReceiptDialog": {
       "title": "Confirm and delete responses",
       "toDeleteHeading": "To delete responses:",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -84,6 +84,16 @@
     "unknown": "Inconnu"
   },
   "downloadResponsesModals": {
+    "confirmDeleteNewDialog": {
+      "confirmAndDelete": "Confirmer et supprimer de nouvelles réponses",
+      "responsesNotYetDownloaded": "Ces réponses n’ont pas encore été téléchargées",
+      "alertBody": "Vous n’avez pas téléchargé les réponses que vous tentez de supprimer. Si vous supprimez ces réponses, elles seront retirées du système après 30 jours.",
+      "deletePrompt": "Si vous souhaitez procéder à la suppression des réponses non téléchargées, entrez le mot « SUPPRIMER » ci-dessous.",
+      "required": "Obligatoire",
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "deleteConfirmationString": "SUPPRIMER"
+    },
     "confirmReceiptDialog": {
       "title": "Confirmer et supprimer les réponses",
       "toDeleteHeading": "Pour supprimer les réponses :",


### PR DESCRIPTION
# Summary | Résumé

Adds the Confirm delete new responses dialog.
Does not delete responses, only placeholder.

![Screen Recording 2023-11-17 at 3 26 39 PM](https://github.com/cds-snc/platform-forms-client/assets/1187115/cf553d51-7c58-4a3d-853c-6769f69322ad)
