### PR TITLE
Fix/sign out time

### DIFF
--- a/app/(gcforms)/[locale]/(user authentication)/auth/logout/components/LocalTime.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/logout/components/LocalTime.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Get the users local time.
+ * The server time on AWS will always be in UTC. To get the users local time, the browesrs locale
+ * (run client side) is used to construct and return the user's local time.
+ */
+export const LocalTime = ({ locale }: { locale: string }) => {
+  // Works around a hydration issue where the time rendered on the server doesn't match the cilent
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return (
+    <>
+      {hydrated &&
+        new Date().toLocaleString(`${locale + "-CA"}`, {
+          timeZone: tz,
+        })}
+    </>
+  );
+};

--- a/app/(gcforms)/[locale]/(user authentication)/auth/logout/components/LocalTime.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/logout/components/LocalTime.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from "react";
 
 /**
- * Get the users local time.
- * The server time on AWS will always be in UTC. To get the users local time, the browesrs locale
+ * Get the user's local time.
+ * The server time on AWS will always be in UTC. To get the user's local time, the browesrs locale
  * (run client side) is used to construct and return the user's local time.
  */
 export const LocalTime = ({ locale }: { locale: string }) => {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/logout/page.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/logout/page.tsx
@@ -1,6 +1,7 @@
 import { serverTranslation } from "@i18n";
 import { Metadata } from "next";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
+import { LocalTime } from "./components/LocalTime";
 
 export async function generateMetadata({
   params: { locale },
@@ -20,10 +21,7 @@ export default async function Page({ params: { locale } }: { params: { locale: s
     <div id="auth-panel">
       <h1 className="mb-12 mt-6 border-b-0">{t("messageContent")}</h1>
       <div className="items-center pb-10 pt-3 text-sm font-normal not-italic">
-        {t("logoutDate")} :{" "}
-        {new Date().toLocaleString(`${locale + "-CA"}`, {
-          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        })}
+        <LocalTime locale={locale} />
       </div>
       <div>
         <LinkButton.Primary href={`/${locale}/auth/login`}>


### PR DESCRIPTION
# Summary | Résumé

Updates the sign out page to use the browser's local timezone to set the current time. 
Previously this was printing UTC time because that is what the AWS node instances are set to.

## Test

Test by going to the sing out page and checking the time is right. Also for bonus points open the browser developer tools and make sure there are no errors.
![Screenshot 2024-05-15 at 1 41 20 PM](https://github.com/cds-snc/platform-forms-client/assets/107579368/49779fda-444e-4720-b036-9533457843a1)


