### PR TITLE
fix: hydration bug in settings pages

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/preview/[[...slug]]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/preview/[[...slug]]/page.tsx
@@ -1,8 +1,12 @@
 import { serverTranslation } from "@i18n";
 import { ClientSide } from "./clientSide";
 import { FormBuilderInitializer } from "@clientComponents/globals/layouts/FormBuilderLayout";
-
 import { Metadata } from "next";
+import { FormRecord } from "@lib/types";
+import { auth } from "@lib/auth";
+import { AccessControlError, createAbility } from "@lib/privileges";
+import { getFullTemplateByID } from "@lib/templates";
+import { redirect } from "next/navigation";
 
 export async function generateMetadata({
   params: { locale },
@@ -15,9 +19,39 @@ export async function generateMetadata({
   };
 }
 
-export default function Page({ params: { locale } }: { params: { locale: string } }) {
+export default async function Page({
+  params: { locale, slug = [] },
+}: {
+  params: { locale: string; slug: string[] };
+}) {
+  const FormbuilderParams: { locale: string; initialForm: null | FormRecord } = {
+    initialForm: null,
+    locale,
+  };
+
+  const session = await auth();
+
+  const formID = slug[0] || null;
+
+  if (session && formID) {
+    try {
+      const ability = createAbility(session);
+
+      const initialForm = await getFullTemplateByID(ability, formID);
+
+      if (initialForm === null) redirect(`/${locale}/404`);
+
+      FormbuilderParams.initialForm = initialForm;
+    } catch (e) {
+      if (e instanceof AccessControlError) redirect(`/${locale}/admin/unauthorized`);
+    }
+  }
+
   return (
-    <FormBuilderInitializer locale={locale}>
+    <FormBuilderInitializer
+      initialForm={FormbuilderParams.initialForm}
+      locale={FormbuilderParams.locale}
+    >
       <ClientSide />
     </FormBuilderInitializer>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/settings/[[...slug]]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/settings/[[...slug]]/page.tsx
@@ -41,22 +41,18 @@ export default async function Page({
 
       const initialForm = await getFullTemplateByID(ability, formID);
 
-      if (initialForm === null) {
-        redirect(`/${locale}/404`);
-      }
-
-      if (initialForm.isPublished) {
-        redirect(`/${locale}/form-builder/settings/${formID}`);
-      }
+      if (initialForm === null) redirect(`/${locale}/404`);
 
       FormbuilderParams.initialForm = initialForm;
+
+      if (initialForm.isPublished) redirect(`/${locale}/form-builder/settings/${formID}`);
     } catch (e) {
-      if (e instanceof AccessControlError) {
-        redirect(`/${locale}/admin/unauthorized`);
-      }
+      if (e instanceof AccessControlError) redirect(`/${locale}/admin/unauthorized`);
     }
   }
+
   const { t } = await serverTranslation("form-builder", { lang: locale });
+
   return (
     <FormBuilderInitializer
       initialForm={FormbuilderParams.initialForm}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/settings/[formID]/form/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/settings/[formID]/form/clientSide.tsx
@@ -6,6 +6,7 @@ import { SettingsNavigation } from "@clientComponents/form-builder/app/navigatio
 import { FormRecord } from "@lib/types";
 import { useTemplateStore } from "@clientComponents/form-builder/store";
 import { useSession } from "next-auth/react";
+import { useRehydrate } from "@clientComponents/form-builder/hooks";
 
 interface AssignUsersToTemplateProps {
   formRecord?: FormRecord;
@@ -25,6 +26,9 @@ export const ClientSide = ({
   const { id } = useTemplateStore((s) => ({
     id: s.id,
   }));
+
+  const hasHydrated = useRehydrate();
+  if (!hasHydrated) return null;
 
   // Can definitely be refactored once the parent components are refactored to server components
   if (

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/settings/branding/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/settings/branding/clientSide.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useTranslation } from "@i18n/client";
+import { SettingsNavigation } from "@clientComponents/form-builder/app/navigation/SettingsNavigation";
+import { useRehydrate } from "@clientComponents/form-builder/hooks";
+import { Branding } from "@clientComponents/form-builder/app/branding";
+
+interface BrandingClientSideProps {
+  hasBrandingRequestForm: boolean;
+}
+
+export const ClientSide = ({ hasBrandingRequestForm }: BrandingClientSideProps) => {
+  const { t } = useTranslation("form-builder");
+
+  const hasHydrated = useRehydrate();
+  if (!hasHydrated) return null;
+
+  return (
+    <div className="max-w-4xl">
+      <h1>{t("gcFormsSettings")}</h1>
+      <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
+        {t("settingsResponseDelivery.beforePublishMessage")}
+      </p>
+      <SettingsNavigation />
+      <Branding hasBrandingRequestForm={hasBrandingRequestForm} />
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/settings/branding/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/settings/branding/page.tsx
@@ -1,11 +1,10 @@
 import { serverTranslation } from "@i18n";
 import { auth } from "@lib/auth";
-import { Branding } from "@clientComponents/form-builder/app/branding";
-import { SettingsNavigation } from "@clientComponents/form-builder/app/navigation/SettingsNavigation";
 import { getAppSetting } from "@lib/appSettings";
-import { FormBuilderInitializer } from "@clientComponents/globals/layouts/FormBuilderLayout";
 import { redirect } from "next/navigation";
 import { Metadata } from "next";
+import { ClientSide } from "./clientSide";
+import { FormBuilderInitializer } from "@clientComponents/globals/layouts/FormBuilderLayout";
 
 export async function generateMetadata({
   params: { locale },
@@ -19,8 +18,8 @@ export async function generateMetadata({
 }
 
 export default async function Page({ params: { locale } }: { params: { locale: string } }) {
-  const { t } = await serverTranslation("form-builder");
   const session = await auth();
+
   if (session && !session.user.acceptableUse) {
     // If they haven't agreed to Acceptable Use redirect to policy page for acceptance
     redirect(`/${locale}/auth/policy`);
@@ -35,14 +34,7 @@ export default async function Page({ params: { locale } }: { params: { locale: s
 
   return (
     <FormBuilderInitializer locale={locale}>
-      <div className="max-w-4xl">
-        <h1>{t("gcFormsSettings")}</h1>
-        <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
-          {t("settingsResponseDelivery.beforePublishMessage")}
-        </p>
-        <SettingsNavigation />
-        <Branding hasBrandingRequestForm={hasBrandingRequestForm} />
-      </div>
+      <ClientSide hasBrandingRequestForm={hasBrandingRequestForm} />
     </FormBuilderInitializer>
   );
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/platform-forms-client/issues/3169

- Fixed hydration issue in settings (base settings, branding and form management) and preview pages.

As discussed with @timarney and @bryan-robitaille, we will continue using this `useRehydrate` hook until we implement a global layout where we will initialize the `TemplateStoreProvider` once instead of having it done on all new rendered pages (something that appears to be creating a new empty context every time).