### PR TITLE
Fixes support success pages

### DIFF
--- a/app/(gcforms)/[locale]/(support)/components/server/Success.tsx
+++ b/app/(gcforms)/[locale]/(support)/components/server/Success.tsx
@@ -3,23 +3,20 @@ import Link from "next/link";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { FocusHeader } from "../client/FocusHeader";
 
-export const Success = async () => {
-  const {
-    t,
-    i18n: { language },
-  } = await serverTranslation("form-builder");
+export const Success = async ({ lang }: { lang: string }) => {
+  const { t } = await serverTranslation("form-builder", { lang });
   return (
     <>
       <FocusHeader>{t("requestSuccess.title")}</FocusHeader>
       <p className="mb-16 mt-[-2rem] font-bold">{t("requestSuccess.weWillRespond")}</p>
       <div className="mb-16">
-        <LinkButton.Primary href={`/${language}/forms`}>
+        <LinkButton.Primary href={`/${lang}/forms`}>
           {t("requestSuccess.backToForms")}
         </LinkButton.Primary>
       </div>
       <p className="mb-8">
         {t("requestSuccess.forOtherEnquiriesPart1")}{" "}
-        <Link href={`https://www.canada.ca/${language}/contact.html`}>
+        <Link href={`https://www.canada.ca/${lang}/contact.html`}>
           {t("requestSuccess.forOtherEnquiriesLink")}
         </Link>{" "}
         {t("requestSuccess.forOtherEnquiriesPart2")}.

--- a/app/(gcforms)/[locale]/(support)/contact/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/contact/page.tsx
@@ -16,8 +16,10 @@ export async function generateMetadata({
 
 export default async function Page({
   searchParams: { success },
+  params: { locale },
 }: {
   searchParams: { success?: string };
+  params: { locale: string };
 }) {
-  return <>{success === undefined ? <ContactForm /> : <Success />}</>;
+  return <>{success === undefined ? <ContactForm /> : <Success lang={locale} />}</>;
 }

--- a/app/(gcforms)/[locale]/(support)/support/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/page.tsx
@@ -16,8 +16,10 @@ export async function generateMetadata({
 
 export default async function Page({
   searchParams: { success },
+  params: { locale },
 }: {
   searchParams: { success?: string };
+  params: { locale: string };
 }) {
-  return <>{success === undefined ? <SupportForm /> : <Success />}</>;
+  return <>{success === undefined ? <SupportForm /> : <Success lang={locale} />}</>;
 }

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/server/Success.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/server/Success.tsx
@@ -2,11 +2,8 @@ import { serverTranslation } from "@i18n";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { FocusHeader } from "../../../components/client/FocusHeader";
 
-export const Success = async () => {
-  const {
-    t,
-    i18n: { language },
-  } = await serverTranslation("unlock-publishing");
+export const Success = async ({ lang }: { lang: string }) => {
+  const { t } = await serverTranslation("unlock-publishing", { lang });
   return (
     <>
       <FocusHeader>{t("unlockPublishingSubmitted.title")}</FocusHeader>
@@ -15,7 +12,7 @@ export const Success = async () => {
       <p className="mt-8 font-bold">{t("unlockPublishingSubmitted.whatNext.paragraph2")}</p>
       <p>{t("unlockPublishingSubmitted.whatNext.paragraph3")}</p>
       <p className="mt-8">{t("unlockPublishingSubmitted.whatNext.paragraph4")}</p>
-      <LinkButton.Primary className="mt-8" href={`/${language}/forms/`}>
+      <LinkButton.Primary className="mt-8" href={`/${lang}/forms/`}>
         {t("continue", { ns: "common" })}
       </LinkButton.Primary>
     </>

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({
       {success === undefined ? (
         <UnlockPublishingForm userEmail={session.user.email} />
       ) : (
-        <Success />
+        <Success lang={locale} />
       )}
     </>
   );


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where the language was not being set correctly on the support pages. 

Impacts:
/support
/contact
/unlock-publishing

Note: this probably also resolves #3454

