### PR TITLE
Refactors cards to use tailwind classes for layout

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/Cards.tsx
@@ -45,10 +45,7 @@ export const Cards = async ({ filter, ability }: { filter?: string; ability: Use
         className={`pt-8`}
       >
         {templates.length > 0 ? (
-          <ol
-            className="grid gap-4 p-0"
-            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(27rem, 1fr))" }}
-          >
+          <ol className="grid gap-4 grid-cols-2 p-0">
             {templates.map((card) => {
               return (
                 <li className="flex flex-col" key={card.id}>

--- a/components/clientComponents/myforms/CardGrid/CardGrid.tsx
+++ b/components/clientComponents/myforms/CardGrid/CardGrid.tsx
@@ -25,10 +25,7 @@ export const CardGrid = (props: CardGridProps): React.ReactElement => {
 
   return (
     <>
-      <ol
-        className="grid gap-4 p-0"
-        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(27rem, 1fr))" }}
-      >
+      <ol className="grid gap-4 grid-cols-2 p-0">
         {cards &&
           cards?.length > 0 &&
           cards.map((card: CardWithoutHandleDelete) => {


### PR DESCRIPTION
# Summary | Résumé

Attempts to fix the single column bug that occasionally appears on the Forms page cards layout.
Even if this does not fix the bug, moving from an inline style to a Tailwind style is more consistent.

## Testing

Try navigating to and from the Forms layout reloading pretty much random things :) and see if you can reproduce the 1-column bug.
