### PR TITLE
Adds initial tabs semantics

### DIFF
--- a/components/form-builder/app/navigation/TabNavLink.tsx
+++ b/components/form-builder/app/navigation/TabNavLink.tsx
@@ -10,6 +10,7 @@ export const TabNavLink = ({
   id,
   defaultActive = false,
   onClick,
+  controlsId,
 }: {
   children: ReactElement;
   href: string;
@@ -17,6 +18,7 @@ export const TabNavLink = ({
   id?: string;
   defaultActive?: boolean;
   onClick?: () => void;
+  controlsId: string;
 }) => {
   const baseClasses =
     "mr-3 rounded-t-[25px] border-x border-t border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
@@ -49,13 +51,19 @@ export const TabNavLink = ({
   }, [asPath, isReady, href, setActive, activePathname, defaultActive]);
 
   return (
+    // TODO in the future if we switch to dynamic content updates on tab activation, this probably
+    // makes more sense as a button
     <Link href={href} legacyBehavior>
       <a
         href={href}
         className={cn(baseClasses, inactiveClasses, active && activeClasses)}
-        {...(setAriaCurrent && active && { "aria-current": "page" })}
+        // TODO
+        {...(setAriaCurrent && active && { "aria-current": "page" })} // TODO
         {...(id && { id })}
         onClick={onClick}
+        role="tab"
+        aria-selected={active ? "true" : "false"}
+        aria-controls={controlsId}
       >
         {children}
       </a>

--- a/pages/form-builder/responses/[[...params]].tsx
+++ b/pages/form-builder/responses/[[...params]].tsx
@@ -136,9 +136,10 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
         </h1>
       )}
 
-      <nav
+      <div
         className="relative mb-10 flex border-b border-black"
         aria-label={t("responses.navLabel")}
+        role="tablist"
       >
         <TabNavLink
           id="new-responses"
@@ -146,6 +147,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           href={`/form-builder/responses/${formId}/new`}
           setAriaCurrent={true}
           onClick={() => setShowSuccessAlert(false)}
+          controlsId="tab-new"
         >
           <span className="text-sm laptop:text-base">
             <InboxIcon className="inline-block h-7 w-7" /> {t("responses.status.new")}
@@ -156,6 +158,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           href={`/form-builder/responses/${formId}/downloaded`}
           setAriaCurrent={true}
           onClick={() => setShowSuccessAlert(false)}
+          controlsId="tab-downloaded"
         >
           <span className="text-sm laptop:text-base">
             <FolderIcon className="inline-block h-7 w-7" /> {t("responses.status.downloaded")}
@@ -166,70 +169,180 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
           href={`/form-builder/responses/${formId}/confirmed`}
           setAriaCurrent={true}
           onClick={() => setShowSuccessAlert(false)}
+          controlsId="tab-confirmed"
         >
           <span className="text-sm laptop:text-base">
             <DeleteIcon className="inline-block h-7 w-7" /> {t("responses.status.deleted")}
           </span>
         </TabNavLink>
-      </nav>
+      </div>
 
-      {isAuthenticated && vaultSubmissions.length > 0 && (
-        <>
-          {isStatus(statusQuery, VaultStatus.NEW) && (
-            <>
-              <h1>{t("tabs.newResponses.title")}</h1>
-              <div className="mb-4">
-                <p className="mb-4">
-                  <strong>{t("tabs.newResponses.message1")}</strong>
-                  <br />
-                  {t("tabs.newResponses.message2")}
-                </p>
-              </div>
-            </>
-          )}
-          {isStatus(statusQuery, VaultStatus.DOWNLOADED) && (
-            <>
-              <h1>{t("tabs.downloadedResponses.title")}</h1>
-              <div className="mb-4">
-                <p className="mb-4">
-                  <strong>{t("tabs.downloadedResponses.message1")}</strong>
-                  <br />
-                  {t("tabs.downloadedResponses.message2")}
-                </p>
-                <Button onClick={() => setShowConfirmReceiptDialog(true)} theme="secondary">
-                  {t("responses.confirmReceipt")}
-                </Button>
-              </div>
-            </>
-          )}
-          {isStatus(statusQuery, VaultStatus.CONFIRMED) && (
-            <>
-              <h1>{t("tabs.confirmedResponses.title")}</h1>
-              <div className="mb-4">
-                <p className="mb-4">
-                  <strong>{t("tabs.confirmedResponses.message1")}</strong>
-                  <br />
-                  {t("tabs.confirmedResponses.message2")}
-                </p>
-              </div>
-            </>
-          )}
-          {isStatus(statusQuery, VaultStatus.PROBLEM) && (
-            <>
-              <h1>{t("tabs.problemResponses.title")}</h1>
-              <div className="mb-4">
-                <p className="mb-4">
-                  <strong>{t("tabs.problemResponses.message1")}</strong>
-                  <br />
-                  {t("tabs.problemResponses.message2")}
-                </p>
-                <Button onClick={() => setShowConfirmReceiptDialog(true)} theme="secondary">
-                  {t("responses.confirmReceipt")}
-                </Button>
-              </div>
-            </>
-          )}
-        </>
+      {isAuthenticated && (
+        <div id="tabs">
+          <div
+            role="tabpanel"
+            id="tab-new"
+            className={isStatus(statusQuery, VaultStatus.NEW) ? "" : "hidden"}
+          >
+            {vaultSubmissions.length > 0 && (
+              <>
+                <h1>{t("tabs.newResponses.title")}</h1>
+                <div className="mb-4">
+                  <p className="mb-4">
+                    <strong>{t("tabs.newResponses.message1")}</strong>
+                    <br />
+                    {t("tabs.newResponses.message2")}
+                  </p>
+                </div>
+                <DownloadTable
+                  vaultSubmissions={vaultSubmissions}
+                  formName={formName}
+                  formId={formId}
+                  nagwareResult={nagwareResult}
+                  responseDownloadLimit={responseDownloadLimit}
+                  responsesRemaining={responsesRemaining}
+                  showDownloadSuccess={successAlertMessage}
+                  setShowDownloadSuccess={setShowSuccessAlert}
+                />
+              </>
+            )}
+            {vaultSubmissions.length <= 0 && (
+              <Card
+                icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                title={t("downloadResponsesTable.card.noNewResponses")}
+                content={t("downloadResponsesTable.card.noNewResponsesMessage")}
+                headingTag={HeadingLevel.H1}
+                headingStyle="gc-h2 text-[#748094]"
+              />
+            )}
+          </div>
+
+          <div
+            role="tabpanel"
+            id="tab-downloaded"
+            className={isStatus(statusQuery, VaultStatus.DOWNLOADED) ? "" : "hidden"}
+          >
+            {vaultSubmissions.length > 0 && (
+              <>
+                <h1>{t("tabs.downloadedResponses.title")}</h1>
+                <div className="mb-4">
+                  <p className="mb-4">
+                    <strong>{t("tabs.downloadedResponses.message1")}</strong>
+                    <br />
+                    {t("tabs.downloadedResponses.message2")}
+                  </p>
+                  <Button onClick={() => setShowConfirmReceiptDialog(true)} theme="secondary">
+                    {t("responses.confirmReceipt")}
+                  </Button>
+                </div>
+                <DownloadTable
+                  vaultSubmissions={vaultSubmissions}
+                  formName={formName}
+                  formId={formId}
+                  nagwareResult={nagwareResult}
+                  responseDownloadLimit={responseDownloadLimit}
+                  responsesRemaining={responsesRemaining}
+                  showDownloadSuccess={successAlertMessage}
+                  setShowDownloadSuccess={setShowSuccessAlert}
+                />
+              </>
+            )}
+            {vaultSubmissions.length <= 0 && (
+              <>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noDownloadedResponses")}
+                  content={t("downloadResponsesTable.card.noDownloadedResponsesMessage")}
+                  headingTag={HeadingLevel.H1}
+                  headingStyle="gc-h2 text-[#748094]"
+                />
+              </>
+            )}
+          </div>
+
+          <div
+            role="tabpanel"
+            id="tab-confirmed"
+            className={isStatus(statusQuery, VaultStatus.CONFIRMED) ? "" : "hidden"}
+          >
+            {vaultSubmissions.length > 0 && (
+              <>
+                <h1>{t("tabs.confirmedResponses.title")}</h1>
+                <div className="mb-4">
+                  <p className="mb-4">
+                    <strong>{t("tabs.confirmedResponses.message1")}</strong>
+                    <br />
+                    {t("tabs.confirmedResponses.message2")}
+                  </p>
+                </div>
+                <DownloadTable
+                  vaultSubmissions={vaultSubmissions}
+                  formName={formName}
+                  formId={formId}
+                  nagwareResult={nagwareResult}
+                  responseDownloadLimit={responseDownloadLimit}
+                  responsesRemaining={responsesRemaining}
+                  showDownloadSuccess={successAlertMessage}
+                  setShowDownloadSuccess={setShowSuccessAlert}
+                />
+              </>
+            )}
+            {vaultSubmissions.length <= 0 && (
+              <>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noDeletedResponses")}
+                  content={t("downloadResponsesTable.card.noDeletedResponsesMessage")}
+                  headingTag={HeadingLevel.H1}
+                  headingStyle="gc-h2 text-[#748094]"
+                />
+              </>
+            )}
+          </div>
+
+          <div
+            role="tabpanel"
+            id="tab-confirmed"
+            className={isStatus(statusQuery, VaultStatus.PROBLEM) ? "" : "hidden"}
+          >
+            {vaultSubmissions.length > 0 && (
+              <>
+                <h1>{t("tabs.problemResponses.title")}</h1>
+                <div className="mb-4">
+                  <p className="mb-4">
+                    <strong>{t("tabs.problemResponses.message1")}</strong>
+                    <br />
+                    {t("tabs.problemResponses.message2")}
+                  </p>
+                  <Button onClick={() => setShowConfirmReceiptDialog(true)} theme="secondary">
+                    {t("responses.confirmReceipt")}
+                  </Button>
+                </div>
+
+                <DownloadTable
+                  vaultSubmissions={vaultSubmissions}
+                  formName={formName}
+                  formId={formId}
+                  nagwareResult={nagwareResult}
+                  responseDownloadLimit={responseDownloadLimit}
+                  responsesRemaining={responsesRemaining}
+                  showDownloadSuccess={successAlertMessage}
+                  setShowDownloadSuccess={setShowSuccessAlert}
+                />
+              </>
+            )}
+            {vaultSubmissions.length <= 0 && (
+              <>
+                <h1 className="visually-hidden">{t("tabs.problemResponses.title")}</h1>
+                <Card
+                  icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+                  title={t("downloadResponsesTable.card.noProblemResponses")}
+                  content={t("downloadResponsesTable.card.noProblemResponsesMessage")}
+                />
+              </>
+            )}
+          </div>
+        </div>
       )}
 
       {successAlertMessage && (
@@ -243,7 +356,7 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
 
       {isAuthenticated && (
         <>
-          <div aria-live="polite">
+          {/* <div role="tabpanel">
             <ClosedBanner id={formId} />
             {vaultSubmissions.length > 0 && (
               <DownloadTable
@@ -304,7 +417,8 @@ const Responses: NextPageWithLayout<ResponsesProps> = ({
                 />
               </>
             )}
-          </div>
+          </div> */}
+
           <div className="mt-8">
             <Link
               onClick={() => setIsShowReportProblemsDialog(true)}


### PR DESCRIPTION
# Summary | Résumé

To break up the work for creating a reusable tabs component/pattern here is one way to break down the work:

### 1. Semantics (this PR)
This PR will be about adding the base ARIA attributes to follow the tab pattern.

### 2. Behaviour
Add the keyboard controls

### 3. Performance
Improve the loading, async or server-side. Probably start with some measurements.

### 4. Make it a pattern
Start looking at places in the app where this tabs component/pattern can be reused. Refactor the tabs as needed and updated the app