### PR TITLE
Escape all csv columns

### DIFF
--- a/lib/responseDownloadFormats/csv/index.ts
+++ b/lib/responseDownloadFormats/csv/index.ts
@@ -1,6 +1,8 @@
 import { createArrayCsvStringifier as createCsvStringifier } from "csv-writer";
 import { FormResponseSubmissions } from "../types";
 
+const specialChars = ["=", "+", "-", "@"];
+
 export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
   const header = formResponseSubmissions.submissions[0].answers.map((item) => {
     return `${item.questionEn}\n${item.questionFr}`;
@@ -11,6 +13,7 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
 
   const csvStringifier = createCsvStringifier({
     header: header,
+    alwaysQuote: true,
   });
 
   const records = formResponseSubmissions.submissions.map((response) => {
@@ -22,15 +25,22 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
           return item.answer
             .map((answer) =>
               answer
-                .map(
-                  (subAnswer) =>
-                    `${subAnswer.questionEn}\n${subAnswer.questionFr}: ${subAnswer.answer}\n`
-                )
+                .map((subAnswer) => {
+                  let answerText = `${subAnswer.questionEn}\n${subAnswer.questionFr}: ${subAnswer.answer}\n`;
+                  if (specialChars.some((char) => answerText.startsWith(char))) {
+                    answerText = `'${answerText}`;
+                  }
+                  return answerText;
+                })
                 .join("")
             )
             .join("\n");
         }
-        return item.answer;
+        let answerText = item.answer;
+        if (specialChars.some((char) => answerText.startsWith(char))) {
+          answerText = `'${answerText}`;
+        }
+        return answerText;
       }),
       "Get receipt codes in the Official record of responses to sign off on the removal of responses from GC Forms\n" +
         "Obtenez les codes de réception dans le registre officiel des réponses afin d'autoriser la suppression de réponses de Formulaires GC",


### PR DESCRIPTION
# Summary | Résumé

Taking a two-prong approach to preventing user-provided text from being interpreted as formula when importing to spreadsheets:
- Double-quote all columns
- If a string starts with any of `=,+,-,@` then add a single quote `'` character to the beginning

The second approach is required because for example in Google Sheets on Import, you can instruct Sheets to interpret strings as formatted text or formula, which bypasses the quoting in the first approach.