### PR TITLE
Add number shown to "more responses" alert

### DIFF
--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -237,11 +237,12 @@ export const DownloadTable = ({
             {responsesRemaining && (
               <Alert.Warning icon={false}>
                 <Alert.Title headingTag="h3">
-                  TEMP - There are remaining responses on the server
+                  {t("downloadResponsesTable.errors.remainingResponses")}
                 </Alert.Title>
                 <p className="text-sm text-black">
-                  TEMP - Not all responses can be shown on the screen. Please download responses to
-                  see more responses.
+                  {t("downloadResponsesTable.errors.remainingResponsesBody", {
+                    max: responseDownloadLimit,
+                  })}
                 </p>
               </Alert.Warning>
             )}

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -74,6 +74,8 @@
       "errorDownloadingFilesHeader": "Error downloading the selected files.",
       "errorDownloadingFiles": "Try again in a few minutes. If the problem persists, ",
       "errorDownloadingFilesLink": "contact Support",
+      "remainingResponses": "There are remaining responses on the server",
+      "remainingResponsesBody": "Showing {{max}} responses. Not all responses can be shown, please download responses to see more.",
       "overdueAlert": {
         "title": "Access to new responses is restricted until overdue responses are downloaded and confirmed",
         "description": "There are {{numberOfOverdueResponses}} unconfirmed responses that are {{escalatedAfter}} days old. Download and confirm all overdue responses to remove this restriction."

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -75,7 +75,7 @@
       "errorDownloadingFiles": "Try again in a few minutes. If the problem persists, ",
       "errorDownloadingFilesLink": "contact Support",
       "remainingResponses": "There are remaining responses on the server",
-      "remainingResponsesBody": "Showing {{max}} responses. Not all responses can be shown, please download responses to see more.",
+      "remainingResponsesBody": "Showing {{max}} responses. Not all responses can be shown, download responses to see more.",
       "overdueAlert": {
         "title": "Access to new responses is restricted until overdue responses are downloaded and confirmed",
         "description": "There are {{numberOfOverdueResponses}} unconfirmed responses that are {{escalatedAfter}} days old. Download and confirm all overdue responses to remove this restriction."

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -74,6 +74,8 @@
       "errorDownloadingFilesHeader": "Erreur lors du téléchargement des fichiers sélectionnés.",
       "errorDownloadingFiles": "Réessayez dans quelques minutes. Si le problème persiste, ",
       "errorDownloadingFilesLink": "contactez Soutien",
+      "remainingResponses": "[FR] There are remaining responses on the server",
+      "remainingResponsesBody": "[FR] Showing {{max}} responses. Not all responses can be shown, please download responses to see more.",
       "overdueAlert": {
         "title": "L'accès aux nouvelles réponses est restreint jusqu'à ce que les réponses en retard soient téléchargées et confirmées",
         "description": "Il y a {{numberOfOverdueResponses}} réponses qui datent de {{escalatedAfter}} jours. Téléchargez et confirmez toutes les réponses en retard pour enlever cette restriction."


### PR DESCRIPTION
# Summary | Résumé

When displaying responses in the DownloadTable, an Alert has been added to the bottom to indicate there are more responses available. This just adds the current number of responses shown to that message.

Note, this messaging should be reviewed by Content/Design.

<img width="788" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/9923403f-8737-48c7-be16-d05e61787772">

