### PR TITLE
chore: switch GitHub workflows to OIDC roles

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -6,19 +6,25 @@ on:
     - cron: "0 4 * * *"
 
 env:
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
+  AWS_REGION: ca-central-1
   ECR_REPOSITORY: form_viewer_staging
+
+permissions:
+  id-token: write
+  contents: write
+  security-events: write
 
 jobs:
   docker-vulnerability-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure Staging AWS credentials
-        id: aws-form-viewer
-        uses: aws-actions/configure-aws-credentials@7ca194810a339d88e7c8d84405d963c9b2b5044f
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-plan
+          role-session-name: ECRPull
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Staging Amazon ECR
         id: login-ecr-staging

--- a/.github/workflows/pr-review-client-delete-unused.yml
+++ b/.github/workflows/pr-review-client-delete-unused.yml
@@ -6,22 +6,26 @@ on:
     - cron: "0 4 * * *" # Nightly at 4am
 
 env:
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_DEFAULT_REGION: ca-central-1
   DELETE_AFTER_DAYS: 21
   FUNCTION_PREFIX: "forms-client-pr"
   IMAGE: pr_review
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   delete-unused-test-client:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-apply
+          role-session-name: PRReviewDeleteUnused
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Delete old PR review environments
         run: |

--- a/.github/workflows/pr-review-client-deploy.yml
+++ b/.github/workflows/pr-review-client-deploy.yml
@@ -12,13 +12,18 @@ on:
       - synchronize
 
 env:
-  AWS_DEFAULT_REGION: ca-central-1
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
+  AWS_REGION: ca-central-1
   FUNCTION_NAME: "forms-client-pr"
   IMAGE: pr_review
-  REGISTRY: 687401027353.dkr.ecr.ca-central-1.amazonaws.com
-  ROLE_ARN: arn:aws:iam::687401027353:role/forms-lambda-client
+  REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com
+  ROLE_ARN: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/forms-lambda-client
   COGNITO_APP_CLIENT_ID: ${{secrets.STAGING_COGNITO_APP_CLIENT_ID}}
   COGNITO_USER_POOL_ID: ${{ secrets.STAGING_COGNITO_USER_POOL_ID}}
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   run-check:
@@ -45,13 +50,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-pr-review-env
+          role-session-name: PRReviewECRPush
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
         id: login-ecr
@@ -86,13 +90,12 @@ jobs:
       - name: Set envs
         run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-pr-review-env
+          role-session-name: PRReviewDeploy
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Create/Update lambda function
         run: |

--- a/.github/workflows/pr-review-client-remove.yml
+++ b/.github/workflows/pr-review-client-remove.yml
@@ -9,10 +9,15 @@ on:
       - closed
 
 env:
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_DEFAULT_REGION: ca-central-1
   FUNCTION_NAME: "forms-client-pr"
   IMAGE: pr_review
-  REGISTRY: 687401027353.dkr.ecr.ca-central-1.amazonaws.com
+  REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   remove-test-client:
@@ -22,13 +27,12 @@ jobs:
       - name: Set envs
         run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-pr-review-env
+          role-session-name: PRReviewRemove
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Delete lambda function resources
         run: |

--- a/.github/workflows/pr-review-sync-env-vars.yml
+++ b/.github/workflows/pr-review-sync-env-vars.yml
@@ -7,7 +7,12 @@ on:
       - completed
 
 env:
-    AWS_REGION: ca-central-1
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
+  AWS_REGION: ca-central-1
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   deploy-form-viewer-service:
@@ -17,11 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7ca194810a339d88e7c8d84405d963c9b2b5044f
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-apply
+          role-session-name: PRReviewSyncEnvVars
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync environment variables

--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -5,6 +5,8 @@ on:
     types: [published]
 
 env:
+  AWS_ACCOUNT_ID: ${{ vars.PRODUCTION_AWS_ACCOUNT_ID }}
+  AWS_REGION: ca-central-1
   ECR_REPOSITORY: form_viewer_production
   TAG_VERSION: ${{  github.ref_name }}
   COGNITO_APP_CLIENT_ID: ${{secrets.PRODUCTION_COGNITO_APP_CLIENT_ID}}
@@ -26,13 +28,12 @@ jobs:
           --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID . \
           --build-arg INDEX_SITE=true
 
-      - name: Configure Production AWS credentials
-        id: aws-form-viewer
-        uses: aws-actions/configure-aws-credentials@7ca194810a339d88e7c8d84405d963c9b2b5044f
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-release
+          role-session-name: ECRPush
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Production Amazon ECR
         id: login-ecr-production

--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -10,10 +10,17 @@ on:
       - "__*/**"
 
 env:
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
+  AWS_REGION: ca-central-1
   ECR_REPOSITORY: form_viewer_staging
   GITHUB_SHA: ${{ github.sha }}
   COGNITO_APP_CLIENT_ID: ${{secrets.STAGING_COGNITO_APP_CLIENT_ID}}
   COGNITO_USER_POOL_ID: ${{ secrets.STAGING_COGNITO_USER_POOL_ID}}
+
+permissions:
+  id-token: write
+  contents: write
+  security-events: write
 
 jobs:
   push-staging:
@@ -28,13 +35,12 @@ jobs:
             --build-arg COGNITO_APP_CLIENT_ID=$COGNITO_APP_CLIENT_ID \
             --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID .
 
-      - name: Configure Staging AWS credentials
-        id: aws-form-viewer
-        uses: aws-actions/configure-aws-credentials@7ca194810a339d88e7c8d84405d963c9b2b5044f
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-apply
+          role-session-name: ECRPush
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Staging Amazon ECR
         id: login-ecr-staging

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -7,6 +7,7 @@ on:
       - completed
 
 env:
+  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
 
 permissions:
@@ -37,7 +38,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          role-to-assume: arn:aws:iam::687401027353:role/platform-forms-client-apply
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-apply
           role-session-name: ECSDeploy
           aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
# Summary
Update the GitHub workflows to replace their use of AWS access keys/secrets with OIDC roles.  This improves the security of the workflow and removes the need to manage AWS access key secret rotation.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512