### PR TITLE
Fix for re-verify not sending a code

### DIFF
--- a/components/clientComponents/auth/ReVerify.tsx
+++ b/components/clientComponents/auth/ReVerify.tsx
@@ -48,13 +48,12 @@ export const ReVerify = ({
         url: "/api/auth/2fa/request-new-verification-code",
         method: "POST",
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
           "X-CSRF-Token": token,
         },
-        data: new URLSearchParams({
+        data: {
           email: username.current,
           authenticationFlowToken: authenticationFlowToken.current,
-        }),
+        },
         timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
       });
 


### PR DESCRIPTION
# Summary | Résumé

Updates re-verify to be consistent with how other POST requests add data the http body. This was originally not working because the data was added to the http message body as url encoded and trying to be read as json.

## Test

Try signing on and at the Verify step, try clicking the link/button to send a new code. If you get a code it works.