### PR TITLE
Fix - Hide Forms link when logged out

### DIFF
--- a/components/clientComponents/globals/layouts/UserNavLayout.tsx
+++ b/components/clientComponents/globals/layouts/UserNavLayout.tsx
@@ -7,6 +7,7 @@ import { Footer, Brand, SkipLink, LanguageToggle } from "@clientComponents/globa
 import { LoginMenu } from "@clientComponents/auth/LoginMenu";
 import { SiteLogo } from "@serverComponents/icons";
 import { ToastContainer } from "@formBuilder/components/shared/Toast";
+import { useSession } from "next-auth/react";
 
 const SiteLink = () => {
   const {
@@ -46,6 +47,8 @@ const UserNavLayout = ({
     i18n: { language },
   } = useTranslation("common");
 
+  const { status } = useSession();
+
   return (
     <div className="flex min-h-full flex-col bg-gray-soft">
       <SkipLink />
@@ -56,11 +59,13 @@ const UserNavLayout = ({
             <Brand brand={null} />
           </div>
           <div className="inline-flex gap-4">
-            <div className="text-base font-normal not-italic md:text-sm">
-              <Link id="forms_link" href={`/${language}/forms`}>
-                {t("adminNav.myForms")}
-              </Link>
-            </div>
+            {status === "authenticated" && (
+              <div className="text-base font-normal not-italic md:text-sm">
+                <Link id="forms_link" href={`/${language}/forms`}>
+                  {t("adminNav.myForms")}
+                </Link>
+              </div>
+            )}
             <LoginMenu />
             <LanguageToggle />
           </div>


### PR DESCRIPTION
# Summary | Résumé

Forms link was displaying on certain pages when logged out. Added a conditional wrapper around the link in UserNavLayout.tsx

| Logged out                                          | Login                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![image](https://github.com/cds-snc/platform-forms-client/assets/1187115/90c236c8-a326-4607-89ad-351ca625376a) | ![image](https://github.com/cds-snc/platform-forms-client/assets/1187115/b60f8eb0-d461-4da8-a0e2-12aec6c74572) |


