### PR TITLE
chore: with the new infra update LOCAL_LAMBDA_ENDPOINT is now replaced by LOCAL_AWS_ENDPOINT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,12 +20,12 @@ LOCAL_AWS_ENDPOINT=http://localhost:4566
 # When running locally from devcontainer to devcontainer
 # If running localstack outside of the devcontainer, replace
 # all references of host.docker.internal with localhost
-LOCAL_AWS_ENDPOINT=http://host.docker.internal:4566
+LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
+
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
 NEXTAUTH_URL=http://localhost:3000
 REDIS_URL=redis
-LOCAL_LAMBDA_ENDPOINT=http://host.docker.internal:3001
 RELIABILITY_FILE_STORAGE=forms-local-reliability-file-storage
 DATABASE_URL=postgres://postgres:chummy@db:5432/formsDB
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ REDIS_URL=localhost
 For local development of the complete solution (running SAM for local Lambdas) add the following two environment variables to your .env file and see the instructions for launching the Lambda's locally in our [Infrastructure ReadME](https://github.com/cds-snc/forms-staging-terraform)
 
 ```
-LOCAL_LAMBDA_ENDPOINT=http://127.0.0.1:3001
+LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
 DATABASE_URL=postgres://postgres:password@localhost:5432/formsDB
 ```
 
@@ -196,7 +196,7 @@ REDIS_URL=localhost
 Pour le développement local de la solution complète (exécutant SAM pour les Lambda locaux), ajoutez les deux variables d'environnement suivantes à votre fichier .env et consultez les instructions pour lancer les Lambda localement dans notre [Infrastructure ReadME] (https://github.com/cds -snc/forms-staging-terraform)
 
 ```
-LOCAL_LAMBDA_ENDPOINT=http://127.0.0.1:3001
+LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
 DATABASE_URL=postgres://postgres:password@localhost:5432/formsDB
 ```
 

--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -23,7 +23,7 @@ const protectedMethods = ["POST"];
 const lambdaClient = new LambdaClient({
   region: "ca-central-1",
   retryMode: "standard",
-  endpoint: process.env.LOCAL_LAMBDA_ENDPOINT,
+  ...(process.env.LOCAL_AWS_ENDPOINT && { endpoint: process.env.LOCAL_AWS_ENDPOINT }),
 });
 
 const submit = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {

--- a/utils/responseGenerator/.env_example
+++ b/utils/responseGenerator/.env_example
@@ -1,7 +1,6 @@
 # Copy to .env
 
-LOCAL_LAMBDA_ENDPOINT=http://127.0.0.1:3001
-LOCAL_AWS_ENDPOINT=http://localhost:4566
+LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
 RELIABILITY_FILE_STORAGE=forms-local-reliability-file-storage
 
 AWS_ACCESS_KEY_ID=test


### PR DESCRIPTION
# Summary | Résumé

- With the new infra update we can now only use specific AWS endpoint for the whole application