### PR TITLE
Adds fix for removing street-address

### DIFF
--- a/components/form-builder/util.ts
+++ b/components/form-builder/util.ts
@@ -200,7 +200,6 @@ export const autoCompleteFields = [
   "honorific-prefix",
   "honorific-suffix",
   "organization-title",
-  "street-address",
   "address-line1",
   "address-line2",
   "address-line3",

--- a/form-builder-templates/address.json
+++ b/form-builder-templates/address.json
@@ -39,7 +39,7 @@
       "descriptionFr": "Indiquez votre numéro civique et le nom de la rue, l'appartement ou la suite, ainsi que d'autres détails de l'adresse",
       "placeholderEn": "",
       "placeholderFr": "",
-      "autoComplete": "street-address"
+      "autoComplete": "address-line1"
     }
   },
   {

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -157,7 +157,6 @@
     "organization-title": "Job title",
     "tel": "Phone number",
     "postal-code": "Postal or zip code",
-    "street-address": "Full street address (includes address lines 1-3)",
     "url": "Website address"
   },
   "autocompleteWhenNotToUse": {

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -157,7 +157,6 @@
     "organization-title": "Titre du poste",
     "tel": "Numéro de téléphone",
     "postal-code": "Code postal ou zip",
-    "street-address": "Adresse complète (y compris les lignes 1 à 3 de l'adresse)",
     "url": "Adresse du site Web"
   },
   "autocompleteWhenNotToUse": {


### PR DESCRIPTION
# Summary | Résumé

Based on the original bug report, the form-builder street-address was updated. Previously `autoselect="street-address"` was used for a Street Address input field. To be valid HTML a `street-address` must be on a textarea (multi-line element). The fix is probably temporary since we may want to have a multi-line  (textarea) in the future.

TODO
 - fix tests probably failing
 - test loading old form templates in the form builder that have the old `street-address`
