### PR TITLE
chore: rework file validation

### DIFF
--- a/__utils__/mocks/file-type/index.ts
+++ b/__utils__/mocks/file-type/index.ts
@@ -1,0 +1,1 @@
+export const fileTypeFromBuffer = (buffer: Uint8Array | ArrayBuffer) => Promise.resolve(undefined);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsDialog.tsx
@@ -9,7 +9,7 @@ import { Logos, options } from "../../../settings/branding/components";
 import Brand from "@clientComponents/globals/Brand";
 import { LocalizedFormProperties } from "@lib/types/form-builder-types";
 import { ResponseEmail } from "@formBuilder/components/ResponseEmail";
-import { isValidGovEmail } from "@lib/validation";
+import { isValidGovEmail } from "@lib/validation/validation";
 import { completeEmailAddressRegex } from "@lib/utils/form-builder";
 import {
   ClassificationSelect,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -12,7 +12,7 @@ import {
 } from "@lib/responseDownloadFormats/types";
 import { getFullTemplateByID } from "@lib/templates";
 import { FormElementTypes, VaultStatus } from "@lib/types";
-import { isResponseId } from "@lib/validation";
+import { isResponseId } from "@lib/validation/validation";
 import { listAllSubmissions, retrieveSubmissions, updateLastDownloadedBy } from "@lib/vault";
 import { transform as csvTransform } from "@lib/responseDownloadFormats/csv";
 import { transform as htmlAggregatedTransform } from "@lib/responseDownloadFormats/html-aggregated";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Dialogs/ConfirmDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Dialogs/ConfirmDialog.tsx
@@ -8,7 +8,7 @@ import { Button, Alert } from "@clientComponents/globals";
 import { randomId, runPromisesSynchronously } from "@lib/client/clientHelpers";
 import axios from "axios";
 import Link from "next/link";
-import { isUUID } from "@lib/validation";
+import { isUUID } from "@lib/validation/validation";
 import { DialogStates } from "./DialogStates";
 import { chunkArray } from "@lib/utils";
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Dialogs/ReportDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Dialogs/ReportDialog.tsx
@@ -7,7 +7,7 @@ import {
 import { useTranslation } from "@i18n/client";
 import { randomId } from "@lib/client/clientHelpers";
 import { logMessage } from "@lib/logger";
-import { isResponseId } from "@lib/validation";
+import { isResponseId } from "@lib/validation/validation";
 import { WarningIcon } from "@serverComponents/icons";
 import axios from "axios";
 import Link from "next/link";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -4,7 +4,7 @@ import { LocalizedFormProperties } from "@lib/types/form-builder-types";
 import { useTranslation } from "@i18n/client";
 import { useSession } from "next-auth/react";
 import { useRefresh } from "@lib/hooks";
-import { isValidGovEmail } from "@lib/validation";
+import { isValidGovEmail } from "@lib/validation/validation";
 import { ResponseEmail } from "@formBuilder/components/ResponseEmail";
 import { Radio } from "@formBuilder/components/shared";
 import { Button } from "@clientComponents/globals";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/ResponseEmail.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/ResponseEmail.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect } from "react";
 import { useTranslation } from "@i18n/client";
-import { isValidGovEmail } from "@lib/validation";
+import { isValidGovEmail } from "@lib/validation/validation";
 import { Input } from "./shared";
 import { completeEmailAddressRegex } from "@lib/utils/form-builder";
 

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/buildFormDataObject.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/buildFormDataObject.ts
@@ -103,8 +103,8 @@ function _handleFormDataFileInput(
   key: string,
   value: FileInputResponse
 ): [string, FileInputResponse | string] {
-  return value.file
-    ? [key, { file: value.file, name: value.name, size: value.size, type: value.type }]
+  return value.based64EncodedFile
+    ? [key, { name: value.name, size: value.size, based64EncodedFile: value.based64EncodedFile }]
     : _handleFormDataText(key, "");
 }
 

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
@@ -15,7 +15,7 @@ import {
   toLowerCase,
   toTrimmed,
 } from "valibot";
-import { isValidGovEmail } from "@lib/validation";
+import { isValidGovEmail } from "@lib/validation/validation";
 
 export interface ErrorStates {
   validationErrors: {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { useTranslation } from "@i18n/client";
 import { useRouter, useSearchParams } from "next/navigation";
-import { localPathRegEx } from "@lib/validation";
+import { localPathRegEx } from "@lib/validation/validation";
 import { Button } from "@clientComponents/globals";
 import { useSession } from "next-auth/react";
 

--- a/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
@@ -6,7 +6,7 @@ import {
   containsLowerCaseCharacter,
   containsNumber,
   containsSymbol,
-} from "@lib/validation";
+} from "@lib/validation/validation";
 import { serverTranslation } from "@i18n";
 import { begin2FAAuthentication, initiateSignIn } from "@lib/auth";
 import {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
@@ -21,7 +21,7 @@ import {
   containsLowerCaseCharacter,
   containsNumber,
   containsSymbol,
-} from "@lib/validation";
+} from "@lib/validation/validation";
 import { deleteMagicLinkEntry } from "@lib/auth/passwordReset";
 
 export interface ErrorStates {

--- a/app/api/id/[form]/apiusers/apiusers.ts
+++ b/app/api/id/[form]/apiusers/apiusers.ts
@@ -1,7 +1,7 @@
 // import { NextApiRequest, NextApiResponse } from "next";
 // import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
 // import { Prisma } from "@prisma/client";
-// import { isValidGovEmail } from "@lib/validation";
+// import { isValidGovEmail } from "@lib/validation/validation";
 // import { MiddlewareProps, WithRequired, UserAbility } from "@lib/types";
 // import { createAbility, AccessControlError } from "@lib/privileges";
 // import { checkPrivileges } from "@lib/privileges";

--- a/components/clientComponents/admin/FormAccess/FormAccess.tsx
+++ b/components/clientComponents/admin/FormAccess/FormAccess.tsx
@@ -5,7 +5,7 @@ import Loader from "@clientComponents/globals/Loader";
 import axios from "axios";
 import { useTranslation } from "@i18n/client";
 import React, { useEffect, useState } from "react";
-import { isValidGovEmail } from "@lib/validation";
+import { isValidGovEmail } from "@lib/validation/validation";
 import { FormOwner } from "@lib/types";
 
 export interface FormAccessProps {

--- a/components/clientComponents/forms/FileInput/FileInput.tsx
+++ b/components/clientComponents/forms/FileInput/FileInput.tsx
@@ -4,8 +4,8 @@ import { useField } from "formik";
 import classNames from "classnames";
 import { useTranslation } from "@i18n/client";
 import { ErrorMessage } from "@clientComponents/forms";
-import { acceptedFileMimeTypes } from "@lib/tsUtils";
 import { InputFieldProps } from "@lib/types";
+import { htmlInputAccept } from "@lib/validation/fileValidationClientSide";
 
 interface FileInputProps extends InputFieldProps {
   error?: boolean;
@@ -59,11 +59,9 @@ export const FileInput = (props: FileInputProps): React.ReactElement => {
           if (newFile.name !== fileName) {
             setFileName(newFile.name);
             setValue({
-              file: reader.result?.toString(),
-              src: reader,
               name: newFile.name,
               size: newFile.size,
-              type: newFile.type,
+              based64EncodedFile: reader.result?.toString().split(";base64,").pop(),
             });
           }
         };
@@ -103,7 +101,7 @@ export const FileInput = (props: FileInputProps): React.ReactElement => {
             id={`${name}_hidden`}
             tabIndex={-1}
             type="file"
-            accept={acceptedFileMimeTypes}
+            accept={htmlInputAccept}
             onChange={_onChange}
             onClick={(e) => e.stopPropagation()}
             disabled={disabled}

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { FormikProps, withFormik } from "formik";
 import { getFormInitialValues } from "@lib/formBuilder";
-import { getErrorList, setFocusOnErrorMessage, validateOnSubmit } from "@lib/validation";
+import { getErrorList, setFocusOnErrorMessage, validateOnSubmit } from "@lib/validation/validation";
 import { useFormTimer } from "@lib/hooks";
 import { Alert, Button, RichText } from "@clientComponents/forms";
 import { logMessage } from "@lib/logger";

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -30,6 +30,7 @@ const customJestConfig: Config = {
     }),
     "^next-auth(/?.*)$": "<rootDir>/__utils__/mocks/next-auth",
     "^lib/auth/nextAuth$": "<rootDir>/__utils__/mocks/nextAuth",
+    "^file-type$": "<rootDir>/__utils__/mocks/file-type",
   },
   moduleDirectories: ["node_modules", "<rootDir>"],
   clearMocks: true,

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -283,7 +283,7 @@ const _getElementInitialValue = (element: FormElement, language: string): Respon
     case FormElementTypes.checkbox:
       return [];
     case FormElementTypes.fileInput:
-      return { file: null, src: null, name: "", size: 0 };
+      return { name: null, size: null, based64EncodedFile: null };
     case FormElementTypes.dynamicRow: {
       const dynamicRowInitialValue: Responses =
         element.properties.subElements?.reduce((accumulator, currentValue, currentIndex) => {

--- a/lib/tests/validation/fileValidationClientSide.test.ts
+++ b/lib/tests/validation/fileValidationClientSide.test.ts
@@ -1,0 +1,35 @@
+import { isFileExtensionValid, isFileSizeValid } from "@lib/validation/fileValidationClientSide";
+
+describe("File extension validator", () => {
+  it.each([
+    ["pdf", true],
+    ["txt", true],
+    ["csv", true],
+    ["doc", true],
+    ["docx", true],
+    ["jpg", true],
+    ["png", true],
+    ["numbers", true],
+    ["PDF", true],
+    ["CSV", true],
+    ["ca", false],
+    ["reg", false],
+    ["mov", false],
+    ["mp3", false],
+    ["tar", false],
+    ["zip", false],
+  ])(`Should return true if file extension is valid (testing "%s")`, async (extension, isValid) => {
+    expect(isFileExtensionValid(`file.${extension}`)).toBe(isValid);
+  });
+});
+
+describe("File size validator", () => {
+  it.each([
+    [1000, true],
+    [8000000, true],
+    [8000001, false],
+    [10000000, false],
+  ])(`Should return true if file size is valid (testing "%s")`, async (fileSize, isValid) => {
+    expect(isFileSizeValid(fileSize)).toBe(isValid);
+  });
+});

--- a/lib/tests/validation/fileValidationServerSide.test.ts
+++ b/lib/tests/validation/fileValidationServerSide.test.ts
@@ -1,0 +1,93 @@
+import { fileTypeFromBuffer } from "file-type";
+import {
+  FileValidationResult,
+  validateFileToUpload,
+} from "@lib/validation/fileValidationServerSide";
+
+jest.mock("file-type");
+const mockFileTypeFromBuffer = jest.mocked(fileTypeFromBuffer, { shallow: true });
+
+describe("Regarless of the MIME type detection, it", () => {
+  beforeAll(() => {
+    mockFileTypeFromBuffer.mockResolvedValueOnce(undefined);
+  });
+
+  it("should return a VALID result if the size and the extension are both valid", async () => {
+    const sut = await validateFileToUpload(
+      "fileName.txt",
+      100,
+      Buffer.from("dGhpcyBpcyBhIG1lc3NhZ2U=")
+    );
+
+    expect(sut.result).toEqual(FileValidationResult.VALID);
+  });
+
+  it("should return a SIZE_IS_TOO_LARGE result if the given size is too large", async () => {
+    const sut = await validateFileToUpload(
+      "fileName.txt",
+      8000001,
+      Buffer.from("dGhpcyBpcyBhIG1lc3NhZ2U=")
+    );
+
+    expect(sut.result).toEqual(FileValidationResult.SIZE_IS_TOO_LARGE);
+    expect(sut.detectedValue).toEqual("8000001 (fileSize) / 24 (sizeOfBuffer)");
+  });
+
+  it("should return a SIZE_IS_TOO_LARGE result if the buffer size is too large", async () => {
+    const sut = await validateFileToUpload("fileName.txt", 100, Buffer.alloc(8000001));
+
+    expect(sut.result).toEqual(FileValidationResult.SIZE_IS_TOO_LARGE);
+    expect(sut.detectedValue).toEqual("100 (fileSize) / 8000001 (sizeOfBuffer)");
+  });
+
+  it("should return an INVALID_EXTENSION result if the given fileName has an invalid extension", async () => {
+    const sut = await validateFileToUpload(
+      "fileName.zip",
+      100,
+      Buffer.from("dGhpcyBpcyBhIG1lc3NhZ2U=")
+    );
+
+    expect(sut.result).toEqual(FileValidationResult.INVALID_EXTENSION);
+    expect(sut.detectedValue).toEqual("fileName.zip");
+  });
+});
+
+describe("When given file has detectable MIME type", () => {
+  it("should return a VALID result if the size, extension and MIME type are valid", async () => {
+    mockFileTypeFromBuffer.mockResolvedValueOnce({ ext: "pdf", mime: "application/pdf" });
+
+    const sut = await validateFileToUpload(
+      "fileName.pdf",
+      100,
+      Buffer.from("dGhpcyBpcyBhIG1lc3NhZ2U=")
+    );
+
+    expect(sut.result).toEqual(FileValidationResult.VALID);
+  });
+
+  it("should return an INVALID_EXTENSION result if the detected extension is invalid", async () => {
+    mockFileTypeFromBuffer.mockResolvedValueOnce({ ext: "zip", mime: "application/pdf" });
+
+    const sut = await validateFileToUpload(
+      "fileName.pdf",
+      100,
+      Buffer.from("dGhpcyBpcyBhIG1lc3NhZ2U=")
+    );
+
+    expect(sut.result).toEqual(FileValidationResult.INVALID_EXTENSION);
+    expect(sut.detectedValue).toEqual("zip");
+  });
+
+  it("should return an INVALID_MIME_TYPE result if the detected MIME type is invalid", async () => {
+    mockFileTypeFromBuffer.mockResolvedValueOnce({ ext: "pdf", mime: "application/zip" });
+
+    const sut = await validateFileToUpload(
+      "fileName.pdf",
+      100,
+      Buffer.from("dGhpcyBpcyBhIG1lc3NhZ2U=")
+    );
+
+    expect(sut.result).toEqual(FileValidationResult.INVALID_MIME_TYPE);
+    expect(sut.detectedValue).toEqual("application/zip");
+  });
+});

--- a/lib/tests/validation/validation.test.js
+++ b/lib/tests/validation/validation.test.js
@@ -7,7 +7,7 @@ import {
   containsLowerCaseCharacter,
   containsUpperCaseCharacter,
   containsNumber,
-} from "@lib/validation";
+} from "@lib/validation/validation";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -163,14 +163,12 @@ const testCases = [
     fieldType: "fileInput",
     passConditions: [
       {
-        file: new File([""], "fileName", { type: "application/pdf" }),
-        src: null,
-        name: "",
-        size: 0,
-        type: "application/pdf",
+        name: "fileName.csv",
+        size: 1,
+        based64EncodedFile: "myFile",
       },
     ],
-    failConditions: [{ 1: { file: null, src: null, name: "", size: 0, type: null } }],
+    failConditions: [{ 1: { name: null, size: null, based64EncodedFile: null } }],
     expectedError: { 1: "input-validation.required" },
     required: true,
   },
@@ -178,19 +176,17 @@ const testCases = [
     fieldType: "fileInput",
     passConditions: [
       {
-        file: new File([""], "fileName", { type: "application/pdf" }),
-        src: null,
-        name: "",
+        name: "fileName.csv",
         size: 8000000,
+        based64EncodedFile: "myFile",
       },
     ],
     failConditions: [
       {
         1: {
-          file: new File([""], "fileName", { type: "application/pdf" }),
-          src: null,
-          name: "",
+          name: "fileName.csv",
           size: 8000001,
+          based64EncodedFile: "myFile",
         },
       },
     ],
@@ -201,19 +197,17 @@ const testCases = [
     fieldType: "fileInput",
     passConditions: [
       {
-        file: new File([""], "fileName", { type: "application/pdf" }),
-        src: null,
-        name: "",
-        size: 0,
+        name: "fileName.csv",
+        size: 1,
+        based64EncodedFile: "myFile",
       },
     ],
     failConditions: [
       {
         1: {
-          file: new File([""], "fileName", { type: "application/fake" }),
-          src: null,
-          name: "",
-          size: 0,
+          name: "fileName.weird",
+          size: 1,
+          based64EncodedFile: "myFile",
         },
       },
     ],

--- a/lib/tsUtils.ts
+++ b/lib/tsUtils.ts
@@ -12,6 +12,3 @@ export const isServer = (): boolean => {
 export function filterUndef<T>(ts: (T | undefined)[]): T[] {
   return ts.filter((t: T | undefined): t is T => !!t);
 }
-
-export const acceptedFileMimeTypes =
-  "application/pdf,text/plain,text/csv,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,image/jpeg,image/png,image/svg+xml,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.apple.numbers";

--- a/lib/types/form-response-types.ts
+++ b/lib/types/form-response-types.ts
@@ -12,7 +12,7 @@ export type Response =
   | Record<string, unknown>;
 
 export type FileInputResponse = {
-  name: string;
-  file: string;
-  [key: string]: string | number | File | FileReader;
+  name: string | null;
+  size: number | null;
+  based64EncodedFile: string | null;
 };

--- a/lib/validation/fileValidationClientSide.tsx
+++ b/lib/validation/fileValidationClientSide.tsx
@@ -1,0 +1,30 @@
+export const ALLOWED_FILE_TYPES = [
+  { mime: "application/pdf", extensions: ["pdf"] },
+  { mime: "text/plain", extensions: ["txt"] },
+  { mime: "text/csv", extensions: ["csv"] },
+  { mime: "application/msword", extensions: ["doc"] },
+  { mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", extensions: ["docx"] },
+  { mime: "image/jpeg", extensions: ["jpg", "jpeg"] },
+  { mime: "image/png", extensions: ["png"] },
+  { mime: "image/svg+xml", extensions: ["svg"] },
+  { mime: "application/vnd.ms-excel", extensions: ["xls"] },
+  { mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", extensions: ["xlsx"] },
+  { mime: "application/vnd.apple.numbers", extensions: ["numbers"] },
+];
+
+const MAXIMUM_FILE_SIZE_IN_BYTES = 8000000; // 8 MB
+
+// See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept
+export const htmlInputAccept = ALLOWED_FILE_TYPES.map(t => [t.mime].concat(t.extensions.map(e => `.${e}`))).flat().join(",");
+
+export function isFileExtensionValid(fileName: string): boolean {
+  const extension = fileName.split(".").pop()?.toLowerCase();
+
+  if (!extension) return false;
+
+  return ALLOWED_FILE_TYPES.map(t => t.extensions).flat().includes(extension);
+}
+
+export function isFileSizeValid(sizeInBytes: number): boolean {
+  return sizeInBytes <= MAXIMUM_FILE_SIZE_IN_BYTES;
+}

--- a/lib/validation/fileValidationServerSide.tsx
+++ b/lib/validation/fileValidationServerSide.tsx
@@ -1,0 +1,66 @@
+import { fileTypeFromBuffer } from "file-type";
+import {
+  ALLOWED_FILE_TYPES,
+  isFileExtensionValid,
+  isFileSizeValid,
+} from "./fileValidationClientSide";
+
+export enum FileValidationResult {
+  VALID,
+  SIZE_IS_TOO_LARGE,
+  INVALID_EXTENSION,
+  INVALID_MIME_TYPE,
+}
+
+export async function validateFileToUpload(
+  fileName: string,
+  fileSize: number,
+  fileAsBuffer: Buffer
+): Promise<{ result: FileValidationResult; detectedValue?: string }> {
+  const sizeOfBufferInBytes = Buffer.byteLength(fileAsBuffer);
+
+  if (!isFileSizeValid(fileSize) || !isFileSizeValid(sizeOfBufferInBytes)) {
+    return {
+      result: FileValidationResult.SIZE_IS_TOO_LARGE,
+      detectedValue: `${fileSize} (fileSize) / ${sizeOfBufferInBytes.toString()} (sizeOfBuffer)`,
+    };
+  }
+
+  if (!isFileExtensionValid(fileName)) {
+    return {
+      result: FileValidationResult.INVALID_EXTENSION,
+      detectedValue: fileName,
+    };
+  }
+
+  const fileTypeResult = await fileTypeFromBuffer(fileAsBuffer);
+
+  if (fileTypeResult) {
+    // isFileExtensionValid expect a complete filename but the file-type API only gives us the extension
+    if (!isFileExtensionValid(`test.${fileTypeResult.ext}`)) {
+      return {
+        result: FileValidationResult.INVALID_EXTENSION,
+        detectedValue: fileTypeResult.ext,
+      };
+    }
+
+    if (!isFileMimeTypeValid(fileTypeResult.mime)) {
+      return {
+        result: FileValidationResult.INVALID_MIME_TYPE,
+        detectedValue: fileTypeResult.mime,
+      };
+    }
+  } else {
+    /**
+     * The `file-type`library is not able to detect some type of files (e.g. doc;xls;csv;svg). (See https://www.npmjs.com/package/file-type#supported-file-types)
+     * We used to have https://www.npmjs.com/package/mmmagic to detect text-based file format but it is no longer compatible with our version of NextJS.
+     * Since there is a file scanner on the infra side we can let the files go through and assume they are probably text/plain files.
+     */
+  }
+
+  return { result: FileValidationResult.VALID };
+}
+
+function isFileMimeTypeValid(mimeType: string): boolean {
+  return ALLOWED_FILE_TYPES.map((t) => t.mime).includes(mimeType);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
# Summary | Résumé

part of the work related to https://github.com/cds-snc/platform-forms-client/issues/3293

- Reworked file validation for the file input component. Two types of validation are applied at different stages (client and server)

# Test instructions | Instructions pour tester la modification

- Create a form with a file input component
- Try to upload a file with a size larger than 8 MB
- Try to upload a file with an extension that is not allowed (e.g. .zip)
- Try to upload a file with a modified extension (e.g. rename a .zip to .csv)


You can also call the submit API directly to try to bypass the client side validation. Here is an example where I tried to upload a file larger than 8 MB by passing a fake size value:
```
POST
http://localhost:3000/api/submit

HEADERS
X-CSRF-Token: <insert_valid_token>

DATA:
{
    "formID": "<insert_form_id_with_a_single_component_that_is_file_input>",
    "securityAttribute": "Protected A",
    "1": {
        "name": "myfile.txt",
        "size": 100,
        "based64EncodedFile": "<insert_a_base64_encoded_file_that_is_larger_than_8_mb>"
    }
}
```

I used https://base64.guru/converter/encode/file to convert a file to a base64 string (I could not upload the result here in the comments because it is too big).