### PR TITLE
feat: Render Responses page navigation as tabs

### DIFF
--- a/components/form-builder/app/navigation/TabNavLink.tsx
+++ b/components/form-builder/app/navigation/TabNavLink.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import React, { ReactElement, useEffect, useState } from "react";
+import { useActivePathname } from "../../hooks/useActivePathname";
+import { cn } from "@lib/utils";
+
+export const TabNavLink = ({
+  href,
+  children,
+  setAriaCurrent = false,
+  id,
+  defaultActive = false,
+  onClick,
+}: {
+  children: ReactElement;
+  href: string;
+  setAriaCurrent?: boolean;
+  id?: string;
+  defaultActive?: boolean;
+  onClick?: () => void;
+}) => {
+  const baseClasses =
+    "mr-3 rounded-t-[20px] border-x border-t border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
+
+  const inactiveClasses =
+    "!text-black hover:bg-gray-600 hover:!text-white-default focus:!text-white [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white";
+  const activeClasses =
+    "bg-[#475569] !text-white [&_svg]:fill-white ${svgStroke} focus:text-white [&_svg]:focus:stroke-white";
+
+  const { asPath, isReady, activePathname } = useActivePathname();
+  const [active, setActive] = useState(defaultActive);
+
+  useEffect(() => {
+    // Check if the router fields are updated client-side
+    if (isReady) {
+      let linkPathname = new URL(href as string, location.href).pathname;
+
+      const langRegex = /\/(en|fr)\//;
+      linkPathname = linkPathname.replace(langRegex, "/");
+
+      // Only one nav link can be active at a time
+      if (linkPathname === activePathname) {
+        setActive(true);
+      } else {
+        if (!defaultActive) {
+          setActive(false);
+        }
+      }
+    }
+  }, [asPath, isReady, href, setActive, activePathname, defaultActive]);
+
+  return (
+    <Link href={href} legacyBehavior>
+      <a
+        href={href}
+        className={cn(baseClasses, inactiveClasses, active && activeClasses)}
+        {...(setAriaCurrent && active && { "aria-current": "page" })}
+        {...(id && { id })}
+        onClick={onClick}
+      >
+        {children}
+      </a>
+    </Link>
+  );
+};

--- a/components/form-builder/app/navigation/TabNavLink.tsx
+++ b/components/form-builder/app/navigation/TabNavLink.tsx
@@ -19,7 +19,7 @@ export const TabNavLink = ({
   onClick?: () => void;
 }) => {
   const baseClasses =
-    "mr-3 rounded-t-[20px] border-x border-t border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
+    "mr-3 rounded-t-[25px] border-x border-t border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
 
   const inactiveClasses =
     "!text-black hover:bg-gray-600 hover:!text-white-default focus:!text-white [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white";

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -25,7 +25,6 @@ import { Button } from "@components/globals";
 import { ClosedBanner } from "@components/form-builder/app/shared/ClosedBanner";
 import { getAppSetting } from "@lib/appSettings";
 import { DeleteIcon, FolderIcon, InboxIcon, WarningIcon } from "@components/form-builder/icons";
-import { SubNavLink } from "@components/form-builder/app/navigation/SubNavLink";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import { ConfirmDialog } from "@components/form-builder/app/responses/Dialogs/ConfirmDialog";

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -31,6 +31,7 @@ import Image from "next/image";
 import { ConfirmDialog } from "@components/form-builder/app/responses/Dialogs/ConfirmDialog";
 import { Alert } from "@components/globals";
 import { isStatus, ucfirst } from "@lib/clientHelpers";
+import { TabNavLink } from "@components/form-builder/app/navigation/TabNavLink";
 
 interface ResponsesProps {
   initialForm: FormRecord | null;
@@ -136,8 +137,11 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         </h1>
       )}
 
-      <nav className="relative mb-4 flex" aria-label={t("responses.navLabel")}>
-        <SubNavLink
+      <nav
+        className="relative mb-4 flex border-b border-black"
+        aria-label={t("responses.navLabel")}
+      >
+        <TabNavLink
           id="new-responses"
           defaultActive={statusQuery === "new"}
           href={`/form-builder/responses/${formId}/new`}
@@ -147,8 +151,8 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           <span className="text-sm laptop:text-base">
             <InboxIcon className="inline-block h-7 w-7" /> {t("responses.status.new")}
           </span>
-        </SubNavLink>
-        <SubNavLink
+        </TabNavLink>
+        <TabNavLink
           id="downloaded-responses"
           href={`/form-builder/responses/${formId}/downloaded`}
           setAriaCurrent={true}
@@ -157,8 +161,8 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           <span className="text-sm laptop:text-base">
             <FolderIcon className="inline-block h-7 w-7" /> {t("responses.status.downloaded")}
           </span>
-        </SubNavLink>
-        <SubNavLink
+        </TabNavLink>
+        <TabNavLink
           id="deleted-responses"
           href={`/form-builder/responses/${formId}/confirmed`}
           setAriaCurrent={true}
@@ -167,7 +171,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           <span className="text-sm laptop:text-base">
             <DeleteIcon className="inline-block h-7 w-7" /> {t("responses.status.deleted")}
           </span>
-        </SubNavLink>
+        </TabNavLink>
       </nav>
 
       {isAuthenticated && vaultSubmissions.length > 0 && (

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -138,7 +138,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
       )}
 
       <nav
-        className="relative mb-4 flex border-b border-black"
+        className="relative mb-10 flex border-b border-black"
         aria-label={t("responses.navLabel")}
       >
         <TabNavLink


### PR DESCRIPTION
# Summary | Résumé

Updates the styling of the navigation on the Responses page to appear more like tabs.

<img width="1390" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/a79fdfa1-323f-4409-970d-ab8ff7f8c4f8">
