### PR TITLE
Fix/3357

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/NavLink.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/NavLink.tsx
@@ -17,7 +17,7 @@ export const NavLink = ({
     "mb-4 mr-3 rounded-[100px] border-1 border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
 
   const inactiveClasses =
-    "!text-black hover:bg-gray-600 hover:!text-white-default focus:!text-white [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white";
+    "!text-black hover:bg-gray-600 hover:!text-white-default focus:!text-white [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white focus:bg-blue-focus";
   const activeClasses =
     "bg-[#475569] !text-white [&_svg]:fill-white ${svgStroke} focus:text-white [&_svg]:focus:stroke-white";
 

--- a/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/NavLink.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/NavLink.tsx
@@ -15,7 +15,6 @@ export const NavLink = ({
 }) => {
   const baseClasses =
     "mb-4 mr-3 rounded-[100px] border-1 border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
-
   const inactiveClasses =
     "!text-black hover:bg-gray-600 hover:!text-white-default focus:!text-white [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white focus:bg-blue-focus";
   const activeClasses =

--- a/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/NavLink.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/[[...path]]/components/server/NavLink.tsx
@@ -14,9 +14,9 @@ export const NavLink = ({
   active: boolean;
 }) => {
   const baseClasses =
-    "mb-4 mr-3 rounded-[100px] border-1 border-black bg-white px-5 pb-2 pt-1 no-underline !shadow-none laptop:py-2";
+    "mb-4 mr-3 rounded-[100px] border-1 border-black bg-white px-5 pb-2 pt-1 no-underline laptop:py-2";
   const inactiveClasses =
-    "!text-black hover:bg-gray-600 hover:!text-white-default focus:!text-white [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white focus:bg-blue-focus";
+    "!text-black hover:bg-gray-600 hover:!text-white-default focus:border-1 focus:border-black focus:bg-blue-focus focus:!text-white focus:outline-none [&_svg]:hover:fill-white [&_svg]:hover:stroke-white [&_svg]:focus:fill-white";
   const activeClasses =
     "bg-[#475569] !text-white [&_svg]:fill-white ${svgStroke} focus:text-white [&_svg]:focus:stroke-white";
 


### PR DESCRIPTION
# Summary | Résumé

Fixes active focus style when tabbing to a nav link on the Forms page.
When tabbing to a nav link on the Forms page, the link text should be visible.
