### PR TITLE
Bugfix: Fix date format helper

### DIFF
--- a/lib/clientHelpers.ts
+++ b/lib/clientHelpers.ts
@@ -290,11 +290,7 @@ export const formatDate = (date: Date): string => {
     return "Unknown";
   }
 
-  const formattedDate = date.toLocaleDateString("en-CA", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
+  const formattedDate = date.toISOString().split("T")[0];
   return formattedDate;
 };
 


### PR DESCRIPTION
# Summary | Résumé

In some environments the test for the formatDate helper method started to fail. This is because Node 19 included a change to the `toLocaleDateString("en-CA"...` date format, so dates started coming out as `mm/dd/yyyy` instead of `yyyy-mm-dd`. See: https://github.com/nodejs/node/issues/45945

This PR updates the helper to just use the ISO8601 date, splitting off the time part.
