### PR TITLE
Share modal update error handling

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/ShareModal.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/ShareModal.tsx
@@ -41,6 +41,11 @@ export const ShareModal = ({
     setStatus("sending");
     const filename = name ? name : i18n.language === "fr" ? form.titleFr : form.titleEn;
     try {
+      if (!emails.length) {
+        setStatus("error");
+        return;
+      }
+
       await axios({
         url: "/api/share",
         method: "POST",
@@ -50,6 +55,7 @@ export const ShareModal = ({
         data: { name, form: getSchema(), emails: emails, filename },
         timeout: process.env.NODE_ENV === "production" ? 60000 : 0,
       });
+
       setStatus("sent");
     } catch (err) {
       setStatus("error");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/tag-input/TagInput.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/tag-input/TagInput.tsx
@@ -48,7 +48,7 @@ export const TagInput = ({
 
   return (
     <div
-      className="flex flex-wrap rounded-md box-border border-black-default border-2 w-[533px]"
+      className="box-border flex w-[533px] flex-wrap rounded-md border-2 border-black-default"
       data-testid="tags"
     >
       <Tags tags={tags} onRemove={onRemove} />

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -13,7 +13,7 @@ export const POST = middleware([sessionExists()], async (req, props) => {
 
     const { emails, form, filename }: { emails?: string[]; form?: string; filename?: string } =
       props.body;
-    if (!emails || !form || !filename) {
+    if (!emails || emails.length < 1 || !form || !filename) {
       return NextResponse.json({ error: "Malformed request" }, { status: 400 });
     }
 


### PR DESCRIPTION
# Summary | Résumé

Fixes 2 issues with error handling while testing the share functionality

1) An empty array of emails could be sent in the payload
2) If an empty array was sent to the server it was getting past the validation as the value exists but was empty.

With fixes

<img width="790" alt="Screenshot 2024-05-23 at 9 08 00 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/f94c907c-6b37-4218-9397-8558100be69a">

