### PR TITLE
Feature/forms flow add group titles

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -231,7 +231,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
             {isGroupsCheck &&
               currentGroup !== LockedSections.REVIEW &&
               currentGroup !== LockedSections.START && (
-                <h2 className="pb-8">{getGroupTitle(currentGroup, props.language)}</h2>
+                <h2 className="pb-8">{getGroupTitle(currentGroup)}</h2>
               )}
 
             {children}

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -144,7 +144,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const [canFocusOnError, setCanFocusOnError] = useState(false);
   const [lastSubmitCount, setLastSubmitCount] = useState(-1);
 
-  const { currentGroup, groupsCheck } = useGCFormsContext();
+  const { currentGroup, groupsCheck, getGroupTitle } = useGCFormsContext();
   const isGroupsCheck = groupsCheck(props.allowGrouping);
   const showIntro = isGroupsCheck ? currentGroup === LockedSections.START : true;
 
@@ -228,6 +228,12 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
             // TODO move this to each child container but that I think will take some thought.
             aria-live="polite"
           >
+            {isGroupsCheck &&
+              currentGroup !== LockedSections.REVIEW &&
+              currentGroup !== LockedSections.START && (
+                <h2 className="pb-8">{getGroupTitle(currentGroup, props.language)}</h2>
+              )}
+
             {children}
 
             {showIntro && (

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -15,7 +15,6 @@ import {
   pushIdToHistory as _pushIdToHistory,
   clearHistoryAfterId as _clearHistoryAfterId,
 } from "@lib/utils/form-builder/groupsHistory";
-import { getLocalizedProperty } from "@lib/utils";
 
 interface GCFormsContextValueType {
   updateValues: ({ formValues }: { formValues: FormValues }) => void;
@@ -32,7 +31,7 @@ interface GCFormsContextValueType {
   getGroupHistory: () => string[];
   pushIdToHistory: (groupId: string) => string[];
   clearHistoryAfterId: (groupId: string) => string[];
-  getGroupTitle: (groupId: string | null, locale?: string) => string;
+  getGroupTitle: (groupId: string | null) => string;
 }
 
 const GCFormsContext = createContext<GCFormsContextValueType | undefined>(undefined);
@@ -108,11 +107,11 @@ export const GCFormsProvider = ({
   // Note: this only removes the group entry and not the values
   const clearHistoryAfterId = (groupId: string) => _clearHistoryAfterId(groupId, history.current);
 
-  // Note: once localized versions of the section name have been added, the `groups[groupId]?.name`
-  // check can be removed
-  const getGroupTitle = (groupId: string | null, locale?: string) => {
+  // Note: once localized versions of the section name have been added, update the below to use
+  // something like `getLocalizedProperty("name", locale || "en")`
+  const getGroupTitle = (groupId: string | null) => {
     if (!groupId) return "";
-    return getLocalizedProperty("name", locale || "en") || groups[groupId]?.name || "";
+    return groups[groupId]?.name || "";
   };
 
   return (

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -15,6 +15,7 @@ import {
   pushIdToHistory as _pushIdToHistory,
   clearHistoryAfterId as _clearHistoryAfterId,
 } from "@lib/utils/form-builder/groupsHistory";
+import { getLocalizedProperty } from "@lib/utils";
 
 interface GCFormsContextValueType {
   updateValues: ({ formValues }: { formValues: FormValues }) => void;
@@ -31,6 +32,7 @@ interface GCFormsContextValueType {
   getGroupHistory: () => string[];
   pushIdToHistory: (groupId: string) => string[];
   clearHistoryAfterId: (groupId: string) => string[];
+  getGroupTitle: (groupId: string | null, locale?: string) => string;
 }
 
 const GCFormsContext = createContext<GCFormsContextValueType | undefined>(undefined);
@@ -106,6 +108,13 @@ export const GCFormsProvider = ({
   // Note: this only removes the group entry and not the values
   const clearHistoryAfterId = (groupId: string) => _clearHistoryAfterId(groupId, history.current);
 
+  // Note: once localized versions of the section name have been added, the `groups[groupId]?.name`
+  // check can be removed
+  const getGroupTitle = (groupId: string | null, locale?: string) => {
+    if (!groupId) return "";
+    return getLocalizedProperty("name", locale || "en") || groups[groupId]?.name || "";
+  };
+
   return (
     <GCFormsContext.Provider
       value={{
@@ -123,6 +132,7 @@ export const GCFormsProvider = ({
         getGroupHistory,
         pushIdToHistory,
         clearHistoryAfterId,
+        getGroupTitle,
       }}
     >
       {children}
@@ -153,6 +163,7 @@ export const useGCFormsContext = () => {
       getGroupHistory: () => [],
       pushIdToHistory: () => [],
       clearHistoryAfterId: () => [],
+      getGroupTitle: () => "",
     };
   }
   return formsContext;


### PR DESCRIPTION
# Summary | Résumé

Adds the Group/Section title to the forms flow.
Note: this will need to be updated when the Group/Section titles can be localized.


https://github.com/cds-snc/platform-forms-client/assets/107579368/fccbec66-a53b-427b-ab58-1d0fd44c4064

