### PR TITLE
Update form-builder header title to be consistent

### DIFF
--- a/components/clientComponents/globals/Header/Header.tsx
+++ b/components/clientComponents/globals/Header/Header.tsx
@@ -49,12 +49,12 @@ export const Header = ({ context = "default", user, className }: HeaderParams) =
 
           {isDefault && (
             <div className="mt-3 box-border block h-[40px] px-2 py-1 text-xl font-semibold">
-              {t("title", { ns: "common" })}
+              {t("adminNav.allForms", { ns: "common" })}
             </div>
           )}
           {isAdmin && (
             <div className="mt-3 box-border block h-[40px] px-2 py-1 text-xl font-semibold">
-              {t("title", { ns: "admin-login" })}
+              {t("adminNav.allForms", { ns: "admin-login" })}
             </div>
           )}
           {isFormBuilder && status === "authenticated" && (

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -82,7 +82,7 @@
     "typography": "Typography",
     "upload": "Upload",
     "viewTemplates": "View Templates",
-    "allForms": "All Forms"
+    "allForms": "Forms"
   },
   "formElements": {
     "characterCount": {

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -82,7 +82,7 @@
     "typography": "[FR]Typography",
     "upload": "[FR]Upload",
     "viewTemplates": "[FR]View Templates",
-    "allForms": "All Forms [FR]"
+    "allForms": "Formulaires"
   },
   "formElements": {
     "characterCount": {


### PR DESCRIPTION
# Summary | Résumé

Updates the form-builder header to be "Forms" consistently across pages.