### PR TITLE
Download link instead of MoreMenu

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -16,6 +16,7 @@ export const DownloadDialog = ({
   formId,
   formName,
   onSuccessfulDownload,
+  responseDownloadLimit,
 }: {
   checkedItems: Map<string, boolean>;
   isDialogVisible: boolean;
@@ -25,6 +26,7 @@ export const DownloadDialog = ({
   formId: string;
   formName: string;
   onSuccessfulDownload: () => void;
+  responseDownloadLimit: number;
 }) => {
   const dialogRef = useDialogRef();
   const { t } = useTranslation("form-builder-responses");
@@ -66,7 +68,7 @@ export const DownloadDialog = ({
 
     const url = `/api/id/${formId}/submission/download?format=${selectedFormat}`;
 
-    if (!checkedItems.size) {
+    if (!checkedItems.size || checkedItems.size > responseDownloadLimit) {
       setDownloadError(true);
       return;
     }

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -288,6 +288,7 @@ export const DownloadTable = ({
         }}
         downloadError={downloadError}
         setDownloadError={setDownloadError}
+        responseDownloadLimit={responseDownloadLimit}
       />
     </>
   );

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -67,8 +67,6 @@ export const DownloadTable = ({
     initialTableItemsState(vaultSubmissions, overdueAfter)
   );
 
-  const MAX_FILE_DOWNLOADS = responseDownloadLimit;
-
   const handleChecked = (e: React.ChangeEvent<HTMLInputElement>) => {
     const name = e.target.id;
     const checked: boolean = e.target.checked;

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -155,7 +155,7 @@ export const DownloadTable = ({
               </th>
               <th className="p-4 text-left">{t("downloadResponsesTable.header.confirmReceipt")}</th>
               <th className="p-4 text-left">{t("downloadResponsesTable.header.removal")}</th>
-              <th className="p-4 text-left">{t("downloadResponsesTable.header.more")}</th>
+              <th className="p-4 text-left">{t("downloadResponsesTable.header.download")}</th>
             </tr>
           </thead>
           <tbody>
@@ -217,7 +217,7 @@ export const DownloadTable = ({
                       removalAt={submission.removedAt}
                     />
                   </td>
-                  <td className="px-4">
+                  <td>
                     <MoreMenu
                       formId={submission.formID}
                       responseId={submission.name}

--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -5,7 +5,6 @@ import axios from "axios";
 import { useTranslation } from "react-i18next";
 import { logMessage } from "@lib/logger";
 import { useRouter } from "next/router";
-import { Button } from "@components/globals";
 
 export const MoreMenu = ({
   formId,
@@ -64,7 +63,10 @@ export const MoreMenu = ({
 
   return (
     <>
-      <button onClick={handleDownload}>
+      <button
+        onClick={handleDownload}
+        className="rounded border-2 border-white pr-4 hover:underline active:border-blue-focus"
+      >
         <DownloadIcon className="inline-block scale-50" />
         <span className="pt-2">{t("downloadResponsesTable.download")}</span>
       </button>

--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -5,6 +5,7 @@ import axios from "axios";
 import { useTranslation } from "react-i18next";
 import { logMessage } from "@lib/logger";
 import { useRouter } from "next/router";
+import { Button } from "@components/globals";
 
 export const MoreMenu = ({
   formId,
@@ -63,36 +64,42 @@ export const MoreMenu = ({
 
   return (
     <>
-      <DropdownMenu.Root>
-        <DropdownMenu.Trigger>
-          <MoreIcon className="h-10 w-10" />
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Portal>
-          <DropdownMenu.Content
-            side="right"
-            sideOffset={15}
-            align="start"
-            className="rounded-lg border-1 border-black bg-white px-1.5 py-1 shadow-md"
-          >
-            <DropdownMenu.Item
-              onClick={handleDownload}
-              className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
+      <button onClick={handleDownload}>
+        <DownloadIcon className="inline-block scale-50" />
+        <span className="pt-2">{t("downloadResponsesTable.download")}</span>
+      </button>
+      {false && (
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger>
+            <MoreIcon className="h-10 w-10" />
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              side="right"
+              sideOffset={15}
+              align="start"
+              className="rounded-lg border-1 border-black bg-white px-1.5 py-1 shadow-md"
             >
-              <DownloadIcon className="scale-50" />
-              {t("downloadResponsesTable.download")}
-            </DropdownMenu.Item>
-            {statusQuery === "new" && false && (
               <DropdownMenu.Item
-                onClick={handleDelete}
+                onClick={handleDownload}
                 className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
               >
-                <DeleteIcon className="scale-50" />
-                {t("downloadResponsesTable.delete")}
+                <DownloadIcon className="scale-50" />
+                {t("downloadResponsesTable.download")}
               </DropdownMenu.Item>
-            )}
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
-      </DropdownMenu.Root>
+              {statusQuery === "new" && false && (
+                <DropdownMenu.Item
+                  onClick={handleDelete}
+                  className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
+                >
+                  <DeleteIcon className="scale-50" />
+                  {t("downloadResponsesTable.delete")}
+                </DropdownMenu.Item>
+              )}
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      )}
     </>
   );
 };

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -43,7 +43,8 @@
       "lastDownloadedBy": "Downloaded by",
       "confirmReceipt": "Confirmation of receipt",
       "removal": "Data removal",
-      "more": "More"
+      "more": "More",
+      "download": "Download"
     },
     "status": {
       "downloaded": "Downloaded",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -43,7 +43,8 @@
       "lastDownloadedBy": "Téléchargée par",
       "confirmReceipt": "Confirmation de réception",
       "removal": "Suppression des données",
-      "more": "Plus"
+      "more": "Plus",
+      "download": "Téléchargement"
     },
     "status": {
       "downloaded": "Téléchargée",


### PR DESCRIPTION
# Summary | Résumé

Replaces the MoreMenu with a direct Download link, since there is currently only one item in the MoreMenu.

Note, instead of removing all the MoreMenu code, just blocked it out behind a false boolean and rendered the Download button from the MoreMenu component itself. We can cleanup or re-use in future as necessary.

<img width="395" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/1b9613d1-d4ea-4cfb-a4c0-7e85fd59840c">

<img width="359" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/ae256d6c-2e03-4532-831e-1d202349ad83">

