### PR TITLE
fix: Don't append "copy" to title on duplicate richText elements

### DIFF
--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -372,9 +372,11 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
                 // deep copy the element
                 const element = JSON.parse(JSON.stringify(state.form.elements[elIndex]));
                 element.id = id;
-                element.properties[state.localizeField("title")] = `${
-                  element.properties[state.localizeField("title")]
-                } copy`;
+                if (element.type !== "richText") {
+                  element.properties[state.localizeField("title")] = `${
+                    element.properties[state.localizeField("title")]
+                  } copy`;
+                }
                 state.form.elements.splice(elIndex + 1, 0, element);
                 state.form.layout.splice(elIndex + 1, 0, id);
               });


### PR DESCRIPTION
# Summary | Résumé

Fixes #3130 

When duplicating fields, the duplicate function in useTemplateStore appends the word `copy` to the title of the element. 

Problem is, in richText elements, the title is not normally used and by appending text to it causes the word `copy` to render to the screen on the rendered form. Since the richText field doesn't have a Title field, it is then not fixable by the user.

This addresses the issue by ignoring the title field when duplicating richText elements.
