### PR TITLE
* Add missing error message should unlock publish request fail.

### DIFF
--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
@@ -2,7 +2,8 @@
 import { useTranslation } from "@i18n/client";
 import { useFormState } from "react-dom";
 import { unlockPublishing } from "../../actions";
-import { Label, Alert, ErrorListItem, Description } from "@clientComponents/forms";
+import { Label, ErrorListItem, Description } from "@clientComponents/forms";
+import { Alert } from "@clientComponents/globals";
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { TextInput } from "../../../components/client/TextInput";
@@ -51,6 +52,11 @@ export const UnlockPublishingForm = ({ userEmail }: { userEmail: string }) => {
       <h1>{t("unlockPublishing.title")}</h1>
       <p className="mb-14">{t("unlockPublishing.paragraph1")}</p>
       <form id="unlock-publishing" action={formAction} noValidate>
+        {state.error && (
+          <Alert.Danger focussable={true} title={t("error")} className="mb-2 mt-2">
+            <p>{t(state.error)}</p>
+          </Alert.Danger>
+        )}
         <div className="focus-group">
           <Label id="label-managerEmail" htmlFor="managerEmail" className="required" required>
             {t("unlockPublishing.form.field1.title")}

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
@@ -2,7 +2,12 @@
 import { useTranslation } from "@i18n/client";
 import { useFormState } from "react-dom";
 import { unlockPublishing } from "../../actions";
-import { Label, ErrorListItem, Description } from "@clientComponents/forms";
+import {
+  Label,
+  ErrorListItem,
+  Description,
+  Alert as ValidationMessage,
+} from "@clientComponents/forms";
 import { Alert } from "@clientComponents/globals";
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
@@ -28,7 +33,7 @@ export const UnlockPublishingForm = ({ userEmail }: { userEmail: string }) => {
     <>
       {/* @todo  Add general error to show user there was an internal service error */}
       {Object.keys(state.validationErrors).length > 0 && (
-        <Alert
+        <ValidationMessage
           type={ErrorStatus.ERROR}
           validation={true}
           tabIndex={0}
@@ -46,7 +51,7 @@ export const UnlockPublishingForm = ({ userEmail }: { userEmail: string }) => {
               );
             })}
           </ol>
-        </Alert>
+        </ValidationMessage>
       )}
 
       <h1>{t("unlockPublishing.title")}</h1>


### PR DESCRIPTION
Part of #3655 

Adds an alert that the request failed if clicking unlock publish throws an error.