### PR TITLE
chore: add more information to null operation log message

### DIFF
--- a/pages/api/templates/[formID].ts
+++ b/pages/api/templates/[formID].ts
@@ -44,7 +44,12 @@ const templates = async (req: NextApiRequest, res: NextApiResponse, props: Middl
       ...req.body,
     });
 
-    if (!response) throw new Error("Null operation response");
+    if (!response)
+      throw new Error(
+        `Template API response was null. Request information: method = ${
+          req.method
+        } ; query = ${JSON.stringify(req.query)} ; body = ${JSON.stringify(req.body)}`
+      );
 
     return res.status(200).json(response);
   } catch (e) {

--- a/pages/api/templates/index.ts
+++ b/pages/api/templates/index.ts
@@ -34,7 +34,12 @@ const templates = async (req: NextApiRequest, res: NextApiResponse, props: Middl
       ...req.body,
     });
 
-    if (!response) throw new Error("Null operation response");
+    if (!response)
+      throw new Error(
+        `Template API response was null. Request information: method = ${
+          req.method
+        } ; query = ${JSON.stringify(req.query)} ; body = ${JSON.stringify(req.body)}`
+      );
 
     return res.status(200).json(response);
   } catch (e) {


### PR DESCRIPTION
# Summary | Résumé

- Add more information to null operation response log message (in Template API).

Before:
`Null operation response`

After:
`Template API response was null. Request: method = GET ; query = {"formID":"clrgrjwny000cmgxc9e838q7f"} ; body = ""`