### PR TITLE
fix: Download ensure questions/answers are sorted according to form.layout

### DIFF
--- a/lib/responseDownloadFormats/types.ts
+++ b/lib/responseDownloadFormats/types.ts
@@ -1,10 +1,11 @@
 import { SecurityAttribute } from "@lib/types";
 
 export interface Answer {
+  questionId: number;
   questionEn: string | undefined;
   questionFr: string | undefined;
   answer: string | Array<Answer[]>;
-  [key: string]: string | Array<Answer[]> | undefined;
+  [key: string]: string | number | Array<Answer[]> | undefined;
 }
 
 export interface Submission {

--- a/pages/api/id/[form]/submission/download.ts
+++ b/pages/api/id/[form]/submission/download.ts
@@ -19,9 +19,7 @@ import { logMessage } from "@lib/logger";
 import { getAppSetting } from "@lib/appSettings";
 
 const sortByLayout = ({ layout, elements }: { layout: number[]; elements: Answer[] }) => {
-  return elements.sort((a, b) => {
-    return layout.indexOf(a.questionId) - layout.indexOf(b.questionId);
-  });
+  return elements.sort((a, b) => layout.indexOf(a.questionId) - layout.indexOf(b.questionId));
 };
 
 const logDownload = async (

--- a/pages/api/id/[form]/submission/download.ts
+++ b/pages/api/id/[form]/submission/download.ts
@@ -9,10 +9,20 @@ import { transform as htmlTransform } from "@lib/responseDownloadFormats/html";
 import { transform as zipTransform } from "@lib/responseDownloadFormats/html-zipped";
 import { transform as jsonTransform } from "@lib/responseDownloadFormats/json";
 import { retrieveSubmissions, updateLastDownloadedBy } from "@lib/vault";
-import { DownloadFormat, FormResponseSubmissions } from "@lib/responseDownloadFormats/types";
+import {
+  Answer,
+  DownloadFormat,
+  FormResponseSubmissions,
+} from "@lib/responseDownloadFormats/types";
 import { logEvent } from "@lib/auditLogs";
 import { logMessage } from "@lib/logger";
 import { getAppSetting } from "@lib/appSettings";
+
+const sortByLayout = ({ layout, elements }: { layout: number[]; elements: Answer[] }) => {
+  return elements.sort((a, b) => {
+    return layout.indexOf(a.questionId) - layout.indexOf(b.questionId);
+  });
+};
 
 const logDownload = async (
   responseIdStatusArray: { id: string; status: string }[],
@@ -70,7 +80,6 @@ const getSubmissions = async (
     // most sense to use the form submission language vs sesion/*. If not, the output could have
     // e.g. French questions and English answers etc.
     const lang = req.query?.lang === "fr" ? "fr" : "en";
-    logMessage.info("lang: " + lang);
 
     const queryResult = await retrieveSubmissions(ability, formId, ids);
 
@@ -87,6 +96,7 @@ const getSubmissions = async (
 
           if (question?.type === FormElementTypes.dynamicRow && answer instanceof Array) {
             return {
+              questionId: question.id,
               type: question?.type,
               questionEn: question?.properties.titleEn,
               questionFr: question?.properties.titleFr,
@@ -94,6 +104,7 @@ const getSubmissions = async (
                 return Object.values(item).map((value, index) => {
                   if (question?.properties.subElements) {
                     return {
+                      questionId: question?.id,
                       type: question?.properties.subElements[index].type,
                       questionEn: question?.properties.subElements[index].properties.titleEn,
                       questionFr: question?.properties.subElements[index].properties.titleFr,
@@ -102,22 +113,24 @@ const getSubmissions = async (
                   }
                 });
               }),
-            };
+            } as Answer;
           }
 
           return {
+            questionId: question?.id,
             type: question?.type,
             questionEn: question?.properties.titleEn,
             questionFr: question?.properties.titleFr,
             answer: question?.type === "checkbox" ? Array(answer).join(", ") : answer,
-          };
+          } as Answer;
         }
       );
+      const sorted = sortByLayout({ layout: fullFormTemplate.form.layout, elements: submission });
       return {
         id: item.name,
         createdAt: parseInt(item.createdAt.toString()),
         confirmationCode: item.confirmationCode,
-        answers: submission,
+        answers: sorted,
       };
     }) as FormResponseSubmissions["submissions"];
 


### PR DESCRIPTION
# Summary | Résumé

Sorts questions/answers according to the form.layout array before downloading.

## To test
- Create a form with multiple inputs and use the Move up/down functions to re-order the questions.
- Create one or more responses
- Download responses in any format
- See that the questions/answers are sorted according to the sort order you set

Previously, doing these same steps, the questions/answers would be sorted by the order they were added, regardless of the layout array.
