### PR TITLE
* Add missing error handler on client side for support form.

### DIFF
--- a/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
@@ -69,6 +69,12 @@ export const SupportForm = () => {
         </p>
       </Alert.Warning>
       <form id="support" action={formAction} noValidate>
+        {state.error && (
+          <Alert.Danger focussable={true} title={t("error")} className="mb-2 mt-2">
+            <p>{t(state.error)}</p>
+          </Alert.Danger>
+        )}
+
         <div className="focus-group mt-14">
           <Label id={"label-name"} htmlFor={"name"} className="required" required>
             {t("support.name")}


### PR DESCRIPTION
Part of #3655 

Adds a missing alert for the client side if a server side error occurs.