### PR TITLE
Fix for form input autocomplete tel type

### DIFF
--- a/components/form-builder/__tests__/util.test.js
+++ b/components/form-builder/__tests__/util.test.js
@@ -87,7 +87,7 @@ describe("Util", () => {
     expect(isValidatedTextType("textField")).toEqual(false);
     expect(isValidatedTextType("richText")).toEqual(false);
     expect(isValidatedTextType("email")).toEqual(true);
-    expect(isValidatedTextType("phone")).toEqual(true);
+    expect(isValidatedTextType("tel")).toEqual(true);
     expect(isValidatedTextType("date")).toEqual(true);
     expect(isValidatedTextType("number")).toEqual(true);
   });

--- a/components/form-builder/util.ts
+++ b/components/form-builder/util.ts
@@ -214,12 +214,12 @@ export const autoCompleteFields = [
   "bday-year",
   "url",
   "email",
-  "phone",
+  "tel",
 ];
 
 // check if the type is being passed is a "text field" input but has a ƒspecific type
 export const isValidatedTextType = (type: FormElementTypes | undefined) => {
-  return type && ["email", "phone", "date", "number"].includes(type);
+  return type && ["email", "tel", "date", "number"].includes(type);
 };
 
 export const isAutoCompleteField = (type: string) => {

--- a/components/form-builder/utils/itemHelper.test.ts
+++ b/components/form-builder/utils/itemHelper.test.ts
@@ -45,10 +45,10 @@ describe("Set localized Item properties", () => {
 
 describe("Update elements", () => {
   it("sets properties for phone", () => {
-    const item = createElement(getItem(), "phone");
+    const item = createElement(getItem(), "tel");
     expect(item.type).toEqual("textField");
-    expect(item.properties.validation?.type).toEqual("phone");
-    expect(item.properties.autoComplete).toEqual("phone");
+    expect(item.properties.validation?.type).toEqual("tel");
+    expect(item.properties.autoComplete).toEqual("tel");
   });
 
   it("sets properties for email", () => {

--- a/cypress/e2e/form-builder/autocomplete.cy.ts
+++ b/cypress/e2e/form-builder/autocomplete.cy.ts
@@ -25,7 +25,7 @@ describe("Test FormBuilder autocomplete props", () => {
     ["language", "Language"],
     ["name", "Full name (includes first, middle and last names)"],
     ["organization-title", "Job title"],
-    ["phone", "Phone number"],
+    ["tel", "Phone number"],
     ["postal-code", "Postal or zip code"],
     ["street-address", "Full street address (includes address lines 1-3)"],
     ["url", "Website address"],

--- a/cypress/e2e/form-builder/form-templates.cy.ts
+++ b/cypress/e2e/form-builder/form-templates.cy.ts
@@ -79,7 +79,7 @@ describe("Test FormBuilder", () => {
     cy.visitPage("/form-builder/preview");
     cy.get('[data-testid="textInput"]').each(($el, index) => {
       if (index === 0) {
-        cy.wrap($el).should("have.attr", "autocomplete", "phone");
+        cy.wrap($el).should("have.attr", "autocomplete", "tel");
       } else if (index === 1) {
         cy.wrap($el).should("have.attr", "autocomplete", "email");
       }

--- a/form-builder-templates/contact.json
+++ b/form-builder-templates/contact.json
@@ -39,7 +39,7 @@
         "descriptionFr": "Entrez votre numéro de téléphone. Par exemple : 111-222-3333",
         "placeholderEn": "",
         "placeholderFr": "",
-        "autoComplete": "phone"
+        "autoComplete": "tel"
       }
     },
     {

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -155,7 +155,7 @@
     "language": "Language",
     "name": "Full name (includes first, middle and last names)",
     "organization-title": "Job title",
-    "phone": "Phone number",
+    "tel": "Phone number",
     "postal-code": "Postal or zip code",
     "street-address": "Full street address (includes address lines 1-3)",
     "url": "Website address"

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -155,7 +155,7 @@
     "language": "Langue",
     "name": "Nom complet (y compris le prénom, le deuxième prénom et le nom de famille)",
     "organization-title": "Titre du poste",
-    "phone": "Numéro de téléphone",
+    "tel": "Numéro de téléphone",
     "postal-code": "Code postal ou zip",
     "street-address": "Adresse complète (y compris les lignes 1 à 3 de l'adresse)",
     "url": "Adresse du site Web"


### PR DESCRIPTION
# Summary | Résumé

A minor update that changes autocomplete fields to use `tel` instead of `phone`
![Screenshot 2024-01-04 at 2 25 07 PM](https://github.com/cds-snc/platform-forms-client/assets/107579368/b53744b2-32c8-4fa7-b973-ebf721a9618b)



See #3046 for test instructions
