### PR TITLE
Updates form-builder address content

### DIFF
--- a/form-builder-templates/address.json
+++ b/form-builder-templates/address.json
@@ -35,8 +35,8 @@
       "validation": {
         "required": false
       },
-      "descriptionEn": "Include your civic number and street name, apartment or suite, and other address details",
-      "descriptionFr": "Indiquez votre numéro civique et le nom de la rue, l'appartement ou la suite, ainsi que d'autres détails de l'adresse",
+      "descriptionEn": "Include your street name and number. For example: 123 Main St. Apt 10",
+      "descriptionFr": "Indiquez le nom de rue et le numéro d'unité. Par exemple : 123 Rue Principale Apt 10",
       "placeholderEn": "",
       "placeholderFr": "",
       "autoComplete": "address-line1"

--- a/public/static/locales/en/form-builder.json
+++ b/public/static/locales/en/form-builder.json
@@ -10,7 +10,7 @@
       "postal": "Postal or zip code",
       "province": "Province or state",
       "street": {
-        "description": "Include your civic number and street name, apartment or suite, and other address details.",
+        "description": "Include your street name and number. For example: 123 Main St. Apt 10",
         "label": "Street address"
       },
       "title": "What is your address?"

--- a/public/static/locales/fr/form-builder.json
+++ b/public/static/locales/fr/form-builder.json
@@ -10,7 +10,7 @@
       "postal": "Code postal ou zip",
       "province": "Province ou état",
       "street": {
-        "description": "Indiquez votre numéro civique, le nom de la rue, l'appartement, et d'autres détails de l'adresse.",
+        "description": "Indiquez le nom de rue et le numéro d'unité. Par exemple : 123 Rue Principale Apt 10",
         "label": "Adresse municipale"
       },
       "title": "Quelle est votre adresse?"


### PR DESCRIPTION
# Summary | Résumé

Updates form-builder address content to fit semantically with a 1-line input vs. the old multi-line content. See #3046 form more info.

Content Update
```
EN: Include your street name and number. For example: 123 Main St. Apt 10
FR: Indiquez le nom de rue et le numéro d'unité. Par exemple : 123 Rue Principale Apt 10
```
![Screenshot 2024-01-16 at 3 06 34 PM](https://github.com/cds-snc/platform-forms-client/assets/107579368/e2a23f80-1343-4e9b-a1d5-ea1d92287083)
![Screenshot 2024-01-16 at 3 06 46 PM](https://github.com/cds-snc/platform-forms-client/assets/107579368/92531653-a9f3-426e-bb63-052015323e8f)
