### PR TITLE
fix: conditional indicator question number output

### DIFF
--- a/components/form-builder/app/shared/conditionals/ConditionalIndicator.tsx
+++ b/components/form-builder/app/shared/conditionals/ConditionalIndicator.tsx
@@ -3,25 +3,31 @@ import { useTranslation } from "next-i18next";
 import { FormElementWithIndex } from "../../../types";
 import { useTemplateStore } from "@components/form-builder/store";
 import { ConditionalIcon } from "@components/form-builder/icons/ConditionalIcon";
+import { getQuestionNumber } from "@formbuilder/util";
+import { getElementIndexes } from "@formbuilder/getPath";
 
 const RuleIndicator = ({ choiceId }: { choiceId: string }) => {
   const { t } = useTranslation("form-builder");
-
   const getChoice = useTemplateStore((state) => state.getChoice);
   const translationLanguagePriority = useTemplateStore(
     (state) => state.translationLanguagePriority
   );
 
+  const elements = useTemplateStore((state) => state.form.elements);
   const parentId = Number(choiceId.split(".")[0]);
   const childId = Number(choiceId.split(".")[1]);
   const choice = getChoice(parentId, childId);
   if (!choice) return null;
   const choiceValue = choice[translationLanguagePriority];
+  const indexes = getElementIndexes(parentId, elements);
+  if (!indexes || !indexes[0]) return null;
+  const itemId = indexes[0];
+  const questionNumber = getQuestionNumber(elements[itemId], elements);
   return (
     <div>
       <ConditionalIcon className="mr-2 mt-[-5px] inline-block" />
       <div className="inline-block p-2">
-        {t("question")} {`${parentId}`}
+        {t("question")} {questionNumber}
       </div>
       <span className="hidden">{`${choiceValue}`}</span>
     </div>


### PR DESCRIPTION
# Summary | Résumé

[(#16582)](https://cds-snc.freshdesk.com/a/tickets/16582)

Fixes issue where conditional indicator was showing a parent id and not a question #

Before

<img width="1135" alt="Screenshot 2024-02-02 at 3 00 33 PM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/c6e60b0b-ea25-4181-9d4f-0076153ca778">

After 
<img width="912" alt="Screenshot 2024-02-02 at 3 12 46 PM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/1edbc1f0-7024-42ff-81fc-652e8bd285a6">



