### PR TITLE
fix: validation when conditional rules array is empty

### DIFF
--- a/lib/validation.tsx
+++ b/lib/validation.tsx
@@ -227,7 +227,10 @@ export const validateOnSubmit = (
       continue;
     }
 
-    if (formElement.properties.conditionalRules) {
+    if (
+      formElement.properties.conditionalRules &&
+      formElement.properties.conditionalRules.length > 0
+    ) {
       // check if a conditional rule is met
       const rules = formElement.properties.conditionalRules;
       if (!rules.some((rule) => matchRule(rule, props.formRecord, values as FormValues))) {


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where when using conditional rules ... elements with empty rules arrays we're bypassing validation checks.