### PR TITLE
chore: Update link URLs with CDS website update

### DIFF
--- a/public/static/content/en/terms-and-conditions.md
+++ b/public/static/content/en/terms-and-conditions.md
@@ -49,7 +49,7 @@ When a threat to the website or computer systems of the Government of Canada is 
 
 This website uses a third-party service provider, Google Inc. to reduce malicious activity and detect fraud. Information about visits to this website is transferred to Google Inc. through the reCAPTCHA service. This information may include: IP addresses, mouse movements, and the length of a visit. This information is used to determine whether or not the visit is from a human being or a bot. 
 
-The [Treasury Board of Canada Secretariat](https://www.canada.ca/en/treasury-board-secretariat.html) is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, let us know so we can fix it as soon as possible. Please visit the [Security Notice](https://digital.canada.ca/legal/security-notice/) to learn more about that process.
+The [Treasury Board of Canada Secretariat](https://www.canada.ca/en/treasury-board-secretariat.html) is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, let us know so we can fix it as soon as possible. Please visit the [Security Notice](https://digital.canada.ca/security-notice/) to learn more about that process.
 
 ## Using files located on non-Government of Canada servers
 

--- a/public/static/content/en/terms-of-use.md
+++ b/public/static/content/en/terms-of-use.md
@@ -39,7 +39,7 @@ You are responsible for:
 
 - Use a valid government email to create your account and for two-factor authentication (2FA).
 - Do not share your password with anyone or store it where others could find it. If someone else needs access to a form, [contact us](/en/form-builder/support). 
-- Report any security breach or vulnerability using the steps outlined in our [Security notice](https://digital.canada.ca/legal/security-notice/). 
+- Report any security breach or vulnerability using the steps outlined in our [Security notice](https://digital.canada.ca/security-notice/). 
 
 ## Publish in both Official Languages
 

--- a/public/static/content/fr/terms-and-conditions.md
+++ b/public/static/content/fr/terms-and-conditions.md
@@ -49,7 +49,7 @@ Lorsque l’on détecte une menace pour le site du Service numérique canadien o
 
 Ce site a recours à un fournisseur de services tiers, Google Inc., afin de réduire les activités malveillantes et détecter la fraude. Les données recueillies relatives aux consultations de ce site Web sont communiquées à Google Inc. par le biais du service reCAPTCHA. Ces données comportent : des adresses IP, des mouvements avec la souris, et la durée de la visite. Ces renseignements sont utilisés afin de déterminer si la visite au site Web est faite par une personne ou par un robot.
 
-Le [Secrétariat du Conseil du Trésor du Canada](https://www.canada.ca/fr/secretariat-conseil-tresor.html) est un défenseur de la divulgation responsable des vulnérabilités. Si vous avez repéré une vulnérabilité, nous aimerions le savoir afin de la corriger. Veuillez consulter cet [Avis de sécurité](https://numerique.canada.ca/transparence/avis-de-securite/) pour en savoir plus.
+Le [Secrétariat du Conseil du Trésor du Canada](https://www.canada.ca/fr/secretariat-conseil-tresor.html) est un défenseur de la divulgation responsable des vulnérabilités. Si vous avez repéré une vulnérabilité, nous aimerions le savoir afin de la corriger. Veuillez consulter cet [Avis de sécurité](https://numerique.canada.ca/avis-de-securite/) pour en savoir plus.
 
 ## Emploi de fichiers situés sur des serveurs autres que ceux du gouvernement du Canada
 

--- a/public/static/content/fr/terms-of-use.md
+++ b/public/static/content/fr/terms-of-use.md
@@ -39,7 +39,7 @@ Vous avez pour responsabilité :
 
 - Utilisez une adresse courriel gouvernementale pour créer votre compte et pour l’authentification à deux facteurs.
 - Ne communiquez pas votre mot de passe à personne et ne le conservez pas dans un endroit où d’autres personnes pourraient le trouver. Si quelqu’un d’autre a besoin d’accéder à un formulaire, [contactez-nous](/fr/form-builder/support).
-- Signalez toute faille de sécurité et vulnérabilité en utilisant les étapes détaillées dans l’[avis de sécurité](https://numerique.canada.ca/transparence/avis-de-securite/).
+- Signalez toute faille de sécurité et vulnérabilité en utilisant les étapes détaillées dans l’[avis de sécurité](https://numerique.canada.ca/avis-de-securite/).
 
 ## Publication du formulaire dans les deux langues officielles 
 


### PR DESCRIPTION
Fixes #2890 

`https://digital.canada.ca/legal/terms/` ----->  https://digital.canada.ca/terms/
`https://digital.canada.ca/legal/security-notice/` -----> https://digital.canada.ca/security-notice/