### PR TITLE
Fix - Logged out responses page should render LoggedOutTab

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/layout.tsx
@@ -6,6 +6,7 @@ import { DeliveryOptionEmail } from "./components/DeliveryOptionEmail";
 import { NavigationTabs } from "./components/NavigationTabs";
 import { TitleAndDescription } from "./components/TitleAndDescription";
 import { fetchSubmissions, fetchTemplate } from "./actions";
+import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/LoggedOutTab";
 
 export default async function Layout({
   children,
@@ -14,9 +15,18 @@ export default async function Layout({
   children: React.ReactNode;
   params: { locale: string; statusFilter: string; id: string };
 }) {
-  const initialForm = await fetchTemplate(id);
   const session = await auth();
   const isAuthenticated = session !== null;
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-4xl">
+        <LoggedOutTab tabName={LoggedOutTabName.RESPONSES} />
+      </div>
+    );
+  }
+
+  const initialForm = await fetchTemplate(id);
   const responseDownloadLimit = Number(await getAppSetting("responseDownloadLimit"));
   const deliveryOption = initialForm?.deliveryOption;
   const isPublished = initialForm?.isPublished || false;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
@@ -2,10 +2,8 @@ import { Metadata } from "next";
 import { auth } from "@lib/auth";
 import { redirect } from "next/navigation";
 import { serverTranslation } from "@i18n";
-import { AccessControlError } from "@lib/privileges";
 import { getAppSetting } from "@lib/appSettings";
 import { Responses, ResponsesProps } from "./components/Responses";
-import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/LoggedOutTab";
 import { fetchSubmissions, fetchTemplate } from "./actions";
 
 export async function generateMetadata({
@@ -38,48 +36,31 @@ export default async function Page({
   };
 
   const session = await auth();
-  const isAuthenticated = session !== null;
 
   if (session && id) {
-    try {
-      const initialForm = await fetchTemplate(id);
+    const initialForm = await fetchTemplate(id);
 
-      if (initialForm === null) {
-        redirect(`/${locale}/404`);
-      }
+    if (initialForm === null) {
+      redirect(`/${locale}/404`);
+    }
 
-      pageProps.initialForm = initialForm;
+    pageProps.initialForm = initialForm;
 
-      const { submissions, lastEvaluatedKey } = await fetchSubmissions({
-        formId: id,
-        status: statusFilter,
-        lastKey,
-      });
+    const { submissions, lastEvaluatedKey } = await fetchSubmissions({
+      formId: id,
+      status: statusFilter,
+      lastKey,
+    });
 
-      pageProps.vaultSubmissions = submissions;
-      pageProps.lastEvaluatedKey = lastEvaluatedKey;
+    pageProps.vaultSubmissions = submissions;
+    pageProps.lastEvaluatedKey = lastEvaluatedKey;
 
-      // TODO: re-enable nagware when we have a better solution for how to handle filtered statuses
-      /*
+    // TODO: re-enable nagware when we have a better solution for how to handle filtered statuses
+    /*
         nagwareResult = allSubmissions.submissions.length
         ? await detectOldUnprocessedSubmissions(allSubmissions.submissions)
         : null;
         */
-    } catch (e) {
-      if (e instanceof AccessControlError) {
-        redirect(`/${locale}/admin/unauthorized`);
-      }
-    }
-  }
-
-  if (!isAuthenticated) {
-    return (
-      <>
-        <div className="max-w-4xl">
-          <LoggedOutTab tabName={LoggedOutTabName.RESPONSES} />
-        </div>
-      </>
-    );
   }
 
   return <Responses {...pageProps} />;


### PR DESCRIPTION
# Summary | Résumé

Visiting Responses when logged out was throwing an error, but should have been rendering the LoggedOutTab component.

This happened when we moved some server actions up to the layout.tsx component, but the LoggedOutTab component was being rendered in the page.tsx component, which was too late.
