### PR TITLE
Remove duplicate end group

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SingleActionSelect.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SingleActionSelect.tsx
@@ -28,8 +28,6 @@ export const SingleActionSelect = ({
     return { label: item.name, value: key };
   });
 
-  groupItems.push({ label: "End", value: "end" });
-
   // Filter out the current group
   groupItems = groupItems.filter((item) => item.value !== currentGroup);
 


### PR DESCRIPTION
# Summary | Résumé

Removes extra group "End" option that was being pushed in before we added it to group initialize. 