### PR TITLE
revert: use AWS access keys instead of OIDC role

### DIFF
--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-release
-          role-session-name: ECRPush
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Production Amazon ECR


### PR DESCRIPTION
# Summary
Revert to using the AWS access keys for the Prod ECR push workflow as the OIDC roles will not exist
until the Prod infrastructure release.

Once the infrastructure release has gone through, this can be switched back to using OIDC roles.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512
- https://github.com/cds-snc/platform-forms-client/pull/3116