### PR TITLE
Updates share api to slugify the filename

### DIFF
--- a/lib/clientHelpers.ts
+++ b/lib/clientHelpers.ts
@@ -333,6 +333,7 @@ export const getDate = (withTime = false) => {
   return withTime ? date.toISOString() : date.toISOString().split("T")[0];
 };
 
+// TODO cosider moving to helpers since this is used by both the client and API
 export const slugify = (str: string) =>
   str
     .toLowerCase()

--- a/pages/api/share.ts
+++ b/pages/api/share.ts
@@ -3,6 +3,7 @@ import { cors, middleware, sessionExists } from "@lib/middleware";
 import { getNotifyInstance } from "@lib/integration/notifyConnector";
 import { logMessage } from "@lib/logger";
 import { MiddlewareProps, WithRequired } from "@lib/types";
+import { slugify } from "@lib/clientHelpers";
 
 const shareFormJSON = async (req: NextApiRequest, res: NextApiResponse, props: MiddlewareProps) => {
   try {
@@ -26,7 +27,7 @@ const shareFormJSON = async (req: NextApiRequest, res: NextApiResponse, props: M
           personalisation: {
             application_file: {
               file: base64data,
-              filename: `${filename}.json`,
+              filename: `${slugify(filename)}.json`,
               sending_method: "attach",
             },
             subject: "Form shared | Formulaire partagé",


### PR DESCRIPTION
# Summary | Résumé

Prevents file save fails by slugifying the json filename of a share.

# Test instructions | Instructions pour tester la modification

Go to a form and edit the form to have a title with special characters etc. like
`Test-TEST &^%$# hi there 2 `

Try Sharing the form (top share menu) and email it to yourself. The result should be an email with a json attachment with a file name that is slugified. 
e.g. the above should become `test-test-hi-there.json`

![Screenshot 2023-12-13 at 1 42 07 PM](https://github.com/cds-snc/platform-forms-client/assets/107579368/23dc4c69-3666-4d2f-91fd-68483419ffad)


