### PR TITLE
Rename getGroups to getTreeData for clarity

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
@@ -78,8 +78,8 @@ const getEdges = (nodeId: string, prevNodeId: string, group: Group | undefined):
 };
 
 export const useFlowData = () => {
-  const getGroups = useGroupStore((s) => s.getGroups);
-  const treeItems = getGroups();
+  const getTreeData = useGroupStore((s) => s.getTreeData);
+  const treeItems = getTreeData();
   const formGroups = useTemplateStore((s) => s.form.groups);
 
   const { edges, nodes } = useMemo(() => {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -34,10 +34,10 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
   ref
 ) => {
   // export const TreeView = () => {
-  const { getGroups, addGroup, setId, updateGroupName, updateGroup, updateElementTitle } =
+  const { getTreeData, addGroup, setId, updateGroupName, updateGroup, updateElementTitle } =
     useGroupStore((s) => {
       return {
-        getGroups: s.getGroups,
+        getTreeData: s.getTreeData,
         addGroup: s.addGroup,
         setId: s.setId,
         updateGroupName: s.updateGroupName,
@@ -61,12 +61,12 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
 
   useImperativeHandle(ref, () => ({
     addItem: async (id: string) => {
-      const parent = findParentGroup(getGroups(), id);
+      const parent = findParentGroup(getTreeData(), id);
       setExpandedItems([parent?.index as TreeItemIndex]);
       setSelectedItems([id]);
     },
     updateItem: (id: string) => {
-      const parent = findParentGroup(getGroups(), id);
+      const parent = findParentGroup(getTreeData(), id);
       setExpandedItems([parent?.index as TreeItemIndex]);
       setSelectedItems([id]);
     },
@@ -75,7 +75,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
   return (
     <ControlledTreeEnvironment
       ref={environment}
-      items={getGroups()}
+      items={getTreeData()}
       getItemTitle={(item) => item.data}
       // renderItem={({ title, arrow, context, children }) => {
       //   return (
@@ -135,7 +135,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         let itemsPriorToInsertion = 0;
 
         // current state of the tree
-        const currentItems = getGroups();
+        const currentItems = getTreeData();
 
         // Ids of the items being dragged
         const itemsIndices = items.map((i) => i.index);
@@ -188,7 +188,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         });
 
         // Get the new state of the tree
-        const newItems = getGroups();
+        const newItems = getTreeData();
 
         // Get the target parent in the new state
         const targetParent = newItems[targetParentIndex];
@@ -209,7 +209,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
       }}
       onFocusItem={(item) => {
         setFocusedItem(item.index);
-        const parent = findParentGroup(getGroups(), String(item.index));
+        const parent = findParentGroup(getTreeData(), String(item.index));
         setId(item.isFolder ? String(item.index) : String(parent?.index));
       }}
       onExpandItem={(item) => setExpandedItems([...expandedItems, item.index])}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/useGroupStore.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/useGroupStore.tsx
@@ -31,7 +31,7 @@ export interface GroupStoreState extends GroupStoreProps {
   setSelectedElementId: (id: number) => void;
   addGroup: (id: string, name: string) => void;
   deleteGroup: (id: string) => void;
-  getGroups: () => TreeItems;
+  getTreeData: () => TreeItems;
   updateGroup: (parent: TreeItemIndex, children: TreeItemIndex[] | undefined) => void;
   findParentGroup: (id: string) => TreeItem | undefined;
   findNextGroup: (id: string) => TreeItem | undefined;
@@ -66,16 +66,16 @@ const createGroupStore = (initProps?: Partial<GroupStoreProps>) => {
           state.selectedElementId = id;
         }),
       findParentGroup: (id: string) => {
-        return findParentGroup(get().getGroups(), id);
+        return findParentGroup(get().getTreeData(), id);
       },
       findNextGroup: (id: string) => {
-        return findNextGroup(get().getGroups(), id);
+        return findNextGroup(get().getTreeData(), id);
       },
       findPreviousGroup: (id: string) => {
-        return findPreviousGroup(get().getGroups(), id);
+        return findPreviousGroup(get().getTreeData(), id);
       },
       getGroupFromId: (id: string) => {
-        return getGroupFromId(get().getGroups(), id);
+        return getGroupFromId(get().getTreeData(), id);
       },
       getId: () => get().id,
       getElement: (id) => {
@@ -106,7 +106,7 @@ const createGroupStore = (initProps?: Partial<GroupStoreProps>) => {
           setChangeKey(String(new Date().getTime()));
         }
       },
-      getGroups: () => {
+      getTreeData: () => {
         const formGroups = get().templateStore.getState().form.groups;
         const elements = get().templateStore.getState().form.elements;
         if (!formGroups) return {};


### PR DESCRIPTION
# Summary | Résumé

Renames getGroups in the useGroupStore to getTreeData for clarity since it returns a treeData object
