### PR TITLE
Responses section error handling

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -97,7 +97,6 @@ const sortByLayout = ({ layout, elements }: { layout: number[]; elements: Answer
 const logDownload = async (
   responseIdStatusArray: { id: string; status: string }[],
   format: DownloadFormat,
-  formId: string,
   ability: ReturnType<typeof createAbility>
 ) => {
   responseIdStatusArray.forEach((item) => {
@@ -151,7 +150,7 @@ export const getSubmissionsByFormat = async ({
     const fullFormTemplate = await getFullTemplateByID(ability, formID);
 
     if (fullFormTemplate === null) {
-      throw new FormBuilderError("Form not found");
+      throw new FormBuilderError("Form not found", FormServerErrorCodes.FORM_NOT_FOUND);
     }
 
     if (ids.length > responseConfirmLimit) {
@@ -240,7 +239,7 @@ export const getSubmissionsByFormat = async ({
     });
 
     await updateLastDownloadedBy(responseIdStatusArray, formID, userEmail);
-    await logDownload(responseIdStatusArray, format, formID, ability);
+    await logDownload(responseIdStatusArray, format, ability);
 
     const revalidateNewTab = async () => {
       // delay revalidation so new tab doesn't refresh immediately

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -1,14 +1,19 @@
 "use server";
-import { Language } from "@lib/types/form-builder-types";
+import { Language, FormServerErrorCodes, ServerActionError } from "@lib/types/form-builder-types";
 import { getAppSetting } from "@lib/appSettings";
 import { logEvent } from "@lib/auditLogs";
 import { auth } from "@lib/auth";
 import { ucfirst } from "@lib/client/clientHelpers";
-import { createAbility } from "@lib/privileges";
+import { AccessControlError, createAbility } from "@lib/privileges";
 import {
   Answer,
+  CSVResponse,
   DownloadFormat,
   FormResponseSubmissions,
+  HtmlAggregatedResponse,
+  HtmlResponse,
+  HtmlZippedResponse,
+  JSONResponse,
 } from "@lib/responseDownloadFormats/types";
 import { getFullTemplateByID } from "@lib/templates";
 import { FormElementTypes, VaultStatus } from "@lib/types";
@@ -21,6 +26,7 @@ import { transform as zipTransform } from "@lib/responseDownloadFormats/html-zip
 import { transform as jsonTransform } from "@lib/responseDownloadFormats/json";
 import { logMessage } from "@lib/logger";
 import { revalidatePath } from "next/cache";
+import { FormBuilderError } from "./exceptions";
 
 // Can throw because it is not called by Client Components
 // @todo Should these types of functions be moved to a different file?
@@ -92,10 +98,8 @@ const logDownload = async (
   responseIdStatusArray: { id: string; status: string }[],
   format: DownloadFormat,
   formId: string,
-  ability: ReturnType<typeof createAbility>,
-  userEmail: string
+  ability: ReturnType<typeof createAbility>
 ) => {
-  await updateLastDownloadedBy(responseIdStatusArray, formId, userEmail);
   responseIdStatusArray.forEach((item) => {
     logEvent(
       ability.userID,
@@ -118,12 +122,19 @@ export const getSubmissionsByFormat = async ({
   format: DownloadFormat;
   lang: Language;
   revalidate?: boolean;
-}) => {
+}): Promise<
+  | HtmlResponse
+  | HtmlZippedResponse
+  | HtmlAggregatedResponse
+  | CSVResponse
+  | JSONResponse
+  | ServerActionError
+> => {
   try {
     const session = await auth();
 
     if (!session) {
-      throw new Error("User is not authenticated");
+      throw new AccessControlError("User is not authenticated");
     }
 
     const responseConfirmLimit = Number(await getAppSetting("responseDownloadLimit"));
@@ -131,8 +142,8 @@ export const getSubmissionsByFormat = async ({
     const userEmail = session.user.email;
 
     if (userEmail === null) {
-      throw new Error(
-        `User does not have an associated email address: ${JSON.stringify(session.user)} `
+      throw new AccessControlError(
+        `User does not have an associated email address: ${JSON.stringify(session.user)}`
       );
     }
 
@@ -140,19 +151,23 @@ export const getSubmissionsByFormat = async ({
     const fullFormTemplate = await getFullTemplateByID(ability, formID);
 
     if (fullFormTemplate === null) {
-      throw new Error("Form not found");
+      throw new FormBuilderError("Form not found");
     }
 
     if (ids.length > responseConfirmLimit) {
-      throw new Error(
-        `You can only download a maximum of ${responseConfirmLimit} responses at a time.`
+      throw new FormBuilderError(
+        `You can only download a maximum of ${responseConfirmLimit} responses at a time.`,
+        FormServerErrorCodes.DOWNLOAD_LIMIT_EXCEEDED
       );
     }
 
     const queryResult = await retrieveSubmissions(ability, formID, ids);
 
     if (!queryResult) {
-      throw new Error("Error retrieving submissions");
+      throw new FormBuilderError(
+        "Error retrieving submissions",
+        FormServerErrorCodes.DOWNLOAD_RETRIEVE_SUBMISSIONS
+      );
     }
 
     // Get responses into a ResponseSubmission array containing questions and answers that can be easily transformed
@@ -204,7 +219,7 @@ export const getSubmissionsByFormat = async ({
     }) as FormResponseSubmissions["submissions"];
 
     if (!responses.length) {
-      throw new Error("No responses found.");
+      throw new FormBuilderError("No responses found.", FormServerErrorCodes.NO_RESPONSES_FOUND);
     }
 
     const formResponse = {
@@ -224,7 +239,8 @@ export const getSubmissionsByFormat = async ({
       };
     });
 
-    await logDownload(responseIdStatusArray, format, formID, ability, userEmail);
+    await updateLastDownloadedBy(responseIdStatusArray, formID, userEmail);
+    await logDownload(responseIdStatusArray, format, formID, ability);
 
     const revalidateNewTab = async () => {
       // delay revalidation so new tab doesn't refresh immediately
@@ -260,10 +276,21 @@ export const getSubmissionsByFormat = async ({
         };
 
       default:
-        throw new Error(`Invalid format: ${format}`);
+        throw new FormBuilderError(
+          `Invalid format: ${format}`,
+          FormServerErrorCodes.DOWNLOAD_INVALID_FORMAT
+        );
     }
   } catch (err) {
     logMessage.error(`Could not create submissions in format ${format}: ${(err as Error).message}`);
-    return { error: "There was an error. Please try again later." };
+
+    if (err instanceof FormBuilderError) {
+      return {
+        error: "There was an error. Please try again later.",
+        code: err.code,
+      } as ServerActionError;
+    } else {
+      return { error: "There was an error. Please try again later." } as ServerActionError;
+    }
   }
 };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Dialogs/DownloadDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Dialogs/DownloadDialog.tsx
@@ -14,8 +14,9 @@ import JSZip from "jszip";
 import { getDate, slugify } from "@lib/client/clientHelpers";
 import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
 import { getSubmissionsByFormat } from "../../actions";
-import { Language } from "@lib/types/form-builder-types";
+import { FormServerErrorCodes, Language, ServerActionError } from "@lib/types/form-builder-types";
 import { usePathname } from "next/navigation";
+import { FormBuilderError } from "../../exceptions";
 
 export const DownloadDialog = ({
   checkedItems,
@@ -30,7 +31,7 @@ export const DownloadDialog = ({
   checkedItems: Map<string, boolean>;
   isDialogVisible: boolean;
   setIsDialogVisible: React.Dispatch<React.SetStateAction<boolean>>;
-  setDownloadError: React.Dispatch<React.SetStateAction<boolean>>;
+  setDownloadError: React.Dispatch<React.SetStateAction<boolean | string>>;
   formId: string;
   formName: string;
   onSuccessfulDownload: () => void;
@@ -95,12 +96,12 @@ export const DownloadDialog = ({
     setIsDownloading(true);
     setDownloadError(false);
     if (!selectedFormat || !availableFormats.includes(selectedFormat)) {
-      setDownloadError(true);
+      setDownloadError(FormServerErrorCodes.DOWNLOAD_INVALID_FORMAT);
       return;
     }
 
     if (!checkedItems.size || checkedItems.size > responseDownloadLimit) {
-      setDownloadError(true);
+      setDownloadError(FormServerErrorCodes.DOWNLOAD_LIMIT_SELECTION);
       return;
     }
 
@@ -116,10 +117,10 @@ export const DownloadDialog = ({
           format: DownloadFormat.HTML_ZIPPED,
           lang: i18n.language as Language,
           revalidate: pathname.includes("new"),
-        })) as HtmlZippedResponse | { error: string };
+        })) as HtmlZippedResponse | ServerActionError;
 
         if ("error" in response) {
-          throw new Error(response.error);
+          throw new FormBuilderError(response.error, response.code);
         }
 
         downloadFormatEvent(formId, selectedFormat, ids.length);
@@ -146,11 +147,12 @@ export const DownloadDialog = ({
           format: DownloadFormat.CSV,
           lang: i18n.language as Language,
           revalidate: pathname.includes("new"),
-        })) as CSVResponse | { error: string };
+        })) as CSVResponse | ServerActionError;
 
         if ("error" in response) {
-          throw new Error(response.error);
+          throw new FormBuilderError(response.error, response.code);
         }
+
         downloadFormatEvent(formId, selectedFormat, ids.length);
 
         if (zipAllFiles) {
@@ -182,10 +184,12 @@ export const DownloadDialog = ({
           format: DownloadFormat.JSON,
           lang: i18n.language as Language,
           revalidate: pathname.includes("new"),
-        })) as JSONResponse | { error: string };
+        })) as JSONResponse | ServerActionError;
+
         if ("error" in response) {
-          throw new Error(response.error);
+          throw new FormBuilderError(response.error, response.code);
         }
+
         downloadFormatEvent(formId, selectedFormat, ids.length);
 
         if (zipAllFiles) {
@@ -210,7 +214,8 @@ export const DownloadDialog = ({
       }
     } catch (err) {
       logMessage.error(err as Error);
-      setDownloadError(true);
+      setDownloadError((err as ServerActionError).code || true);
+      setIsDownloading(false);
       handleClose();
     }
   };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/DownloadTable.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/DownloadTable.tsx
@@ -52,7 +52,7 @@ export const DownloadTable = ({
 
   const { statusFilter: rawStatusFilter } = useParams<{ statusFilter: string }>();
   const statusFilter = ucfirst(rawStatusFilter);
-  const [downloadError, setDownloadError] = useState(false);
+  const [downloadError, setDownloadError] = useState<boolean | string>(false);
   const [noSelectedItemsError, setNoSelectedItemsError] = useState(false);
   const [showConfirmNewtDialog, setShowConfirmNewDialog] = useState(false);
   const [showDownloadDialog, setShowDownloadDialog] = useState(false);
@@ -126,6 +126,7 @@ export const DownloadTable = ({
                 </Link>
                 .
               </p>
+              <p>{typeof downloadError !== "boolean" && <p>Error code: {downloadError}</p>}</p>
             </Alert.Danger>
           )}
         </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/RetrievalError.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/RetrievalError.tsx
@@ -1,6 +1,8 @@
 "use client";
+import { Button } from "@clientComponents/globals";
 import * as Alert from "@clientComponents/globals/Alert/Alert";
 import { useTranslation } from "@i18n/client";
+import { FormServerErrorCodes } from "@lib/types/form-builder-types";
 
 export const RetrievalError = () => {
   const { t } = useTranslation("form-builder-responses");
@@ -10,15 +12,20 @@ export const RetrievalError = () => {
       <Alert.Title>{t("errors.retrieval.title")}</Alert.Title>
       <Alert.Body>
         <>
-          {t("errors.retrieval.message")}
-          <button
+          <p>{t("errors.retrieval.message")}</p>
+          <p>
+            {t("errors.errorCode")} {FormServerErrorCodes.RESPONSES_RETRIEVAL}
+          </p>
+          <Button
+            className="mt-4"
+            theme="secondary"
             onClick={
               // Attempt to recover by trying to re-render the page
               () => document.location.reload()
             }
           >
             {t("errors.retrieval.tryAgain")}
-          </button>
+          </Button>
         </>
       </Alert.Body>
     </Alert.Danger>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/RetrievalError.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/RetrievalError.tsx
@@ -1,0 +1,26 @@
+"use client";
+import * as Alert from "@clientComponents/globals/Alert/Alert";
+import { useTranslation } from "@i18n/client";
+
+export const RetrievalError = () => {
+  const { t } = useTranslation("form-builder-responses");
+
+  return (
+    <Alert.Danger>
+      <Alert.Title>{t("errors.retrieval.title")}</Alert.Title>
+      <Alert.Body>
+        <>
+          {t("errors.retrieval.message")}
+          <button
+            onClick={
+              // Attempt to recover by trying to re-render the page
+              () => document.location.reload()
+            }
+          >
+            {t("errors.retrieval.tryAgain")}
+          </button>
+        </>
+      </Alert.Body>
+    </Alert.Danger>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/error.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/error.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as Alert from "@clientComponents/globals/Alert/Alert";
+import { Button } from "@clientComponents/globals/Buttons/Button";
 import { useTranslation } from "@i18n/client";
+import { FormServerErrorCodes } from "@lib/types/form-builder-types";
 
 export default function Error({ reset }: { reset: () => void }) {
   const { t } = useTranslation("form-builder-responses");
@@ -12,8 +14,13 @@ export default function Error({ reset }: { reset: () => void }) {
         <Alert.Title>{t("errors.generic.title")}</Alert.Title>
         <Alert.Body>
           <>
-            {t("errors.generic.message")}{" "}
-            <button onClick={() => reset()}>{t("errors.generic.tryAgain")}</button>
+            <p>{t("errors.generic.message")}</p>
+            <p>
+              {t("errors.errorCode")} {FormServerErrorCodes.RESPONSES}
+            </p>
+            <Button className="mt-4" theme="secondary" onClick={() => reset()}>
+              {t("errors.retrieval.tryAgain")}
+            </Button>
           </>
         </Alert.Body>
       </Alert.Danger>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/error.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as Alert from "@clientComponents/globals/Alert/Alert";
+import { useTranslation } from "@i18n/client";
+
+export default function Error({ reset }: { reset: () => void }) {
+  const { t } = useTranslation("form-builder-responses");
+
+  return (
+    <div>
+      <Alert.Danger>
+        <Alert.Title>{t("errors.generic.title")}</Alert.Title>
+        <Alert.Body>
+          <>
+            {t("errors.generic.message")}{" "}
+            <button onClick={() => reset()}>{t("errors.generic.tryAgain")}</button>
+          </>
+        </Alert.Body>
+      </Alert.Danger>
+    </div>
+  );
+}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/exceptions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/exceptions.ts
@@ -1,0 +1,10 @@
+import { FormServerErrorCodes } from "@lib/types/form-builder-types";
+
+export class FormBuilderError extends Error {
+  code?: FormServerErrorCodes;
+
+  constructor(message?: string, errorCode?: FormServerErrorCodes) {
+    super(message);
+    this.code = errorCode;
+  }
+}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
@@ -4,6 +4,7 @@ import { getAppSetting } from "@lib/appSettings";
 import { Responses, ResponsesProps } from "./components/Responses";
 import { fetchSubmissions, fetchTemplate } from "./actions";
 import { auth } from "@lib/auth";
+import { RetrievalError } from "./components/RetrievalError";
 
 export async function generateMetadata({
   params: { locale },
@@ -37,19 +38,23 @@ export default async function Page({
     overdueAfter: Number(await getAppSetting("nagwarePhaseEncouraged")),
   };
 
-  if (isAuthenticated) {
-    const initialForm = await fetchTemplate(id);
+  try {
+    if (isAuthenticated) {
+      const initialForm = await fetchTemplate(id);
 
-    pageProps.initialForm = initialForm;
+      pageProps.initialForm = initialForm;
 
-    const { submissions, lastEvaluatedKey } = await fetchSubmissions({
-      formId: id,
-      status: statusFilter,
-      lastKey,
-    });
+      const { submissions, lastEvaluatedKey } = await fetchSubmissions({
+        formId: id,
+        status: statusFilter,
+        lastKey,
+      });
 
-    pageProps.vaultSubmissions = submissions;
-    pageProps.lastEvaluatedKey = lastEvaluatedKey;
+      pageProps.vaultSubmissions = submissions;
+      pageProps.lastEvaluatedKey = lastEvaluatedKey;
+    }
+  } catch (error) {
+    return <RetrievalError />;
   }
 
   // TODO: re-enable nagware when we have a better solution for how to handle filtered statuses

--- a/i18n/translations/en/form-builder-responses.json
+++ b/i18n/translations/en/form-builder-responses.json
@@ -38,15 +38,15 @@
     }
   },
   "errors": {
-    "errorCode": "Error code:",
+    "errorCode": "Contact Support with this error code:",
     "retrieval": {
-      "title": "There was an error retrieving responses",
-      "message": "Something went wrong while trying to retrieve responses.",
+      "title": "Something went wrong",
+      "message": "There was an error while trying to retrieve responses.",
       "tryAgain": "Try again"
     },
     "generic": {
-      "title": "There has been an error",
-      "message": "Something went wrong fulfilling your request.",
+      "title": "Something went wrong",
+      "message": "There was an error loading the page or fulfilling the request.",
       "tryAgain": "Try again"
     }
   },

--- a/i18n/translations/en/form-builder-responses.json
+++ b/i18n/translations/en/form-builder-responses.json
@@ -44,8 +44,8 @@
       "tryAgain": "Try again"
     },
     "generic": {
-      "title": "Sorry something went wront",
-      "message": "Dunno what it is but it's not good",
+      "title": "There has been an error",
+      "message": "Something went wrong fulfilling your request.",
       "tryAgain": "Try again"
     }
   },

--- a/i18n/translations/en/form-builder-responses.json
+++ b/i18n/translations/en/form-builder-responses.json
@@ -37,6 +37,18 @@
       }
     }
   },
+  "errors": {
+    "retrieval": {
+      "title": "There was an error retrieving responses",
+      "message": "Something went wrong while trying to retrieve responses.",
+      "tryAgain": "Try again"
+    },
+    "generic": {
+      "title": "Sorry something went wront",
+      "message": "Dunno what it is but it's not good",
+      "tryAgain": "Try again"
+    }
+  },
   "responses": {
     "recentlyDownloaded": "Recently downloaded",
     "deleted": "Signed off for removal",

--- a/i18n/translations/en/form-builder-responses.json
+++ b/i18n/translations/en/form-builder-responses.json
@@ -38,6 +38,7 @@
     }
   },
   "errors": {
+    "errorCode": "Error code:",
     "retrieval": {
       "title": "There was an error retrieving responses",
       "message": "Something went wrong while trying to retrieve responses.",

--- a/i18n/translations/fr/form-builder-responses.json
+++ b/i18n/translations/fr/form-builder-responses.json
@@ -38,16 +38,16 @@
     }
   },
   "errors": {
-    "errorCode": "Error code:",
+    "errorCode": "Contactez l'équipe de soutien avec le code d'erreur :",
     "retrieval": {
-      "title": "There was an error retrieving responses",
-      "message": "Something went wrong while trying to retrieve responses.",
-      "tryAgain": "Try again"
+      "title": "Quelque chose a mal tourné",
+      "message": "Une erreur s'est produite lors de la récupération des réponses.",
+      "tryAgain": "Réessayer"
     },
     "generic": {
-      "title": "There has been an error",
-      "message": "Something went wrong fulfilling your request.",
-      "tryAgain": "Try again"
+      "title": "Quelque chose a mal tourné",
+      "message": "Une erreur s'est produite lors du chargement de la page ou de l'exécution de la demande.",
+      "tryAgain": "Réessayer"
     }
   },
   "responses": {

--- a/i18n/translations/fr/form-builder-responses.json
+++ b/i18n/translations/fr/form-builder-responses.json
@@ -44,8 +44,8 @@
       "tryAgain": "Try again"
     },
     "generic": {
-      "title": "Sorry something went wront",
-      "message": "Dunno what it is but it's not good",
+      "title": "There has been an error",
+      "message": "Something went wrong fulfilling your request.",
       "tryAgain": "Try again"
     }
   },

--- a/i18n/translations/fr/form-builder-responses.json
+++ b/i18n/translations/fr/form-builder-responses.json
@@ -38,6 +38,7 @@
     }
   },
   "errors": {
+    "errorCode": "Error code:",
     "retrieval": {
       "title": "There was an error retrieving responses",
       "message": "Something went wrong while trying to retrieve responses.",

--- a/i18n/translations/fr/form-builder-responses.json
+++ b/i18n/translations/fr/form-builder-responses.json
@@ -37,6 +37,18 @@
       }
     }
   },
+  "errors": {
+    "retrieval": {
+      "title": "There was an error retrieving responses",
+      "message": "Something went wrong while trying to retrieve responses.",
+      "tryAgain": "Try again"
+    },
+    "generic": {
+      "title": "Sorry something went wront",
+      "message": "Dunno what it is but it's not good",
+      "tryAgain": "Try again"
+    }
+  },
   "responses": {
     "recentlyDownloaded": "Téléchargements récents",
     "deleted": "Pour suppression",

--- a/lib/responseDownloadFormats/types.ts
+++ b/lib/responseDownloadFormats/types.ts
@@ -50,6 +50,8 @@ export type HtmlResponse = {
   html: string;
 }[];
 
+export type HtmlAggregatedResponse = string;
+
 export type HtmlZippedResponse = {
   receipt: string;
   responses: {

--- a/lib/types/form-builder-types.ts
+++ b/lib/types/form-builder-types.ts
@@ -115,17 +115,13 @@ export interface RenderMoreFunc {
   (moreButton: JSX.Element | undefined): React.ReactElement | string | undefined;
 }
 
-export interface FormServerError {
-  formRecord: FormRecord | null;
-  error?: string;
-}
-
 export const FormServerErrorCodes = {
   BRANDING: "550",
   CLASSIFICATION: "551",
   DELIVERY_OPTION: "552",
   RESPONSES: "RS01",
   RESPONSES_RETRIEVAL: "RS02",
+  FORM_NOT_FOUND: "RS03",
   DOWNLOAD_INVALID_FORMAT: "RS05",
   DOWNLOAD_LIMIT_SELECTION: "RS06",
   DOWNLOAD_LIMIT_EXCEEDED: "RS07",
@@ -140,4 +136,9 @@ export type FormServerErrorCodes = ObjectValues<typeof FormServerErrorCodes>;
 export interface ServerActionError {
   error: string;
   code?: FormServerErrorCodes;
+}
+
+export interface FormServerError {
+  formRecord: FormRecord | null;
+  error?: string;
 }

--- a/lib/types/form-builder-types.ts
+++ b/lib/types/form-builder-types.ts
@@ -124,6 +124,20 @@ export const FormServerErrorCodes = {
   BRANDING: "550",
   CLASSIFICATION: "551",
   DELIVERY_OPTION: "552",
-  RESPONSES_RETRIEVAL: "555",
-  RESPONSES: "556",
+  RESPONSES: "RS01",
+  RESPONSES_RETRIEVAL: "RS02",
+  DOWNLOAD_INVALID_FORMAT: "RS05",
+  DOWNLOAD_LIMIT_SELECTION: "RS06",
+  DOWNLOAD_LIMIT_EXCEEDED: "RS07",
+  DOWNLOAD_RETRIEVE_SUBMISSIONS: "RS08",
+  NO_RESPONSES_FOUND: "RS09",
 } as const;
+
+type ObjectValues<T> = T[keyof T];
+
+export type FormServerErrorCodes = ObjectValues<typeof FormServerErrorCodes>;
+
+export interface ServerActionError {
+  error: string;
+  code?: FormServerErrorCodes;
+}

--- a/lib/types/form-builder-types.ts
+++ b/lib/types/form-builder-types.ts
@@ -1,5 +1,5 @@
 import { ComponentType, JSXElementConstructor } from "react";
-import { FormElement, ElementProperties } from "@lib/types";
+import { FormElement, ElementProperties, FormRecord } from "@lib/types";
 export type Language = "en" | "fr";
 
 import { FormElementTypes } from "@lib/types";
@@ -114,3 +114,15 @@ export interface CDSHTMLDialogElement extends HTMLElement {
 export interface RenderMoreFunc {
   (moreButton: JSX.Element | undefined): React.ReactElement | string | undefined;
 }
+
+export interface FormServerError {
+  formRecord: FormRecord | null;
+  error?: string;
+}
+
+export const FormServerErrorCodes = {
+  BRANDING: "550",
+  CLASSIFICATION: "551",
+  RESPONSES_RETRIEVAL: "552",
+  RESPONSES: "553",
+} as const;


### PR DESCRIPTION
# Summary | Résumé

Adds a generic error handler for Responses section.
- Will be displayed if any rendered component throws an uncaught exception
<img width="840" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/ebbc6f77-1357-4cca-a874-afd489ad2192">


Adds a specific error component for when there is an issue fetching responses server side.
- Will be displayed if there was an error retrieving responses in the server action
<img width="865" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/a54d4094-f8d4-43d6-bf92-1bd150cadbe8">


Previously, both of these cases would throw the generic app level error:
<img width="791" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/09d71090-fd45-48c3-bc8a-ec66be3c77d4">
