### PR TITLE
Add "ghost items" to tree view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -164,6 +164,7 @@ export const EditWithGroups = () => {
             addElement={false}
             schemaProperty="privacyPolicy"
             ariaLabel={t("richTextPrivacyTitle")}
+            className={"rounded-b-lg"}
           >
             <div id="privacy-text">
               <h2 className="mt-4 text-2xl laptop:mt-0">{t("richTextPrivacyTitle")}</h2>
@@ -177,6 +178,7 @@ export const EditWithGroups = () => {
             addElement={false}
             schemaProperty="confirmation"
             ariaLabel={t("richTextConfirmationTitle")}
+            className={"rounded-lg"}
           >
             <div id="confirmation-text">
               <h2 className="mt-4 text-2xl laptop:mt-0">{t("richTextConfirmationTitle")}</h2>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -96,6 +96,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         addIntroElement: true,
         addPolicyElement: true,
         addConfirmationElement: true,
+        reviewGroup: false,
       })}
       getItemTitle={(item) => getTitle(item.data as ElementProperties)}
       renderItem={({ title, arrow, context, children }) => {
@@ -149,6 +150,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         setFocusedItem(item.index);
         const parent = findParentGroup(getTreeData(), String(item.index));
 
+        // Don't set ids for pseudo elements
         if (item.index === "intro" || item.index === "policy" || item.index === "confirmation") {
           return;
         }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -92,7 +92,11 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
   return (
     <ControlledTreeEnvironment
       ref={environment}
-      items={getTreeData()}
+      items={getTreeData({
+        addIntroElement: true,
+        addPolicyElement: true,
+        addConfirmationElement: true,
+      })}
       getItemTitle={(item) => getTitle(item.data as ElementProperties)}
       renderItem={({ title, arrow, context, children }) => {
         return (
@@ -144,6 +148,11 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
       onFocusItem={(item) => {
         setFocusedItem(item.index);
         const parent = findParentGroup(getTreeData(), String(item.index));
+
+        if (item.index === "intro" || item.index === "policy" || item.index === "confirmation") {
+          return;
+        }
+
         setId(item.isFolder ? String(item.index) : String(parent?.index));
       }}
       onExpandItem={(item) => setExpandedItems([...expandedItems, item.index])}
@@ -152,7 +161,9 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
           expandedItems.filter((expandedItemIndex) => expandedItemIndex !== item.index)
         )
       }
-      onSelectItems={(items) => setSelectedItems(items)}
+      onSelectItems={(items) => {
+        setSelectedItems(items);
+      }}
     >
       <div className="mb-4 flex justify-between align-middle">
         <label>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -150,8 +150,13 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         setFocusedItem(item.index);
         const parent = findParentGroup(getTreeData(), String(item.index));
 
-        // Don't set ids for pseudo elements
-        if (item.index === "intro" || item.index === "policy" || item.index === "confirmation") {
+        if (item.index === "intro" || item.index === "policy") {
+          setId("start");
+          return;
+        }
+
+        if (item.index === "confirmation") {
+          setId("end");
           return;
         }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/types.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/types.ts
@@ -1,0 +1,36 @@
+import { FormElement } from "@lib/types";
+import { TreeItem, TreeItemIndex } from "react-complex-tree";
+import { Group, GroupsType } from "@lib/formContext";
+import { TreeItems } from "../types";
+import { TemplateStore } from "@lib/store/useTemplateStore";
+import { TreeDataOptions } from "../util/groupsToTreeData";
+
+export interface GroupStoreProps {
+  id: string;
+  selectedElementId?: number;
+  groups: TreeItems;
+  templateStore: TemplateStore;
+}
+
+export interface GroupStoreState extends GroupStoreProps {
+  getId: () => string;
+  setId: (id: string) => void;
+  setSelectedElementId: (id: number) => void;
+  addGroup: (id: string, name: string) => void;
+  deleteGroup: (id: string) => void;
+  replaceGroups: (groups: GroupsType) => void;
+  getGroups: () => GroupsType | undefined;
+  getTreeData: (options?: TreeDataOptions) => TreeItems;
+  updateGroup: (parent: TreeItemIndex, children: TreeItemIndex[] | undefined) => void;
+  findParentGroup: (id: string) => TreeItem | undefined;
+  findNextGroup: (id: string) => TreeItem | undefined;
+  findPreviousGroup: (id: string) => TreeItem | undefined;
+  getGroupFromId: (id: string) => TreeItem | undefined;
+  getElement: (id: number) => FormElement | undefined;
+  updateElementTitle: ({ id, text }: { id: number; text: string }) => void;
+  updateGroupName: ({ id, name }: { id: string; name: string }) => void;
+  getElementsGroupById: (id: string) => Group;
+  getGroupNextAction: (groupId: string) => Group["nextAction"];
+  setGroupNextAction: (groupId: string, nextAction: Group["nextAction"]) => void;
+  autoSetNextActions: () => void;
+}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/useGroupStore.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/useGroupStore.tsx
@@ -6,7 +6,7 @@ import { shallow } from "zustand/shallow";
 import React, { createContext, useRef, useContext } from "react";
 import { TemplateStore, TemplateStoreContext } from "@lib/store/useTemplateStore";
 import { LocalizedElementProperties } from "@lib/types/form-builder-types";
-import { groupsToTreeData } from "../util/groupsToTreeData";
+import { groupsToTreeData, TreeDataOptions } from "../util/groupsToTreeData";
 import { findParentGroup } from "../util/findParentGroup";
 import { TreeItems } from "../types";
 import { FormElement } from "@lib/types";
@@ -33,7 +33,7 @@ export interface GroupStoreState extends GroupStoreProps {
   deleteGroup: (id: string) => void;
   replaceGroups: (groups: GroupsType) => void;
   getGroups: () => GroupsType | undefined;
-  getTreeData: () => TreeItems;
+  getTreeData: (options?: TreeDataOptions) => TreeItems;
   updateGroup: (parent: TreeItemIndex, children: TreeItemIndex[] | undefined) => void;
   findParentGroup: (id: string) => TreeItem | undefined;
   findNextGroup: (id: string) => TreeItem | undefined;
@@ -109,11 +109,11 @@ const createGroupStore = (initProps?: Partial<GroupStoreProps>) => {
         }
       },
       getGroups: () => get().templateStore.getState().form.groups,
-      getTreeData: () => {
+      getTreeData: (options: TreeDataOptions = {}) => {
         const formGroups = get().templateStore.getState().form.groups;
         const elements = get().templateStore.getState().form.elements;
         if (!formGroups) return {};
-        return groupsToTreeData(formGroups, elements);
+        return groupsToTreeData(formGroups, elements, options);
       },
       getElementsGroupById: (id: string) => {
         const formGroups = get().templateStore.getState().form.groups;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/useGroupStore.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/store/useGroupStore.tsx
@@ -4,49 +4,19 @@ import { useStoreWithEqualityFn } from "zustand/traditional";
 import { immer } from "zustand/middleware/immer";
 import { shallow } from "zustand/shallow";
 import React, { createContext, useRef, useContext } from "react";
-import { TemplateStore, TemplateStoreContext } from "@lib/store/useTemplateStore";
+import { TemplateStoreContext } from "@lib/store/useTemplateStore";
 import { LocalizedElementProperties } from "@lib/types/form-builder-types";
 import { groupsToTreeData, TreeDataOptions } from "../util/groupsToTreeData";
 import { findParentGroup } from "../util/findParentGroup";
-import { TreeItems } from "../types";
-import { FormElement } from "@lib/types";
+import { GroupStoreProps, GroupStoreState } from "./types";
+
 import { findNextGroup } from "../util/findNextGroup";
 import { findPreviousGroup } from "../util/findPreviousGroup";
 import { getGroupFromId } from "../util/getGroupFromId";
 import { Group, GroupsType } from "@lib/formContext";
-import { TreeItem, TreeItemIndex } from "react-complex-tree";
+import { TreeItemIndex } from "react-complex-tree";
 import { autoFlowAllNextActions } from "../util/setNextAction";
 import { setGroupNextAction } from "../util/setNextAction";
-
-export interface GroupStoreProps {
-  id: string;
-  selectedElementId?: number;
-  groups: TreeItems;
-  templateStore: TemplateStore;
-}
-
-export interface GroupStoreState extends GroupStoreProps {
-  getId: () => string;
-  setId: (id: string) => void;
-  setSelectedElementId: (id: number) => void;
-  addGroup: (id: string, name: string) => void;
-  deleteGroup: (id: string) => void;
-  replaceGroups: (groups: GroupsType) => void;
-  getGroups: () => GroupsType | undefined;
-  getTreeData: (options?: TreeDataOptions) => TreeItems;
-  updateGroup: (parent: TreeItemIndex, children: TreeItemIndex[] | undefined) => void;
-  findParentGroup: (id: string) => TreeItem | undefined;
-  findNextGroup: (id: string) => TreeItem | undefined;
-  findPreviousGroup: (id: string) => TreeItem | undefined;
-  getGroupFromId: (id: string) => TreeItem | undefined;
-  getElement: (id: number) => FormElement | undefined;
-  updateElementTitle: ({ id, text }: { id: number; text: string }) => void;
-  updateGroupName: ({ id, name }: { id: string; name: string }) => void;
-  getElementsGroupById: (id: string) => Group;
-  getGroupNextAction: (groupId: string) => Group["nextAction"];
-  setGroupNextAction: (groupId: string, nextAction: Group["nextAction"]) => void;
-  autoSetNextActions: () => void;
-}
 
 const createGroupStore = (initProps?: Partial<GroupStoreProps>) => {
   const DEFAULT_PROPS: GroupStoreProps = {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/groupsToTreeData.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/groupsToTreeData.ts
@@ -6,6 +6,7 @@ export type TreeDataOptions = {
   addIntroElement?: boolean;
   addPolicyElement?: boolean;
   addConfirmationElement?: boolean;
+  reviewGroup?: boolean;
 };
 
 export const groupsToTreeData = (
@@ -142,6 +143,11 @@ export const groupsToTreeData = (
 
   if (endChildren.length > 0) {
     items["end"].children = endChildren;
+  }
+
+  if (options.reviewGroup === false) {
+    items.root.children = items.root.children?.filter((child) => child !== "review");
+    delete items["review"];
   }
 
   return items;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/groupsToTreeData.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/groupsToTreeData.ts
@@ -2,7 +2,17 @@ import { GroupsType } from "@lib/formContext";
 import { TreeItems } from "../types";
 import { FormElement } from "@lib/types";
 
-export const groupsToTreeData = (formGroups: GroupsType, elements: FormElement[]): TreeItems => {
+export type TreeDataOptions = {
+  addIntroElement?: boolean;
+  addPolicyElement?: boolean;
+  addConfirmationElement?: boolean;
+};
+
+export const groupsToTreeData = (
+  formGroups: GroupsType,
+  elements: FormElement[],
+  options: TreeDataOptions = {}
+): TreeItems => {
   const items: TreeItems = {
     root: {
       index: "root",
@@ -64,51 +74,75 @@ export const groupsToTreeData = (formGroups: GroupsType, elements: FormElement[]
     });
   }
 
-  // Add items to start
-  // @todo re-add these
-  /*
+  const startChildren = [];
+  const endChildren = [];
+
   const introItem = {
     index: "intro",
     isFolder: false,
-    canRename: true,
-    canMove: true,
+    canRename: false,
+    canMove: false,
     children: [],
-    data: "Introduction",
+    data: {
+      titleEn: "Introduction",
+      titleFr: "Introduction",
+      descriptionEn: "",
+      descriptionFr: "",
+    },
   };
-  */
 
-  // items["intro"] = introItem;
+  if (options.addIntroElement) {
+    items["intro"] = introItem;
+    startChildren.push("intro");
+  }
 
-  /*
   const policyItem = {
     index: "policy",
     isFolder: false,
-    canRename: true,
-    canMove: true,
+    canRename: false,
+    canMove: false,
     children: [],
-    data: "Policy",
+    data: {
+      titleEn: "Policy",
+      titleFr: "Policy",
+      descriptionEn: "",
+      descriptionFr: "",
+    },
   };
-  */
 
-  // items["policy"] = policyItem;
+  if (options.addPolicyElement) {
+    items["policy"] = policyItem;
+    startChildren.push("policy");
+  }
 
-  // Add start item to the beginning
-  // items["start"].children = ["intro", "policy"];
+  if (startChildren.length > 0) {
+    items["start"].children = startChildren;
+  }
 
-  // Add confirmation item to the end
-  /*
+  // ----
+
   const confirmationItem = {
-    index: "confirm",
+    index: "confirmation",
     isFolder: false,
-    canRename: true,
-    canMove: true,
+    canRename: false,
+    canMove: false,
     children: [],
-    data: "Confirmation",
+    data: {
+      titleEn: "Confirmation",
+      titleFr: "Confirmation",
+      descriptionEn: "",
+      descriptionFr: "",
+    },
   };
-  */
 
-  // items["confirm"] = confirmationItem;
-  // items["end"].children = ["confirm"];
+  if (options.addConfirmationElement) {
+    items["confirmation"] = confirmationItem;
+    endChildren.push("confirmation");
+  }
+
+  if (endChildren.length > 0) {
+    items["end"].children = endChildren;
+  }
 
   return items;
 };


### PR DESCRIPTION
# Summary | Résumé

Adds tree items for into, policy, confirmation

<img width="477" alt="Screenshot 2024-05-16 at 9 20 55 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/3700680e-595a-4e46-8b33-67d508e0b1a6">

Removes "review" group from displaying in the TreeView