### PR TITLE
Replace placholder text (dd) with the Form Title

### DIFF
--- a/lib/responseDownloadFormats/html/components/ResponseHtml.tsx
+++ b/lib/responseDownloadFormats/html/components/ResponseHtml.tsx
@@ -46,6 +46,7 @@ export const ResponseHtml = ({
             <Fip language="en" />
             <div className="mt-14" />
             <ResponseSection
+              form={form}
               confirmReceiptCode={confirmationCode}
               lang={"en"}
               responseID={responseID}
@@ -58,6 +59,7 @@ export const ResponseHtml = ({
               <Fip language="fr" />
               <div className="mt-14" />
               <ResponseSection
+                form={form}
                 confirmReceiptCode={confirmationCode}
                 lang={"fr"}
                 responseID={responseID}

--- a/lib/responseDownloadFormats/html/components/ResponseSection.tsx
+++ b/lib/responseDownloadFormats/html/components/ResponseSection.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Submission } from "../../types";
+import { Form, Submission } from "../../types";
 import { ColumnTable } from "./ColumnTable";
 import { RowTable } from "./RowTable";
 import { customTranslate } from "@lib/responseDownloadFormats/helpers";
+import { getProperty } from "@lib/formBuilder";
 
 export interface ResponseSectionProps {
   confirmReceiptCode: string;
@@ -10,6 +11,7 @@ export interface ResponseSectionProps {
   responseID: string;
   submissionDate: number;
   formResponse: Submission;
+  form: Form;
 }
 
 export function capitalize(string: string) {
@@ -22,6 +24,7 @@ export const ResponseSection = ({
   responseID,
   submissionDate,
   formResponse,
+  form,
 }: ResponseSectionProps) => {
   const { t } = customTranslate("my-forms");
 
@@ -116,7 +119,7 @@ export const ResponseSection = ({
         </ul>
       </nav>
 
-      <h2 className="gc-h1 mt-20">dd</h2>
+      <h2 className="gc-h1 mt-20">{String(form[getProperty("title", lang)])}</h2>
       <h3 id={`columnTable${capitalizedLang}`} className="gc-h2 mt-20" tabIndex={-1}>
         {t("responseTemplate.columnTable", { lng: lang })}
       </h3>


### PR DESCRIPTION
# Summary | Résumé

See #2958 
There was some placeholder text on the individual HTML file rendering leftover from the initial refactor.
