### PR TITLE
Fixes Card Title Localization

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/server/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/server/Card.tsx
@@ -104,7 +104,7 @@ const CardLinks = async ({ isPublished, url, id, deliveryOption }: CardLinksProp
 const CardTitle = async ({ name }: { name: string }) => {
   const { t } = await serverTranslation("my-forms");
   const classes = "mb-0 mr-2 overflow-hidden pb-0 text-base font-bold";
-  return <h2 className={classes}>{name ? name : t("unnamedForm", { ns: "form-builder" })}</h2>;
+  return <h2 className={classes}>{name ? name : t("card.unnamedForm")}</h2>;
 };
 
 const CardDate = async ({ id, date }: { id: string; date: string }) => {

--- a/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
@@ -50,10 +50,7 @@ export default async function Page({
       redirect: true,
     });
 
-    const {
-      t,
-      i18n: { language },
-    } = await serverTranslation("my-forms");
+    const { t } = await serverTranslation("my-forms", { lang: locale });
 
     // Moved from Cards to Page to avoid component being cached when navigating back to this page
     const where = {
@@ -76,7 +73,7 @@ export default async function Page({
         name,
         isPublished,
         date: updatedAt ?? Date.now().toString(),
-        url: `/${language}/id/${id}`,
+        url: `/${locale}/id/${id}`,
         overdue: 0,
       };
     });

--- a/i18n/translations/en/my-forms.json
+++ b/i18n/translations/en/my-forms.json
@@ -43,7 +43,8 @@
       "description": "Action required: ",
       "linkSingular": "<a href=\"{{link}}\">Sign off on {{responses}} response</a>",
       "linkPlural": "<a href=\"{{link}}\">Sign off on {{responses}} responses</a>"
-    }
+    },
+    "unnamedForm": "Unnamed form file"
   },
   "responseTemplate": {
     "responseNumber": "Submission ID",

--- a/i18n/translations/fr/my-forms.json
+++ b/i18n/translations/fr/my-forms.json
@@ -43,7 +43,8 @@
       "description": "Action requise : ",
       "linkSingular": "<a href=\"{{link}}\">Approuver la suppression de {{responses}} réponse</a>",
       "linkPlural": "<a href=\"{{link}}\">Approuver la suppression de {{responses}} réponses</a>"
-    }
+    },
+    "unnamedForm": "Fichier sans nom"
   },
   "responseTemplate": {
     "responseNumber": "Identifiant de soumission",


### PR DESCRIPTION
# Summary | Résumé

Fixes card title localization string by adding it to the my-forms locale file.  The localization key was copy+paste from the form-builder file. The key is used in form-builder also so there is a chance that the key might be updated and then a bug created in my-forms.

Also, the locale from the Page params is used to be more consistent (vs. using 18n locale one place and page params locale another place)

**Before**
![Screenshot 2024-04-25 at 9 18 38 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/9e6e5771-2692-4f11-95de-6cc8af781f97)

**After**
![Screenshot 2024-04-25 at 9 33 08 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/395299f3-4ccf-4c9a-a19e-4568bfe375ed)


## Test

Go to the Forms (my-forms) page. Select French for the language. Any card without a name should have the French string printed out.