### PR TITLE
Don't hide titleAndDescription with success message

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
@@ -49,13 +49,11 @@ export const Responses = ({
   return (
     <>
       {vaultSubmissions.length > 0 && (
-        <div className="has-[.gc-confirm-success]:hidden">
-          <TitleAndDescription
-            statusFilter={ucfirst(statusFilter)}
-            formId={id}
-            responseDownloadLimit={responseDownloadLimit}
-          />
-        </div>
+        <TitleAndDescription
+          statusFilter={ucfirst(statusFilter)}
+          formId={id}
+          responseDownloadLimit={responseDownloadLimit}
+        />
       )}
       {nagwareResult && <Nagware nagwareResult={nagwareResult} />}
       <div aria-live="polite">


### PR DESCRIPTION
# Summary | Résumé

Fixes #3588 
We were using css to hide the TitleAndDescription when there is a success message on screen, this assumes that users always confirm all downloaded responses, which does not always apply.
