### PR TITLE
Fixes support actions error handling

### DIFF
--- a/app/(gcforms)/[locale]/(support)/contact/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/contact/actions.ts
@@ -16,12 +16,17 @@ export async function contact({
   email: string;
   request: string;
   description: string;
-  department: string;
+  department?: string;
   branch?: string;
   jobTitle?: string;
   language?: string;
 }) {
   // No auth etc. checking since this is a public endpoint
+
+  //Mandatory fields
+  if (!name || !email || !request || !description) {
+    throw new Error("Malformed request");
+  }
 
   // Request may be a list of strings (checkbox), format it a bit if so, or just a string (radio)
   const requestParsed =

--- a/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
@@ -18,9 +18,14 @@ import { Button } from "@clientComponents/globals";
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
 import { useRouter } from "next/navigation";
 import { contact } from "../../actions";
+import { Alert } from "@clientComponents/globals";
+import Link from "next/link";
 
 export const ContactForm = () => {
-  const { t, i18n } = useTranslation(["form-builder", "common"]);
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation(["form-builder", "common"]);
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
@@ -61,7 +66,7 @@ export const ContactForm = () => {
             description,
           });
           setErrorMessage("");
-          router.replace(`/${i18n.language}/contact?success`);
+          router.replace(`/${language}/contact?success`);
         } catch (err) {
           logMessage.error(err);
           setErrorMessage(t("contactus.errors.submissionError"));
@@ -100,110 +105,142 @@ export const ContactForm = () => {
             </ValidationMessage>
           )}
           {!errorMessage && (
-            <form id="contactus" method="POST" onSubmit={handleSubmit} noValidate>
-              <fieldset className="focus-group mt-14">
-                <legend className="gc-label required">
-                  {t("contactus.request.title")}{" "}
-                  <span data-testid="required" aria-hidden>
-                    ({t("required")})
-                  </span>
-                </legend>
-                <MultipleChoiceGroup
-                  name="request"
-                  type="checkbox"
-                  choicesProps={[
-                    {
-                      id: "request-question",
-                      name: "question",
-                      label: t("contactus.request.option1"),
-                      required: true,
-                    },
-                    {
-                      id: "request-feedback",
-                      name: "feedback",
-                      label: t("contactus.request.option2"),
-                      required: true,
-                    },
-                    {
-                      id: "request-feature",
-                      name: "feature",
-                      label: t("contactus.request.option3"),
-                      required: true,
-                    },
-                    {
-                      id: "request-other",
-                      name: "other",
-                      label: t("contactus.request.option4"),
-                      required: true,
-                    },
-                  ]}
-                ></MultipleChoiceGroup>
-              </fieldset>
-              <div className="focus-group">
-                <Label
-                  id={"label-description"}
-                  htmlFor={"description"}
-                  className="required"
-                  required
-                >
-                  {t("contactus.description.title")}
-                </Label>
-                <Description id={"description-description"}>
-                  {t("contactus.description.description")}
-                </Description>
-                <TextArea
-                  id={"description"}
-                  name={"description"}
-                  className="required mt-4 w-[34rem]"
-                  required
-                />
-              </div>
-              <p className="mt-14 text-[1.6rem]">{t("contactus.followUp")}</p>
-              <div className="focus-group mt-14">
-                <Label id={"label-name"} htmlFor={"name"} className="required" required>
-                  {t("contactus.name")}
-                </Label>
-                <TextInput type={"text"} id={"name"} name={"name"} className="required w-[34rem]" />
-              </div>
-              <div className="focus-group">
-                <Label id={"label-email"} htmlFor={"email"} className="required" required>
-                  {t("contactus.email")}
-                </Label>
-                <TextInput
-                  type={"text"}
-                  id={"email"}
-                  name={"email"}
-                  className="required w-[34rem]"
-                  required
-                />
-              </div>
-              <div className="focus-group mt-14">
-                <Label id={"label-department"} htmlFor={"department"} className="required" required>
-                  {t("contactus.department")}
-                </Label>
-                <TextInput
-                  type={"text"}
-                  id={"department"}
-                  name={"department"}
-                  className="required w-[34rem]"
-                />
-              </div>
-              <div className="focus-group mt-14">
-                <Label id={"label-branch"} htmlFor={"branch"}>
-                  {t("contactus.branch")}
-                </Label>
-                <TextInput type={"text"} id={"branch"} name={"branch"} className="w-[34rem]" />
-              </div>
-              <div className="focus-group mt-14">
-                <Label id={"label-jobTitle"} htmlFor={"jobTitle"}>
-                  {t("contactus.jobTitle")}
-                </Label>
-                <TextInput type={"text"} id={"jobTitle"} name={"jobTitle"} className="w-[34rem]" />
-              </div>
-              <Button type="submit" className="gc-button--blue" disabled={isSubmitting}>
-                {t("submitButton", { ns: "common" })}
-              </Button>
-            </form>
+            <>
+              <h1>{t("contactus.title")}</h1>
+              <p className="mb-6 mt-[-2rem] text-[1.6rem]">{t("contactus.useThisForm")}</p>
+              <p className="mb-14">
+                {t("contactus.gcFormsTeamPart1")}{" "}
+                <Link href={`https://www.canada.ca/${language}/contact.html`}>
+                  {t("contactus.gcFormsTeamLink")}
+                </Link>{" "}
+                {t("contactus.gcFormsTeamPart2")}
+              </p>
+              <Alert.Warning title={t("contactus.needSupport")} role="note">
+                <p>
+                  {t("contactus.ifYouExperience")}{" "}
+                  <Link href={`/${language}/support`}>{t("contactus.supportFormLink")}</Link>.
+                </p>
+              </Alert.Warning>
+              <form id="contactus" method="POST" onSubmit={handleSubmit} noValidate>
+                <fieldset className="focus-group mt-14">
+                  <legend className="gc-label required">
+                    {t("contactus.request.title")}{" "}
+                    <span data-testid="required" aria-hidden>
+                      ({t("required")})
+                    </span>
+                  </legend>
+                  <MultipleChoiceGroup
+                    name="request"
+                    type="checkbox"
+                    choicesProps={[
+                      {
+                        id: "request-question",
+                        name: "question",
+                        label: t("contactus.request.option1"),
+                        required: true,
+                      },
+                      {
+                        id: "request-feedback",
+                        name: "feedback",
+                        label: t("contactus.request.option2"),
+                        required: true,
+                      },
+                      {
+                        id: "request-feature",
+                        name: "feature",
+                        label: t("contactus.request.option3"),
+                        required: true,
+                      },
+                      {
+                        id: "request-other",
+                        name: "other",
+                        label: t("contactus.request.option4"),
+                        required: true,
+                      },
+                    ]}
+                  ></MultipleChoiceGroup>
+                </fieldset>
+                <div className="focus-group">
+                  <Label
+                    id={"label-description"}
+                    htmlFor={"description"}
+                    className="required"
+                    required
+                  >
+                    {t("contactus.description.title")}
+                  </Label>
+                  <Description id={"description-description"}>
+                    {t("contactus.description.description")}
+                  </Description>
+                  <TextArea
+                    id={"description"}
+                    name={"description"}
+                    className="required mt-4 w-[34rem]"
+                    required
+                  />
+                </div>
+                <p className="mt-14 text-[1.6rem]">{t("contactus.followUp")}</p>
+                <div className="focus-group mt-14">
+                  <Label id={"label-name"} htmlFor={"name"} className="required" required>
+                    {t("contactus.name")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"name"}
+                    name={"name"}
+                    className="required w-[34rem]"
+                  />
+                </div>
+                <div className="focus-group">
+                  <Label id={"label-email"} htmlFor={"email"} className="required" required>
+                    {t("contactus.email")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"email"}
+                    name={"email"}
+                    className="required w-[34rem]"
+                    required
+                  />
+                </div>
+                <div className="focus-group mt-14">
+                  <Label
+                    id={"label-department"}
+                    htmlFor={"department"}
+                    className="required"
+                    required
+                  >
+                    {t("contactus.department")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"department"}
+                    name={"department"}
+                    className="required w-[34rem]"
+                  />
+                </div>
+                <div className="focus-group mt-14">
+                  <Label id={"label-branch"} htmlFor={"branch"}>
+                    {t("contactus.branch")}
+                  </Label>
+                  <TextInput type={"text"} id={"branch"} name={"branch"} className="w-[34rem]" />
+                </div>
+                <div className="focus-group mt-14">
+                  <Label id={"label-jobTitle"} htmlFor={"jobTitle"}>
+                    {t("contactus.jobTitle")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"jobTitle"}
+                    name={"jobTitle"}
+                    className="w-[34rem]"
+                  />
+                </div>
+                <Button type="submit" className="gc-button--blue" disabled={isSubmitting}>
+                  {t("submitButton", { ns: "common" })}
+                </Button>
+              </form>
+            </>
           )}
         </>
       )}

