### PR TITLE
Add "sign off" message, new titles, and confirm dialog button

### DIFF
--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -17,7 +17,7 @@ import { useSetting } from "@lib/hooks/useSetting";
 import Link from "next/link";
 import { TableActions, initialTableItemsState, reducerTableItems } from "./DownloadTableReducer";
 import { getDaysPassed } from "@lib/clientHelpers";
-import { Alert } from "@components/globals";
+import { Alert, Button } from "@components/globals";
 import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
@@ -26,6 +26,8 @@ import { ActionsPanel } from "./ActionsPanel";
 import { DeleteButton } from "./DeleteButton";
 import { ConfirmDeleteNewDialog } from "./Dialogs/ConfirmDeleteNewDialog";
 import { DownloadDialog } from "./Dialogs/DownloadDialog";
+import { ConfirmDialog } from "./Dialogs/ConfirmDialog";
+import { Close } from "@components/form-builder/icons";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -17,7 +17,7 @@ import { useSetting } from "@lib/hooks/useSetting";
 import Link from "next/link";
 import { TableActions, initialTableItemsState, reducerTableItems } from "./DownloadTableReducer";
 import { getDaysPassed } from "@lib/clientHelpers";
-import { Alert, Button } from "@components/globals";
+import { Alert } from "@components/globals";
 import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
 import { toast } from "../shared";
@@ -26,8 +26,6 @@ import { ActionsPanel } from "./ActionsPanel";
 import { DeleteButton } from "./DeleteButton";
 import { ConfirmDeleteNewDialog } from "./Dialogs/ConfirmDeleteNewDialog";
 import { DownloadDialog } from "./Dialogs/DownloadDialog";
-import { ConfirmDialog } from "./Dialogs/ConfirmDialog";
-import { Close } from "@components/form-builder/icons";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -169,7 +169,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         </SubNavLink>
       </nav>
 
-      {isAuthenticated && statusQuery === "downloaded" && (
+      {isAuthenticated && statusQuery === "downloaded" && vaultSubmissions.length > 0 && (
         <>
           <h1>{t("responses.previouslyDownloaded")}</h1>
           <div className="mb-4">
@@ -185,9 +185,13 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         </>
       )}
 
-      {isAuthenticated && statusQuery === "new" && <h1>{t("responses.newResponses")}</h1>}
+      {isAuthenticated && statusQuery === "new" && vaultSubmissions.length > 0 && (
+        <h1>{t("responses.newResponses")}</h1>
+      )}
 
-      {isAuthenticated && statusQuery === "confirmed" && <h1>{t("responses.deleted")}</h1>}
+      {isAuthenticated && statusQuery === "confirmed" && vaultSubmissions.length > 0 && (
+        <h1>{t("responses.deleted")}</h1>
+      )}
 
       {nagwareResult && <Nagware nagwareResult={nagwareResult} />}
 
@@ -206,27 +210,36 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             )}
 
             {vaultSubmissions.length <= 0 && statusQuery === "new" && (
-              <Card
-                icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
-                title={t("downloadResponsesTable.card.noNewResponses")}
-                content={t("downloadResponsesTable.card.noNewResponsesMessage")}
-              />
+              <>
+                <h1 className="visually-hidden">{t("responses.newResponses")}</h1>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noNewResponses")}
+                  content={t("downloadResponsesTable.card.noNewResponsesMessage")}
+                />
+              </>
             )}
 
             {vaultSubmissions.length <= 0 && statusQuery === "downloaded" && (
-              <Card
-                icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
-                title={t("downloadResponsesTable.card.noDownloadedResponses")}
-                content={t("downloadResponsesTable.card.noDownloadedResponsesMessage")}
-              />
+              <>
+                <h1 className="visually-hidden">{t("responses.previouslyDownloaded")}</h1>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noDownloadedResponses")}
+                  content={t("downloadResponsesTable.card.noDownloadedResponsesMessage")}
+                />
+              </>
             )}
 
             {vaultSubmissions.length <= 0 && statusQuery === "confirmed" && (
-              <Card
-                icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
-                title={t("downloadResponsesTable.card.noDeletedResponses")}
-                content={t("downloadResponsesTable.card.noDeletedResponsesMessage")}
-              />
+              <>
+                <h1 className="visually-hidden">{t("responses.deleted")}</h1>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noDeletedResponses")}
+                  content={t("downloadResponsesTable.card.noDeletedResponsesMessage")}
+                />
+              </>
             )}
           </div>
           <div className="mt-8">

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -13,7 +13,6 @@ import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Card } from "@components/globals/card/Card";
 import { DownloadTable } from "@components/form-builder/app/responses/DownloadTable";
