### PR TITLE
chore: add script to convert TTL data type from String to Number in the ReliabilityQueue DynamoDB table

### DIFF
--- a/utils/reliabilityQueueTableTTLDataTypeMigration/.env_example
+++ b/utils/reliabilityQueueTableTTLDataTypeMigration/.env_example
@@ -1,0 +1,8 @@
+# Copy to .env
+
+LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
+
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
+AWS_SESSION_TOKEN=test
+AWS_REGION=ca-central-1

--- a/utils/reliabilityQueueTableTTLDataTypeMigration/change_ttl_data_type_from_string_to_number.ts
+++ b/utils/reliabilityQueueTableTTLDataTypeMigration/change_ttl_data_type_from_string_to_number.ts
@@ -1,0 +1,80 @@
+/* eslint-disable no-console */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { ScanCommand, ScanCommandOutput, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { config } from "dotenv";
+
+const main = async () => {
+  try {
+    const dynamodbClient = new DynamoDBClient({
+      region: process.env.AWS_REGION ?? "ca-central-1",
+      ...(process.env.LOCAL_AWS_ENDPOINT && { endpoint: process.env.LOCAL_AWS_ENDPOINT }),
+    });
+
+    let lastEvaluatedKey = null;
+    let numberOfReliabilityQueueItems = 0;
+
+    while (lastEvaluatedKey !== undefined) {
+      const scanResults: ScanCommandOutput = await dynamodbClient.send(
+        new ScanCommand({
+          TableName: "ReliabilityQueue",
+          ExclusiveStartKey: lastEvaluatedKey ?? undefined,
+          Limit: 100, // The upcoming `TransactWriteCommand` operation can only update 100 items per request
+          FilterExpression: "attribute_type(#ttl,:type)",
+          ProjectionExpression: "SubmissionID,#ttl",
+          ExpressionAttributeNames: {
+            "#ttl": "TTL",
+          },
+          ExpressionAttributeValues: {
+            ":type": "S",
+          },
+        })
+      );
+
+      if (scanResults.Items && scanResults.Items.length > 0) {
+        await dynamodbClient.send(
+          new TransactWriteCommand({
+            TransactItems: scanResults.Items.map((item) => {
+              return {
+                Update: {
+                  TableName: "ReliabilityQueue",
+                  Key: {
+                    SubmissionID: item["SubmissionID"],
+                  },
+                  UpdateExpression: "SET #ttl = :ttlValue",
+                  ExpressionAttributeNames: {
+                    "#ttl": "TTL",
+                  },
+                  ExpressionAttributeValues: {
+                    ":ttlValue": Number(item["TTL"]),
+                  },
+                },
+              };
+            }),
+          })
+        );
+
+        numberOfReliabilityQueueItems += scanResults.Items.length;
+
+        process.stdout.write(
+          `Migration in progress ... ${numberOfReliabilityQueueItems} ReliabilityQueue items have been updated.\r`
+        );
+      }
+
+      lastEvaluatedKey = scanResults.LastEvaluatedKey;
+
+      // Rate limiting to avoid exceeding provisioned capacity
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    console.log(
+      `\nMigration completed successfully!\nA total of ${numberOfReliabilityQueueItems} ReliabilityQueue items have been updated and are now compatible with the TTL feature.`
+    );
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// config() adds the .env variables to process.env
+config();
+
+main();

--- a/utils/reliabilityQueueTableTTLDataTypeMigration/package.json
+++ b/utils/reliabilityQueueTableTTLDataTypeMigration/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "reliability_queue_table_ttl_data_type_migration",
+  "version": "0.1.0",
+  "description": "Update existing items in the ReliabilityQueue table to convert the TTL data type from String to Number",
+  "main": "change_ttl_data_type_from_string_to_number.ts",
+  "scripts": {
+    "migrate-ttl-data-type": "tsx change_ttl_data_type_from_string_to_number.ts"
+  },
+  "keywords": [],
+  "author": "Clément Janin",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.518.0",
+    "@aws-sdk/lib-dynamodb": "^3.518.0",
+    "dotenv": "^16.3.1",
+    "tsx": "^3.14.0"
+  },
+  "packageManager": "yarn@4.0.2"
+}

--- a/utils/reliabilityQueueTableTTLDataTypeMigration/tsconfig.json
+++ b/utils/reliabilityQueueTableTTLDataTypeMigration/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+
+    /* Interop Constraints */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+
+    /* Completeness */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16635,6 +16635,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reliability_queue_table_ttl_data_type_migration@workspace:utils/reliabilityQueueTableTTLDataTypeMigration":
+  version: 0.0.0-use.local
+  resolution: "reliability_queue_table_ttl_data_type_migration@workspace:utils/reliabilityQueueTableTTLDataTypeMigration"
+  dependencies:
+    "@aws-sdk/client-dynamodb": "npm:^3.518.0"
+    "@aws-sdk/lib-dynamodb": "npm:^3.518.0"
+    dotenv: "npm:^16.3.1"
+    tsx: "npm:^3.14.0"
+  languageName: unknown
+  linkType: soft
+
 "request-progress@npm:^3.0.0":
   version: 3.0.0
   resolution: "request-progress@npm:3.0.0"


### PR DESCRIPTION
# Summary | Résumé

Follow up for https://github.com/cds-snc/forms-terraform/pull/637

- Adds script to convert TTL data type from String to Number in the ReliabilityQueue DynamoDB table.

# IMPORTANT

This script should be executed in both environments once https://github.com/cds-snc/forms-terraform/pull/637 has been deployed. We can already do it in Staging.