### PR TITLE
fix: Move zipping of individual HTML files to client side

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -82,14 +82,22 @@ export const DownloadDialog = ({
         const response = await axios({
           url,
           method: "POST",
-          responseType: "blob",
           data: {
             ids: ids.join(","),
           },
         });
 
-        const fileName = `${filePrefix}responses-reponses.zip`;
-        downloadFileFromBlob(new Blob([response.data]), fileName);
+        const zip = new JSZip();
+        zip.file("receipt-recu.html", response.data.receipt);
+
+        response.data.responses.forEach((response: { id: string; html: string }) => {
+          zip.file(`${response.id}.html`, response.html);
+        });
+
+        zip.generateAsync({ type: "nodebuffer", streamFiles: true }).then((buffer) => {
+          const fileName = `${filePrefix}responses-reponses.zip`;
+          downloadFileFromBlob(new Blob([buffer]), fileName);
+        });
 
         onSuccessfulDownload();
         handleClose();

--- a/lib/responseDownloadFormats/html-zipped/index.ts
+++ b/lib/responseDownloadFormats/html-zipped/index.ts
@@ -1,7 +1,7 @@
 import { ResponseHtml } from "../html/components/ResponseHtml";
 import { renderToStaticMarkup } from "react-dom/server";
 import { FormResponseSubmissions } from "../types";
-import JSZip from "jszip";
+// import JSZip from "jszip";
 import { transform as transformAggregated } from "../html-aggregated";
 
 export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
@@ -23,11 +23,15 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
     };
   });
 
-  const zip = new JSZip();
-  zip.file("receipt-recu.html", aggregated);
-  records.forEach((response) => {
-    zip.file(`${response.id}.html`, response.html);
-  });
+  // const zip = new JSZip();
+  // zip.file("receipt-recu.html", aggregated);
+  // records.forEach((response) => {
+  //   zip.file(`${response.id}.html`, response.html);
+  // });
 
-  return zip;
+  // return zip;
+  return {
+    aggregated: aggregated,
+    responses: records,
+  };
 };

--- a/lib/responseDownloadFormats/html-zipped/index.ts
+++ b/lib/responseDownloadFormats/html-zipped/index.ts
@@ -4,7 +4,7 @@ import { FormResponseSubmissions } from "../types";
 import { transform as transformAggregated } from "../html-aggregated";
 
 export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
-  const aggregated = transformAggregated(formResponseSubmissions);
+  const receipt = transformAggregated(formResponseSubmissions);
   const responses = formResponseSubmissions.submissions.map((response) => {
     return {
       id: response.id,
@@ -23,7 +23,7 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
   });
 
   return {
-    aggregated: aggregated,
-    responses: responses,
+    receipt,
+    responses,
   };
 };

--- a/lib/responseDownloadFormats/html-zipped/index.ts
+++ b/lib/responseDownloadFormats/html-zipped/index.ts
@@ -1,12 +1,11 @@
 import { ResponseHtml } from "../html/components/ResponseHtml";
 import { renderToStaticMarkup } from "react-dom/server";
 import { FormResponseSubmissions } from "../types";
-// import JSZip from "jszip";
 import { transform as transformAggregated } from "../html-aggregated";
 
 export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
   const aggregated = transformAggregated(formResponseSubmissions);
-  const records = formResponseSubmissions.submissions.map((response) => {
+  const responses = formResponseSubmissions.submissions.map((response) => {
     return {
       id: response.id,
       created_at: response.createdAt,
@@ -23,15 +22,8 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
     };
   });
 
-  // const zip = new JSZip();
-  // zip.file("receipt-recu.html", aggregated);
-  // records.forEach((response) => {
-  //   zip.file(`${response.id}.html`, response.html);
-  // });
-
-  // return zip;
   return {
     aggregated: aggregated,
-    responses: records,
+    responses: responses,
   };
 };

--- a/pages/api/id/[form]/submission/download.ts
+++ b/pages/api/id/[form]/submission/download.ts
@@ -191,13 +191,17 @@ const getSubmissions = async (
             .send(htmlTransform(formResponse));
 
         case DownloadFormat.HTML_ZIPPED: {
-          const zip = zipTransform(formResponse);
-
           return res
             .status(200)
-            .setHeader("Content-Type", "application/zip")
-            .setHeader("Content-Disposition", `attachment; filename=records.zip`)
-            .send(zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }));
+            .setHeader("Content-Type", "text/json")
+            .send(zipTransform(formResponse));
+          // const zip = zipTransform(formResponse);
+
+          // return res
+          //   .status(200)
+          //   .setHeader("Content-Type", "application/zip")
+          //   .setHeader("Content-Disposition", `attachment; filename=records.zip`)
+          //   .send(zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }));
         }
 
         case DownloadFormat.JSON:

--- a/pages/api/id/[form]/submission/download.ts
+++ b/pages/api/id/[form]/submission/download.ts
@@ -195,13 +195,6 @@ const getSubmissions = async (
             .status(200)
             .setHeader("Content-Type", "text/json")
             .send(zipTransform(formResponse));
-          // const zip = zipTransform(formResponse);
-
-          // return res
-          //   .status(200)
-          //   .setHeader("Content-Type", "application/zip")
-          //   .setHeader("Content-Disposition", `attachment; filename=records.zip`)
-          //   .send(zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }));
         }
 
         case DownloadFormat.JSON:


### PR DESCRIPTION
# Summary | Résumé

Moves the .zipping of individual HTML files + receipt to the client side.