### PR TITLE
If form isn't saved, still allow downloading

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -7,6 +7,7 @@ import { ManageForm } from "./ManageForm";
 import { notFound, redirect } from "next/navigation";
 
 import { Metadata } from "next";
+import { DownloadForm } from "./DownloadForm";
 
 export async function generateMetadata({
   params: { locale },
@@ -68,7 +69,9 @@ export default async function Page({
     if (!id || Array.isArray(id)) notFound();
 
     const templateWithAssociatedUsers = await getTemplateWithAssociatedUsers(ability, id);
-    if (!templateWithAssociatedUsers) notFound();
+    if (!templateWithAssociatedUsers) {
+      return <DownloadForm />;
+    }
 
     const allUsers = (await getUsers(ability)).map((user) => {
       return { id: user.id, name: user.name || "", email: user.email || "" };


### PR DESCRIPTION
# Summary | Résumé

Previously Form Management would throw a not found error if you navigated to it without having saved the form first.
This PR removes the notFound response and displays the DownloadForm component.