### PR TITLE
Fix settings panel protected B

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsPanel.tsx
@@ -120,6 +120,7 @@ export const SettingsPanel = () => {
           <div className="ml-4 inline-block">
             <div className="my-[6px] border-[.5px] border-violet-50 p-1 px-2 hover:border-[.5px] hover:border-slate-800">
               <ClassificationSelect
+                disableProtectedB={email ? true : false}
                 className="w-auto max-w-[400px] truncate border-none bg-violet-50 p-1 text-sm"
                 lang={lang}
                 isPublished={isPublished}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/ClassificationSelect.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/ClassificationSelect.tsx
@@ -22,6 +22,7 @@ export interface ClassificationSelectProps {
   classification: ClassificationType;
   handleUpdateClassification: (classification: ClassificationType) => void;
   className?: string;
+  disableProtectedB?: boolean;
 }
 
 export const ClassificationSelect = ({
@@ -30,6 +31,7 @@ export const ClassificationSelect = ({
   classification,
   handleUpdateClassification,
   className,
+  disableProtectedB,
   ...rest
 }: ClassificationSelectProps) => {
   return (
@@ -50,7 +52,11 @@ export const ClassificationSelect = ({
         {...rest}
       >
         {classificationOptions.map((option) => (
-          <option key={option.value} value={option.value}>
+          <option
+            key={option.value}
+            value={option.value}
+            disabled={option.value === "Protected B" && disableProtectedB}
+          >
             {option[lang]}
           </option>
         ))}


### PR DESCRIPTION
# Summary | Résumé

Ensure protected B isn't available to be chosen in the settings panel dropdown if the delivery option is set to email. 