### PR TITLE
fix: Notify Error Handling Centralization

### DIFF
--- a/lib/auth/2fa.ts
+++ b/lib/auth/2fa.ts
@@ -1,30 +1,23 @@
-import { getNotifyInstance } from "@lib/integration/notifyConnector";
-import { logMessage } from "@lib/logger";
-import { generateTokenCode } from "@lib/auth/tokenGenerator";
+import { sendEmail } from "@lib/integration/notifyConnector";
 
-const TEMPLATE_ID = process.env.TEMPLATE_ID;
+import { generateTokenCode } from "@lib/auth/tokenGenerator";
+import { logMessage } from "@lib/logger";
 
 export const generateVerificationCode = async () => generateTokenCode(5);
 
 export const sendVerificationCode = async (email: string, verificationCode: string) => {
   try {
-    const notify = getNotifyInstance();
-
-    await notify.sendEmail(TEMPLATE_ID, email, {
-      personalisation: {
-        subject: "Your security code | Votre code de sécurité",
-        formResponse: `
-**Your security code | Votre code de sécurité**
-\n\n
-${verificationCode}`,
-      },
+    await sendEmail(email, {
+      subject: "Your security code | Votre code de sécurité",
+      formResponse: `
+      **Your security code | Votre code de sécurité**
+      \n\n
+      ${verificationCode}`,
     });
   } catch (err) {
     logMessage.error(
-      `{"status": "failed", "message": "Notify Failed To Send the Code", "error":${
-        (err as Error).message
-      }}`
+      `Failed to send verification code email to ${email}. Reason: ${(err as Error).message}.`
     );
-    throw new Error("Notify failed to send the code");
+    throw err;
   }
 };

--- a/lib/deactivate.ts
+++ b/lib/deactivate.ts
@@ -1,17 +1,14 @@
-import { getNotifyInstance } from "./integration/notifyConnector";
+import { sendEmail } from "./integration/notifyConnector";
 import { logMessage } from "@lib/logger";
 import { getOrigin } from "./origin";
 
 export const sendDeactivationEmail = async (email: string) => {
   try {
     const HOST = getOrigin();
-    const TEMPLATE_ID = process.env.TEMPLATE_ID;
-    const notify = getNotifyInstance();
 
-    await notify.sendEmail(TEMPLATE_ID, email, {
-      personalisation: {
-        subject: "Account deactivated | Compte désactivé",
-        formResponse: `
+    await sendEmail(email, {
+      subject: "Account deactivated | Compte désactivé",
+      formResponse: `
 (la version française suit)
 
 Hello,
@@ -32,14 +29,13 @@ Pour en savoir plus ou pour demander la réactivation de votre compte, n’hési
 Merci,
 L’équipe Formulaires GC
 `,
-      },
     });
   } catch (err) {
     logMessage.error(
-      `{"status": "failed", "message": "Notify failed to send deactivation notice", "error":${
+      `{"status": "failed", "message": "Notify failed to send deactivation notice to ${email}", "error":${
         (err as Error).message
       }}`
     );
-    throw new Error("Notify failed to send deactivation notice");
+    throw err;
   }
 };

--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -53,7 +53,7 @@ export const getNotifyInstance = () => {
 export const sendEmail = async (email: string, personalisation: Record<string, string>) => {
   try {
     const templateId = process.env.TEMPLATE_ID;
-    if (!templateId) {
+    if (!templateId && process.env.APP_ENV !== "test") {
       throw new Error("No Notify template ID configured.");
     }
 

--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -78,7 +78,7 @@ export const sendEmail = async (email: string, personalisation: Record<string, s
          * is an instance of XMLHttpRequest in the browser and an instance
          * of http.ClientRequest in Node.js
          */
-        errorMessage = `${error.request}.`;
+        errorMessage = `Error sending to Notify with request :${error.request}.`;
       }
     } else if (error instanceof Error) {
       errorMessage = `${(error as Error).message}.`;

--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -1,5 +1,6 @@
 import { NotifyClient } from "notifications-node-client";
 import { logMessage } from "@lib/logger";
+import { AxiosError } from "axios";
 
 // TODO: create a type for NotifyClient
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,4 +48,51 @@ export const getNotifyInstance = () => {
   }
 
   return notifyInstance;
+};
+
+export const sendEmail = async (email: string, personalisation: Record<string, string>) => {
+  try {
+    const templateId = process.env.TEMPLATE_ID;
+    if (!templateId) {
+      throw new Error("No Notify template ID configured.");
+    }
+
+    const notify = getNotifyInstance();
+    await notify.sendEmail(templateId, email, { personalisation });
+  } catch (error) {
+    let errorMessage = "";
+
+    if (error instanceof AxiosError) {
+      if (error.response) {
+        /*
+         * The request was made and the server responded with a
+         * status code that falls out of the range of 2xx
+         */
+        const notifyErrors = Array.isArray(error.response.data.errors)
+          ? JSON.stringify(error.response.data.errors)
+          : error.response.data.errors;
+        errorMessage = `GC Notify errored with status code ${error.response.status} and returned the following detailed errors ${notifyErrors}.`;
+      } else if (error.request) {
+        /*
+         * The request was made but no response was received, `error.request`
+         * is an instance of XMLHttpRequest in the browser and an instance
+         * of http.ClientRequest in Node.js
+         */
+        errorMessage = `${error.request}.`;
+      }
+    } else if (error instanceof Error) {
+      errorMessage = `${(error as Error).message}.`;
+    }
+
+    logMessage.error(
+      JSON.stringify({
+        level: "error",
+        severity: 2,
+        msg: `Failed to send email through GC Notify to ${email}.`,
+        error: errorMessage,
+      })
+    );
+
+    throw new Error(`Failed to send submission through GC Notify.`);
+  }
 };

--- a/lib/ownership.ts
+++ b/lib/ownership.ts
@@ -1,4 +1,4 @@
-import { getNotifyInstance } from "./integration/notifyConnector";
+import { sendEmail } from "./integration/notifyConnector";
 import { logMessage } from "@lib/logger";
 import { getOrigin } from "./origin";
 
@@ -19,16 +19,13 @@ export const transferOwnershipEmail = async ({
 }) => {
   try {
     const HOST = getOrigin();
-    const TEMPLATE_ID = process.env.TEMPLATE_ID;
-    const notify = getNotifyInstance();
 
     const formUrlEn = `${HOST}/en/form-builder/${formId}/responses`;
     const formUrlFr = `${HOST}/fr/form-builder/${formId}/responses`;
 
-    await notify.sendEmail(TEMPLATE_ID, emailTo, {
-      personalisation: {
-        subject: "Transferred form and responses | Formulaire et réponses transférés",
-        formResponse: `
+    await sendEmail(emailTo, {
+      subject: "Transferred form and responses | Formulaire et réponses transférés",
+      formResponse: `
 (la version française suit)
 
 Hello,
@@ -54,7 +51,6 @@ Assurez-vous de [télécharger et approuver la suppression de toutes les répons
 
 Merci,
 L’équipe Formulaires GC`,
-      },
     });
   } catch (err) {
     logMessage.error(
@@ -62,7 +58,7 @@ L’équipe Formulaires GC`,
         (err as Error).message
       }}`
     );
-    throw new Error("Notify failed to transfer ownership email");
+    throw err;
   }
 };
 
@@ -81,16 +77,13 @@ export const addOwnershipEmail = async ({
 }) => {
   try {
     const HOST = getOrigin();
-    const TEMPLATE_ID = process.env.TEMPLATE_ID;
-    const notify = getNotifyInstance();
 
     const formUrlEn = `${HOST}/en/form-builder/${formId}/responses`;
     const formUrlFr = `${HOST}/fr/form-builder/${formId}/responses`;
 
-    await notify.sendEmail(TEMPLATE_ID, emailTo, {
-      personalisation: {
-        subject: "Shared form access | Accès partagé au formulaire",
-        formResponse: `
+    await sendEmail(emailTo, {
+      subject: "Shared form access | Accès partagé au formulaire",
+      formResponse: `
 (la version française suit)
 
 Hello,
@@ -111,7 +104,6 @@ ${formOwner}
 
 Merci,
 L’équipe Formulaires GC`,
-      },
     });
   } catch (err) {
     logMessage.error(
@@ -119,6 +111,6 @@ L’équipe Formulaires GC`,
         (err as Error).message
       }}`
     );
-    throw new Error("Notify failed to add ownership email");
+    throw err;
   }
 };


### PR DESCRIPTION
# Summary | Résumé

Centralizes the `sendEmail` function calls and error handling into the `@lib/integrations`.
- The error handling includes extracting the exact detailed error message from Notify to include it in the logs.
- Adds a check to ensure the env var `TEMPLATE_ID` is set before calling the `sendEmail` function.

Should provide more context for issue: #3530 

