### PR TITLE
fix: Profile translation for locked publishing

### DIFF
--- a/i18n/translations/fr/profile.json
+++ b/i18n/translations/fr/profile.json
@@ -4,7 +4,7 @@
     "title": "Informations de compte",
     "email": "Courriel",
     "publishing": "Publication de formulaires",
-    "locked": "Vérouillé",
+    "locked": "Verrouillée",
     "unlocked": "Déverrouillée"
   },
   "securityPanel": {


### PR DESCRIPTION
# Summary | Résumé

fixes: #3456

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![Screenshot 2024-04-22 at 14-35-32 Profil](https://github.com/cds-snc/platform-forms-client/assets/25329319/56615eed-e5b3-4340-9405-2e13d131e7c9) | ![Screenshot 2024-04-22 at 14-34-02 Profil](https://github.com/cds-snc/platform-forms-client/assets/25329319/9d80b9a3-0c42-4c28-a132-db6e82b41697) |


# Test instructions | Instructions pour tester la modification

Login to an account without publishing permissions and navigate to Profile page.

