### PR TITLE
fix: Manage Forms page refresh after delete

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UserCard.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UserCard.tsx
@@ -7,11 +7,13 @@ import { ManageFormsButton } from "../client/ManageFormsButton";
 export const UserCard = async ({
   user,
   canManageUser,
+  canManageForms,
   currentUserId,
   publishFormsId,
 }: {
   user: AppUser;
   canManageUser: boolean;
+  canManageForms: boolean;
   currentUserId: string;
   publishFormsId: string;
 }) => {
@@ -32,6 +34,10 @@ export const UserCard = async ({
                   <PublishPermission user={user} publishFormsId={publishFormsId} />
                 </div>
               )}
+            </>
+          )}
+          {canManageForms && (
+            <>
               <div className="flex-none">
                 <ManageFormsButton userId={user.id} />
               </div>

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UsersList.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UsersList.tsx
@@ -5,13 +5,19 @@ import { createAbility } from "@lib/privileges";
 import { serverTranslation } from "@i18n";
 import { Card } from "@clientComponents/globals/card/Card";
 import { ScrollHelper } from "../client/ScrollHelper";
+import { checkPrivilegesAsBoolean } from "@lib/privileges";
 
 export const UsersList = async ({ filter }: { filter?: string }) => {
   const session = await auth();
   if (!session) throw new Error("No session found");
   const ability = createAbility(session);
 
-  const canManageUser = ability.can("update", "User");
+  const canManageUser = checkPrivilegesAsBoolean(ability, [
+    { action: "update", subject: { type: "User", object: {} } },
+  ]);
+  const canManageForms = checkPrivilegesAsBoolean(ability, [
+    { action: "update", subject: { type: "FormRecord", object: {} } },
+  ]);
 
   const publishFormsId = await getPublishedFormsPrivilegeId();
   if (!publishFormsId) throw new Error("No publish forms privilege found in global privileges.");
@@ -35,6 +41,7 @@ export const UsersList = async ({ filter }: { filter?: string }) => {
                 <UserCard
                   user={user}
                   canManageUser={canManageUser}
+                  canManageForms={canManageForms}
                   currentUserId={session.user.id}
                   publishFormsId={publishFormsId}
                 />

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/page.tsx
@@ -35,7 +35,7 @@ export default async function Page({
   checkPrivilegesAsBoolean(
     ability,
     [
-      { action: "view", subject: "User" },
+      { action: "view", subject: { type: "User", object: {} } },
       { action: "view", subject: "Privilege" },
     ],
     { logic: "all", redirect: true }


### PR DESCRIPTION
# Summary | Résumé

closes: #3422 

- Ensures the data is refreshed when a form is deleted or modified on the manage forms page
- Fixes permissions on the account page.
  -  fixed user view permission so it checks if a user has view all users
  - updated permission to manage all forms to pass to card list.