### PR TITLE
Use responseDownloadLimit setting for listAllSubmissions query

### DIFF
--- a/lib/tests/vault.test.ts
+++ b/lib/tests/vault.test.ts
@@ -14,6 +14,11 @@ import formConfiguration from "@jestFixtures/cdsIntakeTestForm.json";
 import { DeliveryOption } from "@lib/types";
 import { BatchWriteItemCommand } from "@aws-sdk/client-dynamodb";
 import { TemplateAlreadyPublishedError } from "@lib/templates";
+import { getAppSetting } from "@lib/appSettings";
+
+jest.mock("@lib/appSettings");
+
+const mockedGetAppSetting = jest.mocked(getAppSetting, { shallow: true });
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
@@ -63,6 +68,13 @@ describe("Vault `numberOfUnprocessedSubmissions` function", () => {
         privileges: mockUserPrivileges(Base, { user: { id: "1" } }),
       },
     };
+
+    mockedGetAppSetting.mockImplementation((key) => {
+      if (key === "responseDownloadLimit") {
+        return Promise.resolve("500");
+      }
+      return Promise.resolve(null);
+    });
 
     const ability = createAbility(fakeSession as Session);
 

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -338,7 +338,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     }
   }
 
-  const responseDownloadLimit = Number(await getAppSetting("responseDownloadLimit")) || 20;
+  const responseDownloadLimit = Number(await getAppSetting("responseDownloadLimit"));
 
   return {
     props: {


### PR DESCRIPTION
# Summary | Résumé

The responseDownloadLimit setting was added to limit the number of concurrent HTML file downloads. 

This PR applies that same limit to listAllSubmissions (the max number of submissions that can be displayed)