--- a/app/(gcforms)/[locale]/(support)/contact/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/contact/page.tsx
@@ -2,8 +2,6 @@ import { serverTranslation } from "@i18n";
 import { Metadata } from "next";
 import { ContactForm } from "./components/client/ContactForm";
 import { Success } from "../components/server/Success";
-import { Alert } from "@clientComponents/globals";
-import Link from "next/link";
 
 export async function generateMetadata({
   params: { locale },
@@ -21,35 +19,5 @@ export default async function Page({
 }: {
   searchParams: { success?: string };
 }) {
-  const {
-    t,
-    i18n: { language },
-  } = await serverTranslation(["form-builder"]);
-
-  return (
-    <>
-      {success === undefined ? (
-        <>
-          <h1>{t("contactus.title")}</h1>
-          <p className="mb-6 mt-[-2rem] text-[1.6rem]">{t("contactus.useThisForm")}</p>
-          <p className="mb-14">
-            {t("contactus.gcFormsTeamPart1")}{" "}
-            <Link href={`https://www.canada.ca/${language}/contact.html`}>
-              {t("contactus.gcFormsTeamLink")}
-            </Link>{" "}
-            {t("contactus.gcFormsTeamPart2")}
-          </p>
-          <Alert.Warning title={t("contactus.needSupport")} role="note">
-            <p>
-              {t("contactus.ifYouExperience")}{" "}
-              <Link href={`/${language}/support`}>{t("contactus.supportFormLink")}</Link>.
-            </p>
-          </Alert.Warning>
-          <ContactForm />
-        </>
-      ) : (
-        <Success />
-      )}
-    </>
-  );
+  return <>{success === undefined ? <ContactForm /> : <Success />}</>;
 }

--- a/app/(gcforms)/[locale]/(support)/support/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/support/actions.ts
@@ -13,9 +13,14 @@ export async function support({
   email: string;
   request: string;
   description: string;
-  language: string;
+  language?: string;
 }) {
   // No auth etc. checking since this is a public endpoint
+
+  //Mandatory fields
+  if (!name || !email || !request || !description) {
+    throw new Error("Malformed request");
+  }
 
   // Request may be a list of strings (checkbox), format it a bit if so, or just a string (radio)
   const requestParsed =

--- a/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
@@ -18,6 +18,8 @@ import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
 import { useState } from "react";
 import { support } from "../../actions";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Alert } from "@clientComponents/globals";
 
 export const SupportForm = () => {
   const {
@@ -95,87 +97,109 @@ export const SupportForm = () => {
             </ValidationMessage>
           )}
           {!errorMessage && (
-            <form id="support" method="POST" onSubmit={handleSubmit} noValidate>
-              <div className="focus-group mt-14">
-                <Label id={"label-name"} htmlFor={"name"} className="required" required>
-                  {t("support.name")}
-                </Label>
-                <TextInput type={"text"} id={"name"} name={"name"} className="required w-[34rem]" />
-              </div>
-              <div className="focus-group">
-                <Label id={"label-email"} htmlFor={"email"} className="required" required>
-                  {t("support.email")}
-                </Label>
-                <TextInput
-                  type={"text"}
-                  id={"email"}
-                  name={"email"}
-                  className="required w-[34rem]"
-                  required
-                />
-              </div>
-              <fieldset className="focus-group">
-                <legend className="gc-label required">
-                  {t("support.request.title")}{" "}
-                  <span data-testid="required" aria-hidden>
-                    ({t("required", { ns: "common" })})
-                  </span>
-                </legend>
-                <MultipleChoiceGroup
-                  name="request"
-                  type="radio"
-                  choicesProps={[
-                    {
-                      id: "request-question",
-                      name: "question",
-                      label: t("support.request.option1"),
-                      required: true,
-                    },
-                    {
-                      id: "request-technical",
-                      name: "technical",
-                      label: t("support.request.option2"),
-                      required: true,
-                    },
-                    {
-                      id: "request-form",
-                      name: "form",
-                      label: t("support.request.option3"),
-                      required: true,
-                    },
-                    {
-                      id: "request-other",
-                      name: "other",
-                      label: t("support.request.option4"),
-                      required: true,
-                    },
-                  ]}
-                ></MultipleChoiceGroup>
-              </fieldset>
-              <div className="focus-group">
-                <Label
-                  id={"label-description"}
-                  htmlFor={"description"}
-                  className="required"
-                  required
-                >
-                  {t("support.description.title")}
-                </Label>
-                <Description id={"description-description"}>
-                  {t("support.description.description")}
-                </Description>
-                <TextArea
-                  id={"description"}
-                  name={"description"}
-                  className="required w-[34rem] mt-4"
-                  required
-                />
-              </div>
+            <>
+              <h1>{t("support.title")}</h1>
+              <p className="mb-6 mt-[-2rem] text-[1.6rem]">{t("support.useThisForm")}</p>
+              <p className="mb-14">
+                {t("support.gcFormsTeamPart1")}{" "}
+                <Link href={`https://www.canada.ca/${language}/contact.html`}>
+                  {t("support.gcFormsTeamLink")}
+                </Link>{" "}
+                {t("support.gcFormsTeamPart2")}
+              </p>
+              <Alert.Warning title={t("support.lookingForADemo")} role="note">
+                <p>
+                  {t("support.ifYouWouldLike")}{" "}
+                  <Link href={`/${language}/contact`}>{t("support.contactUs")}</Link>.
+                </p>
+              </Alert.Warning>
+              <form id="support" method="POST" onSubmit={handleSubmit} noValidate>
+                <div className="focus-group mt-14">
+                  <Label id={"label-name"} htmlFor={"name"} className="required" required>
+                    {t("support.name")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"name"}
+                    name={"name"}
+                    className="required w-[34rem]"
+                  />
+                </div>
+                <div className="focus-group">
+                  <Label id={"label-email"} htmlFor={"email"} className="required" required>
+                    {t("support.email")}
+                  </Label>
+                  <TextInput
+                    type={"text"}
+                    id={"email"}
+                    name={"email"}
+                    className="required w-[34rem]"
+                    required
+                  />
+                </div>
+                <fieldset className="focus-group">
+                  <legend className="gc-label required">
+                    {t("support.request.title")}{" "}
+                    <span data-testid="required" aria-hidden>
+                      ({t("required", { ns: "common" })})
+                    </span>
+                  </legend>
+                  <MultipleChoiceGroup
+                    name="request"
+                    type="radio"
+                    choicesProps={[
+                      {
+                        id: "request-question",
+                        name: "question",
+                        label: t("support.request.option1"),
+                        required: true,
+                      },
+                      {
+                        id: "request-technical",
+                        name: "technical",
+                        label: t("support.request.option2"),
+                        required: true,
+                      },
+                      {
+                        id: "request-form",
+                        name: "form",
+                        label: t("support.request.option3"),
+                        required: true,
+                      },
+                      {
+                        id: "request-other",
+                        name: "other",
+                        label: t("support.request.option4"),
+                        required: true,
+                      },
+                    ]}
+                  ></MultipleChoiceGroup>
+                </fieldset>
+                <div className="focus-group">
+                  <Label
+                    id={"label-description"}
+                    htmlFor={"description"}
+                    className="required"
+                    required
+                  >
+                    {t("support.description.title")}
+                  </Label>
+                  <Description id={"description-description"}>
+                    {t("support.description.description")}
+                  </Description>
+                  <TextArea
+                    id={"description"}
+                    name={"description"}
+                    className="required w-[34rem] mt-4"
+                    required
+                  />
+                </div>
 
-              <Button type="submit" theme="primary" disabled={isSubmitting}>
-                {t("submitButton", { ns: "common" })}
-              </Button>
-            </form>
+                <Button type="submit" theme="primary" disabled={isSubmitting}>
+                  {t("submitButton", { ns: "common" })}
+                </Button>
+              </form>
+            </>
           )}
         </>
       )}

--- a/app/(gcforms)/[locale]/(support)/support/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/page.tsx
@@ -2,8 +2,6 @@ import { serverTranslation } from "@i18n";
 import { Metadata } from "next";
 import { SupportForm } from "./components/client/SupportForm";
 import { Success } from "../components/server/Success";
-import Link from "next/link";
-import { Alert } from "@clientComponents/globals";
 
 export async function generateMetadata({
   params: { locale },
@@ -21,35 +19,5 @@ export default async function Page({
 }: {
   searchParams: { success?: string };
 }) {
-  const {
-    t,
-    i18n: { language },
-  } = await serverTranslation(["form-builder"]);
-
-  return (
-    <>
-      {success === undefined ? (
-        <>
-          <h1>{t("support.title")}</h1>
-          <p className="mb-6 mt-[-2rem] text-[1.6rem]">{t("support.useThisForm")}</p>
-          <p className="mb-14">
-            {t("support.gcFormsTeamPart1")}{" "}
-            <Link href={`https://www.canada.ca/${language}/contact.html`}>
-              {t("support.gcFormsTeamLink")}
-            </Link>{" "}
-            {t("support.gcFormsTeamPart2")}
-          </p>
-          <Alert.Warning title={t("support.lookingForADemo")} role="note">
-            <p>
-              {t("support.ifYouWouldLike")}{" "}
-              <Link href={`/${language}/contact`}>{t("support.contactUs")}</Link>.
-            </p>
-          </Alert.Warning>
-          <SupportForm />
-        </>
-      ) : (
-        <Success />
-      )}
-    </>
-  );
+  return <>{success === undefined ? <SupportForm /> : <Success />}</>;
 }

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
@@ -9,13 +9,18 @@ export async function unlockPublishing({
   goals,
   language = "en",
 }: {
-  managerEmail?: string;
-  department?: string;
-  goals?: string;
+  managerEmail: string;
+  department: string;
+  goals: string;
   language?: string;
 }) {
   const session = await auth();
   if (!session) throw new Error("No session");
+
+  //Mandatory fields
+  if (!managerEmail || !department || !goals) {
+    throw new Error("Malformed request");
+  }
 
   const description = `
   ${session.user.name} (${session.user.email}) from ${department} has requested permission to publish forms.<br/>

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
@@ -101,73 +101,77 @@ export const UnlockPublishingForm = ({ email }: { email: string }) => {
                   </ol>
                 </Alert>
               )}
-              <form id="unlock-publishing" method="POST" onSubmit={handleSubmit} noValidate>
-                <div className="focus-group">
-                  <Label
-                    id={"label-managerEmail"}
-                    htmlFor={"managerEmail"}
-                    className="required"
-                    required
-                  >
-                    {t("unlockPublishing.form.field1.title")}
-                  </Label>
-                  <Description id={"unlock-publishing-description"}>
-                    {t("unlockPublishing.form.field1.description")}
-                  </Description>
-                  <TextInput
-                    type={"text"}
-                    id={"managerEmail"}
-                    name={"managerEmail"}
-                    className="required w-[34rem]"
-                    ariaDescribedBy={"unlock-publishing-description"}
-                  />
-                </div>
+              <>
+                <h1>{t("unlockPublishing.title")}</h1>
+                <p className="mb-14">{t("unlockPublishing.paragraph1")}</p>
+                <form id="unlock-publishing" method="POST" onSubmit={handleSubmit} noValidate>
+                  <div className="focus-group">
+                    <Label
+                      id={"label-managerEmail"}
+                      htmlFor={"managerEmail"}
+                      className="required"
+                      required
+                    >
+                      {t("unlockPublishing.form.field1.title")}
+                    </Label>
+                    <Description id={"unlock-publishing-description"}>
+                      {t("unlockPublishing.form.field1.description")}
+                    </Description>
+                    <TextInput
+                      type={"text"}
+                      id={"managerEmail"}
+                      name={"managerEmail"}
+                      className="required w-[34rem]"
+                      ariaDescribedBy={"unlock-publishing-description"}
+                    />
+                  </div>
 
-                <div className="focus-group">
-                  <Label
-                    id={"label-department"}
-                    htmlFor={"department"}
-                    className="required"
-                    required
-                  >
-                    {t("unlockPublishing.form.field2.title")}
-                  </Label>
-                  <TextInput
-                    type={"text"}
-                    id={"department"}
-                    name={"department"}
-                    className="required w-[34rem]"
-                    required
-                  />
-                </div>
+                  <div className="focus-group">
+                    <Label
+                      id={"label-department"}
+                      htmlFor={"department"}
+                      className="required"
+                      required
+                    >
+                      {t("unlockPublishing.form.field2.title")}
+                    </Label>
+                    <TextInput
+                      type={"text"}
+                      id={"department"}
+                      name={"department"}
+                      className="required w-[34rem]"
+                      required
+                    />
+                  </div>
 
-                <div className="focus-group">
-                  <Label id={"label-goals"} htmlFor={"goals"} className="required" required>
-                    {t("unlockPublishing.form.field3.title")}
-                  </Label>
-                  <TextArea
-                    id={"goals"}
-                    name={"goals"}
-                    className="required mt-4 w-[34rem]"
-                    required
-                  />
-                </div>
+                  <div className="focus-group">
+                    <Label id={"label-goals"} htmlFor={"goals"} className="required" required>
+                      {t("unlockPublishing.form.field3.title")}
+                    </Label>
+                    <TextArea
+                      id={"goals"}
+                      name={"goals"}
+                      className="required mt-4 w-[34rem]"
+                      required
+                    />
+                  </div>
 
-                <div className="mt-14 flex gap-4">
-                  <Button
-                    type="submit"
-                    data-submit="unlock-publishing"
-                    theme="primary"
-                    disabled={submitting}
-                  >
-                    {t("submitButton", { ns: "common" })}
-                  </Button>
+                  <div className="mt-14 flex gap-4">
+                    <Button
+                      type="submit"
+                      data-submit="unlock-publishing"
+                      theme="primary"
+                      disabled={submitting}
+                    >
+                      {t("submitButton", { ns: "common" })}
+                    </Button>
 
-                  <LinkButton.Secondary href={`/${language}/forms/`}>
-                    {t("unlockPublishing.skipStepButton")}
-                  </LinkButton.Secondary>
-                </div>
-              </form>
+                    <LinkButton.Secondary href={`/${language}/forms/`}>
+                      {t("unlockPublishing.skipStepButton")}
+                    </LinkButton.Secondary>
+                  </div>
+                </form>
+              </>
             </>
           )}
         </>

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/page.tsx
@@ -36,19 +36,5 @@ export default async function Page({
     redirect(`/${locale}/forms`, RedirectType.replace);
   }
 
-  const { t } = await serverTranslation("unlock-publishing");
-
-  return (
-    <>
-      {success === undefined ? (
-        <>
-          <h1>{t("unlockPublishing.title")}</h1>
-          <p className="mb-14">{t("unlockPublishing.paragraph1")}</p>
-          <UnlockPublishingForm email={email} />
-        </>
-      ) : (
-        <Success />
-      )}
-    </>
-  );
+  return <>{success === undefined ? <UnlockPublishingForm email={email} /> : <Success />}</>;
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes server actions not throwing a "Malformed request" error. 
Also moves the forms intro content back into the forms components. This keeps the original design of showing just an error card (not the page title etc.) when an error is thrown from the server.