### PR TITLE
fix: Validations passing multiple issues per field and Error highlighting on input fields

### DIFF
--- a/app/(gcforms)/[locale]/(support)/contact/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/contact/actions.ts
@@ -39,7 +39,7 @@ const validate = async (
     jobTitle: string(),
   });
 
-  return safeParse(SupportSchema, formEntries);
+  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
 };
 
 export async function contact(

--- a/app/(gcforms)/[locale]/(support)/support/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/support/actions.ts
@@ -33,7 +33,7 @@ const validate = async (
     description: string([minLength(1, t("input-validation.required"))]),
   });
 
-  return safeParse(SupportSchema, formEntries);
+  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
 };
 
 export async function support(

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
@@ -55,7 +55,7 @@ const validate = async (
     goals: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
   });
 
-  return safeParse(SupportSchema, formEntries);
+  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
 };
 
 export async function unlockPublishing(

--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/actions.ts
@@ -44,7 +44,7 @@ const validate = async (
       v.maxLength(50, t("fields.password.errors.maxLength")),
     ]),
   });
-  return v.safeParse(formValidationSchema, formEntries);
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
 };
 export const login = async (
   language: string,

--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
@@ -97,6 +97,9 @@ export const LoginForm = () => {
             name={"username"}
             required
             ariaDescribedBy="login-description"
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "username")?.fieldValue
+            }
           />
         </div>
         <div className="focus-group">
@@ -109,6 +112,9 @@ export const LoginForm = () => {
             id={"password"}
             name={"password"}
             required
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "password")?.fieldValue
+            }
           />
         </div>
         <p className="-mt-6 mb-10">

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/actions.ts
@@ -44,7 +44,7 @@ const validate = async (
     authenticationFlowToken: v.string([v.minLength(1)]),
     email: v.string([v.toTrimmed(), v.toLowerCase(), v.minLength(1)]),
   });
-  return v.safeParse(formValidationSchema, formEntries);
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
 };
 
 const isUserActive = async (email: string) => {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
@@ -168,6 +168,9 @@ export const MFAForm = () => {
               name="verificationCode"
               ariaDescribedBy="verificationCode-hint"
               required
+              validationError={
+                state.validationErrors?.find((e) => e.fieldKey === "verificationCode")?.fieldValue
+              }
             />
           </div>
           <Button

--- a/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
@@ -91,7 +91,7 @@ const validate = async (
       ),
     ]
   );
-  return v.safeParse(formValidationSchema, formEntries);
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
 };
 export const register = async (
   language: string,

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
@@ -95,7 +95,7 @@ const validateQuestionChallengeForm = async (
     ]),
   });
 
-  return v.safeParse(schema, formEntries);
+  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
 };
 
 const validatePasswordResetForm = async (
@@ -150,7 +150,7 @@ const validatePasswordResetForm = async (
       ),
     ]
   );
-  return v.safeParse(schema, formEntries);
+  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
 };
 
 export const sendResetLink = async (

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/components/client/InitiateResetForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/components/client/InitiateResetForm.tsx
@@ -86,6 +86,9 @@ export const InitiateResetForm = ({
             id="username"
             name="username"
             ariaDescribedBy="desc-username-hint"
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "username")?.fieldValue
+            }
           />
         </div>
 

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/components/client/PasswordResetForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/components/client/PasswordResetForm.tsx
@@ -91,6 +91,9 @@ export const PasswordResetForm = ({ email }: { email: string }) => {
             id="confirmationCode"
             name="confirmationCode"
             required
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "confirmationCode")?.fieldValue
+            }
           />
         </div>
         <div className="focus-group">
@@ -106,6 +109,9 @@ export const PasswordResetForm = ({ email }: { email: string }) => {
             id="password"
             name="password"
             ariaDescribedBy="desc-username-hint"
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "password")?.fieldValue
+            }
           />
         </div>
         <div className="focus-group">
@@ -122,6 +128,9 @@ export const PasswordResetForm = ({ email }: { email: string }) => {
             type="password"
             id="passwordConfirmation"
             name="passwordConfirmation"
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "passwordConfirmation")?.fieldValue
+            }
           />
         </div>
 

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/components/client/QuestionChallengeForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/components/client/QuestionChallengeForm.tsx
@@ -102,6 +102,9 @@ export const QuestionChallengeForm = ({
             id="question1"
             name="question1"
             required
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "question1")?.fieldValue
+            }
           />
         </div>
 
@@ -120,6 +123,9 @@ export const QuestionChallengeForm = ({
             id="question2"
             name="question2"
             required
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "question2")?.fieldValue
+            }
           />
         </div>
 
@@ -138,6 +144,9 @@ export const QuestionChallengeForm = ({
             id="question3"
             name="question3"
             required
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "question3")?.fieldValue
+            }
           />
         </div>
 

--- a/app/(gcforms)/[locale]/(user authentication)/auth/setup-security-questions/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/setup-security-questions/actions.ts
@@ -64,7 +64,7 @@ const validateData = async (formData: { [k: string]: FormDataEntryValue }, langu
     ]
   );
 
-  return v.safeParse(schema, formData);
+  return v.safeParse(schema, formData, { abortPipeEarly: true });
 };
 
 export const setupQuestions = async (

--- a/app/(gcforms)/[locale]/(user authentication)/auth/setup-security-questions/components/client/SecurityQuestionsForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/setup-security-questions/components/client/SecurityQuestionsForm.tsx
@@ -93,6 +93,9 @@ export const SecurityQuestionsForm = ({ questions = [] }: { questions: Question[
             name="question1"
             className="mb-0 w-full rounded"
             onChange={onSelect}
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "question1")?.fieldValue
+            }
           >
             <>
               <option key={"default"} value="">
@@ -132,6 +135,9 @@ export const SecurityQuestionsForm = ({ questions = [] }: { questions: Question[
             name="question2"
             className="mb-0 w-full rounded"
             onChange={onSelect}
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "question2")?.fieldValue
+            }
           >
             <>
               <option key={"default"} value="">
@@ -171,6 +177,9 @@ export const SecurityQuestionsForm = ({ questions = [] }: { questions: Question[
             name="question3"
             className="mb-0 w-full rounded"
             onChange={onSelect}
+            validationError={
+              state.validationErrors?.find((e) => e.fieldKey === "question3")?.fieldValue
+            }
           >
             <>
               <option key={"default"} value="">

--- a/app/(gcforms)/[locale]/(user authentication)/profile/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/profile/action.ts
@@ -10,7 +10,7 @@ const validateData = (formData: { [k: string]: unknown }) => {
     newQuestionId: v.string("Field is required", [v.minLength(1)]),
     newAnswer: v.string("Field is required", [v.toLowerCase(), v.toTrimmed(), v.minLength(4)]),
   });
-  return v.safeParse(schema, formData);
+  return v.safeParse(schema, formData, { abortPipeEarly: true });
 };
 
 export const updateSecurityQuestion = async (


### PR DESCRIPTION
# Summary | Résumé

fixes: #3430 

- Modified Valibot to abort validation pipeline early so only 1 validation error is generated per field.
- Ensured validation errors from form state were being passed down to input components.

Fixes pages: 
- Support
- Unlock Publishing
- Login
- MFA
- Register
- Reset Password
- Security Question Setup
- Profile

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![image](https://github.com/cds-snc/platform-forms-client/assets/25329319/cef119e1-fb0e-43eb-b0f2-a9754bd3fc64) | ![image](https://github.com/cds-snc/platform-forms-client/assets/25329319/7205e881-a033-44d5-ba2f-6ebd64b19f86) |


