### PR TITLE
fix: request new 2FA code does not work if there is no active 2FA session

### DIFF
--- a/components/auth/ReVerify.tsx
+++ b/components/auth/ReVerify.tsx
@@ -64,9 +64,10 @@ export const ReVerify = ({
     } catch (err) {
       logMessage.error(err);
 
-      if (hasError(["CredentialsSignin", "CSRF token not found"], err)) {
-        // Missing CsrfToken or username so have the user try signing in
+      if (hasError(["CredentialsSignin", "CSRF token not found", "Missing 2FA session"], err)) {
+        // Missing CsrfToken, username or 2FA session so have the user try signing in again
         await router.push("/auth/login");
+        router.reload();
       } else {
         handleErrorById("InternalServiceException");
       }

--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -40,6 +40,8 @@ export type Validate2FAVerificationCodeResult = {
   decodedCognitoToken?: DecodedCognitoToken;
 };
 
+export class Missing2FASession extends Error {}
+
 export const initiateSignIn = async ({
   username,
   password,
@@ -195,15 +197,15 @@ export const requestNew2FAVerificationCode = async (
       })
       .catch((e) => prismaErrors(e, null));
 
-    if (result === null) {
-      throw new Error("Update failed because of missing 2FA authentication session");
-    }
+    if (result === null) throw new Missing2FASession();
 
     await sendVerificationCode(sanitizedEmail, verificationCode);
   } catch (error) {
-    throw new Error(
-      `Failed to generate and send new verification code. Reason: ${(error as Error).message}.`
-    );
+    if (error instanceof Missing2FASession) {
+      throw error;
+    } else {
+      throw new Error(`Failed to send new verification code. Reason: ${(error as Error).message}.`);
+    }
   }
 };
 

--- a/pages/api/auth/2fa/request-new-verification-code.ts
+++ b/pages/api/auth/2fa/request-new-verification-code.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { middleware, cors, csrfProtected } from "@lib/middleware";
 import { requestNew2FAVerificationCode } from "@lib/auth";
+import { Missing2FASession } from "@lib/auth/cognito";
 
 const requestNewVerificationCode = async (req: NextApiRequest, res: NextApiResponse) => {
   const { authenticationFlowToken, email } = req.body;
@@ -12,7 +13,11 @@ const requestNewVerificationCode = async (req: NextApiRequest, res: NextApiRespo
     await requestNew2FAVerificationCode(authenticationFlowToken, email);
     return res.status(200).json({});
   } catch (error) {
-    return res.status(500).json({ error: "Server failed to send a new verification code." });
+    if (error instanceof Missing2FASession) {
+      return res.status(401).json({ message: "Missing 2FA session" });
+    } else {
+      return res.status(500).json({ message: "Failed to send a new verification code" });
+    }
   }
 };
 


### PR DESCRIPTION
# Summary | Résumé

- Fixed issue with 2FA when requesting new code while there is no active (2FA) session. 

Context: 
It happens if a user has two instances of the GC Forms application opened (2 tabs in a browser) and requests a new 2FA code in of them after he completed the sign-in flow on the other one. 
This is based on the review of some logs due to an alarm being triggered in production. This is something we can reproduce every time when we test locally.

# Test instructions | Instructions pour tester la modification

- Open the GC Forms application in two different tabs on your browser
- Reach the 2FA verification code page on both instances
- Enter a valid code on one of them and complete the sign-in process
- Try to request a new code on the tab that is still expecting a verification code
- You should be redirected to the `http://localhost:3000/auth/login` which will automatically redirect you to the forms dashboard since you got an active session in your browser cookies