### PR TITLE
ESLint - ignore old API tests folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,6 @@
 
 # Ignore polyfills
 /public/static/scripts/
+
+# Ignore old API tests folder
+/__tests__/api/


### PR DESCRIPTION
# Summary | Résumé

Ignore old API tests for ESLint
