### PR TITLE
Feature/fix adds groups history to the form builder

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/GroupOutput.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/GroupOutput.tsx
@@ -11,15 +11,13 @@ export const GroupOutput = () => {
     getValues,
     currentGroup,
     previousGroup,
+    getHistory,
   } = useGCFormsContext();
   const formValues = getValues();
   return (
     <details>
       <summary>Group JSON Schema and Misc</summary>
       <pre className="mt-5 overflow-scroll border-2 border-black/50 p-5">
-        {JSON.stringify(schema.groups, null, 2)}
-        <br />
-        <br />
         Form Id = {formId}
         <br />
         Form Values = {JSON.stringify(formValues, null, 2)}
@@ -27,6 +25,11 @@ export const GroupOutput = () => {
         Current Group = {currentGroup}
         <br />
         Previous Group = {previousGroup}
+        <br />
+        Group History = {JSON.stringify(getHistory(), null, 2)}
+        <br />
+        <br />
+        {JSON.stringify(schema.groups, null, 2)}
       </pre>
     </details>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/GroupOutput.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/GroupOutput.tsx
@@ -11,7 +11,7 @@ export const GroupOutput = () => {
     getValues,
     currentGroup,
     previousGroup,
-    getHistory,
+    getGroupHistory,
   } = useGCFormsContext();
   const formValues = getValues();
   return (
@@ -26,7 +26,7 @@ export const GroupOutput = () => {
         <br />
         Previous Group = {previousGroup}
         <br />
-        Group History = {JSON.stringify(getHistory(), null, 2)}
+        Group History = {JSON.stringify(getGroupHistory(), null, 2)}
         <br />
         <br />
         {JSON.stringify(schema.groups, null, 2)}

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -37,6 +37,8 @@ export const NextButton = ({
 
   return (
     <>
+      {/* For debugging */}
+      <div className="hidden">{`currentGroup=${currentGroup}`}</div>
       <Button
         onClick={async (e) => {
           e.preventDefault();

--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -11,7 +11,7 @@ export const Review = (): React.ReactElement => {
     t,
     i18n: { language: lang },
   } = useTranslation("review");
-  const { groups, getValues, setGroup, formRecord, removeHistory, getHistory } =
+  const { groups, getValues, setGroup, formRecord, clearHistoryAfterId, getGroupHistory } =
     useGCFormsContext();
   const formValues = getValues();
   const headingRef = useRef(null);
@@ -19,7 +19,7 @@ export const Review = (): React.ReactElement => {
   useFocusIt({ elRef: headingRef });
 
   const reviewGroups = { ...groups };
-  const questionsAndAnswers = getHistory()
+  const questionsAndAnswers = getGroupHistory()
     .filter((key) => key !== "review") // Removed to avoid showing as a group
     .map((key) => {
       return {
@@ -53,7 +53,7 @@ export const Review = (): React.ReactElement => {
                     type="button"
                     onClick={() => {
                       setGroup(group.id);
-                      removeHistory(group.id);
+                      clearHistoryAfterId(group.id);
                     }}
                   >
                     {group.name}
@@ -79,7 +79,7 @@ export const Review = (): React.ReactElement => {
                   theme="secondary"
                   onClick={() => {
                     setGroup(group.id);
-                    removeHistory(group.id);
+                    clearHistoryAfterId(group.id);
                   }}
                 >
                   {t("edit")}

--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -11,15 +11,16 @@ export const Review = (): React.ReactElement => {
     t,
     i18n: { language: lang },
   } = useTranslation("review");
-  const { groups, getValues, setGroup, formRecord } = useGCFormsContext();
+  const { groups, getValues, setGroup, formRecord, removeHistory, getHistory } =
+    useGCFormsContext();
   const formValues = getValues();
   const headingRef = useRef(null);
 
   useFocusIt({ elRef: headingRef });
 
   const reviewGroups = { ...groups };
-  const questionsAndAnswers = Object.keys(reviewGroups)
-    .filter((key) => key !== "review" && key !== "end") // Removed to avoid showing as a group
+  const questionsAndAnswers = getHistory()
+    .filter((key) => key !== "review") // Removed to avoid showing as a group
     .map((key) => {
       return {
         id: key,
@@ -52,6 +53,7 @@ export const Review = (): React.ReactElement => {
                     type="button"
                     onClick={() => {
                       setGroup(group.id);
+                      removeHistory(group.id);
                     }}
                   >
                     {group.name}
@@ -77,6 +79,7 @@ export const Review = (): React.ReactElement => {
                   theme="secondary"
                   onClick={() => {
                     setGroup(group.id);
+                    removeHistory(group.id);
                   }}
                 >
                   {t("edit")}

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -10,6 +10,11 @@ import {
 } from "@lib/formContext";
 import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
+import {
+  addGroupHistory,
+  getGroupHistory,
+  removeGroupHistory,
+} from "@lib/utils/form-builder/groupsHistory";
 
 interface GCFormsContextValueType {
   updateValues: ({ formValues }: { formValues: FormValues }) => void;
@@ -23,6 +28,9 @@ interface GCFormsContextValueType {
   hasNextAction: (group: string) => boolean;
   formRecord: PublicFormRecord;
   groupsCheck: (groupsFlag: boolean | undefined) => boolean;
+  getHistory: () => string[];
+  addHistory: (groupId: string) => string[];
+  removeHistory: (groupId: string) => string[];
 }
 
 const GCFormsContext = createContext<GCFormsContextValueType | undefined>(undefined);
@@ -37,6 +45,7 @@ export const GCFormsProvider = ({
   const groups: GroupsType = formRecord.form.groups || {};
   const initialGroup = groups ? LockedSections.START : null;
   const values = React.useRef({});
+  const history = React.useRef<string[]>([LockedSections.START]);
   const [matchedIds, setMatchedIds] = React.useState<string[]>([]);
   const [currentGroup, setCurrentGroup] = React.useState<string | null>(initialGroup);
   const [previousGroup, setPreviousGroup] = React.useState<string | null>(initialGroup);
@@ -56,6 +65,7 @@ export const GCFormsProvider = ({
 
       if (typeof nextAction === "string") {
         setCurrentGroup(nextAction);
+        addHistory(nextAction);
       }
     }
   };
@@ -89,6 +99,13 @@ export const GCFormsProvider = ({
     return formHasGroups(formRecord.form);
   };
 
+  const getHistory = () => getGroupHistory(history.current);
+
+  const addHistory = (groupId: string) => addGroupHistory(groupId, history.current);
+
+  // TODO: may want to also remove form values from groupId positing in history on
+  const removeHistory = (groupId: string) => removeGroupHistory(groupId, history.current);
+
   return (
     <GCFormsContext.Provider
       value={{
@@ -103,6 +120,9 @@ export const GCFormsProvider = ({
         handleNextAction,
         hasNextAction,
         groupsCheck,
+        getHistory,
+        addHistory,
+        removeHistory,
       }}
     >
       {children}
@@ -130,6 +150,9 @@ export const useGCFormsContext = () => {
       handleNextAction: () => void 0,
       formRecord: {} as PublicFormRecord,
       groupsCheck: () => false,
+      getHistory: () => [],
+      addHistory: () => [],
+      removeHistory: () => [],
     };
   }
   return formsContext;

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -103,7 +103,7 @@ export const GCFormsProvider = ({
 
   const addHistory = (groupId: string) => addGroupHistory(groupId, history.current);
 
-  // TODO: may want to also remove form values from groupId positing in history on
+  // Note: this only removes the group entry and not the values
   const removeHistory = (groupId: string) => removeGroupHistory(groupId, history.current);
 
   return (

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -11,9 +11,9 @@ import {
 import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 import {
-  addGroupHistory,
-  getGroupHistory,
-  removeGroupHistory,
+  getGroupHistory as _getGroupHistory,
+  pushIdToHistory as _pushIdToHistory,
+  clearHistoryAfterId as _clearHistoryAfterId,
 } from "@lib/utils/form-builder/groupsHistory";
 
 interface GCFormsContextValueType {
@@ -28,9 +28,9 @@ interface GCFormsContextValueType {
   hasNextAction: (group: string) => boolean;
   formRecord: PublicFormRecord;
   groupsCheck: (groupsFlag: boolean | undefined) => boolean;
-  getHistory: () => string[];
-  addHistory: (groupId: string) => string[];
-  removeHistory: (groupId: string) => string[];
+  getGroupHistory: () => string[];
+  pushIdToHistory: (groupId: string) => string[];
+  clearHistoryAfterId: (groupId: string) => string[];
 }
 
 const GCFormsContext = createContext<GCFormsContextValueType | undefined>(undefined);
@@ -65,7 +65,7 @@ export const GCFormsProvider = ({
 
       if (typeof nextAction === "string") {
         setCurrentGroup(nextAction);
-        addHistory(nextAction);
+        pushIdToHistory(nextAction);
       }
     }
   };
@@ -99,12 +99,12 @@ export const GCFormsProvider = ({
     return formHasGroups(formRecord.form);
   };
 
-  const getHistory = () => getGroupHistory(history.current);
+  const getGroupHistory = () => _getGroupHistory(history.current);
 
-  const addHistory = (groupId: string) => addGroupHistory(groupId, history.current);
+  const pushIdToHistory = (groupId: string) => _pushIdToHistory(groupId, history.current);
 
   // Note: this only removes the group entry and not the values
-  const removeHistory = (groupId: string) => removeGroupHistory(groupId, history.current);
+  const clearHistoryAfterId = (groupId: string) => _clearHistoryAfterId(groupId, history.current);
 
   return (
     <GCFormsContext.Provider
@@ -120,9 +120,9 @@ export const GCFormsProvider = ({
         handleNextAction,
         hasNextAction,
         groupsCheck,
-        getHistory,
-        addHistory,
-        removeHistory,
+        getGroupHistory,
+        pushIdToHistory,
+        clearHistoryAfterId,
       }}
     >
       {children}
@@ -150,9 +150,9 @@ export const useGCFormsContext = () => {
       handleNextAction: () => void 0,
       formRecord: {} as PublicFormRecord,
       groupsCheck: () => false,
-      getHistory: () => [],
-      addHistory: () => [],
-      removeHistory: () => [],
+      getGroupHistory: () => [],
+      pushIdToHistory: () => [],
+      clearHistoryAfterId: () => [],
     };
   }
   return formsContext;

--- a/lib/utils/form-builder/groupsHistory.ts
+++ b/lib/utils/form-builder/groupsHistory.ts
@@ -5,14 +5,14 @@ export const getGroupHistory = (history: string[]) => {
   return history;
 };
 
-export const addGroupHistory = (groupId: string, history: string[]) => {
+export const pushIdToHistory = (groupId: string, history: string[]) => {
   if (Array.isArray(history)) {
     history.push(groupId);
   }
   return getGroupHistory(history);
 };
 
-export const removeGroupHistory = (groupId: string, history: string[]) => {
+export const clearHistoryAfterId = (groupId: string, history: string[]) => {
   if (Array.isArray(history)) {
     // Re-start history from this groupId on
     const endIndex = history.findIndex((id) => id === groupId);

--- a/lib/utils/form-builder/groupsHistory.ts
+++ b/lib/utils/form-builder/groupsHistory.ts
@@ -1,0 +1,26 @@
+import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
+
+// TODO Unit tests
+
+export const getGroupHistory = (history: string[]) => {
+  if (!Array.isArray(history)) return [LockedSections.START];
+  return history;
+};
+
+export const addGroupHistory = (groupId: string, history: string[]) => {
+  if (Array.isArray(history)) {
+    history.push(groupId);
+  }
+  return getGroupHistory(history);
+};
+
+export const removeGroupHistory = (groupId: string, history: string[]) => {
+  if (Array.isArray(history)) {
+    // Re-start history from this groupId on
+    const endIndex = history.findIndex((id) => id === groupId);
+    if (endIndex > -1) {
+      history.splice(endIndex + 1, history.length);
+    }
+  }
+  return getGroupHistory(history);
+};

--- a/lib/utils/form-builder/groupsHistory.ts
+++ b/lib/utils/form-builder/groupsHistory.ts
@@ -1,7 +1,5 @@
 import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
 
-// TODO Unit tests
-
 export const getGroupHistory = (history: string[]) => {
   if (!Array.isArray(history)) return [LockedSections.START];
   return history;

--- a/lib/vitests/groupsHistory.test.ts
+++ b/lib/vitests/groupsHistory.test.ts
@@ -1,5 +1,5 @@
 import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
-import { getGroupHistory, addGroupHistory, removeGroupHistory } from "@lib/utils/form-builder/groupsHistory";
+import { getGroupHistory, pushIdToHistory, clearHistoryAfterId } from "@lib/utils/form-builder/groupsHistory";
 
 const defaultHistory:string[] = [
   LockedSections.START,
@@ -31,15 +31,15 @@ describe("addGroupHistory tests", () => {
 
   it("handles invalid input", () => {
     // @ts-expect-error - testing invalid input
-    expect(addGroupHistory("INVALID", "INVALID").length).toEqual(1);
+    expect(pushIdToHistory("INVALID", "INVALID").length).toEqual(1);
   });
 
   it("adds history", () => {
-    history = addGroupHistory("group6", history);
-    history = addGroupHistory("group7", history);
-    history = addGroupHistory("group8", history);
-    history = addGroupHistory("group9", history);
-    history = addGroupHistory("group10", history);
+    history = pushIdToHistory("group6", history);
+    history = pushIdToHistory("group7", history);
+    history = pushIdToHistory("group8", history);
+    history = pushIdToHistory("group9", history);
+    history = pushIdToHistory("group10", history);
     expect(history.length).toEqual(11);
     expect(history[6]).toEqual("group6");
     expect(history[10]).toEqual("group10");
@@ -51,16 +51,16 @@ describe("removeGroupHistory tests", () => {
 
   it("handles invalid input", () => {
     // @ts-expect-error - testing invalid input
-    expect(removeGroupHistory("INVALID", "INVALID").length).toEqual(1);
+    expect(clearHistoryAfterId("INVALID", "INVALID").length).toEqual(1);
   });
 
   it("removes/sets history in the middle", () => {
-    history = removeGroupHistory("group3", history);
+    history = clearHistoryAfterId("group3", history);
     expect(history.length).toEqual(4);
   });
 
   it("removes/sets history at the end", () => {
-    history = removeGroupHistory("group3", history);
+    history = clearHistoryAfterId("group3", history);
     expect(history.length).toEqual(4);
   });
 });

--- a/lib/vitests/groupsHistory.test.ts
+++ b/lib/vitests/groupsHistory.test.ts
@@ -1,0 +1,66 @@
+import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
+import { getGroupHistory, addGroupHistory, removeGroupHistory } from "@lib/utils/form-builder/groupsHistory";
+
+const defaultHistory:string[] = [
+  LockedSections.START,
+  "group1",
+  "group2",
+  "group3",
+  "group4",
+  "group5",
+];
+
+describe("getGroupHistory tests", () => {
+  const history:string[] = [...defaultHistory];
+
+  it("handles invalid input", () => {
+    // @ts-expect-error - testing invalid input
+    const result = getGroupHistory("INVALID");
+    expect(result.length).toEqual(1);
+    expect(result[0]).toEqual(LockedSections.START);
+  });
+
+  it("gets history", () => {
+    expect(getGroupHistory(history).length).toEqual(6);
+  });
+});
+
+
+describe("addGroupHistory tests", () => {
+  let history:string[] = [...defaultHistory];
+
+  it("handles invalid input", () => {
+    // @ts-expect-error - testing invalid input
+    expect(addGroupHistory("INVALID", "INVALID").length).toEqual(1);
+  });
+
+  it("adds history", () => {
+    history = addGroupHistory("group6", history);
+    history = addGroupHistory("group7", history);
+    history = addGroupHistory("group8", history);
+    history = addGroupHistory("group9", history);
+    history = addGroupHistory("group10", history);
+    expect(history.length).toEqual(11);
+    expect(history[6]).toEqual("group6");
+    expect(history[10]).toEqual("group10");
+  });
+});
+
+describe("removeGroupHistory tests", () => {
+  let history:string[] = [...defaultHistory];
+
+  it("handles invalid input", () => {
+    // @ts-expect-error - testing invalid input
+    expect(removeGroupHistory("INVALID", "INVALID").length).toEqual(1);
+  });
+
+  it("removes/sets history in the middle", () => {
+    history = removeGroupHistory("group3", history);
+    expect(history.length).toEqual(4);
+  });
+
+  it("removes/sets history at the end", () => {
+    history = removeGroupHistory("group3", history);
+    expect(history.length).toEqual(4);
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

Adds a history array and util to keep track of the "path" a user navigates through a form. This is useful for showing what groups and related answers a user filled out. It may also be helpful for things like analytics in the future.
