### PR TITLE
Set is published

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/Publish.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/Publish.tsx
@@ -31,6 +31,7 @@ export const Publish = ({ id }: { id: string }) => {
   const {
     id: storeId,
     setId,
+    setIsPublished,
     getSchema,
     getName,
     getDeliveryOption,
@@ -38,6 +39,7 @@ export const Publish = ({ id }: { id: string }) => {
   } = useTemplateStore((s) => ({
     id: s.id,
     setId: s.setId,
+    setIsPublished: s.setIsPublished,
     getSchema: s.getSchema,
     getName: s.getName,
     getDeliveryOption: s.getDeliveryOption,
@@ -78,6 +80,7 @@ export const Publish = ({ id }: { id: string }) => {
     try {
       const result = await updateTemplatePublishedStatus({ id, isPublished: true });
       setId(result?.id);
+      setIsPublished(result?.isPublished);
 
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/TitleAndDescription.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/TitleAndDescription.tsx
@@ -80,7 +80,7 @@ export const TitleAndDescription = ({
         />
       )}
       {successAlertMessage && (
-        <Alert.Success className="mb-4">
+        <Alert.Success className="my-4">
           <Alert.Title>{t(`${successAlertMessage}.title`)}</Alert.Title>
           <Alert.Body>{t(`${successAlertMessage}.body`)}</Alert.Body>
         </Alert.Success>

--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -147,6 +147,7 @@ export interface TemplateStoreState extends TemplateStoreProps {
   importTemplate: (jsonConfig: FormProperties) => void;
   getSchema: () => string;
   getIsPublished: () => boolean;
+  setIsPublished: (isPublished: boolean) => void;
   getName: () => string;
   getDeliveryOption: () => DeliveryOption | undefined;
   resetDeliveryOption: () => void;
@@ -417,6 +418,11 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
             getSchema: () => JSON.stringify(getSchemaFromState(get()), null, 2),
             getId: () => get().id,
             getIsPublished: () => get().isPublished,
+            setIsPublished: (isPublished) => {
+              set((state) => {
+                state.isPublished = isPublished;
+              });
+            },
             getName: () => get().name,
             getDeliveryOption: () => get().deliveryOption,
             resetDeliveryOption: () => {


### PR DESCRIPTION
# Summary | Résumé

Set isPublished to true in templateStore on publish.
Addresses a bug where the left nav didn't update after publish and Edit was still available, and you could also get to the Edit screen in some cases.