-import { ConfirmDialog } from "@components/form-builder/app/responses/Dialogs/ConfirmDialog";
 import { ReportDialog } from "@components/form-builder/app/responses/Dialogs/ReportDialog";
 import { NagwareResult } from "@lib/types";
 import { Nagware } from "@components/form-builder/app/Nagware";
@@ -35,6 +34,7 @@ import {
 import { SubNavLink } from "@components/form-builder/app/navigation/SubNavLink";
 import { useRouter } from "next/router";
 import Image from "next/image";
+import { ConfirmDialog } from "@components/form-builder/app/responses/Dialogs/ConfirmDialog";
 
 interface ResponsesProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -57,8 +57,8 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
   const { t } = useTranslation("form-builder-responses");
   const { status } = useSession();
   const isAuthenticated = status === "authenticated";
-  const [isShowConfirmReceiptDialog, setIsShowConfirmReceiptDialog] = useState(false);
   const [isShowReportProblemsDialog, setIsShowReportProblemsDialog] = useState(false);
+  const [showConfirmReceiptDialog, setShowConfirmReceiptDialog] = useState(false);
 
   const [isServerError, setIsServerError] = useState(false);
 
@@ -138,11 +138,13 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         <title>{t("responses.title")}</title>
       </Head>
 
-      <h1 className="mb-0 border-none tablet:mb-4 tablet:mr-8">
-        {isAuthenticated ? t("responses.title") : t("responses.unauthenticated.title")}
-      </h1>
+      {!isAuthenticated && (
+        <h1 className="mb-0 border-none tablet:mb-4 tablet:mr-8">
+          {t("responses.unauthenticated.title")}
+        </h1>
+      )}
 
-      <nav className="my-8 flex relative" aria-label={t("responses.navLabel")}>
+      <nav className="relative mb-4 flex" aria-label={t("responses.navLabel")}>
         <SubNavLink
           id="new-responses"
           defaultActive={statusQuery === "new"}
@@ -171,20 +173,27 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             <DeleteIcon className="inline-block h-7 w-7" /> {t("responses.status.deleted")}
           </span>
         </SubNavLink>
-        <div className="absolute right-0">
-          {isAuthenticated && statusQuery === "downloaded" && (
-            <Button
-              onClick={() => setIsShowConfirmReceiptDialog(true)}
-              theme="destructive"
-              className="float-right"
-              disabled={status !== "authenticated"}
-              icon={<Close className="fill-white" />}
-            >
+      </nav>
+
+      {isAuthenticated && statusQuery === "downloaded" && (
+        <>
+          <h1>{t("responses.previouslyDownloaded")}</h1>
+          <div className="mb-4">
+            <p className="mb-4">
+              {t("downloadResponsesTable.confirmReceiptMessage1")}
+              <br />
+              {t("downloadResponsesTable.confirmReceiptMessage2")}
+            </p>
+            <Button onClick={() => setShowConfirmReceiptDialog(true)} theme="secondary">
               {t("responses.confirmReceipt")}
             </Button>
-          )}
-        </div>
-      </nav>
+          </div>
+        </>
+      )}
+
+      {isAuthenticated && statusQuery === "new" && <h1>{t("responses.newResponses")}</h1>}
+
+      {isAuthenticated && statusQuery === "confirmed" && <h1>{t("responses.deleted")}</h1>}
 
       {nagwareResult && <Nagware nagwareResult={nagwareResult} />}
 
@@ -253,19 +262,19 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         </>
       )}
 
