### PR TITLE
Update save button fail CSS

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/SaveButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/SaveButton.tsx
@@ -73,7 +73,7 @@ export const ErrorSavingForm = () => {
       </span>
       <LinkButton
         href={supportHref}
-        className="mr-2 !text-red-700 underline hover:no-underline focus:bg-transparent active:bg-transparent"
+        className="mr-2 !text-red-700 underline hover:no-underline focus:bg-transparent focus:!text-red-700 active:bg-transparent active:!text-red-700"
       >
         {t("errorSavingForm.failedLink", { ns: "form-builder" })}
       </LinkButton>


### PR DESCRIPTION
# Summary | Résumé

Fixes save button CSS so link CSS issue so the text doesn't appear as white -> white when active


Tested fail throwing an error from the sever action using a know string value i.e. 

```javascript
export const createOrUpdateTemplate = async ({
  id,
  formConfig,
  name,
  deliveryOption,
  securityAttribute,
}: CreateOrUpdateTemplateType): Promise<{
  formRecord: FormRecord | null;
  error?: string;
}> => {
  try {
    revalidatePath("/[locale]/forms", "page");

    if (formConfig.titleEn === "fail") {
      throw new Error("Error saving template!!");
    }
    
    ```