### PR TITLE
(fix) Close DownloadDialog on error

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -162,6 +162,7 @@ export const DownloadDialog = ({
     } catch (err) {
       logMessage.error(err as Error);
       setDownloadError(true);
+      handleClose();
     }
   };
 


### PR DESCRIPTION
# Summary | Résumé

Fixes #2922 
When there is an error while downloading, an error is bubbled up to the DownloadTable and rendered there, but the Dialog remains open covering the error message.

This PR closes the dialog on error after setting the error state.
