### PR TITLE
Add H1 to confirm page when using user defined page text

### DIFF
--- a/.eslint-tailwindcss.js
+++ b/.eslint-tailwindcss.js
@@ -34,6 +34,7 @@ module.exports = {
         "example-text",
         "section",
         "maple-leaf-loader",
+        "confirmation",
       ],
     },
   },

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ConfirmationTitle.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ConfirmationTitle.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+export const ConfirmationTitle = () => {
+  const { t } = useTranslation("confirmation");
+  return (
+    <div className="mb-8 text-[1rem]">
+      <div
+        className="mb-10 h-[1px]"
+        style={{
+          backgroundImage: "linear-gradient(to right, #1E293B 50%, transparent 50%)",
+          backgroundSize: "16px 1px",
+          backgroundRepeat: "repeat-x",
+        }}
+      ></div>
+      <div className="mb-2 inline-block rounded-md border-1 border-slate-500 bg-slate-50 px-2 py-1 text-slate-500">
+        {t("sectionTitle")}
+      </div>
+      <h2 className="mt-0 text-2xl text-slate-500 laptop:mt-0">{t("title")}</h2>
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/Edit.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/Edit.tsx
@@ -13,6 +13,7 @@ import { getQuestionNumber, sortByLayout } from "@lib/utils/form-builder";
 import { SettingsPanel } from "./settings/SettingsPanel";
 import { cleanInput } from "@lib/utils/form-builder";
 import { SaveButton } from "@formBuilder/components/shared/SaveButton";
+import { ConfirmationTitle } from "./ConfirmationTitle";
 
 export const Edit = ({ formId }: { formId: string }) => {
   const router = useRouter();
@@ -179,6 +180,7 @@ export const Edit = ({ formId }: { formId: string }) => {
             <div>
               <h2 className="mt-4 text-2xl laptop:mt-0">{t("richTextConfirmationTitle")}</h2>
               <ConfirmationDescription />
+              <ConfirmationTitle />
             </div>
           </RichTextLocked>
         </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -16,6 +16,7 @@ import { useGroupStore } from "@formBuilder/components/shared/right-panel/treevi
 import { Section } from "./Section";
 import { FormElement } from "@lib/types";
 import { LangSwitcher } from "@formBuilder/components/shared/LangSwitcher";
+import { ConfirmationTitle } from "./ConfirmationTitle";
 
 export const EditWithGroups = () => {
   const { t } = useTranslation("form-builder");
@@ -184,6 +185,7 @@ export const EditWithGroups = () => {
             <div id="confirmation-text">
               <h2 className="mt-4 text-2xl laptop:mt-0">{t("richTextConfirmationTitle")}</h2>
               <ConfirmationDescription />
+              <ConfirmationTitle />
             </div>
           </RichTextLocked>
         )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -234,7 +234,9 @@ export const Preview = ({
           </span>
           <div className="mb-8 border-3 border-dashed border-blue-focus bg-white p-4">
             <div className="gc-formview">
-              <h1 tabIndex={-1}>{t("title", { ns: "confirmation" })}</h1>
+              <h1 className="mt-10" tabIndex={-1}>
+                {t("title", { ns: "confirmation" })}
+              </h1>
               <RichText {...getLocalizationAttribute()}>
                 {formRecord.form.confirmation
                   ? formRecord.form.confirmation[

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -233,14 +233,16 @@ export const Preview = ({
             {t("confirmationPage", { ns: "form-builder" })}
           </span>
           <div className="mb-8 border-3 border-dashed border-blue-focus bg-white p-4">
-            <h1 tabIndex={-1}>{t("title", { ns: "confirmation" })}</h1>
-            <RichText {...getLocalizationAttribute()}>
-              {formRecord.form.confirmation
-                ? formRecord.form.confirmation[
-                    localizeField(LocalizedElementProperties.DESCRIPTION, language)
-                  ]
-                : ""}
-            </RichText>
+            <div className="gc-formview">
+              <h1 tabIndex={-1}>{t("title", { ns: "confirmation" })}</h1>
+              <RichText {...getLocalizationAttribute()}>
+                {formRecord.form.confirmation
+                  ? formRecord.form.confirmation[
+                      localizeField(LocalizedElementProperties.DESCRIPTION, language)
+                    ]
+                  : ""}
+              </RichText>
+            </div>
           </div>
         </>
       )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -232,6 +232,7 @@ export const Preview = ({
             {t("confirmationPage", { ns: "form-builder" })}
           </span>
           <div className="mb-8 border-3 border-dashed border-blue-focus bg-white p-4">
+            <h1 tabIndex={-1}>{t("title", { ns: "confirmation" })}</h1>
             <RichText {...getLocalizationAttribute()}>
               {formRecord.form.confirmation
                 ? formRecord.form.confirmation[

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -26,7 +26,7 @@ export const Preview = ({
   allowGrouping?: boolean;
 }) => {
   const { status } = useSession();
-  const { i18n } = useTranslation("common");
+  const { i18n } = useTranslation(["common", "confirmation"]);
   const { id, getSchema, getIsPublished, getSecurityAttribute } = useTemplateStore((s) => ({
     id: s.id,
     getSchema: s.getSchema,
@@ -149,14 +149,11 @@ export const Preview = ({
           <div className="mb-20 mt-0 border-b-4 border-blue-dark py-9">
             <Brand brand={brand} lang={language} className="max-w-[360px]" />
           </div>
-          <h1 className="mt-4">
-            {formRecord.form[localizeField(LocalizedFormProperties.TITLE, language)] ||
-              t("gcFormsTest", { ns: "form-builder" })}
-          </h1>
         </div>
 
         {sent ? (
-          <>
+          <div className="gc-formview">
+            <h1 tabIndex={-1}>{t("title", { ns: "confirmation" })}</h1>
             <RichText {...getLocalizationAttribute()}>
               {formRecord.form.confirmation
                 ? formRecord.form.confirmation[
@@ -164,9 +161,13 @@ export const Preview = ({
                   ]
                 : ""}
             </RichText>
-          </>
+          </div>
         ) : (
           <div className="gc-formview">
+            <h1 className="mt-4">
+              {formRecord.form[localizeField(LocalizedFormProperties.TITLE, language)] ||
+                t("gcFormsTest", { ns: "form-builder" })}
+            </h1>
             {!hasHydrated && <Skeleton count={5} height={40} className="mb-4" />}
             {hasHydrated && (
               <GCFormsProvider formRecord={formRecord}>

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/page.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/page.tsx
@@ -10,6 +10,7 @@ import FormDisplayLayout from "@clientComponents/globals/layouts/FormDisplayLayo
 import { GCFormsProvider } from "@lib/hooks/useGCFormContext";
 import { FormWrapper } from "./clientSide";
 import { allowGrouping } from "@formBuilder/components/shared/right-panel/treeview/util/allowGrouping";
+import { serverTranslation } from "@i18n";
 
 export async function generateMetadata({
   params: { locale, props },
@@ -17,12 +18,19 @@ export async function generateMetadata({
   params: { locale: string; props: string[] };
 }): Promise<Metadata> {
   const formID = props[0];
+  const step = props[1] ?? "";
   const publicForm = await getPublicTemplateByID(formID);
   if (!publicForm) return {};
 
-  const formTitle = publicForm.form[getLocalizedProperty("title", locale)] as string;
+  const { t } = await serverTranslation(["form-builder"], { lang: locale });
+
+  // Update the browser title so AT users know they are on the confirmation page
+  const title = `${step === "confirmation" ? t("confirmationPage") + ": " : ""}${
+    publicForm.form[getLocalizedProperty("title", locale)]
+  }`;
+
   return {
-    title: formTitle,
+    title,
   };
 }
 

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -180,7 +180,10 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   ).length;
 
   return status === "submitting" ? (
-    <Loader message={t("loading")} />
+    <>
+      <title>{t("loading")}</title>
+      <Loader message={t("loading")} />
+    </>
   ) : (
     <>
       {formStatusError && (

--- a/components/clientComponents/forms/TextPage/TextPage.tsx
+++ b/components/clientComponents/forms/TextPage/TextPage.tsx
@@ -23,7 +23,12 @@ const PageContent = ({ pageText, urlQuery }: PageContextProps) => {
 
   // Check if there's a custom text for the end page specified in the form's JSON config
   if (pageText && pageText !== undefined) {
-    return <RichText className="confirmation">{pageText}</RichText>;
+    return (
+      <>
+        <h1 tabIndex={-1}>{t("title")}</h1>
+        <RichText className="confirmation">{pageText}</RichText>;
+      </>
+    );
   }
 
   // Otherwise, display the default confirmation text

--- a/components/clientComponents/forms/TextPage/TextPage.tsx
+++ b/components/clientComponents/forms/TextPage/TextPage.tsx
@@ -23,19 +23,13 @@ const PageContent = ({ pageText, urlQuery }: PageContextProps) => {
 
   // Check if there's a custom text for the end page specified in the form's JSON config
   if (pageText && pageText !== undefined) {
-    return (
-      <>
-        <h1 tabIndex={-1}>{t("title")}</h1>
-        <RichText className="confirmation">{pageText}</RichText>;
-      </>
-    );
+    return <RichText className="confirmation">{pageText}</RichText>;
   }
 
   // Otherwise, display the default confirmation text
   const backToLink = urlQuery ? <a href={urlQuery}>{t("backLink")}</a> : null;
   return (
     <>
-      <h1 tabIndex={-1}>{t("title")}</h1>
       <div>
         <p>{t("body")}</p>
       </div>
@@ -46,6 +40,7 @@ const PageContent = ({ pageText, urlQuery }: PageContextProps) => {
 
 export const TextPage = (props: TextPageProps): React.ReactElement => {
   const { i18n } = useTranslation("confirmation");
+  const { t } = useTranslation("confirmation");
   const {
     formRecord: {
       form: { confirmation },
@@ -66,6 +61,7 @@ export const TextPage = (props: TextPageProps): React.ReactElement => {
 
   return (
     <>
+      <h1 tabIndex={-1}>{t("title")}</h1>
       <PageContent pageText={pageText} urlQuery={urlQuery} />
     </>
   );

--- a/cypress/e2e/platform_intake.cy.ts
+++ b/cypress/e2e/platform_intake.cy.ts
@@ -21,7 +21,7 @@ describe("CDS Platform Intake Form functionality", () => {
 
     cy.get("[type='submit']").click();
     cy.url().should("include", `/confirmation`);
-    cy.get("h1").contains("Your request has been submitted");
+    cy.get("h1").contains("Your form has been submitted");
     cy.get("[data-testid='fip']").find("img").should("have.attr", "src", "/img/sig-blk-en.svg");
     cy.get("#content").contains("Thank you. Our team will contact you by email shortly.");
   });

--- a/i18n/translations/en/confirmation.json
+++ b/i18n/translations/en/confirmation.json
@@ -1,5 +1,5 @@
 {
-  "title": "Your request has been submitted",
+  "title": "Your form has been submitted",
   "body": "Thank you. Our team will contact you by email shortly.",
   "backLink": "Back"
 }

--- a/i18n/translations/en/confirmation.json
+++ b/i18n/translations/en/confirmation.json
@@ -1,5 +1,6 @@
 {
   "title": "Your form has been submitted",
   "body": "Thank you. Our team will contact you by email shortly.",
-  "backLink": "Back"
+  "backLink": "Back",
+  "sectionTitle": "Section title"
 }

--- a/i18n/translations/fr/confirmation.json
+++ b/i18n/translations/fr/confirmation.json
@@ -1,5 +1,6 @@
 {
   "title": "Votre formulaire a été soumis",
   "body": "Merci. Notre équipe vous contactera par courriel sous peu.",
-  "backLink": "Retour"
+  "backLink": "Retour",
+  "sectionTitle": "Titre de la section"
 }

--- a/i18n/translations/fr/confirmation.json
+++ b/i18n/translations/fr/confirmation.json
@@ -1,5 +1,5 @@
 {
-  "title": "Votre demande a été soumise",
+  "title": "Votre formulaire a été soumis",
   "body": "Merci. Notre équipe vous contactera par courriel sous peu.",
   "backLink": "Retour"
 }


### PR DESCRIPTION
# Summary | Résumé

Adds default H1 to confirmation page. 

**Published form**
<img width="500" alt="Screenshot 2024-05-23 at 11 31 00 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/3b204ee9-f4f4-4c05-b91f-6cd85fe41120">


**Form builder editor**
<img width="700" alt="Screenshot 2024-05-23 at 11 47 49 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/f0cf0b5a-cd65-463c-bcc0-1d3ef23db258">


**Form builder  preview logged in**

<img width="700" alt="Screenshot 2024-05-23 at 11 49 31 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/122549e9-4e82-4b77-b3a5-4c7d6508012e">

**Form builder  preview logged out**

<img width="700" alt="Screenshot 2024-05-23 at 11 57 39 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/81713d89-86f1-422a-b0a2-45c91513c621">
