### PR TITLE
fix: settings modal save

### DIFF
--- a/components/form-builder/app/settings-modal/SettingsDialog.tsx
+++ b/components/form-builder/app/settings-modal/SettingsDialog.tsx
@@ -269,7 +269,6 @@ export const SettingsDialog = ({
 
     if (brandName === "") {
       unsetField("form.brand");
-      return;
     }
 
     if (brandName !== initialBrandName) {


### PR DESCRIPTION
# Summary | Résumé

Support ticket  (#16510)

Fixes issue where delivery option was not saving when using the Settings dialog modal.

> ...  If you try to change your Response delivery option from download responses from GC Forms to receive responses by email and click save at the bottom, it doesn’t change the response delivery option. It stays Download responses from GC Forms in both the Form set up and the Settings page. 


<img width="322" alt="Screenshot 2024-01-30 at 9 15 31 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/9a09a3dd-2c4b-4534-9789-0cd6695beebc">


<img width="885" alt="Screenshot 2024-01-30 at 9 16 04 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/e52f5cde-60e2-4d40-bb51-032771157f4f">



