### PR TITLE
Prefix downloaded file names

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -6,6 +6,7 @@ import { logMessage } from "@lib/logger";
 import axios from "axios";
 import { DownloadFormat } from "@lib/responseDownloadFormats/types";
 import JSZip from "jszip";
+import { getDate, slugify } from "@lib/clientHelpers";
 
 export const DownloadDialog = ({
   checkedItems,
@@ -13,6 +14,7 @@ export const DownloadDialog = ({
   setIsDialogVisible,
   setDownloadError,
   formId,
+  formName,
   onSuccessfulDownload,
 }: {
   checkedItems: Map<string, boolean>;
@@ -21,6 +23,7 @@ export const DownloadDialog = ({
   downloadError: boolean;
   setDownloadError: React.Dispatch<React.SetStateAction<boolean>>;
   formId: string;
+  formName: string;
   onSuccessfulDownload: () => void;
 }) => {
   const dialogRef = useDialogRef();
@@ -70,6 +73,8 @@ export const DownloadDialog = ({
 
     const ids = Array.from(checkedItems.keys());
 
+    const filePrefix = slugify(`${formName}-${getDate()}`) + "-";
+
     try {
       if (selectedFormat === DownloadFormat.HTML_ZIPPED) {
         const response = await axios({
@@ -81,7 +86,7 @@ export const DownloadDialog = ({
           },
         });
 
-        const fileName = `records.zip`;
+        const fileName = `${filePrefix}responses-reponses.zip`;
         downloadFileFromBlob(new Blob([response.data]), fileName);
 
         onSuccessfulDownload();
@@ -99,15 +104,18 @@ export const DownloadDialog = ({
 
         if (zipAllFiles) {
           const file = new JSZip();
-          file.file("receipt.html", response.data.receipt);
-          file.file("records.csv", response.data.responses);
+          file.file("receipt-recu.html", response.data.receipt);
+          file.file("responses-reponses.csv", response.data.responses);
           file.generateAsync({ type: "nodebuffer", streamFiles: true }).then((buffer) => {
-            const fileName = `records.zip`;
+            const fileName = `${filePrefix}responses-reponses.zip`;
             downloadFileFromBlob(new Blob([buffer]), fileName);
           });
         } else {
-          downloadFileFromBlob(new Blob([response.data.receipt]), "receipt.html");
-          downloadFileFromBlob(new Blob([response.data.responses]), "records.csv");
+          downloadFileFromBlob(new Blob([response.data.receipt]), `${filePrefix}receipt-recu.html`);
+          downloadFileFromBlob(
+            new Blob([response.data.responses]),
+            `${filePrefix}responses-reponses.csv`
+          );
         }
         onSuccessfulDownload();
         handleClose();
@@ -124,18 +132,18 @@ export const DownloadDialog = ({
 
         if (zipAllFiles) {
           const file = new JSZip();
-          file.file("receipt.html", response.data.receipt);
-          file.file("records.json", JSON.stringify(response.data.responses));
+          file.file("receipt-recu.html", response.data.receipt);
+          file.file("responses-reponses.json", JSON.stringify(response.data.responses));
           file.generateAsync({ type: "nodebuffer", streamFiles: true }).then((buffer) => {
-            const fileName = `records.zip`;
+            const fileName = `${filePrefix}responses-reponses.zip`;
             downloadFileFromBlob(new Blob([buffer]), fileName);
           });
         } else {
           downloadFileFromBlob(
             new Blob([JSON.stringify(response.data.responses)], { type: "application/json" }),
-            "records.json"
+            `${filePrefix}responses-reponses.json`
           );
-          downloadFileFromBlob(new Blob([response.data.receipt]), "receipt.html");
+          downloadFileFromBlob(new Blob([response.data.receipt]), `${filePrefix}receipt-recu.html`);
         }
         onSuccessfulDownload();
         handleClose();

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -29,6 +29,7 @@ import { DownloadDialog } from "./Dialogs/DownloadDialog";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
+  formName: string;
   formId: string;
   nagwareResult: NagwareResult | null;
   responseDownloadLimit: number;
@@ -37,6 +38,7 @@ interface DownloadTableProps {
 
 export const DownloadTable = ({
   vaultSubmissions,
+  formName,
   formId,
   nagwareResult,
   responseDownloadLimit,
@@ -281,6 +283,7 @@ export const DownloadTable = ({
         isDialogVisible={showDownloadDialog}
         setIsDialogVisible={setShowDownloadDialog}
         formId={formId}
+        formName={formName}
         onSuccessfulDownload={() => {
           router.replace(router.asPath, undefined, { scroll: false });
           setShowDownloadSuccess(true);

--- a/lib/responseDownloadFormats/html-zipped/index.ts
+++ b/lib/responseDownloadFormats/html-zipped/index.ts
@@ -24,7 +24,7 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
   });
 
   const zip = new JSZip();
-  zip.file("receipt.html", aggregated);
+  zip.file("receipt-recu.html", aggregated);
   records.forEach((response) => {
     zip.file(`${response.id}.html`, response.html);
   });

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -37,6 +37,7 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 
 interface ResponsesProps {
+  initialForm: FormRecord | null;
   vaultSubmissions: VaultSubmissionList[];
   formId: string;
   nagwareResult: NagwareResult | null;
@@ -48,18 +49,18 @@ interface ResponsesProps {
 const MAX_REPORT_COUNT = 20;
 
 const Responses: NextPageWithLayout<ResponsesProps> = ({
+  initialForm,
   vaultSubmissions,
   formId,
   nagwareResult,
   responseDownloadLimit,
   responsesRemaining,
 }: ResponsesProps) => {
-  const { t } = useTranslation("form-builder-responses");
+  const { t, i18n } = useTranslation("form-builder-responses");
   const { status } = useSession();
   const isAuthenticated = status === "authenticated";
   const [isShowConfirmReceiptDialog, setIsShowConfirmReceiptDialog] = useState(false);
   const [isShowReportProblemsDialog, setIsShowReportProblemsDialog] = useState(false);
-
   const [isServerError, setIsServerError] = useState(false);
 
   const router = useRouter();
@@ -71,6 +72,15 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
   }));
 
   const deliveryOption = getDeliveryOption();
+
+  let formName = "";
+  if (initialForm) {
+    formName = initialForm.name
+      ? initialForm.name
+      : i18n.language === "fr"
+      ? initialForm.form.titleFr
+      : initialForm.form.titleEn;
+  }
 
   if (!isAuthenticated) {
     return (
@@ -195,6 +205,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             {vaultSubmissions.length > 0 && (
               <DownloadTable
                 vaultSubmissions={vaultSubmissions}
+                formName={formName}
                 formId={formId}
                 nagwareResult={nagwareResult}
                 responseDownloadLimit={responseDownloadLimit}


### PR DESCRIPTION
# Summary | Résumé

Adds a prefix to downloaded file names.
`[form-name-slug]-[yyyy-mm-dd]-responses-reponses.zip`
`[form-name-slug]-[yyyy-mm-dd]-responses-reponses.csv`
`[form-name-slug]-[yyyy-mm-dd]-responses-reponses.json`
`[form-name-slug]-[yyyy-mm-dd]-receipt-recu.html`

Note only the downloaded files get the prefix. Files inside .zip files are named:
`receipt-recu.html`
`responses-reponses.json`
`responses-reponses.csv`