### PR TITLE
Add fr string for Next button

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
@@ -117,7 +117,7 @@ export const Item = ({
               })}
             >
               {fieldType === "richText" && descriptionText === "" && (
-                <span className="text-gray-500">{t("groups.treeView.emptyPagetext")}</span>
+                <span className="text-gray-500">{t("groups.treeView.emptyPageTextElement")}</span>
               )}
               {fieldType !== "richText" && titleText === "" && (
                 <span className="text-gray-500">{t("groups.treeView.emptyFormElement")}</span>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -259,7 +259,7 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
       >
         <div className="flex justify-between border-b-2 border-black bg-gray-50 p-3 align-middle">
           <label className="flex items-center hover:fill-white hover:underline">
-            <span className="mr-2 h-[28px] pl-3 text-sm">{newSectionText}</span>
+            <span className="mr-2 pl-3 text-sm">{newSectionText}</span>
             <Button
               theme="secondary"
               className="p-0 hover:!bg-indigo-500 hover:!fill-white focus:!fill-white"

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -48,7 +48,7 @@ export const NextButton = ({
         }}
         type="button"
       >
-        {t("Next")}
+        {t("next")}
       </Button>
     </>
   );

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -893,5 +893,6 @@
   "confirmation": {
     "title": "Your form has been submitted",
     "sectionTitle": "Section title"
-  }
+  },
+  "next": "Next"
 }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -894,5 +894,6 @@
   "confirmation": {
     "title": "Votre formulaire a été soumis",
     "sectionTitle": "Titre de la section"
-  }
+  },
+  "next": "Next"
 }


### PR DESCRIPTION
# Summary | Résumé

- Adds missing string for Next button
- Fixes wrong key for empty page text
- Fixes height issue for add section button