### PR TITLE
Add background to logic view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/FlowWithProvider.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/FlowWithProvider.tsx
@@ -17,6 +17,7 @@ import ReactFlow, {
   useEdgesState,
   useReactFlow,
   ReactFlowInstance,
+  Background,
 } from "reactflow";
 
 import "reactflow/dist/style.css";
@@ -98,6 +99,7 @@ const Flow: ForwardRefRenderFunction<unknown, FlowProps> = ({ children }, ref) =
         }}
       >
         <Controls />
+        <Background />
         {children}
       </ReactFlow>
     </>


### PR DESCRIPTION
# Summary | Résumé

Adds background "dots" to logic view.

<img width="840" alt="Screenshot 2024-05-31 at 9 16 26 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/97870c16-6827-4b2e-863a-9240379a9097">
