### PR TITLE
Update init form to allow direct link to page for groups

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/groupsToTreeData.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/groupsToTreeData.ts
@@ -117,9 +117,9 @@ export const groupsToTreeData = (
     startChildren.push("policy");
   }
 
-  if (startChildren.length > 0) {
+  if (startChildren.length > 0 && items["start"]?.children) {
     // Add startChildren to existing start children
-    const currentStartChildren = items["start"].children ? items["start"].children : [];
+    const currentStartChildren = items["start"]?.children ? items["start"].children : [];
     items["start"].children = [...startChildren, ...currentStartChildren];
   }
 
@@ -144,7 +144,7 @@ export const groupsToTreeData = (
     endChildren.push("confirmation");
   }
 
-  if (endChildren.length > 0) {
+  if (endChildren.length > 0 && items["end"]?.children) {
     items["end"].children = endChildren;
   }
 

--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -49,7 +49,7 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
     translationLanguagePriority: (initProps?.locale as Language) || "en",
     focusInput: false,
     hasHydrated: false,
-    form: defaultForm,
+    form: initializeGroups(defaultForm, initProps?.allowGroupsFlag || false),
     isPublished: false,
     name: "",
     securityAttribute: "Protected A",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
# Summary | Résumé

 Fixes issue where a direct link to `/en/form-builder/0000/edit`
 
 Was not initializing the group sections.