### PR TITLE
Fixes html download page double scroll bar in Edge

### DIFF
--- a/lib/responseDownloadFormats/html/components/RowTable.tsx
+++ b/lib/responseDownloadFormats/html/components/RowTable.tsx
@@ -61,10 +61,7 @@ export const RowTable = (props: TableProps): React.ReactElement => {
 
   return (
     <div className="overflow-x-scroll">
-      <dl
-        id={`responseTableRow${capitalize(lang)}`}
-        className="flex overflow-x-auto border-y-2 border-gray"
-      >
+      <dl id={`responseTableRow${capitalize(lang)}`} className="flex border-y-2 border-gray">
         <div className="flex flex-col">
           <dt className="flex whitespace-nowrap border-b border-gray p-4 font-bold">
             {t("responseTemplate.responseNumber", { lng: lang })}


### PR DESCRIPTION
# Summary | Résumé

Fixes html download page double scroll bar in Edge.

Example download page in Edge
![Screenshot 2024-05-27 at 10 44 17 AM](https://github.com/cds-snc/platform-forms-client/assets/107579368/90344244-51cc-4db5-88bc-9f6da793eb24)
