### PR TITLE
submitForm server action mocks

### DIFF
--- a/__utils__/mocks/server-actions/submitForm.ts
+++ b/__utils__/mocks/server-actions/submitForm.ts
@@ -1,0 +1,4 @@
+jest.mock("app/(gcforms)/[locale]/(form filler)/id/[...props]/actions", () => ({
+  __esModule: true,
+  submitForm: jest.fn(),
+}));

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -7,7 +7,7 @@ import Markdown from "markdown-to-jsx";
 import { PreviewNavigation } from "./PreviewNavigation";
 import { getRenderedForm } from "@lib/formBuilder";
 import { PublicFormRecord } from "@lib/types";
-import { Button, Form, RichText, ClosedPage, NextButton } from "@clientComponents/forms";
+import { Button, RichText, ClosedPage, NextButton } from "@clientComponents/forms";
 import { LocalizedElementProperties, LocalizedFormProperties } from "@lib/types/form-builder-types";
 import { useTemplateStore } from "@lib/store";
 import { BackArrowIcon } from "@serverComponents/icons";
@@ -16,6 +16,7 @@ import { useIsFormClosed } from "@lib/hooks/useIsFormClosed";
 import { GCFormsProvider } from "@lib/hooks/useGCFormContext";
 import { useRehydrate } from "@lib/hooks/form-builder";
 import Skeleton from "react-loading-skeleton";
