### PR TITLE
Disable submit on unsaved form preview

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -18,7 +18,7 @@ import { useRehydrate } from "@lib/hooks/form-builder";
 import Skeleton from "react-loading-skeleton";
 import { Form } from "@clientComponents/forms/Form/Form";
 
-export const Preview = () => {
+export const Preview = ({ disableSubmit = true }: { disableSubmit?: boolean }) => {
   const { status } = useSession();
   const { i18n } = useTranslation("common");
   const { id, getSchema, getIsPublished, getSecurityAttribute } = useTemplateStore((s) => ({
@@ -178,7 +178,7 @@ export const Preview = () => {
                                   id="SubmitButton"
                                   className="mb-4"
                                   onClick={(e) => {
-                                    if (status !== "authenticated") {
+                                    if (disableSubmit) {
                                       return preventSubmit(e);
                                     }
                                   }}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/page.tsx
@@ -26,7 +26,7 @@ export default async function Page({
   params: { locale: string; id: string };
 }) {
   const session = await auth();
-  const formDisabled = id === "0000" || !session?.user;
+  const disableSubmit = id === "0000" || !session?.user;
   const { t } = await serverTranslation("form-builder", { lang: locale });
 
   const formID = id;
@@ -64,5 +64,5 @@ export default async function Page({
     );
   }
 
-  return <Preview disableSubmit={formDisabled} />;
+  return <Preview disableSubmit={disableSubmit} />;
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/page.tsx
@@ -26,6 +26,7 @@ export default async function Page({
   params: { locale: string; id: string };
 }) {
   const session = await auth();
+  const formDisabled = id === "0000" || !session?.user;
   const { t } = await serverTranslation("form-builder", { lang: locale });
 
   const formID = id;
@@ -63,5 +64,5 @@ export default async function Page({
     );
   }
 
-  return <Preview />;
+  return <Preview disableSubmit={formDisabled} />;
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes #3391
Before a form is saved, its id in the url is 0000. 
We can use this to disable form submission.
