### PR TITLE
chore: Set User type to have mandatory email

### DIFF
--- a/lib/users.ts
+++ b/lib/users.ts
@@ -23,7 +23,7 @@ export const getOrCreateUser = async ({
 }: JWT): Promise<{
   newlyRegistered?: boolean;
   name: string | null;
-  email: string | null;
+  email: string;
   privileges: Privilege[];
   id: string;
   active: boolean;

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -174,7 +174,7 @@ export const authOptions: NextAuthOptions = {
         lastLoginTime: token.lastLoginTime,
         acceptableUse: token.acceptableUse,
         name: token.name ?? null,
-        email: token.email ?? null,
+        email: token.email,
         image: token.picture ?? null,
         privileges: await getPrivilegeRulesForUser(token.userId as string),
         ...(token.newlyRegistered && { newlyRegistered: token.newlyRegistered }),

--- a/prisma/migrations/20240214155605_user_email_not_null/migration.sql
+++ b/prisma/migrations/20240214155605_user_email_not_null/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `email` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "email" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,7 +85,7 @@ model Privilege {
 model User {
   id              String           @id @default(cuid())
   name            String?
-  email           String?          @unique
+  email           String           @unique
   image           String?
   emailVerified   DateTime?
   lastLogin       DateTime         @default(now()) @db.Timestamptz(6)

--- a/prisma/seeds/fixtures/users.ts
+++ b/prisma/seeds/fixtures/users.ts
@@ -1,11 +1,16 @@
-import { User } from "@prisma/client";
+interface CreateAppUser {
+  email: string;
+  name: string;
+  active?: boolean;
+  privileges: Record<string, unknown>;
+}
 
 type UserCollection = {
-  test: User[];
-  [key: string]: Array<User | { privileges: Record<string, unknown> }>;
+  test: CreateAppUser[];
+  [key: string]: Array<CreateAppUser>;
 };
 
-const RegularUser: User | { privileges: Record<string, unknown> } = {
+const RegularUser: CreateAppUser = {
   name: "Regular Test User",
   email: "test.user@cds-snc.ca",
   active: true,
@@ -14,7 +19,7 @@ const RegularUser: User | { privileges: Record<string, unknown> } = {
   },
 };
 
-const AdminUser: User | { privileges: Record<string, unknown> } = {
+const AdminUser: CreateAppUser = {
   name: "Admin Test User",
   email: "test.admin@cds-snc.ca",
   active: true,
@@ -29,7 +34,7 @@ const AdminUser: User | { privileges: Record<string, unknown> } = {
   },
 };
 
-const DeactivatedRegularUser: User | { privileges: Record<string, unknown> } = {
+const DeactivatedRegularUser: CreateAppUser = {
   name: "Deactivated Test User",
   email: "test.deactivated@cds-snc.ca",
   active: false,
@@ -38,7 +43,7 @@ const DeactivatedRegularUser: User | { privileges: Record<string, unknown> } = {
   },
 };
 
-export const UserWithoutSecurityAnswers: User | { privileges: Record<string, unknown> } = {
+export const UserWithoutSecurityAnswers: CreateAppUser = {
   name: "Test User Without Scurity Answers",
   email: "test.withoutSecurityAnswers@cds-snc.ca",
   privileges: {

--- a/prisma/seeds/seed.ts
+++ b/prisma/seeds/seed.ts
@@ -234,11 +234,6 @@ async function templateSchemaMigration() {
 
 async function lowercaseEmailAddressMigration() {
   const users = (await prisma.user.findMany({
-    where: {
-      email: {
-        not: null,
-      },
-    },
     select: {
       id: true,
       email: true,

--- a/types/next_auth/index.d.ts
+++ b/types/next_auth/index.d.ts
@@ -12,7 +12,7 @@ declare module "next-auth" {
       privileges: RawRuleOf<MongoAbility<Abilities>>[];
       acceptableUse: boolean;
       name: string | null;
-      email: string | null;
+      email: string;
       image?: string | null;
       newlyRegistered?: boolean;
       deactivated?: boolean;
@@ -26,6 +26,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     userId: string;
     name: string;
+    email: string;
     lastLoginTime: Date;
     acceptableUse: boolean;
     hasSecurityQuestions: boolean;


### PR DESCRIPTION
# Summary | Résumé
Set the User object in Prisma to always have an email.

This aligns towards the actual state of the application instead of next-auth defaults.
# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
