### PR TITLE
Handle drop on empty folder

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
@@ -87,7 +87,12 @@ export const Item = ({
   return (
     <li
       {...context.itemContainerWithChildrenProps}
-      className={cn("flex flex-col", !context.isExpanded && "h-[60px]", children && "bg-slate-50")}
+      className={cn(
+        "flex flex-col",
+        !context.isExpanded && "h-[60px]",
+        children && "bg-slate-50",
+        context.isDraggingOver && "!border-dashed !border-1 !border-blue-focus"
+      )}
     >
       <>
         <div

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleCanDropAt.ts
@@ -1,5 +1,10 @@
 import { GroupsType } from "@lib/formContext";
-import { DraggingPosition, DraggingPositionBetweenItems, TreeItem } from "react-complex-tree";
+import {
+  DraggingPosition,
+  DraggingPositionBetweenItems,
+  DraggingPositionItem,
+  TreeItem,
+} from "react-complex-tree";
 
 const getReviewIndex = (currentGroups: GroupsType) => {
   const elements = Object.keys(currentGroups);
@@ -23,6 +28,10 @@ export const handleCanDropAt = (
   if (groupItemsCount >= 1) {
     // Groups can't be dropped on another group
     if ((<DraggingPositionBetweenItems>target).parentItem !== "root") {
+      return false;
+    }
+
+    if ((<DraggingPositionItem>target).targetType == "item") {
       return false;
     }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
@@ -4,6 +4,7 @@ import {
   DraggingPositionBetweenItems,
   DraggingPositionItem,
   TreeItem,
+  TreeItemIndex,
 } from "react-complex-tree";
 import { findParentGroup } from "../util/findParentGroup";
 import { TreeItems } from "../types";
@@ -116,8 +117,8 @@ export const handleOnDrop = async (
   // Current state of the tree in Groups format
   let currentGroups = getGroups() as GroupsType;
 
-  let targetParent;
-  let targetIndex;
+  let targetParent: TreeItemIndex;
+  let targetIndex: number;
 
   if ((<DraggingPositionItem>target).targetType === "item") {
     targetParent = (<DraggingPositionItem>target).targetItem;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
@@ -116,25 +116,17 @@ export const handleOnDrop = async (
   // Current state of the tree in Groups format
   let currentGroups = getGroups() as GroupsType;
 
-  // When dragging an item to a group
-  if (target.targetType === "item") {
-    console.log({ target });
-    const targetItem = (<DraggingPositionItem>target).targetItem;
-    console.log({ targetItem });
-    const targetGroup = currentGroups[target.targetItem];
-    console.log({ targetGroup });
-    items.forEach((item, index) => {
-      const originParent = findParentGroup(getTreeData(), String(item.index));
-      const originParentGroup = currentGroups[originParent?.index as string];
-      console.log({ originParentGroup });
-    });
+  let targetParent;
+  let targetIndex;
 
-    return;
+  if ((<DraggingPositionItem>target).targetType === "item") {
+    targetParent = (<DraggingPositionItem>target).targetItem;
+    targetIndex = 0;
+  } else {
+    // Target parent and index
+    targetParent = (<DraggingPositionBetweenItems>target).parentItem;
+    targetIndex = (<DraggingPositionBetweenItems>target).childIndex;
   }
-
-  // Target parent and index
-  const { parentItem: targetParent, childIndex: targetIndex } =
-    target as DraggingPositionBetweenItems;
 
   let newGroups: GroupsType;
   const selectedItems: string[] = [];

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/handlers/handleOnDrop.ts
@@ -1,5 +1,10 @@
 import { Group, GroupsType } from "@lib/formContext";
-import { DraggingPosition, DraggingPositionBetweenItems, TreeItem } from "react-complex-tree";
+import {
+  DraggingPosition,
+  DraggingPositionBetweenItems,
+  DraggingPositionItem,
+  TreeItem,
+} from "react-complex-tree";
 import { findParentGroup } from "../util/findParentGroup";
 import { TreeItems } from "../types";
 import { autoFlowGroupNextActions } from "../util/setNextAction";
@@ -110,6 +115,22 @@ export const handleOnDrop = async (
 ) => {
   // Current state of the tree in Groups format
   let currentGroups = getGroups() as GroupsType;
+
+  // When dragging an item to a group
+  if (target.targetType === "item") {
+    console.log({ target });
+    const targetItem = (<DraggingPositionItem>target).targetItem;
+    console.log({ targetItem });
+    const targetGroup = currentGroups[target.targetItem];
+    console.log({ targetGroup });
+    items.forEach((item, index) => {
+      const originParent = findParentGroup(getTreeData(), String(item.index));
+      const originParentGroup = currentGroups[originParent?.index as string];
+      console.log({ originParentGroup });
+    });
+
+    return;
+  }
 
   // Target parent and index
   const { parentItem: targetParent, childIndex: targetIndex } =
@@ -237,7 +258,7 @@ export const handleOnDrop = async (
     // Create a new Groups object
     let newGroups = { ...currentGroups };
     newGroups[String(originParent?.index)] = {
-      name: String(originParent?.data.titleEn),
+      name: String(originParent?.data.name),
       elements: originGroupElements,
       titleEn: originParent?.data.titleEn,
       titleFr: originParent?.data.titleFr,


### PR DESCRIPTION
# Summary | Résumé

Handle dropping on empty Groups.
Adds highlight around Groups when dragging over.
If you drop an item on a group that has items it defaults to dropping it at index 0 (top)