### PR TITLE
Minor UI Fixes for Settings Page

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/branding/components/Branding.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/branding/components/Branding.tsx
@@ -102,9 +102,6 @@ export const Branding = ({ hasBrandingRequestForm }: { hasBrandingRequestForm: b
   return (
     <div>
       <h2 className="mb-6">{t("branding.heading")}</h2>
-      <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
-        {t("settingsResponseDelivery.beforePublishMessage")}
-      </p>
       <p className="block text-sm">{t("branding.text1")}</p>
       {/* Logo select */}
       <div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -284,9 +284,9 @@ export const ResponseDelivery = () => {
     <>
       {status === "authenticated" && (
         <div className="mb-10">
-          <div className="mb-4">
+          <div className="mb-10">
             <h2 className="mb-6">{t("settingsResponseDelivery.selectClassification")}</h2>
-            <div>
+            <div className="mb-10">
               <ClassificationSelect
                 className="max-w-[400px] truncate bg-gray-soft p-1 pr-10"
                 lang={lang}
@@ -296,7 +296,7 @@ export const ResponseDelivery = () => {
               />
             </div>
 
-            <div className="mb-4">
+            <div className="mb-10">
               <h2 className="mb-6">{t("settingsResponseDelivery.title")}</h2>
               {protectedBSelected ? (
                 <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
@@ -342,42 +342,44 @@ export const ResponseDelivery = () => {
               />
             )}
 
-            <h2 className="mb-6">{t("settingsPurposeAndUse.title")}</h2>
-            <p className="mb-2">{t("settingsPurposeAndUse.helpUs")}</p>
-            <p className="text-sm mb-6">{t("settingsPurposeAndUse.description")}</p>
-            <Radio
-              id="purposeAndUseAdmin"
-              name="purpose-use"
-              label={t("settingsPurposeAndUse.personalInfo")}
-              disabled={isPublished}
-              checked={purposeOption === PurposeOption.admin}
-              value={PurposeOption.admin}
-              onChange={updatePurposeOption}
-            />
-            <div className="text-sm ml-10 mb-4">
-              <p>{t("settingsPurposeAndUse.personalInfoDetails")}</p>
-              <ul>
-                <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.1")}</li>
-                <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.2")}</li>
-                <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.3")}</li>
-              </ul>
-            </div>
-            <Radio
-              id="purposeAndUseNonAdmin"
-              name="purpose-use"
-              label={t("settingsPurposeAndUse.nonAdminInfo")}
-              disabled={isPublished}
-              checked={purposeOption === PurposeOption.nonAdmin}
-              value={PurposeOption.nonAdmin}
-              onChange={updatePurposeOption}
-            />
-            <div className="text-sm ml-10 mb-4">
-              <p>{t("settingsPurposeAndUse.nonAdminInfoDetails")}</p>
-              <ul>
-                <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.1")}</li>
-                <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.2")}</li>
-                <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.3")}</li>
-              </ul>
+            <div className="mb-10">
+              <h2>{t("settingsPurposeAndUse.title")}</h2>
+              <p className="mb-2">{t("settingsPurposeAndUse.helpUs")}</p>
+              <p className="text-sm mb-6">{t("settingsPurposeAndUse.description")}</p>
+              <Radio
+                id="purposeAndUseAdmin"
+                name="purpose-use"
+                label={t("settingsPurposeAndUse.personalInfo")}
+                disabled={isPublished}
+                checked={purposeOption === PurposeOption.admin}
+                value={PurposeOption.admin}
+                onChange={updatePurposeOption}
+              />
+              <div className="text-sm ml-10 mb-4">
+                <p>{t("settingsPurposeAndUse.personalInfoDetails")}</p>
+                <ul>
+                  <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.1")}</li>
+                  <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.2")}</li>
+                  <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.3")}</li>
+                </ul>
+              </div>
+              <Radio
+                id="purposeAndUseNonAdmin"
+                name="purpose-use"
+                label={t("settingsPurposeAndUse.nonAdminInfo")}
+                disabled={isPublished}
+                checked={purposeOption === PurposeOption.nonAdmin}
+                value={PurposeOption.nonAdmin}
+                onChange={updatePurposeOption}
+              />
+              <div className="text-sm ml-10 mb-4">
+                <p>{t("settingsPurposeAndUse.nonAdminInfoDetails")}</p>
+                <ul>
+                  <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.1")}</li>
+                  <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.2")}</li>
+                  <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.3")}</li>
+                </ul>
+              </div>
             </div>
           </div>
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -286,9 +286,6 @@ export const ResponseDelivery = () => {
         <div className="mb-10">
           <div className="mb-4">
             <h2 className="mb-6">{t("settingsResponseDelivery.selectClassification")}</h2>
-            <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
-              {t("settingsResponseDelivery.beforePublishMessage")}
-            </p>
             <div>
               <ClassificationSelect
                 className="max-w-[400px] truncate bg-gray-soft p-1 pr-10"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -344,7 +344,9 @@ export const ResponseDelivery = () => {
 
             <div className="mb-10">
               <h2>{t("settingsPurposeAndUse.title")}</h2>
-              <p className="mb-2">{t("settingsPurposeAndUse.helpUs")}</p>
+              <p className="mb-2">
+                <strong>{t("settingsPurposeAndUse.helpUs")}</strong>
+              </p>
               <p className="text-sm mb-6">{t("settingsPurposeAndUse.description")}</p>
               <Radio
                 id="purposeAndUseAdmin"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -357,7 +357,7 @@ export const ResponseDelivery = () => {
                 value={PurposeOption.admin}
                 onChange={updatePurposeOption}
               />
-              <div className="text-sm ml-10 mb-4">
+              <div className="text-sm ml-12 mb-4">
                 <p>{t("settingsPurposeAndUse.personalInfoDetails")}</p>
                 <ul>
                   <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.1")}</li>
@@ -374,7 +374,7 @@ export const ResponseDelivery = () => {
                 value={PurposeOption.nonAdmin}
                 onChange={updatePurposeOption}
               />
-              <div className="text-sm ml-10 mb-4">
+              <div className="text-sm ml-12 mb-4">
                 <p>{t("settingsPurposeAndUse.nonAdminInfoDetails")}</p>
                 <ul>
                   <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.1")}</li>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -22,6 +22,9 @@ export default async function Layout({
     <>
       <h1>{t("gcFormsSettings")}</h1>
       <SettingsNavigation id={id} />
+      <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
+        {t("settingsResponseDelivery.beforePublishMessage")}
+      </p>
       {children}
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -22,7 +22,7 @@ export default async function Layout({
     <>
       <h1>{t("gcFormsSettings")}</h1>
       <SettingsNavigation id={id} />
-      <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
+      <p className="mb-10 inline-block bg-purple-200 p-3 text-sm font-bold">
         {t("settingsResponseDelivery.beforePublishMessage")}
       </p>
       {children}

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -560,7 +560,7 @@
     "beforePublishMessage": "These settings can only be changed before publishing.",
     "protectedBMessage": "PROTECTED B responses must be downloaded from GC Forms.",
     "settingsMessage": "To change these settings, select the data classification of your form responses.",
-    "title": "Response delivery option ",
+    "title": "Delivery option",
     "vaultOption": "Download responses from GC Forms",
     "vaultOptionHint": {
       "text1": "Submitted responses will appear on the",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -557,7 +557,7 @@
   },
   "settingsResponseDelivery": {
     "selectClassification": "Data classification",
-    "beforePublishMessage": "You can change these settings anytime before publishing.",
+    "beforePublishMessage": "These settings can only be changed before publishing.",
     "protectedBMessage": "PROTECTED B responses must be downloaded from GC Forms.",
     "settingsMessage": "To change these settings, select the data classification of your form responses.",
     "title": "Response delivery option ",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -565,7 +565,7 @@
     "vaultOptionHint": {
       "text1": "Submitted responses will appear on the",
       "text2": "Responses page",
-      "text3": " GC Forms holds data temporarily. Retrieve responses within 45 days."
+      "text3": " GC Forms holds data temporarily. GC Forms holds data temporarily for 30 days."
     },
     "emailOption": "Receive responses by email",
     "saveButton": "Save changes",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -557,7 +557,7 @@
   },
   "settingsResponseDelivery": {
     "selectClassification": "Classification des données",
-    "beforePublishMessage": "Vous pouvez modifier ces paramètres à tout moment avant de publier le formulaire.",
+    "beforePublishMessage": "Ces paramètres ne peuvent être modifiés qu’avant la publication.",
     "protectedBMessage": "Les réponses classifiées PROTÉGÉ B doivent être téléchargées de Formulaires GC.",
     "settingsMessage": "Pour modifier ces paramètres, sélectionnez la classification des données de vos réponses au formulaire.",
     "title": "Option de livraison des réponses",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -565,7 +565,7 @@
     "vaultOptionHint": {
       "text1": " Les réponses soumises apparaîtront sur",
       "text2": "la page Réponses",
-      "text3": " Formulaires GC conserve les données temporairement. Les réponses doivent être récupérées dans un délai de 45 jours."
+      "text3": " Formulaires GC conserve les données temporairement. Formulaires GC conserve les données temporairement pour 30 hours."
     },
     "emailOption": "Recevoir les réponses par courriel",
     "saveButton": "Enregistrer les modifications",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -560,7 +560,7 @@
     "beforePublishMessage": "Ces paramètres ne peuvent être modifiés qu’avant la publication.",
     "protectedBMessage": "Les réponses classifiées PROTÉGÉ B doivent être téléchargées de Formulaires GC.",
     "settingsMessage": "Pour modifier ces paramètres, sélectionnez la classification des données de vos réponses au formulaire.",
-    "title": "Option de livraison des réponses",
+    "title": "Option de livraison",
     "vaultOption": "Télécharger les réponses de Formulaires GC",
     "vaultOptionHint": {
       "text1": " Les réponses soumises apparaîtront sur",


### PR DESCRIPTION
Requested changes are marked in #3750.

* Purple help text is currently under "Data Classification" heading, when it should be under the "Settings" heading
* Help text in incorrect it should read "These settings can only be changed before publishing." "Ces paramètres ne peuvent être modifiés qu’avant la publication."
* Spacing is inconsistent and too cramped between each section: Data classification, Response delivery option, Purpose and use. * * Ensure there is a class of "mb-10" between each section.
* text correction: Response delivery option should be "Delivery option" "Option de livraison"
* text correction: "Retrieve responses within 45 days." should be "GC Forms holds data temporarily for 30 days." "Formulaires GC conserve les données temporairement pour 30 hours."
* Bold the line "Help us understand how form responses will be used"
* Alignment of bullets "Personal information used to make a decision about an individual" and hint text is misaligned, try class "ml-12"