### PR TITLE
Bufix Responses TitleAndDescription

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
@@ -8,6 +8,7 @@ import { useParams } from "next/navigation";
 import { DownloadTable } from "./DownloadTable";
 import { NoResponses } from "./NoResponses";
 import { useRehydrate } from "@lib/store/useTemplateStore";
+import { TitleAndDescription } from "./TitleAndDescription";
 
 export interface ResponsesProps {
   initialForm: FormRecord | null;
@@ -44,14 +45,20 @@ export const Responses = ({
   }
 
   const hasHydrated = useRehydrate();
-  if (!hasHydrated) return null;
 
   return (
     <>
+      <div className="has-[.gc-confirm-success]:hidden">
+        <TitleAndDescription
+          statusFilter={ucfirst(statusFilter)}
+          formId={id}
+          responseDownloadLimit={responseDownloadLimit}
+        />
+      </div>
       {nagwareResult && <Nagware nagwareResult={nagwareResult} />}
       <div aria-live="polite">
         <ClosedBanner id={formId} />
-        {vaultSubmissions.length > 0 && (
+        {hasHydrated && vaultSubmissions.length > 0 && (
           <>
             <DownloadTable
               vaultSubmissions={vaultSubmissions}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
@@ -48,13 +48,15 @@ export const Responses = ({
 
   return (
     <>
-      <div className="has-[.gc-confirm-success]:hidden">
-        <TitleAndDescription
-          statusFilter={ucfirst(statusFilter)}
-          formId={id}
-          responseDownloadLimit={responseDownloadLimit}
-        />
-      </div>
+      {vaultSubmissions.length > 0 && (
+        <div className="has-[.gc-confirm-success]:hidden">
+          <TitleAndDescription
+            statusFilter={ucfirst(statusFilter)}
+            formId={id}
+            responseDownloadLimit={responseDownloadLimit}
+          />
+        </div>
+      )}
       {nagwareResult && <Nagware nagwareResult={nagwareResult} />}
       <div aria-live="polite">
         <ClosedBanner id={formId} />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/layout.tsx
@@ -1,11 +1,8 @@
 import { isEmailDelivery } from "@lib/utils/form-builder";
-import { getAppSetting } from "@lib/appSettings";
 import { auth } from "@lib/auth";
-import { ucfirst } from "@lib/client/clientHelpers";
 import { DeliveryOptionEmail } from "./components/DeliveryOptionEmail";
 import { NavigationTabs } from "./components/NavigationTabs";
-import { TitleAndDescription } from "./components/TitleAndDescription";
-import { fetchSubmissions, fetchTemplate } from "./actions";
+import { fetchTemplate } from "./actions";
 import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/LoggedOutTab";
 import { ResponsesFooter } from "./components/ResponsesFooter";
 
@@ -28,14 +25,8 @@ export default async function Layout({
   }
 
   const initialForm = await fetchTemplate(id);
-  const responseDownloadLimit = Number(await getAppSetting("responseDownloadLimit"));
   const deliveryOption = initialForm?.deliveryOption;
   const isPublished = initialForm?.isPublished || false;
-
-  const { submissions } = await fetchSubmissions({
-    formId: id,
-    status: statusFilter,
-  });
 
   if (deliveryOption && isEmailDelivery(deliveryOption)) {
     return (
@@ -54,15 +45,6 @@ export default async function Layout({
   return (
     <div className="mr-10">
       <NavigationTabs statusFilter={statusFilter} formId={id} locale={locale} />
-      <div className="has-[.gc-confirm-success]:hidden">
-        {isAuthenticated && submissions.length > 0 && (
-          <TitleAndDescription
-            statusFilter={ucfirst(statusFilter)}
-            formId={id}
-            responseDownloadLimit={responseDownloadLimit}
-          />
-        )}
-      </div>
       {children}
       <ResponsesFooter formId={id} />
     </div>


### PR DESCRIPTION
# Summary | Résumé

Fixes #3502
I think what was observed in this issue has to do with NextJS server rendering and caching behaviour. Difficult to recreate/test as once the page has been server rendered, there is no longer a problem.

To address, I've moved the TitleAndDescription component out of the Layout file (server rendered) and down into the Responses component which is where it was originally, and is client rendered.

Should be able to test on the review environment for this PR since the page cache will have been cleared.
