### PR TITLE
Updates responses table warning to be contextual

### DIFF
--- a/components/form-builder/app/responses/DownloadTable.tsx
+++ b/components/form-builder/app/responses/DownloadTable.tsx
@@ -160,14 +160,44 @@ export const DownloadTable = ({
                 <td className="px-4 py-2" colSpan={4}>
                   <p>
                     <strong>
-                      {t("downloadResponsesTable.errors.remainingResponses", {
-                        max: responseDownloadLimit,
-                      })}
+                      {isStatus(statusQuery, VaultStatus.NEW) &&
+                        t("downloadResponsesTable.errors.responsesState.new.remainingResponses", {
+                          max: responseDownloadLimit,
+                        })}
+                      {isStatus(statusQuery, VaultStatus.DOWNLOADED) &&
+                        t(
+                          "downloadResponsesTable.errors.responsesState.downloaded.remainingResponses",
+                          {
+                            max: responseDownloadLimit,
+                          }
+                        )}
+                      {isStatus(statusQuery, VaultStatus.CONFIRMED) &&
+                        t(
+                          "downloadResponsesTable.errors.responsesState.confirmed.remainingResponses",
+                          {
+                            max: responseDownloadLimit,
+                          }
+                        )}
                     </strong>
                     <br />
-                    {t("downloadResponsesTable.errors.remainingResponsesBody", {
-                      max: responseDownloadLimit,
-                    })}
+                    {isStatus(statusQuery, VaultStatus.NEW) &&
+                      t("downloadResponsesTable.errors.responsesState.new.remainingResponsesBody", {
+                        max: responseDownloadLimit,
+                      })}
+                    {isStatus(statusQuery, VaultStatus.DOWNLOADED) &&
+                      t(
+                        "downloadResponsesTable.errors.responsesState.downloaded.remainingResponsesBody",
+                        {
+                          max: responseDownloadLimit,
+                        }
+                      )}
+                    {isStatus(statusQuery, VaultStatus.CONFIRMED) &&
+                      t(
+                        "downloadResponsesTable.errors.responsesState.confirmed.remainingResponsesBody",
+                        {
+                          max: responseDownloadLimit,
+                        }
+                      )}
                   </p>
                 </td>
               </tr>

--- a/public/static/locales/en/form-builder-responses.json
+++ b/public/static/locales/en/form-builder-responses.json
@@ -119,8 +119,20 @@
       "errorDownloadingFilesHeader": "Error downloading the selected files.",
       "errorDownloadingFiles": "Try again in a few minutes. If the problem persists, ",
       "errorDownloadingFilesLink": "contact Support",
-      "remainingResponses": "You have over {{max}} responses available.",
-      "remainingResponsesBody": "Showing 1-{{max}}. More will load as displayed responses are downloaded.",
+      "responsesState": {
+        "new": {
+          "remainingResponses": "You have over {{max}} responses available.",
+          "remainingResponsesBody": "Showing 1-{{max}}. More will load as displayed responses are downloaded."
+        },
+        "downloaded": {
+          "remainingResponses": "You have over {{max}} downloaded responses.",
+          "remainingResponsesBody": "Showing 1-{{max}}. More will load as responses are signed off for removal."
+        },
+        "confirmed": {
+          "remainingResponses": "You have over {{max}} responses waiting to be removed.",
+          "remainingResponsesBody": "Showing the latest {{max}}. If you need access to responses not displayed contact Support."
+        }
+      },
       "overdueAlert": {
         "title": "Access to new responses is restricted until overdue responses are retrieved.",
         "description": "There are {{numberOfOverdueResponses}} responses that are {{escalatedAfter}} days old. Download and sign off on the removal of overdue responses to remove this restriction."

--- a/public/static/locales/fr/form-builder-responses.json
+++ b/public/static/locales/fr/form-builder-responses.json
@@ -118,8 +118,20 @@
       "errorDownloadingFilesHeader": "Erreur lors du téléchargement des fichiers sélectionnés.",
       "errorDownloadingFiles": "Réessayez dans quelques minutes. Si le problème persiste, ",
       "errorDownloadingFilesLink": "contactez Soutien",
-      "remainingResponses": "Vous avez plus de {{max}} nouvelles réponses disponibles.",
-      "remainingResponsesBody": "Affichage de 1 à {{max}}. D'autres seront ajoutées au fur et à mesure que celles-ci seront téléchargées.",
+      "responsesState": {
+        "new": {
+          "remainingResponses": "Vous avez plus de {{max}} nouvelles réponses.",
+          "remainingResponsesBody": "Affichage de 1 à {{max}}. D'autres s'ajouteront au fur et à mesure qu'elles seront téléchargées."
+        },
+        "downloaded": {
+          "remainingResponses": "Vous avez plus de {{max}} réponses téléchargées.",
+          "remainingResponsesBody": "Affichage de 1 à {{max}}. D'autres s'ajouteront au fur et à mesure que celles-ci seront approuvées pour suppression."
+        },
+        "confirmed": {
+          "remainingResponses": "Vous avez plus de {{max}} réponses téléchargées.",
+          "remainingResponsesBody": "Affichage des dernières {{max}}. Si vous avez besoin d'accéder à des réponses qui ne sont pas affichées, contactez l'équipe de soutien."
+        }
+      },
       "overdueAlert": {
         "title": "L'accès aux nouvelles réponses est restreint jusqu'à ce que les réponses en retard soient extraites.",
         "description": "Il y a {{numberOfOverdueResponses}} réponses qui datent de {{escalatedAfter}} jours. Téléchargez et approuvez la suppression des réponses en retard pour enlever cette restriction."


### PR DESCRIPTION
# Summary | Résumé

Updates Download Table warning messages to be contextual by tab state.