### PR TITLE
Fix node text wrapping

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
@@ -117,7 +117,9 @@ export const GroupNode = (node: NodeProps) => {
           if (!typesWithOptions.includes(item.type)) {
             return (
               <div key={child.index} className={cn(nodeClassName)}>
-                {getTitle(child.data as ElementProperties)}
+                <div className="line-clamp-2 truncate text-wrap">
+                  {getTitle(child.data as ElementProperties).substring(0, 300)}
+                </div>
               </div>
             );
           }
@@ -135,7 +137,9 @@ export const GroupNode = (node: NodeProps) => {
               }}
               className={cn(nodeClassName, selected)}
             >
-              {getTitle(child.data as ElementProperties)}
+              <div className="line-clamp-2 truncate text-wrap">
+                {getTitle(child.data as ElementProperties).substring(0, 300)}
+              </div>
               <div className="absolute right-[10px] top-[10px] cursor-pointer hover:scale-125">
                 <OptionRuleSvg />
               </div>


### PR DESCRIPTION
# Summary | Résumé


Small update to ensure text wraps and gets truncated for logic view

<img width="1051" alt="Screenshot 2024-05-15 at 3 23 22 PM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/29dd626c-856e-49a2-9a78-c499384a95e0">
