### PR TITLE
feat: Log GA event when downloading to record selected format

### DIFF
--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -67,17 +67,16 @@ export const DownloadDialog = ({
   };
 
   const downloadFormatEvent = (
-    formId: string,
+    formID: string,
     downloadType: DownloadFormat,
     numberOfRecords: number
   ) => {
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({
       event: "download_format",
-      formId,
+      formID,
       downloadType,
       numberOfRecords,
-      timestamp: getDate(true),
     });
   };
 

--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -66,6 +66,21 @@ export const DownloadDialog = ({
     window.URL.revokeObjectURL(href);
   };
 
+  const downloadFormatEvent = (
+    formId: string,
+    downloadType: DownloadFormat,
+    numberOfRecords: number
+  ) => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: "download_format",
+      formId,
+      downloadType,
+      numberOfRecords,
+      time: getDate(true),
+    });
+  };
+
   // Note: The API can provide additional formats, see DownloadFormat enum and update this array if needed
   const availableFormats = [DownloadFormat.CSV, DownloadFormat.JSON, DownloadFormat.HTML_ZIPPED];
 
@@ -97,6 +112,8 @@ export const DownloadDialog = ({
           },
         });
 
+        downloadFormatEvent(formId, selectedFormat, ids.length);
+
         const zip = new JSZip();
         zip.file("_receipt-recu.html", response.data.receipt);
 
@@ -120,6 +137,8 @@ export const DownloadDialog = ({
             ids: ids.join(","),
           },
         });
+
+        downloadFormatEvent(formId, selectedFormat, ids.length);
 
         if (zipAllFiles) {
           const file = new JSZip();
@@ -151,6 +170,8 @@ export const DownloadDialog = ({
             ids: ids.join(","),
           },
         });
+
+        downloadFormatEvent(formId, selectedFormat, ids.length);
 
         if (zipAllFiles) {
           const file = new JSZip();

--- a/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
+++ b/components/form-builder/app/responses/Dialogs/DownloadDialog.tsx
@@ -77,7 +77,7 @@ export const DownloadDialog = ({
       formId,
       downloadType,
       numberOfRecords,
-      time: getDate(true),
+      timestamp: getDate(true),
     });
   };
 


### PR DESCRIPTION
# Summary | Résumé

Adds a GA logging event when downloading to log the selected format, form id, number of records, and a timestamp.
