### PR TITLE
Fix: Treeview Drag/Drop fixes

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
@@ -98,12 +98,11 @@ export const Item = ({
       }}
     >
       <>
-        <button
+        <div
           {...context.itemContainerWithoutChildrenProps}
           {...context.interactiveElementProps}
-          type="button"
           className={cn(
-            "text-left group relative w-full overflow-hidden truncate p-3",
+            "text-left group relative w-full overflow-hidden truncate p-3 cursor-pointer",
             !arrow && "bg-white",
             !arrow && "border-slate-500 border-1 rounded-md"
           )}
@@ -122,12 +121,12 @@ export const Item = ({
           {context.canDrag ? (
             <>
               {context.isExpanded && (
-                <span className="cursor-pointer" onClick={handleDelete}>
+                <button className="cursor-pointer" onClick={handleDelete}>
                   <DeleteIcon
                     title="Delete group"
                     className="absolute right-0 top-0 mr-10 mt-3 size-5"
                   />
-                </span>
+                </button>
               )}
               <DragHandle
                 className={cn(
@@ -139,7 +138,7 @@ export const Item = ({
           ) : (
             <LockIcon className="absolute right-0 mr-2 inline-block scale-75" />
           )}
-        </button>
+        </div>
         {children}
       </>
     </li>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
@@ -146,7 +146,7 @@ export const Item = ({
 };
 
 const Title = ({ title }: { title: string }) => {
-  return <span>{title}</span>;
+  return <div className="w-5/6 truncate">{title}</div>;
 };
 
 const Arrow = ({ item, context }: { item: TreeItem; context: TreeItemRenderContext }) => {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
@@ -87,15 +87,7 @@ export const Item = ({
   return (
     <li
       {...context.itemContainerWithChildrenProps}
-      className={cn(
-        "flex flex-col",
-        arrow && "first:border-t-1 last:border-b-0 border-b-1 border-slate-200 b-t-1",
-        !context.isExpanded && "",
-        children && "bg-slate-50"
-      )}
-      style={{
-        margin: 0,
-      }}
+      className={cn("flex flex-col", !context.isExpanded && "h-[60px]", children && "bg-slate-50")}
     >
       <>
         <div

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -31,6 +31,7 @@ import { ConfirmDeleteSectionDialog } from "../../confirm/ConfirmDeleteSectionDi
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { toast } from "@formBuilder/components/shared";
 import { useTranslation } from "@i18n/client";
+import { cn } from "@lib/utils";
 
 export interface TreeDataProviderProps {
   children?: ReactElement;
@@ -170,6 +171,17 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         renderItemTitle={({ title }) => <Item.Title title={title} />}
         renderItemArrow={({ item, context }) => <Item.Arrow item={item} context={context} />}
         renderLiveDescriptorContainer={() => null}
+        renderDragBetweenLine={({ draggingPosition, lineProps }) => {
+          return (
+            <div
+              {...lineProps}
+              className={cn(
+                "h-[64px] w-full border-t-2 border-blue-focus",
+                draggingPosition.depth > 0 && "ml-10"
+              )}
+            />
+          );
+        }}
         viewState={{
           ["default"]: {
             focusedItem,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -176,10 +176,17 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
             <div
               {...lineProps}
               className={cn(
-                "h-[64px] w-full border-t-2 border-blue-focus",
+                "w-full border-b-2 border-blue-focus",
                 draggingPosition.depth > 0 && "ml-10"
               )}
             />
+          );
+        }}
+        renderItemsContainer={({ children, containerProps }) => {
+          return (
+            <ul className="divide-y-1 p-0" {...containerProps}>
+              {children}
+            </ul>
           );
         }}
         viewState={{

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -199,6 +199,8 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
           });
         }}
         canDropAt={(items, target) => handleCanDropAt(items, target, getGroups)}
+        canDropBelowOpenFolders={true}
+        canDropOnFolder={true}
         onRenameItem={(item, name) => {
           item.isFolder && updateGroupName({ id: String(item.index), name });
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
@@ -31,7 +31,7 @@ export const handleCanDropAt = (
     const currentGroups = getGroups() as GroupsType;
     const reviewIndex = getReviewIndex(currentGroups);
 
-    if (target.linearIndex >= reviewIndex + 1) {
+    if (target.depth === 0 && (<DraggingPositionBetweenItems>target).childIndex > reviewIndex) {
       return false;
     }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
@@ -42,7 +42,7 @@ export const handleCanDropAt = (
 
   // If any of the items is not a group, disallow dropping on root
   if (nonGroupItemsCount >= 1) {
-    if (target.depth === 0) {
+    if (target.targetType === "between-items" && target.parentItem === "root") {
       return false;
     }
   }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
@@ -22,8 +22,7 @@ export const handleCanDropAt = (
   // If any of the selected items is a group
   if (groupItemsCount >= 1) {
     // Groups can't be dropped on another group
-    const { parentItem } = target as DraggingPositionBetweenItems;
-    if (items[0].isFolder && parentItem !== "root") {
+    if ((<DraggingPositionBetweenItems>target).parentItem !== "root") {
       return false;
     }
 
@@ -31,12 +30,12 @@ export const handleCanDropAt = (
     const currentGroups = getGroups() as GroupsType;
     const reviewIndex = getReviewIndex(currentGroups);
 
-    if (target.depth === 0 && (<DraggingPositionBetweenItems>target).childIndex > reviewIndex) {
+    if ((<DraggingPositionBetweenItems>target).childIndex > reviewIndex) {
       return false;
     }
 
     // Groups can't be dropped before Start
-    if (target.linearIndex === 0) {
+    if ((<DraggingPositionBetweenItems>target).childIndex === 0) {
       return false;
     }
   }

--- a/styles/_form-builder.scss
+++ b/styles/_form-builder.scss
@@ -370,10 +370,3 @@
   padding: 0 !important;
   margin: 0;
 }
-
-.rct-tree-items-container {
-  padding: 0;
-  margin: 0;
-  margin-right: 1px;
-  padding-left: 0;
-}


### PR DESCRIPTION
# Summary | Résumé
- Render item container as Div so that the Delete icon can be a button
- Bugfix: Prevent drop after Review when there are open groups
- Truncate long Item titles
- Render custom dragBetweenLine (target)
- Allow dropping items on folders (prop + canDropAt handler)
- Allow dropping items and folders below open folders (prop)
- Eliminate dragBetweenLine "drift"

