### PR TITLE
chore: switch back to prod deploy OIDC role

### DIFF
--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-release
+          role-session-name: ECRPush
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Production Amazon ECR


### PR DESCRIPTION
# Summary
Update the production ECR build/push GitHub workflow to use the OIDC role now that is has been created by the v3.5.0 infrastructure release.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512
- https://github.com/cds-snc/forms-terraform/pull/526