-      <ConfirmDialog
-        isShow={isShowConfirmReceiptDialog}
-        setIsShow={setIsShowConfirmReceiptDialog}
-        apiUrl={`/api/id/${formId}/submission/confirm`}
-        maxEntries={responseDownloadLimit}
-      />
-
       <ReportDialog
         isShow={isShowReportProblemsDialog}
         setIsShow={setIsShowReportProblemsDialog}
         setIsServerError={setIsServerError}
         apiUrl={`/api/id/${formId}/submission/report`}
         maxEntries={MAX_REPORT_COUNT}
+      />
+
+      <ConfirmDialog
+        isShow={showConfirmReceiptDialog}
+        setIsShow={setShowConfirmReceiptDialog}
+        apiUrl={`/api/id/${formId}/submission/confirm`}
+        maxEntries={responseDownloadLimit}
       />
     </>
   );

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -24,13 +24,7 @@ import { FormBuilderLayout } from "@components/globals/layouts/FormBuilderLayout
 import { Button, ErrorPanel } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
-import {
-  Close,
-  DeleteIcon,
-  FolderIcon,
-  InboxIcon,
-  WarningIcon,
-} from "@components/form-builder/icons";
+import { DeleteIcon, FolderIcon, InboxIcon, WarningIcon } from "@components/form-builder/icons";
 import { SubNavLink } from "@components/form-builder/app/navigation/SubNavLink";
 import { useRouter } from "next/router";
 import Image from "next/image";

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -1,7 +1,10 @@
 {
   "responses": {
+    "newResponses": "New responses",
+    "previouslyDownloaded": "Previously downloaded",
+    "deleted": "Signed off for removal",
     "changeSetup": "Change settings",
-    "confirmReceipt": "Confirm and delete",
+    "confirmReceipt": "Sign off on removal with receipt codes",
     "navLabel": "Responses",
     "reportProblems": "Report a problem with responses",
     "title": "Responses",
@@ -21,12 +24,14 @@
     "status": {
       "new": "New",
       "downloaded": "Downloaded",
-      "deleted": "Deleted"
+      "deleted": "Signed off for removal"
     }
   },
   "downloadResponsesTable": {
     "download": "Download",
     "delete": "Delete",
+    "confirmReceiptMessage1": "You must sign off on the removal of responses from GC Forms within the time indicated.",
+    "confirmReceiptMessage2": "Response files will be available for an additional 30 days after sign-off.",
     "header": {
       "tableTitle": "Download responses table",
       "select": "Select",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -1,7 +1,10 @@
 {
   "responses": {
+    "newResponses": "[FR] New responses",
+    "previouslyDownloaded": "[FR] Previously downloaded",
+    "deleted": "[FR] Signed off for removal",
     "changeSetup": "Modifier les paramètres",
-    "confirmReceipt": "Confirmer et supprimer",
+    "confirmReceipt": "[FR] Sign off on removal with receipt codes",
     "navLabel": "Réponses",
     "reportProblems": "Signaler un problème avec les réponses",
     "title": "Réponses",
@@ -21,12 +24,14 @@
     "status": {
       "new": "Nouveautés",
       "downloaded": "Téléchargements",
-      "deleted": "Supprimés"
+      "deleted": "[FR] Signed off for removal"
     }
   },
   "downloadResponsesTable": {
     "download": "Téléchargement",
     "delete": "Supprimer",
+    "confirmReceiptMessage1": "[FR] You must sign off on the removal of responses from GC Forms within the time indicated.",
+    "confirmReceiptMessage2": "[FR] Response files will be available for an additional 30 days after sign-off.",
     "header": {
       "tableTitle": "Tableau des réponses à télécharger",
       "select": "Sélection",


### PR DESCRIPTION
# Summary | Résumé

Responses screen updates:
- Move title below nav
- New titles (hidden on zero results)
- New Confirm delete (Sign off) message and button


<img width="887" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/4adc44cc-6e0c-4989-b9fd-408b786b56db">
