### PR TITLE
Missing product name in header

### DIFF
--- a/components/clientComponents/globals/Header/Header.tsx
+++ b/components/clientComponents/globals/Header/Header.tsx
@@ -41,6 +41,13 @@ export const Header = ({ context = "default", className }: HeaderParams) => {
               </div>
             </a>
           </Link>
+
+          {context === "default" && (
+            <div className="mt-3 box-border block h-[40px] px-2 py-1 text-xl font-semibold">
+              {t("title", { ns: "common" })}
+            </div>
+          )}
+
           {status === "authenticated" && (
             <>
               <div className="mt-3 box-border block h-[40px] px-2 py-1 font-semibold">


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/3643

Adds missing product name to "Start page" and "Forms"

<img width="1245" alt="Screenshot 2024-05-21 at 8 56 52 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/bf79de31-54a5-4c42-a89c-4878e09707d3">
