### PR TITLE
Fix for broken settings link on responses page

### DIFF
--- a/components/clientComponents/form-builder/app/shared/ClosedBanner.tsx
+++ b/components/clientComponents/form-builder/app/shared/ClosedBanner.tsx
@@ -10,7 +10,7 @@ export const ClosedBanner = ({ id }: { id: string | undefined }) => {
     t,
     i18n: { language },
   } = useTranslation("form-closed");
-  const href = `${language}/form-builder/settings/${id}/form`;
+  const href = `/${language}/form-builder/settings/${id}/form`;
 
   if (!isPastClosingDate || !id) {
     return null;


### PR DESCRIPTION
# Summary | Résumé

Fixes responses settings link.

## Test

1. Go to a form with responses
2. Go into settings and set the status to closed
3. Go back to the form responses and a link should be displayed above the table to go to settings
4. Click the settings link
5. You should be sent to the settings page