### PR TITLE
Content updates to clarify "New download formats" feature

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -253,9 +253,6 @@ export const DownloadDialog = ({
                     <span className="block font-semibold">
                       {t("downloadResponsesModals.downloadDialog.downloadAllAsZip")}
                     </span>
-                    <span className="">
-                      {t("downloadResponsesModals.downloadDialog.mayNotBeAvailable")}
-                    </span>
                   </label>
                 </div>
               </div>

--- a/lib/responseDownloadFormats/csv/index.ts
+++ b/lib/responseDownloadFormats/csv/index.ts
@@ -42,8 +42,8 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
         }
         return answerText;
       }),
-      "Get receipt codes in the Official record of responses to sign off on the removal of responses from GC Forms\n" +
-        "Obtenez les codes de réception dans le registre officiel des réponses afin d'autoriser la suppression de réponses de Formulaires GC",
+      "Receipt codes are in the Official receipt and record of responses\n" +
+        "Les codes de réception sont dans le Reçu et registre officiel des réponses",
     ];
   });
 

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -177,27 +177,27 @@
     },
     "reportProblemsDialog": {
       "title": "Report a problem with responses",
-      "findForm": "Find the submission numbers in the list for any responses that will not download or open. They look like 31-12-XCRV.",
-      "enterFormNumbers": "Enter up-to {{max}} submission numbers, one per line.",
+      "findForm": "Find the submission ID in the list for responses that will not download or open. It looks like 31-12-XCRV.",
+      "enterFormNumbers": "Enter up-to {{max}} submission IDs, one per line.",
       "problemReported": "After you report the problem, we will contact you to help resolve the problem.",
       "reportProblems": "Report problem",
       "describeProblem": "Describe the problem",
       "errors": {
         "minEntries": {
           "title": "At least one submission must be specified",
-          "description": "Enter submission numbers for responses that have a problem."
+          "description": "Enter submission IDs for responses that have a problem."
         },
         "maxEntries": {
           "title": "Only {{max}} problems can be reported at a time",
-          "description": "Submit {{max}} submission numbers before adding more."
+          "description": "Submit {{max}} submission IDs before adding more."
         },
         "errorEntries": {
-          "title": "Some submission numbers were not submitted",
-          "description": "Check that the submission numbers below are correct and try again."
+          "title": "Some submission IDs were not submitted",
+          "description": "Check that the submission ID below are correct and try again."
         },
         "invalidEntry": {
-          "title": "The submission number does not match the required format",
-          "description": "Check that the submission number format is correct and try again."
+          "title": "The submission ID does not match the required format",
+          "description": "Check that the submission ID format is correct and try again."
         },
         "unknown": {
           "title": "Sorry, there’s a problem with the site",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -131,7 +131,6 @@
       "json": "JSON",
       "jsonDescription": "For API or data configuration",
       "downloadAllAsZip": "Download all files as ZIP (compressed) file",
-      "mayNotBeAvailable": "May not be available in some departments and agencies",
       "cancel": "Cancel",
       "download": "Download"
     },

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -123,7 +123,7 @@
     "downloadDialog": {
       "title": "Download responses",
       "chooseDownloadFormat": "Choose the format of response files",
-      "downloadFormatContext": "Along with response files, you’ll also get an Official record of responses. You’ll need to keep this receipt to verify all responses made it safely from GC Forms to your computer.",
+      "downloadFormatContext": "You’ll also get an Official receipt and record of responses. You’ll need to keep this receipt to verify all responses made it safely from GC Forms to your computer.",
       "html": "Individual response files",
       "htmlDescription": "Separate files for each form submission",
       "csv": "CSV",

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -7,8 +7,8 @@
     },
     "downloadedResponses": {
       "title": "Recently downloaded responses",
-      "message1": "GC Forms stores responses temporarily. You must sign off on the removal of responses from GC Forms within the time indicated.",
-      "message2": "Response files will continue to be available for an additional 30 days after sign off."
+      "message1": "GC Forms stores responses temporarily.",
+      "message2": "You must sign off on the removal of responses from GC Forms within the time indicated."
     },
     "confirmedResponses": {
       "title": "Responses signed off for removal",

--- a/public/static/locales/en/my-forms.json
+++ b/public/static/locales/en/my-forms.json
@@ -68,7 +68,7 @@
     "officialReceipt": "Official receipt and record of responses",
     "responsesDownloaded": "responses downloaded:",
     "needToVerify": "You’ll need this receipt to verify all responses made it safely from GC Forms to your computer.",
-    "useTheCopy": "Use the “Copy receipt codes” button to copy and paste all the codes, signing off on the removal of these responses from GC Forms. This lets us know that responses made it safely to your computer.",
+    "useTheCopy": "Use the “Copy receipt codes” button to sign off on the removal of responses from GC Forms.",
     "copyCodes": {
       "title":"Sign off on removal of responses from GC Forms",
       "description": "Once you've checked the downloaded responses, and are ready to remove these from GC Forms, copy and paste the receipt codes. This helps us know when responses have been transferred to you so we can remove the data from our system.",

--- a/public/static/locales/en/my-forms.json
+++ b/public/static/locales/en/my-forms.json
@@ -46,7 +46,7 @@
     }
   },
   "responseTemplate": {
-    "responseNumber": "Response number",
+    "responseNumber": "Submission ID",
     "submissionDate": "Submission date",
     "errorNoQuestionsAnswers": "No questions and answers were found.",
     "jumpTo": "Jump to:",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -176,27 +176,27 @@
     },
     "reportProblemsDialog": {
       "title": "Signaler un problème avec les réponses",
-      "findForm": "Trouvez les numéros de soumissions dans la liste des réponses qui ne se téléchargent pas ou ne s'ouvrent pas. Ces numéros ressemblent à : 31-12-XCRV.",
-      "enterFormNumbers": "Entrez jusqu'à {{max}} numéros de soumission, un par ligne.",
+      "findForm": "Trouvez les identifiants de soumission dans la liste des réponses qui ne se téléchargent pas ou ne s'ouvrent pas. Ces identifiants ressemblent à : 31-12-XCRV.",
+      "enterFormNumbers": "Entrez jusqu'à {{max}} identifiants de soumission, un par ligne.",
       "problemReported": "Une fois que vous aurez signalé le problème, nous vous contacterons pour vous aider à le résoudre.",
       "reportProblems": "Signaler le problème",
       "describeProblem": "Décrivez le problème",
       "errors": {
         "minEntries": {
           "title": "Au moins un formulaire doit être spécifié",
-          "description": "Entrez les numéros de soumission pour les réponses qui posent un problème."
+          "description": "Entrez les identifiants de soumission pour les réponses qui posent un problème."
         },
         "maxEntries": {
           "title": "Seulement {{max}} problèmes peuvent être signalés à la fois",
-          "description": "Soumettez {{max}} numéros de soumission avant d'en soumettre d'autres."
+          "description": "Soumettez {{max}} identifiants de soumission avant d'en soumettre d'autres."
         },
         "errorEntries": {
-          "title": "Certains numéros de soumission n'ont pas été soumis",
-          "description": "Vérifiez que les numéros de soumission ci-dessous sont corrects et réessayez."
+          "title": "Certains identifiants de soumission n'ont pas été soumis",
+          "description": "Vérifiez que les identifiants de soumission ci-dessous sont corrects et réessayez."
         },
         "invalidEntry": {
-          "title": "Le numéro de soumission ne correspond pas au format requis",
-          "description": "Vérifiez que le format du numéro de soumission est correct et réessayez."
+          "title": "L'identifiant de soumission ne correspond pas au format requis",
+          "description": "Vérifiez que le format de l'identifiant de soumission est correct et réessayez."
         },
         "unknown": {
           "title": "Désolé, il y a un problème avec le site",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -7,8 +7,8 @@
     },
     "downloadedResponses": {
       "title": "Réponses téléchargées récemment",
-      "message1": "Formulaires GC conserve temporairement les réponses. Vous devez approuver la suppression des réponses de Formulaires GC dans le délai indiqué.",
-      "message2": "Les fichiers de réponses resteront disponibles pendant 30 jours supplémentaires après l’autorisation."
+      "message1": "Formulaires GC conserve temporairement les réponses.",
+      "message2": "Vous devez approuver la suppression des réponses de Formulaires GC dans le délai indiqué."
     },
     "confirmedResponses": {
       "title": "Réponses autorisées pour suppression",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -122,7 +122,7 @@
     "downloadDialog": {
       "title": "Télécharger les réponses",
       "chooseDownloadFormat": "Choisissez le format des fichiers de réponses",
-      "downloadFormatContext": "En plus des fichiers de réponses, vous recevrez également un record officiel des réponses. Vous devrez conserver ce reçu pour vérifier que toutes les réponses sont bien passées de Formulaires GC à votre ordinateur.",
+      "downloadFormatContext": "Vous recevrez également un Reçu et registre officiel des réponses. Vous devrez conserver ce reçu pour vérifier que toutes les réponses sont bien passées de Formulaires GC à votre ordinateur.",
       "html": "Réponses individuelles en HTML",
       "htmlDescription": "Des fichiers distincts pour chaque soumission de formulaire",
       "csv": "CSV",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -3,7 +3,7 @@
     "newResponses": {
       "title": "Nouvelles réponses disponibles",
       "message1": "Formulaires GC conserve temporairement les réponses.",
-      "message2": "Commencez par télécharger les réponses, puis autorisez leur suppression de Formulaires GC."
+      "message2": "Commencez par télécharger les réponses, puis approuvez leur suppression de Formulaires GC."
     },
     "downloadedResponses": {
       "title": "Réponses téléchargées récemment",
@@ -11,7 +11,7 @@
       "message2": "Vous devez approuver la suppression des réponses de Formulaires GC dans le délai indiqué."
     },
     "confirmedResponses": {
-      "title": "Réponses autorisées pour suppression",
+      "title": "Réponses approuvées pour suppression",
       "message1": "Formulaires GC conserve temporairement les réponses. Ces réponses seront définitivement supprimées après 30 jours."
     }
   },
@@ -19,7 +19,7 @@
     "recentlyDownloaded": "Téléchargements récents",
     "deleted": "Pour suppression",
     "changeSetup": "Modifier les paramètres",
-    "confirmReceipt": "Autoriser la suppression avec les codes de réception",
+    "confirmReceipt": "Approuver la suppression avec les codes de réception",
     "navLabel": "Réponses",
     "reportProblems": "Signaler un problème avec les réponses",
     "title": "Réponses",
@@ -44,7 +44,7 @@
   },
   "downloadSuccess": {
     "title": "Réponses déplacées vers Téléchargements",
-    "body": "Prochaine étape : autorisez la suppression des réponses de Formulaires GC."
+    "body": "Prochaine étape : approuvez la suppression des réponses de Formulaires GC."
   },
   "confirmSuccess": {
     "title": "Réponses déplacées vers Pour suppression",
@@ -79,7 +79,7 @@
       "problem": "Problème",
       "done": "Complété",
       "downloadWithinXDays": "À téléchargez d'ici {{daysLeft}} jours",
-      "confirmWithinXDays": "À autoriser pour supression d’ici {{daysLeft}} jours",
+      "confirmWithinXDays": "À approuver pour supression d’ici {{daysLeft}} jours",
       "removeWithinXDays": "Sera supprimée de manière permanente dans {{daysLeft}} jours",
       "overdue": "En retard",
       "wontRemove": "Ne peut pas être supprimée",
@@ -95,7 +95,7 @@
     },
     "notifications": {
       "downloadComplete": "Réponses déplacées vers « Téléchargements »",
-      "downloadCompleteNew": "Prochaine étape : Autorisez la suppression des réponses de Formulaires GC",
+      "downloadCompleteNew": "Prochaine étape : Approuvez la suppression des réponses de Formulaires GC",
       "downloadingXFiles": "Téléchargement de {{fileCount}} fichiers"
     },
     "errors": {
@@ -144,12 +144,12 @@
       "deleteConfirmationString": "SUPPRIMER"
     },
     "confirmReceiptDialog": {
-      "title": "Autoriser la suppression des réponses de Formulaires GC",
+      "title": "Approuver la suppression des réponses de Formulaires GC",
       "contentHeading": "Formulaires GC doit vérifier que les réponses ont bien été téléchargées.",
       "contentBody": "Pourquoi? Parce que les choses peuvent mal tourner lorsque des fichiers numériques passent d’un ordinateur à un autre. Formulaires GC ne supprimera pas de réponses de la base de données sans avoir vérifié que les fichiers ont été téléchargés en toute sécurité sur votre ordinateur.",
       "copyCode": "Collez les codes de réception du Reçu et registre officiel des réponses pour confirmer que vous avez bien reçu les réponses.",
       "copyCodeNote": "Utilisez le bouton « Copier les codes de réception » en haut du fichier de reçu HTML.",
-      "confirmReceipt": "Autoriser la suppression de réponses",
+      "confirmReceipt": "Approuver la suppression de réponses",
       "errors": {
         "minEntries": {
           "title": "Au moins une réponse doit être spécifiée",

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -130,7 +130,6 @@
       "json": "JSON",
       "jsonDescription": "Pour API ou configuration des données",
       "downloadAllAsZip": "Télécharger tout sous forme de fichier ZIP (compressé)",
-      "mayNotBeAvailable": "Pourrait ne pas être disponible dans certains ministères ou organismes",
       "cancel": "Annuler",
       "download": "Télécharger"
     },

--- a/public/static/locales/fr/my-forms.json
+++ b/public/static/locales/fr/my-forms.json
@@ -46,7 +46,7 @@
     }
   },
   "responseTemplate": {
-    "responseNumber": "Numéro de réponse",
+    "responseNumber": "Identifiant de soumission",
     "submissionDate": "Date de soumission",
     "errorNoQuestionsAnswers": "Aucune question ou réponse n'a été trouvée.",
     "jumpTo": "Passer à :",
@@ -60,7 +60,7 @@
     "copyCodeClipboard": "Copier le code dans le presse-papiers",
     "copiedToCipboard": "Copié dans le presse-papiers",
     "errorrCopyingToClipboard": "Erreur lors de la copie dans le presse-papiers",
-    "submissionID": "Identifiant de la soumission",
+    "submissionID": "Identifiant de soumission",
     "copyResponse": "Copier la ligne de réponse dans le presse-papiers"
   },
   "responseAggregatedTemplate": {

--- a/public/static/locales/fr/my-forms.json
+++ b/public/static/locales/fr/my-forms.json
@@ -68,7 +68,7 @@
     "officialReceipt": "Reçu et registre officiel des réponses",
     "responsesDownloaded": "réponses téléchargées :",
     "needToVerify": "Vous aurez besoin de ce reçu pour vérifier que toutes les réponses sont bien passées de Formulaires GC à votre ordinateur.",
-    "useTheCopy": "Utilisez le bouton « Copier les codes de réception » pour copier et coller tous les codes, autorisant ainsi la suppression des réponses de Formulaires GC. Cela nous permet de savoir que les réponses ont bien été transférées sur votre ordinateur.",
+    "useTheCopy": "Utilisez le bouton « Copier les codes de réception » pour approuver la suppression des réponses de Formulaires GC.",
     "copyCodes": {
       "title":"Autoriser la suppression de réponses de Formulaires GC",
       "description": "Une fois que vous aurez vérifié les réponses téléchargées et que vous êtes prêt à les supprimer de Formulaires GC, copiez et collez les codes de réception. Cela nous permet de savoir quand les réponses vous ont été transférées et d’enlever les données de notre système.",

--- a/public/static/locales/fr/my-forms.json
+++ b/public/static/locales/fr/my-forms.json
@@ -70,7 +70,7 @@
     "needToVerify": "Vous aurez besoin de ce reçu pour vérifier que toutes les réponses sont bien passées de Formulaires GC à votre ordinateur.",
     "useTheCopy": "Utilisez le bouton « Copier les codes de réception » pour approuver la suppression des réponses de Formulaires GC.",
     "copyCodes": {
-      "title":"Autoriser la suppression de réponses de Formulaires GC",
+      "title":"Approuver la suppression de réponses de Formulaires GC",
       "description": "Une fois que vous aurez vérifié les réponses téléchargées et que vous êtes prêt à les supprimer de Formulaires GC, copiez et collez les codes de réception. Cela nous permet de savoir quand les réponses vous ont été transférées et d’enlever les données de notre système.",
       "copyButton": "Copier les codes de réception"
     },


### PR DESCRIPTION
## Remove unhelpful hint that zip may not be available 
- Fixes #2929 
- Fixes #2964 

## Tighten copy that was long or redundant
- Fixes #2968
- Fixes #2956 
- Fixes #2957 

## Bring more consistency to the terms we use
- Fixes #2965
- Fixes #2947 
- Fixes #2970 