### PR TITLE
DownloadTable table row + button semantics

### DIFF
--- a/components/form-builder/app/responses/DownloadSingleButton.tsx
+++ b/components/form-builder/app/responses/DownloadSingleButton.tsx
@@ -2,6 +2,7 @@ import { DownloadIcon } from "@components/form-builder/icons";
 import { logMessage } from "@lib/logger";
 import axios from "axios";
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 export const DownloadSingleButton = ({
   id,
@@ -18,6 +19,8 @@ export const DownloadSingleButton = ({
   onDownloadSuccess: () => void;
   ariaLabelledBy: string;
 }) => {
+  const { t } = useTranslation("form-builder-responses");
+
   const handleDownload = () => {
     const url = `/api/id/${formId}/submission/download?format=html`;
 
@@ -59,6 +62,7 @@ export const DownloadSingleButton = ({
       aria-labelledby={`${id} ${ariaLabelledBy}`}
     >
       <DownloadIcon className="inline-block scale-50" />
+      <span className="sr-only">{t("downloadResponsesTable.header.download")}</span>
     </button>
   );
 };

--- a/components/form-builder/app/responses/DownloadSingleButton.tsx
+++ b/components/form-builder/app/responses/DownloadSingleButton.tsx
@@ -1,0 +1,64 @@
+import { DownloadIcon } from "@components/form-builder/icons";
+import { logMessage } from "@lib/logger";
+import axios from "axios";
+import React from "react";
+
+export const DownloadSingleButton = ({
+  id,
+  formId,
+  responseId,
+  setDownloadError,
+  onDownloadSuccess,
+  ariaLabelledBy,
+}: {
+  id: string;
+  formId: string;
+  responseId: string;
+  setDownloadError: (downloadError: boolean) => void;
+  onDownloadSuccess: () => void;
+  ariaLabelledBy: string;
+}) => {
+  const handleDownload = () => {
+    const url = `/api/id/${formId}/submission/download?format=html`;
+
+    axios({
+      url,
+      method: "POST",
+      data: {
+        ids: responseId,
+      },
+    })
+      .then((response) => {
+        const interval = 200;
+        const submission = response.data[0];
+        const fileName = `${submission.id}.html`;
+        const href = window.URL.createObjectURL(new Blob([submission.html]));
+        const anchorElement = document.createElement("a");
+        anchorElement.href = href;
+        anchorElement.download = fileName;
+        document.body.appendChild(anchorElement);
+        anchorElement.click();
+        document.body.removeChild(anchorElement);
+        window.URL.revokeObjectURL(href);
+
+        setTimeout(() => {
+          onDownloadSuccess();
+        }, interval);
+      })
+      .catch((err) => {
+        logMessage.error(err as Error);
+        setDownloadError(true);
+      });
+  };
+
+  return (
+    <button
+      id={id}
+      onClick={handleDownload}
+      className="rounded border-2 border-white active:border-blue-focus"
+      aria-labelledby={`${id} ${ariaLabelledBy}`}
+    >
+      <DownloadIcon className="inline-block scale-50" />
+    </button>
+  );
+};

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -19,13 +19,13 @@ import { getDaysPassed, isStatus } from "@lib/clientHelpers";
 import { Alert } from "@components/globals";
 import { CheckAll } from "./CheckAll";
 import { DownloadButton } from "./DownloadButton";
-import { MoreMenu } from "./MoreMenu";
 import { ActionsPanel } from "./ActionsPanel";
 import { DeleteButton } from "./DeleteButton";
 import { ConfirmDeleteNewDialog } from "./Dialogs/ConfirmDeleteNewDialog";
 import { DownloadDialog } from "./Dialogs/DownloadDialog";
 import { formatDateTime } from "@components/form-builder/util";
 import { WarningIcon } from "@components/form-builder/icons";
+import { DownloadSingleButton } from "./DownloadSingleButton";
 
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
@@ -145,7 +145,7 @@ export const DownloadTable = ({
               <th scope="col" className="w-full p-4 text-left">
                 {t("downloadResponsesTable.header.nextStep")}
               </th>
-              <th scope="col" className="py-4 pl-12 pr-4 text-left">
+              <th scope="col" className="py-4 text-center">
                 {t("downloadResponsesTable.header.download")}
               </th>
             </tr>
@@ -206,7 +206,13 @@ export const DownloadTable = ({
                       </label>
                     </div>
                   </td>
-                  <td className="whitespace-nowrap px-4">{submission.name}</td>
+                  <th
+                    scope="row"
+                    id={submission.name}
+                    className="whitespace-nowrap px-4 font-normal"
+                  >
+                    {submission.name}
+                  </th>
                   <td className="whitespace-nowrap px-4">
                     {isStatus(statusQuery, VaultStatus.NEW) && <span>{createdDateTime}</span>}
                     {isStatus(statusQuery, VaultStatus.DOWNLOADED) && (
@@ -239,8 +245,9 @@ export const DownloadTable = ({
                       />
                     )}
                   </td>
-                  <td className="whitespace-nowrap">
-                    <MoreMenu
+                  <td className="whitespace-nowrap text-center">
+                    <DownloadSingleButton
+                      id={`button-${submission.name}`}
                       formId={submission.formID}
                       responseId={submission.name}
                       onDownloadSuccess={() => {
@@ -250,7 +257,7 @@ export const DownloadTable = ({
                         }
                       }}
                       setDownloadError={setDownloadError}
-                      setShowConfirmNewDialog={setShowConfirmNewDialog}
+                      ariaLabelledBy={submission.name}
                     />
                   </td>
                 </tr>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -211,6 +211,7 @@ export const DownloadTable = ({
                     id={submission.name}
                     className="whitespace-nowrap px-4 font-normal"
                   >
+                    <span className="sr-only">{t("downloadResponsesTable.header.download")}</span>
                     {submission.name}
                   </th>
                   <td className="whitespace-nowrap px-4">

--- a/components/form-builder/app/responses/MoreMenu.tsx
+++ b/components/form-builder/app/responses/MoreMenu.tsx
@@ -63,45 +63,36 @@ export const MoreMenu = ({
 
   return (
     <>
-      <button
-        onClick={handleDownload}
-        className="rounded border-2 border-white pr-4 hover:underline active:border-blue-focus"
-      >
-        <DownloadIcon className="inline-block scale-50" />
-        <span className="pt-2">{t("downloadResponsesTable.download")}</span>
-      </button>
-      {false && (
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger>
-            <MoreIcon className="h-10 w-10" />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              side="right"
-              sideOffset={15}
-              align="start"
-              className="rounded-lg border-1 border-black bg-white px-1.5 py-1 shadow-md"
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <MoreIcon className="h-10 w-10" />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            side="right"
+            sideOffset={15}
+            align="start"
+            className="rounded-lg border-1 border-black bg-white px-1.5 py-1 shadow-md"
+          >
+            <DropdownMenu.Item
+              onClick={handleDownload}
+              className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
             >
+              <DownloadIcon className="scale-50" />
+              {t("downloadResponsesTable.download")}
+            </DropdownMenu.Item>
+            {statusQuery === "new" && (
               <DropdownMenu.Item
-                onClick={handleDownload}
+                onClick={handleDelete}
                 className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
               >
-                <DownloadIcon className="scale-50" />
-                {t("downloadResponsesTable.download")}
+                <DeleteIcon className="scale-50" />
+                {t("downloadResponsesTable.delete")}
               </DropdownMenu.Item>
-              {statusQuery === "new" && false && (
-                <DropdownMenu.Item
-                  onClick={handleDelete}
-                  className="flex cursor-pointer items-center rounded-md pr-4 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
-                >
-                  <DeleteIcon className="scale-50" />
-                  {t("downloadResponsesTable.delete")}
-                </DropdownMenu.Item>
-              )}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-      )}
+            )}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     </>
   );
 };

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -107,7 +107,7 @@
       "errorDownloadingFilesHeader": "Error downloading the selected files.",
       "errorDownloadingFiles": "Try again in a few minutes. If the problem persists, ",
       "errorDownloadingFilesLink": "contact Support",
-      "remainingResponses": "You have over {{max}} new responses available.",
+      "remainingResponses": "You have over {{max}} responses available.",
       "remainingResponsesBody": "Showing 1-{{max}}. More will load as displayed responses are downloaded.",
       "overdueAlert": {
         "title": "Access to new responses is restricted until overdue responses are downloaded and confirmed",


### PR DESCRIPTION
# Summary | Résumé

Split out the "Download single file" button from the MoreMenu
Save the MoreMenu component for future
Add some table row / download button semantics for a11y

Following the example here: https://stackoverflow.com/questions/72231079/accessibility-how-to-handle-buttons-in-a-table
- Added a row header using the response id column for this purpose
- Added aria-labelledBy to the download button referencing the header
- Added some visually-hidden text to the row header and the button itself as well
