### PR TITLE
(feat) Add problem response section

### DIFF
--- a/components/form-builder/app/responses/Dialogs/ReportDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/ReportDialog.tsx
@@ -103,8 +103,7 @@ export const ReportDialog = ({
       })
       .catch((err) => {
         logMessage.error(err as Error);
-        handleClose();
-        setIsServerError(true);
+        setStatus(DialogStates.FAILED_ERROR);
       });
   };
 

--- a/components/form-builder/app/responses/Dialogs/ReportDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/ReportDialog.tsx
@@ -21,14 +21,12 @@ export const ReportDialog = ({
   apiUrl,
   inputRegex = isFormId,
   maxEntries = 20,
-  setIsServerError,
 }: {
   isShow: boolean;
   setIsShow: React.Dispatch<React.SetStateAction<boolean>>;
   apiUrl: string;
   inputRegex?: (field: string) => boolean;
   maxEntries?: number;
-  setIsServerError: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const { t, i18n } = useTranslation(["form-builder-responses", "common"]);
   const router = useRouter();

--- a/components/form-builder/app/responses/Dialogs/line-item-entries/LineItem.tsx
+++ b/components/form-builder/app/responses/Dialogs/line-item-entries/LineItem.tsx
@@ -13,13 +13,13 @@ export const LineItem = ({ value, isInvalid = false, onRemove }: LineItemProps) 
   const label = `${t("lineItemEntries.remove")} ${value}`;
   return (
     <li data-testid="value" className="pl-6 hover:bg-[#fffbf3]">
-      <div className="flex justify-between items-center pr-4 py-2">
+      <div className="flex items-center justify-between py-2 pr-4">
         <span className={`${isInvalid ? " text-red" : ""}`}>{value}</span>
         <button
           className={`
-            align-middle border border-black rounded-full [&_svg]:fill-white [&_rect]:fill-black mt-[5px] mb-[5px] mr-[5px]
-            [&_svg]:hover:fill-gray-600 [&_rect]:hover:fill-white 
-            [&_svg]:focus:fill-[#3242bc] [&_rect]:focus:fill-white focus:border-[#3242bc] focus:border-[4px] focus:p-[2px] focus:m-[0px]
+            my-[5px] mr-[5px] rounded-full border border-black align-middle focus:m-[0px] focus:border-[4px] focus:border-[#3242bc]
+            focus:p-[2px] [&_rect]:fill-black 
+            [&_rect]:hover:fill-white [&_rect]:focus:fill-white [&_svg]:fill-white [&_svg]:hover:fill-gray-600 [&_svg]:focus:fill-[#3242bc]
           `}
           onClick={() => onRemove(value)}
           aria-label={label}

--- a/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
+++ b/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
@@ -4,6 +4,7 @@ import { scrollToBottom } from "@lib/clientHelpers";
 import { useTranslation } from "react-i18next";
 import { DialogStates } from "../DialogStates";
 import { isUUID } from "@lib/validation";
+import { logMessage } from "@lib/logger";
 
 // TODO: handle duplicate entries?
 // TODO: should "backspace" on an empty input set the next entry into "edit mode"?
@@ -133,8 +134,15 @@ export const LineItemEntries = ({
             const pastedText = e.clipboardData.getData("Text");
             const pastedTextArray = pastedText.split(/\r?\n/);
             const cleanedText = pastedTextArray.flatMap((text) => {
-              if (isUUID(text.trim())) {
-                return text.trim().replace(",", "").toLowerCase();
+              const cleanedText = text.trim().replace(",", "").replace("\t", "").toLowerCase();
+              if (validateInput && !validateInput(cleanedText)) {
+                setStatus(DialogStates.FORMAT_ERROR);
+                logMessage.info(cleanedText);
+                return [];
+              } else {
+                if (validateInput && validateInput(cleanedText)) {
+                  return cleanedText;
+                }
               }
               return [];
             });

--- a/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
+++ b/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
@@ -54,7 +54,7 @@ export const LineItemEntries = ({
     const text = (e.target as HTMLInputElement).value.trim().replace(",", "").toLowerCase();
 
     // Reset any errors on an empty list
-    if (!text && (status === DialogStates.MAX_ERROR || status === DialogStates.FORMAT_ERROR)) {
+    if (!inputs && (status === DialogStates.MAX_ERROR || status === DialogStates.FORMAT_ERROR)) {
       setStatus(DialogStates.EDITING);
     }
 
@@ -114,7 +114,12 @@ export const LineItemEntries = ({
       className="box-border max-h-60 overflow-y-auto rounded-md border-2 border-black-default"
     >
       <ol data-testid="values">
-        <LineItems values={inputs} onRemove={onRemove} errorEntriesList={errorEntriesList} />
+        <LineItems
+          values={inputs}
+          onRemove={onRemove}
+          errorEntriesList={errorEntriesList}
+          validateInput={validateInput}
+        />
       </ol>
       <div className="grow p-4">
         <input
@@ -137,14 +142,8 @@ export const LineItemEntries = ({
               const cleanedText = text.trim().replace(",", "").replace("\t", "").toLowerCase();
               if (validateInput && !validateInput(cleanedText)) {
                 setStatus(DialogStates.FORMAT_ERROR);
-                logMessage.info(cleanedText);
-                return [];
-              } else {
-                if (validateInput && validateInput(cleanedText)) {
-                  return cleanedText;
-                }
               }
-              return [];
+              return cleanedText;
             });
             setInputs([...new Set([...inputs, ...cleanedText])]);
             e.preventDefault();

--- a/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
+++ b/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
@@ -3,8 +3,6 @@ import { LineItems } from "./LineItems";
 import { scrollToBottom } from "@lib/clientHelpers";
 import { useTranslation } from "react-i18next";
 import { DialogStates } from "../DialogStates";
-import { isUUID } from "@lib/validation";
-import { logMessage } from "@lib/logger";
 
 // TODO: handle duplicate entries?
 // TODO: should "backspace" on an empty input set the next entry into "edit mode"?

--- a/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
+++ b/components/form-builder/app/responses/Dialogs/line-item-entries/LineItemEntries.tsx
@@ -139,7 +139,7 @@ export const LineItemEntries = ({
             const pastedText = e.clipboardData.getData("Text");
             const pastedTextArray = pastedText.split(/\r?\n/);
             const cleanedText = pastedTextArray.flatMap((text) => {
-              const cleanedText = text.trim().replace(",", "").replace("\t", "").toLowerCase();
+              const cleanedText = text.trim().replace(",", "").replaceAll("\t", "").toLowerCase();
               if (validateInput && !validateInput(cleanedText)) {
                 setStatus(DialogStates.FORMAT_ERROR);
               }

--- a/components/form-builder/app/responses/Dialogs/line-item-entries/LineItems.tsx
+++ b/components/form-builder/app/responses/Dialogs/line-item-entries/LineItems.tsx
@@ -5,9 +5,15 @@ type LineItemsProps = {
   values: string[];
   errorEntriesList: string[];
   onRemove: (value: string) => void;
+  validateInput?: (tag: string) => boolean;
 };
 
-export const LineItems = ({ values = [], errorEntriesList = [], onRemove }: LineItemsProps) => {
+export const LineItems = ({
+  values = [],
+  errorEntriesList = [],
+  onRemove,
+  validateInput,
+}: LineItemsProps) => {
   if (values.length <= 0) {
     return null;
   }
@@ -19,7 +25,12 @@ export const LineItems = ({ values = [], errorEntriesList = [], onRemove }: Line
           value={value}
           key={value}
           onRemove={onRemove}
-          isInvalid={errorEntriesList.find((valueError) => value === valueError) ? true : false}
+          isInvalid={
+            errorEntriesList.find((valueError) => value === valueError) ||
+            (validateInput && !validateInput(value))
+              ? true
+              : false
+          }
         />
       ))}
     </>

--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -215,7 +215,9 @@ export const DownloadTable = ({
                     {submission.name}
                   </th>
                   <td className="whitespace-nowrap px-4">
-                    {isStatus(statusQuery, VaultStatus.NEW) && <span>{createdDateTime}</span>}
+                    {isStatus(statusQuery, [VaultStatus.NEW, VaultStatus.PROBLEM]) && (
+                      <span>{createdDateTime}</span>
+                    )}
                     {isStatus(statusQuery, VaultStatus.DOWNLOADED) && (
                       <span>{downloadedDateTime}</span>
                     )}
@@ -244,6 +246,13 @@ export const DownloadTable = ({
                         vaultStatus={submission.status}
                         removalAt={submission.removedAt}
                       />
+                    )}
+                    {isStatus(statusQuery, VaultStatus.PROBLEM) && (
+                      <p className="text-red">
+                        <strong>{t("supportWillContact")}</strong>
+                        <br />
+                        {t("reportedAsProblem")}
+                      </p>
                     )}
                   </td>
                   <td className="whitespace-nowrap text-center">

--- a/lib/clientHelpers.ts
+++ b/lib/clientHelpers.ts
@@ -356,7 +356,7 @@ export const ucfirst = (string: string) => {
 export const isStatus = (query: string, status: VaultStatus | VaultStatus[]): boolean => {
   const ucQuery = ucfirst(query);
   if (Array.isArray(status)) {
-    status.includes(ucQuery as VaultStatus);
+    return status.includes(ucQuery as VaultStatus);
   }
 
   return ucQuery === status;

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -231,6 +231,9 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
                   <br />
                   {t("tabs.problemResponses.message2")}
                 </p>
+                <Button onClick={() => setShowConfirmReceiptDialog(true)} theme="secondary">
+                  {t("responses.confirmReceipt")}
+                </Button>
               </div>
             </>
           )}

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -298,6 +298,17 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
                 />
               </>
             )}
+
+            {vaultSubmissions.length <= 0 && statusQuery === "problem" && (
+              <>
+                <h1 className="visually-hidden">{t("tabs.problemResponses.title")}</h1>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noProblemResponses")}
+                  content={t("downloadResponsesTable.card.noProblemResponsesMessage")}
+                />
+              </>
+            )}
           </div>
           <div className="mt-8">
             <Link

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -183,16 +183,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             <DeleteIcon className="inline-block h-7 w-7" /> {t("responses.status.deleted")}
           </span>
         </SubNavLink>
-        <SubNavLink
-          id="problem-responses"
-          href={`/form-builder/responses/${formId}/problem`}
-          setAriaCurrent={true}
-          onClick={() => setShowSuccessAlert(false)}
-        >
-          <span className="text-sm laptop:text-base">
-            <WarningIcon className="inline-block h-7 w-7" /> {t("responses.status.problem")}
-          </span>
-        </SubNavLink>
       </nav>
 
       {isAuthenticated && vaultSubmissions.length > 0 && (
@@ -314,6 +304,13 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             >
               <WarningIcon className="mr-2 inline-block" />
               {t("responses.reportProblems")}
+            </Link>
+
+            <Link
+              href={`/form-builder/responses/${formId}/problem`}
+              className="ml-12 text-black visited:text-black"
+            >
+              {t("responses.viewAllProblemResponses")}
             </Link>
           </div>
         </>

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -183,6 +183,16 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
             <DeleteIcon className="inline-block h-7 w-7" /> {t("responses.status.deleted")}
           </span>
         </SubNavLink>
+        <SubNavLink
+          id="problem-responses"
+          href={`/form-builder/responses/${formId}/problem`}
+          setAriaCurrent={true}
+          onClick={() => setShowSuccessAlert(false)}
+        >
+          <span className="text-sm laptop:text-base">
+            <WarningIcon className="inline-block h-7 w-7" /> {t("responses.status.problem")}
+          </span>
+        </SubNavLink>
       </nav>
 
       {isAuthenticated && vaultSubmissions.length > 0 && (

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -21,7 +21,7 @@ import { useTemplateStore } from "@components/form-builder/store";
 import { LoggedOutTabName, LoggedOutTab } from "@components/form-builder/app/LoggedOutTab";
 import Head from "next/head";
 import { FormBuilderLayout } from "@components/globals/layouts/FormBuilderLayout";
-import { Button, ErrorPanel } from "@components/globals";
+import { Button } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
 import { DeleteIcon, FolderIcon, InboxIcon, WarningIcon } from "@components/form-builder/icons";
@@ -58,7 +58,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
   const [isShowReportProblemsDialog, setIsShowReportProblemsDialog] = useState(false);
   const [showConfirmReceiptDialog, setShowConfirmReceiptDialog] = useState(false);
   const [successAlertMessage, setShowSuccessAlert] = useState<false | string>(false);
-  const [isServerError, setIsServerError] = useState(false);
 
   const router = useRouter();
   const [, statusQuery = "new"] = router.query.params || [];
@@ -121,20 +120,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           subjectEn={deliveryOption.emailSubjectEn || ""}
           subjectFr={deliveryOption.emailSubjectFr || ""}
         />
-      </>
-    );
-  }
-
-  if (isServerError) {
-    return (
-      <>
-        <Head>
-          <title>{t("responses.title")}</title>
-        </Head>
-        <div className="mb-8 flex flex-wrap items-baseline">
-          <h1 className="mb-0 border-none tablet:mb-4 tablet:mr-8">{t("responses.title")}</h1>
-          <ErrorPanel supportLink={false}>{t("server-error", { ns: "common" })}</ErrorPanel>
-        </div>
       </>
     );
   }
@@ -347,7 +332,6 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
       <ReportDialog
         isShow={isShowReportProblemsDialog}
         setIsShow={setIsShowReportProblemsDialog}
-        setIsServerError={setIsServerError}
         apiUrl={`/api/id/${formId}/submission/report`}
         maxEntries={MAX_REPORT_COUNT}
       />

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -232,6 +232,18 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
               </div>
             </>
           )}
+          {isStatus(statusQuery, VaultStatus.PROBLEM) && (
+            <>
+              <h1>{t("tabs.problemResponses.title")}</h1>
+              <div className="mb-4">
+                <p className="mb-4">
+                  <strong>{t("tabs.problemResponses.message1")}</strong>
+                  <br />
+                  {t("tabs.problemResponses.message2")}
+                </p>
+              </div>
+            </>
+          )}
         </>
       )}
 

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -13,6 +13,11 @@
     "confirmedResponses": {
       "title": "Responses signed off for removal",
       "message1": "GC Forms stores responses temporarily. These responses will be removed permanently after 30 days."
+    },
+    "problemResponses": {
+      "title": "Responses reported with problems",
+      "message1": "The GC Forms Support Team has been notified.",
+      "message2": "Someone will reach out to help resolve the problem."
     }
   },
   "responses": {

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -47,7 +47,7 @@
       "deleted": "Signed off for removal",
       "problem": "Problems"
     },
-    "viewAllProblemResponses": "View All Problem Responses"
+    "viewAllProblemResponses": "View all responses reported as problems"
   },
   "supportWillContact": "Support will contact you",
   "reportedAsProblem": "Response reported as a problem",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -100,7 +100,9 @@
       "noDownloadedResponses": "No recently downloaded responses",
       "noDownloadedResponsesMessage": "Downloaded responses will appear here until you sign off on their removal from GC Forms.",
       "noDeletedResponses": "No responses for removal",
-      "noDeletedResponsesMessage": "Once you’ve downloaded and signed off on the removal of responses, they will be available here for 30 days."
+      "noDeletedResponsesMessage": "Once you’ve downloaded and signed off on the removal of responses, they will be available here for 30 days.",
+      "noProblemResponses": "No problem responses",
+      "noProblemResponsesMessage": "Responses reported with problems will appear here until you sign off on their removal from GC Forms."
     },
     "notifications": {
 

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -46,7 +46,8 @@
       "downloaded": "Downloaded",
       "deleted": "Signed off for removal",
       "problem": "Problems"
-    }
+    },
+    "viewAllProblemResponses": "View All Problem Responses"
   },
   "supportWillContact": "Support will contact you",
   "reportedAsProblem": "Response reported as a problem",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -39,9 +39,12 @@
     "status": {
       "new": "New",
       "downloaded": "Downloaded",
-      "deleted": "Signed off for removal"
+      "deleted": "Signed off for removal",
+      "problem": "Problems"
     }
   },
+  "supportWillContact": "Support will contact you",
+  "reportedAsProblem": "Response reported as a problem",
   "downloadSuccess": {
     "title": "Responses moved to Downloaded",
     "body": "Next: sign off on the removal of responses from GC Forms."

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -17,7 +17,7 @@
     "problemResponses": {
       "title": "Responses reported with problems",
       "message1": "The GC Forms Support Team has been notified.",
-      "message2": "Someone will reach out to help resolve the problem."
+      "message2": "Someone will reach out to help resolve the problem. Sign off on the removal of these problem responses once resolved."
     }
   },
   "responses": {

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -102,7 +102,7 @@
       "noDeletedResponses": "No responses for removal",
       "noDeletedResponsesMessage": "Once you’ve downloaded and signed off on the removal of responses, they will be available here for 30 days.",
       "noProblemResponses": "No problem responses",
-      "noProblemResponsesMessage": "Responses reported with problems will appear here until you sign off on their removal from GC Forms."
+      "noProblemResponsesMessage": "Problem responses will appear here until you sign off on their removal from GC Forms."
     },
     "notifications": {
 

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -101,7 +101,7 @@
       "noDownloadedResponsesMessage": "Les réponses téléchargées apparaîtront ici jusqu'à ce que vous approuviez leur suppression de Formulaires GC.",
       "noDeletedResponses": "Aucune réponse à supprimer",
       "noDeletedResponsesMessage": "Une fois que vous aurez téléchargé et approuvé la suppression des réponses, celles-ci seront disponibles ici pendant 30 jours.",
-      "noProblemResponses": "[FR] No problem responses",
+      "noProblemResponses": "Aucune réponse signalée avec problème",
       "noProblemResponsesMessage": "[FR] Problem responses will appear here until you sign off on their removal from GC Forms."
     },
     "notifications": {

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -101,8 +101,8 @@
       "noDownloadedResponsesMessage": "Les réponses téléchargées apparaîtront ici jusqu'à ce que vous approuviez leur suppression de Formulaires GC.",
       "noDeletedResponses": "Aucune réponse à supprimer",
       "noDeletedResponsesMessage": "Une fois que vous aurez téléchargé et approuvé la suppression des réponses, celles-ci seront disponibles ici pendant 30 jours.",
-      "noProblemResponses": "No problem responses",
-      "noProblemResponsesMessage": "Responses reported with problems will appear here until you sign off on their removal from GC Forms."
+      "noProblemResponses": "[FR] No problem responses",
+      "noProblemResponsesMessage": "[FR] Problem responses will appear here until you sign off on their removal from GC Forms."
     },
     "notifications": {
       "downloadComplete": "Réponses déplacées vers « Téléchargements »",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -17,7 +17,7 @@
     "problemResponses": {
       "title": "Réponses signalées avec problèmes",
       "message1": "L’équipe de soutien de Formulaires GC a été informée.",
-      "message2": "Quelqu’un communiquera avec vous pour aider à résoudre le problème. [FR] Sign off on the removal of these problem responses once resolved."
+      "message2": "Quelqu’un communiquera avec vous pour aider à résoudre le problème. Approuvez la suppression des ces réponses une fois que les problèmes ont été résolus."
     }
   },
   "responses": {

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -11,7 +11,7 @@
       "message2": "Les fichiers de réponses resteront disponibles pendant 30 jours supplémentaires après l’autorisation."
     },
     "confirmedResponses": {
-      "title": "Réponses autorisées pour suppression",
+      "title": "Réponses approuvées pour suppression",
       "message1": "Formulaires GC conserve temporairement les réponses. Ces réponses seront définitivement supprimées après 30 jours."
     },
     "problemResponses": {

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -13,6 +13,11 @@
     "confirmedResponses": {
       "title": "Réponses autorisées pour suppression",
       "message1": "Formulaires GC conserve temporairement les réponses. Ces réponses seront définitivement supprimées après 30 jours."
+    },
+    "problemResponses": {
+      "title": "Réponses signalées avec problèmes",
+      "message1": "L’équipe de soutien de Formulaires GC a été informée.",
+      "message2": "Quelqu’un communiquera avec vous pour aider à résoudre le problème."
     }
   },
   "responses": {
@@ -43,8 +48,8 @@
       "problem": "Problème"
     }
   },
-  "supportWillContact": "[FR] Support will contact you",
-  "reportedAsProblem": "[FR] Response reported as a problem",
+  "supportWillContact": "L’équipe de soutien vous contactera",
+  "reportedAsProblem": "Réponse signalée avec problème",
   "downloadSuccess": {
     "title": "Réponses déplacées vers Téléchargements",
     "body": "Prochaine étape : autorisez la suppression des réponses de Formulaires GC."

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -47,7 +47,7 @@
       "deleted": "Pour suppression",
       "problem": "Problème"
     },
-    "viewAllProblemResponses": "[FR] View All Problem Responses"
+    "viewAllProblemResponses": "Afficher toutes les réponses signalées avec problèmes"
   },
   "supportWillContact": "L’équipe de soutien vous contactera",
   "reportedAsProblem": "Réponse signalée avec problème",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -102,7 +102,7 @@
       "noDeletedResponses": "Aucune réponse à supprimer",
       "noDeletedResponsesMessage": "Une fois que vous aurez téléchargé et approuvé la suppression des réponses, celles-ci seront disponibles ici pendant 30 jours.",
       "noProblemResponses": "Aucune réponse signalée avec problème",
-      "noProblemResponsesMessage": "[FR] Problem responses will appear here until you sign off on their removal from GC Forms."
+      "noProblemResponsesMessage": "Les réponses signalées avec problèmes apparaîtront ici jusqu'à ce que vous approuviez leur suppression de Formulaires GC."
     },
     "notifications": {
       "downloadComplete": "Réponses déplacées vers « Téléchargements »",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -46,7 +46,8 @@
       "downloaded": "Téléchargements",
       "deleted": "Pour suppression",
       "problem": "Problème"
-    }
+    },
+    "viewAllProblemResponses": "[FR] View All Problem Responses"
   },
   "supportWillContact": "L’équipe de soutien vous contactera",
   "reportedAsProblem": "Réponse signalée avec problème",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -39,9 +39,12 @@
     "status": {
       "new": "Nouveautés",
       "downloaded": "Téléchargements",
-      "deleted": "Pour suppression"
+      "deleted": "Pour suppression",
+      "problem": "Problème"
     }
   },
+  "supportWillContact": "[FR] Support will contact you",
+  "reportedAsProblem": "[FR] Response reported as a problem",
   "downloadSuccess": {
     "title": "Réponses déplacées vers Téléchargements",
     "body": "Prochaine étape : autorisez la suppression des réponses de Formulaires GC."

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -100,7 +100,9 @@
       "noDownloadedResponses": "Aucune réponse téléchargée récemment",
       "noDownloadedResponsesMessage": "Les réponses téléchargées apparaîtront ici jusqu'à ce que vous approuviez leur suppression de Formulaires GC.",
       "noDeletedResponses": "Aucune réponse à supprimer",
-      "noDeletedResponsesMessage": "Une fois que vous aurez téléchargé et approuvé la suppression des réponses, celles-ci seront disponibles ici pendant 30 jours."
+      "noDeletedResponsesMessage": "Une fois que vous aurez téléchargé et approuvé la suppression des réponses, celles-ci seront disponibles ici pendant 30 jours.",
+      "noProblemResponses": "No problem responses",
+      "noProblemResponsesMessage": "Responses reported with problems will appear here until you sign off on their removal from GC Forms."
     },
     "notifications": {
       "downloadComplete": "Réponses déplacées vers « Téléchargements »",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -17,7 +17,7 @@
     "problemResponses": {
       "title": "Réponses signalées avec problèmes",
       "message1": "L’équipe de soutien de Formulaires GC a été informée.",
-      "message2": "Quelqu’un communiquera avec vous pour aider à résoudre le problème."
+      "message2": "Quelqu’un communiquera avec vous pour aider à résoudre le problème. [FR] Sign off on the removal of these problem responses once resolved."
     }
   },
   "responses": {

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -53,7 +53,7 @@
   "reportedAsProblem": "Réponse signalée avec problème",
   "downloadSuccess": {
     "title": "Réponses déplacées vers Téléchargements",
-    "body": "Prochaine étape : autorisez la suppression des réponses de Formulaires GC."
+    "body": "Prochaine étape : approuvez la suppression des réponses de Formulaires GC."
   },
   "confirmSuccess": {
     "title": "Réponses déplacées vers Pour suppression",


### PR DESCRIPTION
# Summary | Résumé

Adds a link to view Responses in Problem status. The link appears below the table next to the "Report a problem link."

In future, the intention is to have a Problem filter at the top like the other statuses, but have it hidden unless there are problems.

<img width="1404" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/e66ebe24-fa5c-4971-9412-cfde7b171fe4">