### PR TITLE
* Add missing contact forms error alert on client side.

### DIFF
--- a/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
@@ -69,6 +69,11 @@ export const ContactForm = () => {
         </p>
       </Alert.Warning>
       <form id="contactus" action={formAction} noValidate>
+        {state.error && (
+          <Alert.Danger focussable={true} title={t("error")} className="mb-2 mt-2">
+            <p>{t(state.error)}</p>
+          </Alert.Danger>
+        )}
         <fieldset className="focus-group mt-14">
           <legend className="gc-label required">
             {t("contactus.request.title")}{" "}


### PR DESCRIPTION
Part of https://github.com/cds-snc/platform-forms-client/issues/3655

Adds a missing alert for the client side if a server side error occurs.