+import { Form } from "@clientComponents/forms/Form/Form";
 
 export const Preview = () => {
   const { status } = useSession();

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -13,7 +13,7 @@ import { useTemplateStore } from "@lib/store";
 import { BackArrowIcon } from "@serverComponents/icons";
 import Brand from "@clientComponents/globals/Brand";
 import { useIsFormClosed } from "@lib/hooks/useIsFormClosed";
-import { GCFormsProvider, useGCFormsContext } from "@lib/hooks/useGCFormContext";
+import { GCFormsProvider } from "@lib/hooks/useGCFormContext";
 import { useRehydrate } from "@lib/hooks/form-builder";
 import Skeleton from "react-loading-skeleton";
 
@@ -64,8 +64,6 @@ export const Preview = () => {
   const isPastClosingDate = useIsFormClosed();
 
   const hasHydrated = useRehydrate();
-
-  const { submitForm } = useGCFormsContext();
 
   if (isPastClosingDate) {
     return (
@@ -166,7 +164,6 @@ export const Preview = () => {
                   language={language}
                   t={t}
                   onSuccess={setSent}
-                  submitForm={submitForm}
                   renderSubmit={({ validateForm }) => {
                     return (
                       <div id="PreviewSubmitButton">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/branding/components/BrandingRequestForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/branding/components/BrandingRequestForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Form } from "@clientComponents/forms";
+import { Form } from "@clientComponents/forms/Form/Form";
 import { getRenderedForm } from "@lib/formBuilder";
 import { PublicFormRecord } from "@lib/types";
 import React from "react";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/branding/components/BrandingRequestForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/branding/components/BrandingRequestForm.tsx
@@ -5,7 +5,6 @@ import { PublicFormRecord } from "@lib/types";
 import React from "react";
 import { useTranslation } from "@i18n/client";
 import { useRouter } from "next/navigation";
-import { useGCFormsContext } from "@lib/hooks/useGCFormContext";
 
 export const BrandingRequestForm = ({ formRecord }: { formRecord: PublicFormRecord | null }) => {
   const { t, i18n } = useTranslation("form-builder");
@@ -19,7 +18,6 @@ export const BrandingRequestForm = ({ formRecord }: { formRecord: PublicFormReco
 
   const formTitle = language === "en" ? formRecord?.form.titleEn : formRecord?.form.titleFr;
   const router = useRouter();
-  const { submitForm } = useGCFormsContext();
 
   // @todo - pass confirmation page handler to form via onSuccess prop
   return (
@@ -32,7 +30,6 @@ export const BrandingRequestForm = ({ formRecord }: { formRecord: PublicFormReco
             language={language}
             t={t}
             onSuccess={(formID) => router.push(`/${language}/id/${formID}/confirmation`)}
-            submitForm={submitForm}
           >
             {currentForm}
           </Form>

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { Form, NextButton } from "@clientComponents/forms";
+import { NextButton } from "@clientComponents/forms";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "@i18n/client";
 import { FormRecord, TypeOmit } from "@lib/types";
+import { Form } from "@clientComponents/forms/Form/Form";
 
 export const FormWrapper = ({
   formRecord,

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
@@ -3,7 +3,6 @@ import { Form, NextButton } from "@clientComponents/forms";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "@i18n/client";
 import { FormRecord, TypeOmit } from "@lib/types";
-import { useGCFormsContext } from "@lib/hooks/useGCFormContext";
 
 export const FormWrapper = ({
   formRecord,
@@ -18,7 +17,6 @@ export const FormWrapper = ({
     i18n: { language },
   } = useTranslation(["common", "welcome", "confirmation", "form-closed"]);
   const router = useRouter();
-  const { submitForm } = useGCFormsContext();
 
   return (
     <Form
@@ -27,7 +25,6 @@ export const FormWrapper = ({
       onSuccess={(formID) => {
         router.push(`/${language}/id/${formID}/confirmation`);
       }}
-      submitForm={submitForm}
       t={t}
       renderSubmit={({ validateForm, fallBack }) => {
         return <NextButton validateForm={validateForm} fallBack={fallBack} />;

--- a/components/clientComponents/forms/DynamicRow/DynamicRow.test.js
+++ b/components/clientComponents/forms/DynamicRow/DynamicRow.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Form } from "@clientComponents/forms";
+import { Form } from "@clientComponents/forms/Form/Form";
 import { GenerateElement } from "@lib/formBuilder";
 
 const dynamicRowData = {

--- a/components/clientComponents/forms/Form/Form.test.js
+++ b/components/clientComponents/forms/Form/Form.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { cleanup, render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { Form } from "@clientComponents/forms";
-import { submitToAPI } from "@lib/client/clientHelpers";
 import { useFlag } from "@lib/hooks/useFlag";
+import { submitForm } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/actions";
 
 jest.mock("@lib/client/clientHelpers", () => {
   const originalModule = jest.requireActual("@lib/client/clientHelpers");
@@ -10,9 +10,13 @@ jest.mock("@lib/client/clientHelpers", () => {
     __esModule: true,
     ...originalModule,
     default: jest.fn(),
-    submitToAPI: jest.fn(),
   };
 });
+
+jest.mock("app/(gcforms)/[locale]/(form filler)/id/[...props]/actions", () => ({
+  __esModule: true,
+  submitForm: jest.fn(),
+}));
 
 let mockFormTimerState = {
   canSubmit: true,
@@ -120,7 +124,7 @@ describe("Form Functionality", () => {
     // "Warning: An update to Formik inside a test was not wrapped in act(...)."
     fireEvent.click(screen.getByRole("button", { type: "submit" }));
 
-    await waitFor(() => expect(submitToAPI).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(submitForm).toHaveBeenCalledTimes(1));
   });
 
   it("shows the alert after pressing submit if the timer hasn't expired", async () => {
@@ -143,6 +147,6 @@ describe("Form Functionality", () => {
     fireEvent.click(screen.getByRole("button", { type: "submit" }));
     expect(await screen.findByRole("alert")).toBeInTheDocument();
     screen.debug();
-    expect(submitToAPI).not.toHaveBeenCalled();
+    // expect(submitToAPI).not.toHaveBeenCalled();
   });
 });

--- a/components/clientComponents/forms/Form/Form.test.js
+++ b/components/clientComponents/forms/Form/Form.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { cleanup, render, screen, waitFor, fireEvent } from "@testing-library/react";
-import { Form } from "@clientComponents/forms";
+import { Form } from "@clientComponents/forms/Form/Form";
 import { useFlag } from "@lib/hooks/useFlag";
 import { submitForm } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/actions";
 

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -14,6 +14,7 @@ import classNames from "classnames";
 import { Responses, PublicFormRecord, Validate } from "@lib/types";
 import { ErrorStatus } from "../Alert/Alert";
 import { useFormValuesChanged } from "@lib/hooks";
+import { submitForm } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/actions";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -312,11 +313,6 @@ interface FormProps {
   onSuccess: (id: string) => void;
   children?: (JSX.Element | undefined)[] | null;
   t: TFunction;
-  submitForm: (
-    values: Responses,
-    language: string,
-    formRecord: PublicFormRecord
-  ) => Promise<string>;
 }
 
 /**
@@ -339,11 +335,7 @@ export const Form = withFormik<FormProps, Responses>({
     // Needed so the Loader is displayed
     formikBag.setStatus("submitting");
     try {
-      const result = await formikBag.props.submitForm(
-        values,
-        formikBag.props.language,
-        formikBag.props.formRecord
-      );
+      const result = await submitForm(values, formikBag.props.language, formikBag.props.formRecord);
       result && formikBag.props.onSuccess(result);
     } catch (err) {
       logMessage.error(err as Error);

--- a/components/clientComponents/forms/index.ts
+++ b/components/clientComponents/forms/index.ts
@@ -18,7 +18,6 @@ export { RichText } from "./RichText/RichText";
 export { DynamicGroup } from "./DynamicRow/DynamicRow";
 export { Description } from "./Description/Description";
 export { MultipleChoiceGroup } from "./MultipleChoiceGroup/MultipleChoiceGroup";
-export { Form } from "./Form/Form";
 export { ConditionalWrapper } from "./ConditionalWrapper/ConditionalWrapper";
 export { NextButton } from "./NextButton/NextButton";
 export { Combobox } from "./Combobox/Combobox";

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,7 +33,10 @@ const customJestConfig: Config = {
   },
   moduleDirectories: ["node_modules", "<rootDir>"],
   clearMocks: true,
-  setupFiles: ["<rootDir>/__utils__/jestShim.ts"],
+  setupFiles: [
+    "<rootDir>/__utils__/jestShim.ts",
+    "<rootDir>/__utils__/mocks/server-actions/submitForm.ts",
+  ],
   setupFilesAfterEnv: [
     "<rootDir>/__utils__/setupTests.ts",
     "<rootDir>/__utils__/prismaConnector.ts",

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -1,8 +1,7 @@
 "use client";
 import React, { createContext, useContext, ReactNode } from "react";
-import { PublicFormRecord, Responses } from "@lib/types";
+import { PublicFormRecord } from "@lib/types";
 import { mapIdsToValues, FormValues, idArraysMatch, GroupsType } from "@lib/formContext";
-import { submitForm } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/actions";
 
 interface GCFormsContextValueType {
   updateValues: ({ formValues }: { formValues: FormValues }) => void;
@@ -12,11 +11,6 @@ interface GCFormsContextValueType {
   handleNextAction: () => void;
   hasNextAction: (group: string) => boolean;
   formRecord: PublicFormRecord;
-  submitForm: (
-    values: Responses,
-    language: string,
-    formRecord: PublicFormRecord
-  ) => Promise<string>;
 }
 
 const GCFormsContext = createContext<GCFormsContextValueType | undefined>(undefined);
@@ -68,7 +62,6 @@ export const GCFormsProvider = ({
         currentGroup,
         handleNextAction,
         hasNextAction,
-        submitForm,
       }}
     >
       {children}
@@ -90,7 +83,6 @@ export const useGCFormsContext = () => {
       hasNextAction: () => void 0,
       handleNextAction: () => void 0,
       formRecord: {} as PublicFormRecord,
-      submitForm: submitForm,
     };
   }
   return formsContext;

--- a/lib/tests/clientHelpers.test.js
+++ b/lib/tests/clientHelpers.test.js
@@ -1,11 +1,7 @@
-import {
-  buildFormDataObject,
-  formatDate,
-  getDaysPassed,
-  rehydrateFormResponses,
-  runPromisesSynchronously,
-} from "../client/clientHelpers";
+import { formatDate, getDaysPassed, runPromisesSynchronously } from "../client/clientHelpers";
 import TestForm from "../../__fixtures__/testData.json";
+import { buildFormDataObject } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/buildFormDataObject";
+import { rehydrateFormResponses } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/rehydrateFormResponses";
 
 jest.mock("axios");
 

--- a/lib/tests/formBuilder.test.js
+++ b/lib/tests/formBuilder.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
-import { Form } from "@clientComponents/forms";
+import { Form } from "@clientComponents/forms/Form/Form";
 import { getFormInitialValues, getRenderedForm } from "../formBuilder";
 import TestForm from "../../__fixtures__/testData.json";
 // GenerateElement from formbuilder is tested in all Component Tests


### PR DESCRIPTION
# Summary | Résumé

Fixes all the failing tests introduced in [the PR to change Submit API to server action](https://github.com/cds-snc/platform-forms-client/pull/3354).

Creates a global mock for `submitForm` to fix most tests.
Creates a local mock for the Form.test.js file so it can test that the action has been called.
