### PR TITLE
Fix urls with formId in wrong position

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-forms/components/server/FormCard.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-forms/components/server/FormCard.tsx
@@ -54,13 +54,13 @@ export const FormCard = async ({
       <div className="mt-10 flex flex-row items-end justify-between">
         <div>
           <LinkButton.Secondary
-            href={`/${language}/form-builder/settings/${id}/form?backLink=${ability.userID}`}
+            href={`/${language}/form-builder/${id}/settings/manage?backLink=${ability.userID}`}
             className="mb-2 mr-3"
           >
             {t("manageOwnerships")}
           </LinkButton.Secondary>
           <LinkButton.Secondary
-            href={`/${language}/form-builder/responses/${id}`}
+            href={`/${language}/form-builder/${id}/responses`}
             className="mb-2 mr-3"
           >
             {t("gotoResponses")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsDialog.tsx
@@ -81,7 +81,7 @@ export const SettingsDialog = ({
     updateField: s.updateField,
   }));
 
-  const responsesLink = `/${i18n.language}/form-builder/responses/${id}`;
+  const responsesLink = `/${i18n.language}/form-builder/${id}/responses/new`;
 
   /*--------------------------------------------*
    * Classification state and handlers

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -43,7 +43,7 @@ export default async function Layout({
       }
 
       if (initialForm.isPublished) {
-        redirect(`/${locale}/form-builder/settings/${formID}`);
+        redirect(`/${locale}/form-builder/${formID}/settings`);
       }
 
       FormbuilderParams.initialForm = initialForm;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -56,8 +56,8 @@ export const Preview = () => {
     return false;
   };
 
-  const responsesLink = `/${i18n.language}/form-builder/responses/${id}`;
-  const settingsLink = `/${i18n.language}/form-builder/settings/${id}`;
+  const responsesLink = `/${i18n.language}/form-builder/${id}/responses/new`;
+  const settingsLink = `/${i18n.language}/form-builder/${id}/settings`;
 
   const brand = formRecord?.form ? formRecord.form.brand : null;
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/Publish.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/Publish.tsx
@@ -70,7 +70,7 @@ export const Publish = ({ id }: { id: string }) => {
     );
   };
 
-  const supportHref = `/${i18n.language}/form-builder/${id}/support`;
+  const supportHref = `/${i18n.language}/support`;
 
   const handlePublish = async () => {
     setError(false);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/DeliveryOptionEmail.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/DeliveryOptionEmail.tsx
@@ -26,9 +26,9 @@ export const DeliveryOptionEmail = async ({
         <h1 className="mb-0 border-none tablet:mb-4">{t("responses.email.title")}</h1>
         <nav className="flex gap-3">
           {!isPublished && (
-            <Link href={`/${language}/form-builder/settings`} legacyBehavior>
+            <Link href={`/${language}/form-builder/${formId}/settings`} legacyBehavior>
               <a
-                href={`/${language}/form-builder/settings`}
+                href={`/${language}/form-builder/${formId}/settings`}
                 className="mb-0 mr-3 rounded-[100px] border-1 border-black px-5 py-1 text-black no-underline visited:text-black hover:bg-[#475569] hover:!text-white focus:bg-[#475569] focus:!text-white laptop:py-2 [&_svg]:focus:fill-white"
               >
                 {t("responses.changeSetup")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -207,7 +207,7 @@ export const ResponseDelivery = () => {
     setDeliveryOption(value as DeliveryOption);
   }, []);
 
-  const responsesLink = `/${i18n.language}/form-builder/responses/${id}`;
+  const responsesLink = `/${i18n.language}/form-builder/${id}/responses`;
 
   const handleUpdateClassification = useCallback((value: ClassificationType) => {
     if (value === "Protected B") {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/ClosedBanner.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/ClosedBanner.tsx
@@ -10,7 +10,7 @@ export const ClosedBanner = ({ id }: { id: string | undefined }) => {
     t,
     i18n: { language },
   } = useTranslation("form-closed");
-  const href = `/${language}/form-builder/settings/${id}/form`;
+  const href = `/${language}/form-builder/${id}/settings/manage`;
 
   if (!isPastClosingDate || !id) {
     return null;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/ConfirmFormDeleteDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/ConfirmFormDeleteDialog.tsx
@@ -111,7 +111,7 @@ export const ConfirmFormDeleteDialog = ({
     </>
   );
 
-  const responsesLink = `/${i18n.language}/form-builder/responses/${formId}`;
+  const responsesLink = `/${i18n.language}/form-builder/${formId}/responses/new`;
 
   if (data && data.error === "unprocessed") {
     return (

--- a/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/client/Menu.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/client/Menu.tsx
@@ -43,7 +43,7 @@ export const Menu = ({
     },
     {
       title: t("card.menu.settings"),
-      url: `/${language}/form-builder/settings/${id}`,
+      url: `/${language}/form-builder/${id}/settings`,
     },
     {
       title: t("card.menu.delete"),

--- a/components/clientComponents/myforms/Card/Card.tsx
+++ b/components/clientComponents/myforms/Card/Card.tsx
@@ -151,7 +151,7 @@ export const Card = (props: CardProps): React.ReactElement => {
     },
     {
       title: t("card.menu.settings"),
-      url: `/${i18n.language}/form-builder/settings/${id}`,
+      url: `/${i18n.language}/form-builder/${id}/settings`,
     },
     {
       title: t("card.menu.delete"),

--- a/lib/ownership.ts
+++ b/lib/ownership.ts
@@ -21,8 +21,8 @@ export const transferOwnershipEmail = async ({
     const TEMPLATE_ID = process.env.TEMPLATE_ID;
     const notify = getNotifyInstance();
 
-    const formUrlEn = `${HOST}/en/form-builder/responses/${formId}`;
-    const formUrlFr = `${HOST}/fr/form-builder/responses/${formId}`;
+    const formUrlEn = `${HOST}/en/form-builder/${formId}/responses`;
+    const formUrlFr = `${HOST}/fr/form-builder/${formId}/responses`;
 
     await notify.sendEmail(TEMPLATE_ID, emailTo, {
       personalisation: {
@@ -83,8 +83,8 @@ export const addOwnershipEmail = async ({
     const TEMPLATE_ID = process.env.TEMPLATE_ID;
     const notify = getNotifyInstance();
 
-    const formUrlEn = `${HOST}/en/form-builder/responses/${formId}`;
-    const formUrlFr = `${HOST}/fr/form-builder/responses/${formId}`;
+    const formUrlEn = `${HOST}/en/form-builder/${formId}/responses`;
+    const formUrlFr = `${HOST}/fr/form-builder/${formId}/responses`;
 
     await notify.sendEmail(TEMPLATE_ID, emailTo, {
       personalisation: {

--- a/lib/responseDownloadFormats/html-aggregated/components/CopyCodes.tsx
+++ b/lib/responseDownloadFormats/html-aggregated/components/CopyCodes.tsx
@@ -35,7 +35,7 @@ export const CopyCodes = ({
       </div>
       <div>
         <a
-          href={`${HOST}/form-builder/responses/${formId}/downloaded`}
+          href={`${HOST}/form-builder/${formId}/responses/downloaded`}
           className="ml-4 block h-16 rounded-lg border border-black bg-white px-6 py-4 text-black shadow hover:bg-gray-400"
         >
           {t("responseAggregatedTemplate.goToGcForms", { lng: lang })}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,7 +32,7 @@ const nextConfig = {
   poweredByHeader: false,
   compiler: {
     // Remove all console.* calls
-    removeConsole: false,
+    removeConsole: true,
   },
   output: isOutputStandalone ? "standalone" : undefined,
   webpack: (config) => {
@@ -58,23 +58,18 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: "/en/form-builder/support",
-        destination: "/en/support",
+        source: "/:locale/form-builder/support",
+        destination: "/:locale/support",
         permanent: true,
       },
       {
-        source: "/fr/form-builder/support",
-        destination: "/fr/support",
+        source: "/:locale/form-builder/support/contactus",
+        destination: "/:locale/contact",
         permanent: true,
       },
       {
-        source: "/en/form-builder/support/contactus",
-        destination: "/en/contact",
-        permanent: true,
-      },
-      {
-        source: "/fr/form-builder/support/contactus",
-        destination: "/fr/contact",
+        source: "/:locale/form-builder/:id/responses",
+        destination: "/:locale/form-builder/:id/responses/new",
         permanent: true,
       },
     ];


### PR DESCRIPTION
# Summary | Résumé

Fixes a bunch of stray URLs with the FormID in the wrong spot.
Also adds a redirect from `/form-builder/[id]/responses` to `/form-builder/[id]/responses/new`
...and simplifies two existing redirects.