### PR TITLE
fix: get choice lookup when question is removed

### DIFF
--- a/components/form-builder/store/useTemplateStore.tsx
+++ b/components/form-builder/store/useTemplateStore.tsx
@@ -363,7 +363,7 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
               }),
             getChoice: (elId, choiceIndex) => {
               const elIndex = get().form.elements.findIndex((el) => el.id === elId);
-              return get().form.elements[elIndex].properties.choices?.[choiceIndex];
+              return get().form.elements[elIndex]?.properties.choices?.[choiceIndex];
             },
             duplicateElement: (itemId) => {
               const elIndex = get().form.elements.findIndex((el) => el.id === itemId);


### PR DESCRIPTION
# Summary | Résumé

Support ticket https://cds-snc.freshdesk.com/a/tickets/16520

Issue when an element is removed that has conditional rules attached the get choice look up was failing. 

<img width="1209" alt="Screenshot 2024-01-30 at 11 30 29 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/7ba5eec4-0838-4027-8bab-df4f5f4e5808">
