### PR TITLE
Fix: Only show Translate Navigation when groups off

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/page.tsx
@@ -21,7 +21,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
 
   return (
     <>
-      {conditionalLogic && <EditNavigation id={id} />}
+      {!conditionalLogic && <EditNavigation id={id} />}
       {conditionalLogic ? <TranslateWithGroups /> : <Translate />}
     </>
   );


### PR DESCRIPTION
# Summary | Résumé

Translate Navigation should only be displayed when Groups are turned off.
