### PR TITLE
Append query params when redirecting in language middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -85,7 +85,9 @@ export async function middleware(req: NextRequest) {
         `Middleware - Redirecting to cookie language: ${cookieLang}, pathname: ${pathname}`
       );
 
-      return NextResponse.redirect(new URL(`/${cookieLang}${pathname}?${searchParams}`, req.url));
+      return NextResponse.redirect(
+        new URL(`/${cookieLang}${pathname}${searchParams && "?" + searchParams}`, req.url)
+      );
     } else {
       // Redirect to fallback language
       logMessage.debug(`Middleware - Redirecting to fallback language: : ${pathname}`);

--- a/middleware.ts
+++ b/middleware.ts
@@ -33,6 +33,7 @@ const allowedOrigins = [process.env.NEXTAUTH_URL];
 
 export async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
+  const searchParams = req.nextUrl.searchParams.toString();
 
   // Layer 0 - Set CORS on API routes
   if (pathname.startsWith("/api")) {
@@ -83,7 +84,8 @@ export async function middleware(req: NextRequest) {
       logMessage.debug(
         `Middleware - Redirecting to cookie language: ${cookieLang}, pathname: ${pathname}`
       );
-      return NextResponse.redirect(new URL(`/${cookieLang}${pathname}`, req.url));
+
+      return NextResponse.redirect(new URL(`/${cookieLang}${pathname}?${searchParams}`, req.url));
     } else {
       // Redirect to fallback language
       logMessage.debug(`Middleware - Redirecting to fallback language: : ${pathname}`);


### PR DESCRIPTION
# Summary | Résumé

Closes #3162 

Fixes pagination on Responses page by ensuring searchParams are appended to a URL when redirecting in the language middleware.


