### PR TITLE
Add Edit page redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,6 +79,11 @@ const nextConfig = {
         destination: "/:locale/form-builder/:id/responses/new",
         permanent: true,
       },
+      {
+        source: "/:locale/form-builder/edit",
+        destination: "/:locale/form-builder/0000/edit",
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
# Summary | Résumé

The app router branch edit route now always uses an ID in the path.

This PR adds a redirect to the correct new path for edit.

Testing

- Visit /form-builder/edit
- You should be automatically redirected to  `/en/form-builder/0000/edit`

