### PR TITLE
chore: Rename NEXTAUTH_URL as it is no longer required for Next-Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,6 @@ LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
 
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
-NEXTAUTH_URL=http://localhost:3000
 REDIS_URL=redis
 LOCAL_LAMBDA_ENDPOINT=http://host.docker.internal:3001
 RELIABILITY_FILE_STORAGE=forms-local-reliability-file-storage

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -34,7 +34,7 @@ jobs:
           - 6379:6379
     env:
       # Needed for Next Auth to initialize
-      NEXTAUTH_URL: http://localhost:3000
+      HOST_URL: http://localhost:3000
       TOKEN_SECRET: testKey
       APP_ENV: test
       REDIS_URL: localhost

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ SUBMISSION_API=Submission
 TEMPLATES_API=Templates
 AWS_ACCESS_KEY_ID= // ask the dev team
 AWS_SECRET_ACCESS_KEY= // ask the dev team
-NEXTAUTH_URL=http://localhost:3000
+HOST_URL=http://localhost:3000
 REDIS_URL=localhost
 ```
 
@@ -186,7 +186,7 @@ SUBMISSION_API=Submission
 TEMPLATES_API=Templates
 AWS_ACCESS_KEY_ID= // Can be found in LastPass
 AWS_SECRET_ACCESS_KEY= // Can be found in LastPass
-NEXTAUTH_URL=http://localhost:3000
+HOST_URL=http://localhost:3000
 REDIS_URL=localhost
 ```
 

--- a/lib/auth/passwordReset.ts
+++ b/lib/auth/passwordReset.ts
@@ -89,7 +89,7 @@ const sendPasswordResetEmail = async (email: string, token: string) => {
   try {
     const notify = getNotifyInstance();
 
-    const baseUrl = process.env.NEXTAUTH_URL;
+    const baseUrl = process.env.HOST_URL;
 
     await notify.sendEmail(process.env.TEMPLATE_ID, email, {
       personalisation: {

--- a/lib/deactivate.ts
+++ b/lib/deactivate.ts
@@ -3,7 +3,7 @@ import { logMessage } from "@lib/logger";
 
 export const sendDeactivationEmail = async (email: string) => {
   try {
-    const HOST = process.env.NEXTAUTH_URL;
+    const HOST = process.env.HOST_URL;
     const TEMPLATE_ID = process.env.TEMPLATE_ID;
     const notify = getNotifyInstance();
 

--- a/lib/integration/freshdesk.ts
+++ b/lib/integration/freshdesk.ts
@@ -15,7 +15,7 @@ export const formatTicketData = ({
   description,
   language,
 }: createTicketProps) => {
-  const HOST = process.env.NEXTAUTH_URL || "";
+  const HOST = process.env.HOST_URL || "";
   const hostTag = tagHost(HOST);
 
   const ticket = {

--- a/lib/ownership.ts
+++ b/lib/ownership.ts
@@ -17,7 +17,7 @@ export const transferOwnershipEmail = async ({
   formId: string;
 }) => {
   try {
-    const HOST = process.env.NEXTAUTH_URL;
+    const HOST = process.env.HOST_URL;
     const TEMPLATE_ID = process.env.TEMPLATE_ID;
     const notify = getNotifyInstance();
 
@@ -79,7 +79,7 @@ export const addOwnershipEmail = async ({
   formId: string;
 }) => {
   try {
-    const HOST = process.env.NEXTAUTH_URL;
+    const HOST = process.env.HOST_URL;
     const TEMPLATE_ID = process.env.TEMPLATE_ID;
     const notify = getNotifyInstance();
 

--- a/lib/responseDownloadFormats/html-aggregated/components/CopyCodes.tsx
+++ b/lib/responseDownloadFormats/html-aggregated/components/CopyCodes.tsx
@@ -12,7 +12,7 @@ export const CopyCodes = ({
 }) => {
   const { t } = customTranslate("my-forms");
   const capitalizedLang = lang === "en" ? "En" : "Fr";
-  const HOST = process.env.NEXTAUTH_URL || "";
+  const HOST = process.env.HOST_URL || "";
 
   return (
     <div className="flex flex-row">


### PR DESCRIPTION
# Summary | Résumé
Renames the NEXTAUTH_URL parameter to HOST_URL as it is used in other parts of the application.

Future versions of Next-Auth (v5) have an issue when the NEXTAUTH_URL is present.  Our current version (V4) does not explicitly require the NEXTAUTH_URL and can operate without it.

Infrastructure Dependency: https://github.com/cds-snc/forms-terraform/pull/606

# Test instructions | Instructions pour tester la modification

- Rename the NEXTAUTH_URL in you .env file to HOST_ENV
- Run the app with yarn dev  or yarn build && yarn start

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
