### PR TITLE
Fix: autoSave on navigation

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -30,19 +30,21 @@ const _getSessionAndAbility = async () => {
   return { session, ability };
 };
 
+export type CreateOrUpdateTemplateType = {
+  id?: string;
+  formConfig: FormProperties;
+  name?: string;
+  deliveryOption?: DeliveryOption;
+  securityAttribute?: SecurityAttribute;
+};
+
 export const createOrUpdateTemplate = async ({
   id,
   formConfig,
   name,
   deliveryOption,
   securityAttribute,
-}: {
-  id?: string;
-  formConfig: FormProperties;
-  name?: string;
-  deliveryOption?: DeliveryOption;
-  securityAttribute?: SecurityAttribute;
-}) => {
+}: CreateOrUpdateTemplateType) => {
   if (id) {
     return updateTemplate({ id, formConfig, name, deliveryOption, securityAttribute });
   }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/SaveButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/SaveButton.tsx
@@ -11,7 +11,6 @@ import { useTemplateContext } from "@lib/hooks/form-builder";
 import { formatDateTime } from "@lib/utils/form-builder";
 import { SavedFailIcon, SavedCheckIcon } from "@serverComponents/icons";
 import { usePathname } from "next/navigation";
-import { createOrUpdateTemplate } from "@formBuilder/actions";
 import { ErrorSaving } from "./ErrorSaving";
 
 const SaveDraft = ({
@@ -93,7 +92,7 @@ export const SaveButton = () => {
       setId: s.setId,
     }));
 
-  const { templateIsDirty } = useTemplateContext();
+  const { templateIsDirty, createOrUpdateTemplate } = useTemplateContext();
   const { status } = useSession();
   const [updatedAt, setUpdatedAt] = useState<number | undefined>();
   const [error, setError] = useState(false);
@@ -107,6 +106,10 @@ export const SaveButton = () => {
     const formConfig = getSchema();
 
     try {
+      if (!createOrUpdateTemplate) {
+        return;
+      }
+
       const template = await createOrUpdateTemplate({
         id: id,
         formConfig: JSON.parse(formConfig),

--- a/lib/hooks/form-builder/useTemplateContext.tsx
+++ b/lib/hooks/form-builder/useTemplateContext.tsx
@@ -2,6 +2,8 @@
 import React, { createContext, useState, useContext, useRef } from "react";
 import { useTemplateStore, useSubscibeToTemplateStore } from "../../store";
 import { logMessage } from "@lib/logger";
+import { CreateOrUpdateTemplateType, createOrUpdateTemplate } from "@formBuilder/actions";
+import { PublicFormRecord } from "@lib/types";
 
 interface TemplateApiType {
   templateIsDirty: React.MutableRefObject<boolean>;
@@ -9,6 +11,15 @@ interface TemplateApiType {
   introChanged: boolean | null;
   privacyChanged: boolean | null;
   confirmationChanged: boolean | null;
+  createOrUpdateTemplate:
+    | (({
+        id,
+        formConfig,
+        name,
+        deliveryOption,
+        securityAttribute,
+      }: CreateOrUpdateTemplateType) => Promise<PublicFormRecord>)
+    | null;
 }
 
 const defaultTemplateApi: TemplateApiType = {
@@ -17,6 +28,7 @@ const defaultTemplateApi: TemplateApiType = {
   introChanged: null,
   privacyChanged: null,
   confirmationChanged: null,
+  createOrUpdateTemplate: null,
 };
 
 const TemplateApiContext = createContext<TemplateApiType>(defaultTemplateApi);
@@ -111,6 +123,7 @@ export function TemplateApiProvider({ children }: { children: React.ReactNode })
         introChanged,
         privacyChanged,
         confirmationChanged,
+        createOrUpdateTemplate,
       }}
     >
       {children}


### PR DESCRIPTION
# Summary | Résumé

Previously, the SaveButton imported the `createOrUpdateTemplate` server action directly. The problem when autosaving on page exit seems to be that the serverAction becomes de/re-registered when navigating and does not fire.

This PR moves the actions import to useTemplateContext which does not unmount on navigation, and SaveButton can just access it through there.
