### PR TITLE
Fix/3365

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -58,8 +58,6 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({
       // Which recalls this useEffect at least every second
       const timerID = setTimeout(() => checkTimer(), 1000);
 
-      logMessage.info(`Form Timer useEffect - timer enabled`);
-
       return () => {
         clearTimeout(timerID);
       };


### PR DESCRIPTION
# Summary | Résumé

Removes a log message in forms-form that was causing a lot of "noise" in the debugger.

Test by going to a forms-form and opening your dev console. You should no longer see this log message "Form Timer useEffect - timer enabled"