### PR TITLE
fix: i18n language switching

### DIFF
--- a/components/clientComponents/form-builder/app/responses/Pagination.tsx
+++ b/components/clientComponents/form-builder/app/responses/Pagination.tsx
@@ -16,7 +16,10 @@ export const Pagination = ({
   responseDownloadLimit: number;
   recordCount: number;
 }) => {
-  const { t } = useTranslation("form-builder-responses");
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation("form-builder-responses");
   const router = useRouter();
 
   // Need statusQuery when building up the prev/next links
@@ -45,9 +48,11 @@ export const Pagination = ({
       setKeys(decodedKeys);
     } catch (e) {
       // If the base64 encoded string has been tampered with, redirect to the first page
-      router.push(`/form-builder/responses/${formId}${statusQuery ? "/" + statusQuery : ""}`);
+      router.push(
+        `/${language}/form-builder/responses/${formId}${statusQuery ? "/" + statusQuery : ""}`
+      );
     }
-  }, [formId, router, searchParams, statusQuery]);
+  }, [formId, router, searchParams, statusQuery, language]);
 
   // When going back, we pop the last item off the keys array
   const previousKeys = keys.slice(0, -1);
@@ -84,11 +89,15 @@ export const Pagination = ({
   return (
     <>
       <Link
-        href={`/form-builder/responses/${formId}${statusQuery ? "/" + statusQuery : ""}`}
+        href={`/${language}/form-builder/responses/${formId}${
+          statusQuery ? "/" + statusQuery : ""
+        }`}
         legacyBehavior
       >
         <a
-          href={`/form-builder/responses/${formId}${statusQuery ? "/" + statusQuery : ""}`}
+          href={`/${language}/form-builder/responses/${formId}${
+            statusQuery ? "/" + statusQuery : ""
+          }`}
           className={`group mr-4 inline-block ${
             isFirstPage ? "pointer-events-none opacity-50" : ""
           }`}
@@ -101,13 +110,13 @@ export const Pagination = ({
 
       <div className="float-right inline-block">
         <Link
-          href={`/form-builder/responses/${formId}${
+          href={`/${language}/form-builder/responses/${formId}${
             statusQuery ? "/" + statusQuery : ""
           }${previousLink}`}
           legacyBehavior
         >
           <a
-            href={`/form-builder/responses/${formId}${
+            href={`/${language}/form-builder/responses/${formId}${
               statusQuery ? "/" + statusQuery : ""
             }${previousLink}`}
             className={`group mr-4 inline-block ${
@@ -121,13 +130,13 @@ export const Pagination = ({
         </Link>
         {t("downloadResponsesTable.header.pagination.showing", { start, end })}
         <Link
-          href={`/form-builder/responses/${formId}${
+          href={`/${language}/form-builder/responses/${formId}${
             statusQuery ? "/" + statusQuery : ""
           }?keys=${btoa(keys.join(","))}&lastKey=${lastEvaluatedResponseId}`}
           legacyBehavior
         >
           <a
-            href={`/form-builder/responses/${formId}${
+            href={`/${language}/form-builder/responses/${formId}${
               statusQuery ? "/" + statusQuery : ""
             }?keys=${btoa(keys.join(","))}&lastKey=${lastEvaluatedResponseId}`}
             className={`group ml-4 inline-block ${

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -23,11 +23,10 @@ export async function serverTranslation(
   ns?: string | string[],
   options?: { keyPrefix?: string; lang?: string }
 ) {
-  const cookieLang = cookies().get("i18next")?.value;
-  const path = headers().get("x-invoke-path") ?? "";
+  const path = headers().get("x-path") ?? "";
   const pathLang = pathLanguageDetection(path, languages);
 
-  const i18nLang = options?.lang || pathLang || cookieLang || languages[0];
+  const i18nLang = options?.lang || pathLang || languages[0];
 
   const i18nextInstance = await initI18next(i18nLang, ns ?? ["common"]);
   return {

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -54,7 +54,9 @@ export async function requireAuthentication() {
       session.user.hasSecurityQuestions &&
       !session.user.acceptableUse &&
       !currentPath.startsWith("/auth/policy") &&
-      !currentPath.startsWith("/auth/setup-security-questions")
+      !currentPath.startsWith("/auth/setup-security-questions") &&
+      // If they don't want to accept let them log out
+      !currentPath.startsWith("/auth/logout")
     ) {
       // If they haven't agreed to Acceptable Use redirect to policy page for acceptance
       // If already on the policy page don't redirect, aka endless redirect loop.

--- a/middleware.ts
+++ b/middleware.ts
@@ -100,8 +100,6 @@ export async function middleware(req: NextRequest) {
   let cookieSyncRequired = false;
   if (pathLang && cookieLang !== pathLang) {
     logMessage.debug(`Middleware - Setting language cookie: ${cookieLang} for path: ${pathname}`);
-    // Set missing cookie on incoming request so server can render correct language on server components
-    req.cookies.set("i18next", pathLang);
     cookieSyncRequired = true;
   }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prisma:studio": "prisma studio",
     "prisma:test": "prisma migrate deploy && tsx prisma/seeds/seed_cli.ts --environment=test",
     "start:test": "yarn prisma:test && yarn initialize && APP_ENV=test next start",
-    "dev:test": "prisma migrate reset -f --skip-seed && yarn prisma:test && yarn initialize && APP_ENV=test next dev",
+    "dev:test": "prisma migrate reset -f --skip-seed && yarn prisma:test && yarn initialize && APP_ENV=test next dev | pino-pretty -c -i time",
     "build:test": "APP_ENV=test next build",
     "lint": "next lint && tsc --noEmit",
     "lint:tailwindcss": "eslint -c .eslint-tailwindcss.js",


### PR DESCRIPTION
# Summary | Résumé

closes #3223 

Fixes an issue where React Server Components are being sent stale request cookies and not updated cookies from the middleware.  The mismatch was causing indefinite redirects.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![Acceptable Use page lang switch](https://github.com/cds-snc/platform-forms-client/assets/25329319/b1125350-36f9-44ac-9693-5876ad39dd70) | ![lang switcher fix](https://github.com/cds-snc/platform-forms-client/assets/25329319/8c8bce38-8245-4ec5-8a79-8df8bc198854) |

Also adds the locale to the router.push() paths in Pagination to avoid a redirect request on every page transition.

# Test instructions | Instructions pour tester la modification
- Log in
- On Acceptable Use page switch between french and english.


