### PR TITLE
Adds GMT time format function for receipt

### DIFF
--- a/components/form-builder/util.ts
+++ b/components/form-builder/util.ts
@@ -183,6 +183,35 @@ export const formatDateTimeLong = (updatedAt: number | undefined, locale = "en-C
   return date.toLocaleDateString(locale, options);
 };
 
+// Note: GMT = UTC as far as date-time is concerned
+export const formatDateTimeGMT = (updatedAt: number | undefined) => {
+  function formatHours(hours: number) {
+    return ((hours % 12 || 12) < 10 ? "0" : "") + (hours % 12 || 12);
+  }
+
+  function formatAmOrPm(hours: number) {
+    return hours < 12 ? "AM" : "PM";
+  }
+
+  function maybePrefixZero(timeNumber: number | string) {
+    return String(timeNumber).length < 2 ? `0${timeNumber}` : timeNumber;
+  }
+
+  const date = new Date(updatedAt || 0);
+
+  const year = date.getUTCFullYear();
+  const month = maybePrefixZero(date.getUTCMonth());
+  const day = maybePrefixZero(date.getUTCDate());
+  const hour = maybePrefixZero(formatHours(date.getUTCHours()));
+  const minute = maybePrefixZero(date.getUTCMinutes());
+  const amOrPm = formatAmOrPm(date.getUTCHours());
+
+  const yearMonthDay = `${year}-${month}-${day}`;
+  const time = `${hour}:${minute} ${amOrPm}`;
+
+  return [yearMonthDay, time, "GMT"];
+};
+
 export const autoCompleteFields = [
   "name",
   "given-name",

--- a/lib/responseDownloadFormats/html-aggregated/components/ResponseHTMLAggregated.tsx
+++ b/lib/responseDownloadFormats/html-aggregated/components/ResponseHTMLAggregated.tsx
@@ -14,7 +14,7 @@ import { copyCodeToClipboardScript } from "../scripts";
 import { TableHeader } from "./AggregatedTable";
 import { CopyCodes } from "./CopyCodes";
 import { ProtectedLevel } from "./ProtectedLevel";
-import { formatDateTime } from "@components/form-builder/util";
+import { formatDateTimeGMT } from "@components/form-builder/util";
 
 interface HTMLDownloadProps {
   lang: string;
@@ -27,7 +27,7 @@ export const ResponseHtmlAggregated = ({
 }: HTMLDownloadProps) => {
   const { t } = customTranslate("my-forms");
   const form = formResponseSubmissions.form;
-  const [yearMonthDay, time] = formatDateTime(Date.now());
+  const [yearMonthDay, time, timeZone] = formatDateTimeGMT(Date.now());
 
   // Newline deliniated will work to paste multiple codes in the confirmation dialog.
   // Note: The "\r\n" delimiter may be OS dependent. If so use an actual newline with .join(`
@@ -93,9 +93,10 @@ export const ResponseHtmlAggregated = ({
                 <ProtectedLevel securityAttribute={form.securityAttribute} lang={lang} />
               </div>
               <p className="mb-4">
-                <strong>{submissions.length}</strong>{" "}
-                {t("responseAggregatedTemplate.responsesDownloaded", { lng: lang })} {yearMonthDay}{" "}
-                {time}
+                <strong>{submissions.length}</strong>
+                {` ${t("responseAggregatedTemplate.responsesDownloaded", {
+                  lng: lang,
+                })} ${yearMonthDay} ${time} ${timeZone}`}
               </p>
               <p className="mb-4">{t("responseAggregatedTemplate.needToVerify", { lng: lang })}</p>
               <p className="mb-8">{t("responseAggregatedTemplate.useTheCopy", { lng: lang })}</p>


### PR DESCRIPTION
# Summary | Résumé

Sets the receipt date-time in GMT (UTC). 

![Screenshot 2023-11-30 at 2 32 59 PM](https://github.com/cds-snc/platform-forms-client/assets/107579368/349038ed-f99e-40cc-bac5-847d9aaa45f4)
