### PR TITLE
fix: Replace Notify Client with custom instance

### DIFF
--- a/lib/auth/2fa.ts
+++ b/lib/auth/2fa.ts
@@ -10,9 +10,11 @@ export const sendVerificationCode = async (email: string, verificationCode: stri
     await sendEmail(email, {
       subject: "Your security code | Votre code de sécurité",
       formResponse: `
-      **Your security code | Votre code de sécurité**
-      \n\n
-      ${verificationCode}`,
+**Your security code | Votre code de sécurité**
+
+
+
+${verificationCode}`,
     });
   } catch (err) {
     logMessage.error(

--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -1,68 +1,38 @@
-import { NotifyClient } from "notifications-node-client";
 import { logMessage } from "@lib/logger";
-import { AxiosError } from "axios";
+import axios from "axios";
 
-// TODO: create a type for NotifyClient
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let notifyInstance: any = null;
-
-// For unit and e2e tests
-const mockNotify = {
-  sendEmail: () => {
-    logMessage.info("Mock Notify email sent.");
-
-    // Returns an example Notify response with sender etc. replaced with generic text
-    return {
-      id: "740e5834-3a29-46b4-9a6f-16142fde533a",
-      reference: "STRING",
-      content: {
-        subject: "SUBJECT TEXT",
-        body: "MESSAGE TEXT",
-        from_email: "SENDER EMAIL",
-      },
-      uri: "https://api.notification.canada.ca/v2/notifications/740e5834-3a29-46b4-9a6f-16142fde533a",
-      template: {
-        id: "f33517ff-2a88-4f6e-b855-c550268ce08a",
-        version: 1,
-        uri: "https://api.notification.canada.ca/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a",
-      },
-    };
+const NotifyClient = axios.create({
+  baseURL: "https://api.notification.canada.ca",
+  timeout: 2000,
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `ApiKey-v1 ${process.env.NOTIFY_API_KEY}`,
   },
-};
+});
 
-const createNotifyInstance = () => {
-  if (process.env.APP_ENV === "test") {
-    return mockNotify;
-  }
-
-  if (!process.env.NOTIFY_API_KEY) {
-    throw new Error("No Notify API key configured");
-  }
-
-  return new NotifyClient("https://api.notification.canada.ca", process.env.NOTIFY_API_KEY);
-};
-
-export const getNotifyInstance = () => {
-  if (!notifyInstance) {
-    notifyInstance = createNotifyInstance();
-  }
-
-  return notifyInstance;
-};
-
-export const sendEmail = async (email: string, personalisation: Record<string, string>) => {
+export const sendEmail = async (
+  email: string,
+  personalisation: Record<string, string | Record<string, string>>
+) => {
   try {
+    if (process.env.APP_ENV === "test") {
+      logMessage.info("Mock Notify email sent.");
+      return;
+    }
+
     const templateId = process.env.TEMPLATE_ID;
-    if (!templateId && process.env.APP_ENV !== "test") {
+    if (!templateId) {
       throw new Error("No Notify template ID configured.");
     }
 
-    const notify = getNotifyInstance();
-    await notify.sendEmail(templateId, email, { personalisation });
+    await NotifyClient.post("/v2/notifications/email", {
+      email_address: email,
+      template_id: templateId,
+      personalisation,
+    });
   } catch (error) {
     let errorMessage = "";
-
-    if (error instanceof AxiosError) {
+    if (axios.isAxiosError(error)) {
       if (error.response) {
         /*
          * The request was made and the server responded with a

--- a/lib/tests/auth/passwordReset.test.ts
+++ b/lib/tests/auth/passwordReset.test.ts
@@ -38,7 +38,13 @@ const mockSendEmail = {
 };
 
 jest.mock("@lib/integration/notifyConnector", () => ({
-  getNotifyInstance: jest.fn(() => mockSendEmail),
+  sendEmail: jest.fn(() => {
+    if (IsGCNotifyServiceAvailable) {
+      return Promise.resolve();
+    } else {
+      return Promise.reject(new Error("something went wrong"));
+    }
+  }),
 }));
 
 describe.skip("Test Password Reset library", () => {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "next": "14.2.3",
     "next-auth": "5.0.0-beta.16",
     "node-fetch": "^3.3.2",
-    "notifications-node-client": "7.0.6",
     "pino": "8.17.2",
     "prisma": "^5.10.2",
     "react": "^18.2.0",

--- a/types/notifications-node-client/index.d.ts
+++ b/types/notifications-node-client/index.d.ts
@@ -1,1 +1,0 @@
-declare module "notifications-node-client";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8095,7 +8095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.6.1, axios@npm:^1.6.3":
+"axios@npm:^1.6.3":
   version: 1.6.7
   resolution: "axios@npm:1.6.7"
   dependencies:
@@ -8364,13 +8364,6 @@ __metadata:
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
   checksum: 10c0/cb0a8ddf5cf4f766466db63279e47761eb825693eeba6a5a95ee4ec8cb8f81ede70aa7f9d8aeec083e781d47154290eb5d4d26b3f7a465ec57fb9e7d59c47150
-  languageName: node
-  linkType: hard
-
-"buffer-equal-constant-time@npm:1.0.1":
-  version: 1.0.1
-  resolution: "buffer-equal-constant-time@npm:1.0.1"
-  checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
   languageName: node
   linkType: hard
 
@@ -9942,15 +9935,6 @@ __metadata:
     jsbn: "npm:~0.1.0"
     safer-buffer: "npm:^2.1.0"
   checksum: 10c0/6cf168bae1e2dad2e46561d9af9cbabfbf5ff592176ad4e9f0f41eaaf5fe5e10bb58147fe0a804de62b1ee9dad42c28810c88d652b21b6013c47ba8efa274ca1
-  languageName: node
-  linkType: hard
-
-"ecdsa-sig-formatter@npm:1.0.11":
-  version: 1.0.11
-  resolution: "ecdsa-sig-formatter@npm:1.0.11"
-  dependencies:
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
   languageName: node
   linkType: hard
 
@@ -11540,7 +11524,6 @@ __metadata:
     next: "npm:14.2.3"
     next-auth: "npm:5.0.0-beta.16"
     node-fetch: "npm:^3.3.2"
-    notifications-node-client: "npm:7.0.6"
     pino: "npm:8.17.2"
     pino-pretty: "npm:^9.4.1"
     postcss: "npm:^8.4.32"
@@ -13450,24 +13433,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.0":
-  version: 9.0.2
-  resolution: "jsonwebtoken@npm:9.0.2"
-  dependencies:
-    jws: "npm:^3.2.2"
-    lodash.includes: "npm:^4.3.0"
-    lodash.isboolean: "npm:^3.0.3"
-    lodash.isinteger: "npm:^4.0.4"
-    lodash.isnumber: "npm:^3.0.3"
-    lodash.isplainobject: "npm:^4.0.6"
-    lodash.isstring: "npm:^4.0.1"
-    lodash.once: "npm:^4.0.0"
-    ms: "npm:^2.1.1"
-    semver: "npm:^7.5.4"
-  checksum: 10c0/d287a29814895e866db2e5a0209ce730cbc158441a0e5a70d5e940eb0d28ab7498c6bf45029cc8b479639bca94056e9a7f254e2cdb92a2f5750c7f358657a131
-  languageName: node
-  linkType: hard
-
 "jsprim@npm:^2.0.2":
   version: 2.0.2
   resolution: "jsprim@npm:2.0.2"
@@ -13508,27 +13473,6 @@ __metadata:
   version: 6.2.0
   resolution: "just-extend@npm:6.2.0"
   checksum: 10c0/d41cbdb6d85b986d4deaf2144d81d4f7266cd408fc95189d046d63f610c2dc486b141aeb6ef319c2d76fe904d45a6bb31f19b098ff0427c35688e0c383fc0511
-  languageName: node
-  linkType: hard
-
-"jwa@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "jwa@npm:1.4.1"
-  dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
-    ecdsa-sig-formatter: "npm:1.0.11"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/5c533540bf38702e73cf14765805a94027c66a0aa8b16bc3e89d8d905e61a4ce2791e87e21be97d1293a5ee9d4f3e5e47737e671768265ca4f25706db551d5e9
-  languageName: node
-  linkType: hard
-
-"jws@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "jws@npm:3.2.2"
-  dependencies:
-    jwa: "npm:^1.4.1"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/e770704533d92df358adad7d1261fdecad4d7b66fa153ba80d047e03ca0f1f73007ce5ed3fbc04d2eba09ba6e7e6e645f351e08e5ab51614df1b0aa4f384dfff
   languageName: node
   linkType: hard
 
@@ -13777,13 +13721,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.includes@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "lodash.includes@npm:4.3.0"
-  checksum: 10c0/7ca498b9b75bf602d04e48c0adb842dfc7d90f77bcb2a91a2b2be34a723ad24bc1c8b3683ec6b2552a90f216c723cdea530ddb11a3320e08fa38265703978f4b
-  languageName: node
-  linkType: hard
-
 "lodash.isarguments@npm:^3.1.0":
   version: 3.1.0
   resolution: "lodash.isarguments@npm:3.1.0"
@@ -13791,45 +13728,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.isboolean@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "lodash.isboolean@npm:3.0.3"
-  checksum: 10c0/0aac604c1ef7e72f9a6b798e5b676606042401dd58e49f051df3cc1e3adb497b3d7695635a5cbec4ae5f66456b951fdabe7d6b387055f13267cde521f10ec7f7
-  languageName: node
-  linkType: hard
-
 "lodash.isequal@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.isequal@npm:4.5.0"
   checksum: 10c0/dfdb2356db19631a4b445d5f37868a095e2402292d59539a987f134a8778c62a2810c2452d11ae9e6dcac71fc9de40a6fedcb20e2952a15b431ad8b29e50e28f
-  languageName: node
-  linkType: hard
-
-"lodash.isinteger@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "lodash.isinteger@npm:4.0.4"
-  checksum: 10c0/4c3e023a2373bf65bf366d3b8605b97ec830bca702a926939bcaa53f8e02789b6a176e7f166b082f9365bfec4121bfeb52e86e9040cb8d450e64c858583f61b7
-  languageName: node
-  linkType: hard
-
-"lodash.isnumber@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "lodash.isnumber@npm:3.0.3"
-  checksum: 10c0/2d01530513a1ee4f72dd79528444db4e6360588adcb0e2ff663db2b3f642d4bb3d687051ae1115751ca9082db4fdef675160071226ca6bbf5f0c123dbf0aa12d
-  languageName: node
-  linkType: hard
-
-"lodash.isplainobject@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "lodash.isplainobject@npm:4.0.6"
-  checksum: 10c0/afd70b5c450d1e09f32a737bed06ff85b873ecd3d3d3400458725283e3f2e0bb6bf48e67dbe7a309eb371a822b16a26cca4a63c8c52db3fc7dc9d5f9dd324cbb
-  languageName: node
-  linkType: hard
-
-"lodash.isstring@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "lodash.isstring@npm:4.0.1"
-  checksum: 10c0/09eaf980a283f9eef58ef95b30ec7fee61df4d6bf4aba3b5f096869cc58f24c9da17900febc8ffd67819b4e29de29793190e88dc96983db92d84c95fa85d1c92
   languageName: node
   linkType: hard
 
@@ -13847,7 +13749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.once@npm:^4.0.0, lodash.once@npm:^4.1.1":
+"lodash.once@npm:^4.1.1":
   version: 4.1.1
   resolution: "lodash.once@npm:4.1.1"
   checksum: 10c0/46a9a0a66c45dd812fcc016e46605d85ad599fe87d71a02f6736220554b52ffbe82e79a483ad40f52a8a95755b0d1077fba259da8bfb6694a7abbf4a48f1fc04
@@ -14501,16 +14403,6 @@ __metadata:
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 10c0/95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
-  languageName: node
-  linkType: hard
-
-"notifications-node-client@npm:7.0.6":
-  version: 7.0.6
-  resolution: "notifications-node-client@npm:7.0.6"
-  dependencies:
-    axios: "npm:^1.6.1"
-    jsonwebtoken: "npm:^9.0.0"
-  checksum: 10c0/ea91bad06dad6aa9d857c76159e60f9c5c442c97bcd4982704cfb204ccfb8352ffbc6db8804cdb45104d9bf001fc669cd166b9c4b16ef21ff14196ee16ea12f3
   languageName: node
   linkType: hard
 
@@ -16497,17 +16389,6 @@ __metadata:
   checksum: 10c0/6f7da8c5e422ac26aa38354870b1afac09963572cf2879443540449068cb43476e9cbccf6f8de3e0171e0d6f7f533c2bc1a0a008003c9a525bbc098e89041318
   languageName: node
   linkType: hard
-
-"retrieval_api@workspace:utils/retrievalAPI":
-  version: 0.0.0-use.local
-  resolution: "retrieval_api@workspace:utils/retrievalAPI"
-  dependencies:
-    "@types/node": "npm:^18.19.3"
-    csv-writer: "npm:^1.6.0"
-    tsx: "npm:^4.7.0"
-    typescript: "npm:^5.3.3"
-  languageName: unknown
-  linkType: soft
 
 "retry@npm:^0.12.0":
   version: 0.12.0


### PR DESCRIPTION
# Summary | Résumé

Removes `notifications-node-client` and implements a custom instance that creates a custom axios config.

Testing now shows that the detailed error is included in the logs.

![Screenshot 2024-05-03 at 1 47 58 PM](https://github.com/cds-snc/platform-forms-client/assets/25329319/88c5dec2-87d2-40b8-8893-c3ddd47d0bba)
