### PR TITLE
fix: Download receipt first

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -97,7 +97,7 @@ export const DownloadDialog = ({
         });
 
         const zip = new JSZip();
-        zip.file("receipt-recu.html", response.data.receipt);
+        zip.file("_receipt-recu.html", response.data.receipt);
 
         response.data.responses.forEach((response: { id: string; html: string }) => {
           zip.file(`${response.id}.html`, response.html);
@@ -162,11 +162,11 @@ export const DownloadDialog = ({
             handleDownloadComplete();
           });
         } else {
+          downloadFileFromBlob(new Blob([response.data.receipt]), `${filePrefix}receipt-recu.html`);
           downloadFileFromBlob(
             new Blob([JSON.stringify(response.data.responses)], { type: "application/json" }),
             `${filePrefix}responses-reponses.json`
           );
-          downloadFileFromBlob(new Blob([response.data.receipt]), `${filePrefix}receipt-recu.html`);
 
           handleDownloadComplete();
         }

--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -50,8 +50,6 @@ export const DownloadDialog = ({
   };
 
   const handleDownloadComplete = () => {
-    setSelectedFormat(defaultSelectedFormat);
-    setZipAllFiles(true);
     setIsDownloading(false);
     onSuccessfulDownload();
     handleClose();


### PR DESCRIPTION
# Summary | Résumé

Fixes #2933 
When downloading the Individual HTML Files with receipt, add a `_` prefix to the receipt filename so it appears at the top of the downloaded files.

When downloading CSV or JSON formats, ensure the receipt is delivered first, in case the multiple-file-download fails.