### PR TITLE
Fixes unlock publishing page localization string

### DIFF
--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/server/Success.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/server/Success.tsx
@@ -3,7 +3,7 @@ import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { FocusHeader } from "../../../components/client/FocusHeader";
 
 export const Success = async ({ lang }: { lang: string }) => {
-  const { t } = await serverTranslation("unlock-publishing", { lang });
+  const { t } = await serverTranslation(["unlock-publishing", "common"], { lang });
   return (
     <>
       <FocusHeader>{t("unlockPublishingSubmitted.title")}</FocusHeader>


### PR DESCRIPTION
# Summary | Résumé

Fixes issue with missing localization string in a button on the Unlock Publishing success screen.

Before
![Screenshot 2024-04-24 at 9 59 57 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/52b9902c-0355-4971-a52a-681c7476d5e7)


After
![Screenshot 2024-04-24 at 9 59 27 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/1cda058b-122b-488a-9b13-e98af5cad54b)
