### PR TITLE
Fix disappearing group name

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
@@ -237,7 +237,7 @@ export const handleOnDrop = async (
     // Create a new Groups object
     let newGroups = { ...currentGroups };
     newGroups[String(originParent?.index)] = {
-      name: String(originParent?.data.titleEn),
+      name: String(originParent?.data.name),
       elements: originGroupElements,
       titleEn: originParent?.data.titleEn,
       titleFr: originParent?.data.titleFr,


### PR DESCRIPTION
# Summary | Résumé

When dragging items across groups, the group name was being set to titleEn instead of name
