### PR TITLE
Accessibility Updates for the New File Formats Work

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -241,7 +241,7 @@ export const DownloadDialog = ({
                     className="gc-input-checkbox__input"
                     onChange={() => setZipAllFiles(zipAllFiles === true ? false : true)}
                   />
-                  <label htmlFor="combined" className="ml-14 inline-block">
+                  <label htmlFor="zipped" className="ml-14 inline-block">
                     <span className="block font-semibold">
                       {t("downloadResponsesModals.downloadDialog.downloadAllAsZip")}
                     </span>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -38,6 +38,8 @@ interface DownloadTableProps {
   setShowDownloadSuccess: React.Dispatch<React.SetStateAction<false | string>>;
 }
 
+// TODO remove this
+
 export const DownloadTable = ({
   vaultSubmissions,
   formName,

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -38,8 +38,6 @@ interface DownloadTableProps {
   setShowDownloadSuccess: React.Dispatch<React.SetStateAction<false | string>>;
 }
 
-// TODO remove this
-
 export const DownloadTable = ({
   vaultSubmissions,
   formName,
@@ -106,7 +104,7 @@ export const DownloadTable = ({
       <section>
         <SkipLinkReusable
           text={t("downloadResponsesTable.skipLink")}
-          anchor="#downloadTableButtonId"
+          anchor="#reportProblemButton"
         />
         <div id="notificationsTop">
           {downloadError && (

--- a/components/forms/RichText/RichText.tsx
+++ b/components/forms/RichText/RichText.tsx
@@ -13,7 +13,7 @@ interface RichTextProps {
 // able to be programmatically focusable
 const H1 = ({ children, ...props }: { children: React.ReactElement }) => {
   return (
-    <h1 {...props} tabIndex={-1}>
+    <h1 {...props} id="main-header" tabIndex={-1}>
       {children}
     </h1>
   );

--- a/components/globals/SkipLink.tsx
+++ b/components/globals/SkipLink.tsx
@@ -5,7 +5,7 @@ const SkipLink = () => {
   const { t } = useTranslation("common");
   return (
     <div id="skip-link-container">
-      <a href="#content" id="skip-link">
+      <a href="#main-header" id="skip-link">
         {t("skip-link")}
       </a>
     </div>

--- a/components/globals/card/Card.tsx
+++ b/components/globals/card/Card.tsx
@@ -1,14 +1,44 @@
 import React from "react";
 
+export enum HeadingLevel {
+  H1 = "h1",
+  H2 = "h2",
+  H3 = "h3",
+  H4 = "h4",
+  H5 = "h5",
+  H6 = "h6",
+}
+
 interface CardProps {
   children?: React.ReactNode;
   icon?: JSX.Element;
   title?: string;
   content?: string;
+  heading?: HeadingLevel;
+  headingStyle?: string;
 }
 
 export const Card = (props: CardProps) => {
-  const { children, icon, title, content } = props;
+  const { children, icon, title, content, heading, headingStyle } = props;
+
+  function createTitle(
+    heading: HeadingLevel | undefined,
+    content: string | undefined
+  ): React.JSX.Element {
+    if (heading && content) {
+      return React.createElement(
+        heading,
+        { ...(headingStyle && { className: headingStyle }) },
+        content
+      );
+    }
+
+    if (title) {
+      return <p className="gc-h2 text-[#748094]">{title}</p>;
+    }
+
+    return <></>;
+  }
 
   return (
     <div className="inline-flex justify-between rounded-lg border-2 border-solid border-[#ebf0f4] p-4">
@@ -17,7 +47,7 @@ export const Card = (props: CardProps) => {
         {children && children}
         {!children && (
           <>
-            {title && <p className="gc-h2 text-[#748094]">{title}</p>}
+            {createTitle(heading, title)}
             {content && <p>{content}</p>}
           </>
         )}

--- a/components/globals/card/Card.tsx
+++ b/components/globals/card/Card.tsx
@@ -33,8 +33,8 @@ export const Card = (props: CardProps) => {
       );
     }
 
-    if (title) {
-      return <p className="gc-h2 text-[#748094]">{title}</p>;
+    if (content) {
+      return <p className="gc-h2 text-[#748094]">{content}</p>;
     }
 
     return <></>;

--- a/components/globals/layouts/DefaultLayout.tsx
+++ b/components/globals/layouts/DefaultLayout.tsx
@@ -7,6 +7,7 @@ import { HeadMeta } from "./HeadMeta";
 import LanguageToggle from "../LanguageToggle";
 import LoginMenu from "@components/auth/LoginMenu";
 import { cn } from "@lib/utils";
+import { useSkipLink } from "@lib/hooks/useSkipLink";
 
 interface DefaultLayoutProps extends React.PropsWithChildren {
   showLanguageToggle?: boolean;
@@ -44,6 +45,8 @@ const DefaultLayout = ({
   showLogin,
   isSplashPage,
 }: DefaultLayoutProps) => {
+  useSkipLink();
+
   return (
     <div className="flex h-full flex-col">
       <HeadMeta />

--- a/components/globals/layouts/FullWidthLayout.tsx
+++ b/components/globals/layouts/FullWidthLayout.tsx
@@ -7,6 +7,7 @@ import { Header } from "../Header";
 import { User } from "next-auth";
 import { HeadMeta } from "./HeadMeta";
 import Footer from "../Footer";
+import { useSkipLink } from "@lib/hooks/useSkipLink";
 
 export const FullWidthLayout = ({
   children,
@@ -19,6 +20,8 @@ export const FullWidthLayout = ({
 }) => {
   // This will check to see if a user is deactivated and redirect them to the account deactivated page
   useAccessControl(); // @TODO: this belongs somewhere else
+
+  useSkipLink();
 
   // Wait until the Template Store has fully hydrated before rendering the page
   return (

--- a/components/globals/layouts/TwoColumnLayout.tsx
+++ b/components/globals/layouts/TwoColumnLayout.tsx
@@ -6,6 +6,7 @@ import { User } from "next-auth";
 import { HeadMeta } from "./HeadMeta";
 import { cn } from "@lib/utils";
 import Footer from "../Footer";
+import { useSkipLink } from "@lib/hooks/useSkipLink";
 export const TwoColumnLayout = ({
   children,
   leftColumnContent,
@@ -17,6 +18,8 @@ export const TwoColumnLayout = ({
   user?: User;
   context?: "admin" | "formBuilder" | "default";
 }) => {
+  useSkipLink();
+
   return (
     <>
       <HeadMeta />

--- a/components/globals/layouts/UserNavLayout.tsx
+++ b/components/globals/layouts/UserNavLayout.tsx
@@ -8,6 +8,7 @@ import LoginMenu from "@components/auth/LoginMenu";
 import { SiteLogo } from "@formbuilder/icons";
 import { ToastContainer } from "@formbuilder/app/shared/Toast";
 import { HeadMeta } from "./HeadMeta";
+import { useSkipLink } from "@lib/hooks/useSkipLink";
 
 const SiteLink = () => {
   const { t } = useTranslation("common");
@@ -41,6 +42,8 @@ const UserNavLayout = ({
 }: UserNavLayoutProps) => {
   const { ability } = useAccessControl();
   const { t } = useTranslation("common");
+
+  useSkipLink();
 
   return (
     <div className="flex min-h-full flex-col bg-gray-soft">

--- a/lib/hooks/useSkipLink.ts
+++ b/lib/hooks/useSkipLink.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * Sets the first h1 in a page to allow being focussed from SkipLink. This alows a user to "skip"
+ * to the main content - a win for AT users.
+ */
+export const useSkipLink = () => {
+  useEffect(() => {
+    const els = document.getElementsByTagName("h1");
+    const h1 = els && els[0];
+
+    if (h1) {
+      h1.setAttribute("tabindex", "-1");
+      // Leave any existing id just encase changing it would break functionality
+      if (!h1.getAttribute("id")) {
+        // Used by SkipLink as the target anchor
+        h1.setAttribute("id", "main-header");
+      }
+    }
+  }, []);
+};

--- a/lib/hooks/useSkipLink.ts
+++ b/lib/hooks/useSkipLink.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
-// TODO: ideally each H1 would manually have the id="main-header" but that could take some work 
-// given many H1's are dynamic shown/hidden/updated. When refactoring consider doing that and 
+// TODO: ideally each H1 would manually have the id="main-header" but that could take some work
+// given many H1's are dynamic shown/hidden/updated. When refactoring consider doing that and
 // deleting this.
 
 /**

--- a/lib/hooks/useSkipLink.ts
+++ b/lib/hooks/useSkipLink.ts
@@ -1,8 +1,11 @@
 import { useEffect } from "react";
 
 /**
- * Sets the first h1 in a page to allow being focussed from SkipLink. This alows a user to "skip"
- * to the main content - a win for AT users.
+ * This alows a user to "skip" to the main content - a win for AT users.
+ * 
+ * TODO: ideally each H1 would manually have the id="main-header" but that could take some work 
+ * given many H1's are dynamic shown/hidden/updated. When refactoring consider doing that and 
+ * deleting this.
  */
 export const useSkipLink = () => {
   useEffect(() => {

--- a/lib/hooks/useSkipLink.ts
+++ b/lib/hooks/useSkipLink.ts
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
 
+// TODO: ideally each H1 would manually have the id="main-header" but that could take some work 
+// given many H1's are dynamic shown/hidden/updated. When refactoring consider doing that and 
+// deleting this.
+
 /**
  * This alows a user to "skip" to the main content - a win for AT users.
- * 
- * TODO: ideally each H1 would manually have the id="main-header" but that could take some work 
- * given many H1's are dynamic shown/hidden/updated. When refactoring consider doing that and 
- * deleting this.
  */
 export const useSkipLink = () => {
   useEffect(() => {

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -11,7 +11,7 @@ import { FormRecord, VaultStatus, VaultSubmissionList } from "@lib/types";
 import { listAllSubmissions } from "@lib/vault";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { Card } from "@components/globals/card/Card";
+import { Card, HeadingLevel } from "@components/globals/card/Card";
 import { DownloadTable } from "@components/form-builder/app/responses/DownloadTable";
 import { ReportDialog } from "@components/form-builder/app/responses/Dialogs/ReportDialog";
 import { NagwareResult } from "@lib/types";
@@ -253,33 +253,36 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
 
             {vaultSubmissions.length <= 0 && statusQuery === "new" && (
               <>
-                <h1 className="visually-hidden">{t("tabs.newResponses.title")}</h1>
                 <Card
                   icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
                   title={t("downloadResponsesTable.card.noNewResponses")}
                   content={t("downloadResponsesTable.card.noNewResponsesMessage")}
+                  heading={HeadingLevel.H1}
+                  headingStyle="gc-h2 text-[#748094]"
                 />
               </>
             )}
 
             {vaultSubmissions.length <= 0 && statusQuery === "downloaded" && (
               <>
-                <h1 className="visually-hidden">{t("tabs.downloadedResponses.title")}</h1>
                 <Card
                   icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
                   title={t("downloadResponsesTable.card.noDownloadedResponses")}
                   content={t("downloadResponsesTable.card.noDownloadedResponsesMessage")}
+                  heading={HeadingLevel.H1}
+                  headingStyle="gc-h2 text-[#748094]"
                 />
               </>
             )}
 
             {vaultSubmissions.length <= 0 && statusQuery === "confirmed" && (
               <>
-                <h1 className="visually-hidden">{t("tabs.confirmedResponses.title")}</h1>
                 <Card
                   icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
                   title={t("downloadResponsesTable.card.noDeletedResponses")}
                   content={t("downloadResponsesTable.card.noDeletedResponsesMessage")}
+                  heading={HeadingLevel.H1}
+                  headingStyle="gc-h2 text-[#748094]"
                 />
               </>
             )}

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -289,6 +289,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
               onClick={() => setIsShowReportProblemsDialog(true)}
               href={"#"}
               className="text-black visited:text-black"
+              id="reportProblemButton"
             >
               <WarningIcon className="mr-2 inline-block" />
               {t("responses.reportProblems")}

--- a/pages/unlock-publishing.tsx
+++ b/pages/unlock-publishing.tsx
@@ -130,7 +130,7 @@ export default function UnlockPublishing() {
                         </ol>
                       </Alert>
                     )}
-                    <h1>{t("unlockPublishing.title")}</h1>
+                    <h1 id="main-heading">{t("unlockPublishing.title")}</h1>
                     <p className="mb-14">{t("unlockPublishing.paragraph1")}</p>
                     <form id="unlock-publishing" method="POST" onSubmit={handleSubmit} noValidate>
                       <div className="focus-group">


### PR DESCRIPTION
# Summary | Résumé

I'll be using this PR to track accessibility issues.

Accessibility Issues
- [x] Skip the response table doesn’t jump anywhere #2913 
- [x] Heading of empty states not coded as headings. #2914
- [ ] Download responses dialog, radio button/group on initial entry missing a focus indication
- [ ] Download responses dialog, checkbox button is controllable but missing keyboard focus indicator
- [x] Download responses dialog, checkbox not associated with label correctly (wrong Id?)
- [x] Skip link broken (minimal change - see notes below)

Browser/AT Quirks?
- Official receipt: Windows Chrome/Edge/FF+NVDA/Jaws not announcing “Copied to clipboard” 
	- macOS Chrome/FF announces correctly

Notes/Future Thought
- On closing Download response dialog, the browser takes focus with it's own download dialog so there isn't much we can do here. So it's difficult to say where/how to return focus to an element.
- On download/signing-off all submissions in the download table, all the submissions will be removed. The default for aria-live=polite is to have additions/removals announced. This makes sense but in this case it can be quite "noisy" for the a screen reader user. Imagine 50+ announcements that an item has been removed. Probably most users would just skip all the announcements in the queue. But still something to keep in mind
-  Skip link broken - More work to be done for pages with a hidden H1 e.g. /form-builder. It's not possible to focus a hidden h1 so we'll probably need to come with another solution/design that includes consistent visible h1's across the app
