### PR TITLE
* Update and add learn more administrative purposes box.

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -25,6 +25,8 @@ import {
 } from "@formBuilder/actions";
 import { useRefresh } from "@lib/hooks/useRefresh";
 
+import Markdown from "markdown-to-jsx";
+
 import { toast } from "@formBuilder/components/shared/Toast";
 import { ErrorSaving } from "@formBuilder/components/shared/ErrorSaving";
 
@@ -368,7 +370,11 @@ export const ResponseDelivery = () => {
                 onChange={updatePurposeOption}
               />
               <div className="text-sm ml-12 mb-4">
-                <p>{t("settingsPurposeAndUse.personalInfoDetails")}</p>
+                <div>
+                  <Markdown options={{ forceBlock: true }}>
+                    {t("settingsPurposeAndUse.personalInfoDetails")}
+                  </Markdown>
+                </div>
                 <ul>
                   <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.1")}</li>
                   <li>{t("settingsPurposeAndUse.personalInfoDetailsVals.2")}</li>
@@ -385,7 +391,11 @@ export const ResponseDelivery = () => {
                 onChange={updatePurposeOption}
               />
               <div className="text-sm ml-12 mb-4">
-                <p>{t("settingsPurposeAndUse.nonAdminInfoDetails")}</p>
+                <div>
+                  <Markdown options={{ forceBlock: true }}>
+                    {t("settingsPurposeAndUse.nonAdminInfoDetails")}
+                  </Markdown>
+                </div>
                 <ul>
                   <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.1")}</li>
                   <li>{t("settingsPurposeAndUse.nonAdminInfoDetailsVals.2")}</li>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -13,7 +13,7 @@ import { Radio } from "@formBuilder/components/shared";
 import { Button } from "@clientComponents/globals";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { completeEmailAddressRegex } from "@lib/utils/form-builder";
-import { ResponseDeliveryHelpButton } from "@formBuilder/components/shared";
+import { ResponseDeliveryHelpButton, FormPurposeHelpButton } from "@formBuilder/components/shared";
 import {
   ClassificationType,
   ClassificationSelect,
@@ -327,20 +327,30 @@ export const ResponseDelivery = () => {
                 label={emailLabel}
                 onChange={updateDeliveryOption}
               />
-            </div>
 
-            {deliveryOptionValue === DeliveryOption.email && (
-              <ResponseEmail
-                inputEmail={inputEmailValue}
-                setInputEmail={setInputEmailValue}
-                subjectEn={subjectEnValue}
-                setSubjectEn={setSubjectEnValue}
-                subjectFr={subjectFrValue}
-                setSubjectFr={setSubjectFrValue}
-                isInvalidEmailError={isInvalidEmailError}
-                setIsInvalidEmailError={setIsInvalidEmailError}
-              />
-            )}
+              {deliveryOptionValue === DeliveryOption.email && (
+                <ResponseEmail
+                  inputEmail={inputEmailValue}
+                  setInputEmail={setInputEmailValue}
+                  subjectEn={subjectEnValue}
+                  setSubjectEn={setSubjectEnValue}
+                  subjectFr={subjectFrValue}
+                  setSubjectFr={setSubjectFrValue}
+                  isInvalidEmailError={isInvalidEmailError}
+                  setIsInvalidEmailError={setIsInvalidEmailError}
+                />
+              )}
+              {deliveryOptionValue !== DeliveryOption.email && <div className="mb-8"></div>}
+
+              <Button
+                disabled={!isValid || isPublished}
+                theme="secondary"
+                onClick={saveDeliveryOptions}
+              >
+                {t("settingsResponseDelivery.saveButton")}
+              </Button>
+              <ResponseDeliveryHelpButton />
+            </div>
 
             <div className="mb-10">
               <h2>{t("settingsPurposeAndUse.title")}</h2>
@@ -392,7 +402,7 @@ export const ResponseDelivery = () => {
           >
             {t("settingsResponseDelivery.saveButton")}
           </Button>
-          <ResponseDeliveryHelpButton />
+          <FormPurposeHelpButton />
         </div>
       )}
     </>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/FormPurposeHelpButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/FormPurposeHelpButton.tsx
@@ -1,0 +1,98 @@
+"use client";
+import React, { useCallback, useState } from "react";
+import { useTranslation } from "@i18n/client";
+
+import { Button } from "@clientComponents/globals";
+import { useDialogRef, Dialog } from ".";
+import { InfoIcon } from "@serverComponents/icons";
+
+import Markdown from "markdown-to-jsx";
+
+const FormPurposeHelpDialog = ({ handleClose }: { handleClose: () => void }) => {
+  const { t } = useTranslation("form-builder");
+  const dialog = useDialogRef();
+
+  const actions = (
+    <>
+      <Button
+        theme="primary"
+        onClick={() => {
+          dialog.current?.close();
+          handleClose();
+        }}
+      >
+        {t("close")}
+      </Button>
+    </>
+  );
+
+  return (
+    <Dialog
+      dialogRef={dialog}
+      handleClose={handleClose}
+      actions={actions}
+      title={t("settingsPurposeAndUse.learnMoreBox.title")}
+    >
+      <div className="p-5">
+        <div className="mt-0">
+          <p className="mb-6 text-sm">
+            <Markdown options={{ forceBlock: true }}>
+              {t("settingsPurposeAndUse.learnMoreBox.description")}
+            </Markdown>
+          </p>
+          <div className="mb-8">
+            <div className="mb-6">
+              <strong>{t("settingsPurposeAndUse.learnMoreBox.personalInfo")}</strong>
+            </div>
+            <ul>
+              <Markdown options={{ forceBlock: true }}>
+                {t("settingsPurposeAndUse.learnMoreBox.personalInfoList")}
+              </Markdown>
+            </ul>
+          </div>
+          <div className="mb-8">
+            <div className="mb-6">
+              <strong>{t("settingsPurposeAndUse.learnMoreBox.nonAdminInfo")}</strong>
+            </div>
+            <ul>
+              <Markdown options={{ forceBlock: true }}>
+                {t("settingsPurposeAndUse.learnMoreBox.nonAdminInfoList")}
+              </Markdown>
+            </ul>
+          </div>
+          <div>
+            <Markdown options={{ forceBlock: true }}>
+              {t("settingsPurposeAndUse.learnMoreBox.contactCoordinator")}
+            </Markdown>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export const FormPurposeHelpButton = () => {
+  const { t } = useTranslation("form-builder");
+
+  const [downloadDialog, showDownloadDialog] = useState(false);
+
+  const handleOpenDialog = useCallback(() => {
+    showDownloadDialog(true);
+  }, []);
+
+  const handleCloseDialog = useCallback(() => {
+    showDownloadDialog(false);
+  }, []);
+
+  return (
+    <>
+      <InfoIcon className="ml-4 inline-block" />
+      <div className="ml-2 inline-block">
+        <Button onClick={handleOpenDialog} theme="link">
+          {t("settingsPurposeAndUse.learnMore")}
+        </Button>
+        {downloadDialog && <FormPurposeHelpDialog handleClose={handleCloseDialog} />}
+      </div>
+    </>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/index.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/index.ts
@@ -11,6 +11,7 @@ export { TagInput } from "./tag-input";
 export { LockedBadge } from "./LockedBadge";
 export { InfoDetails } from "./InfoDetails";
 export { ResponseDeliveryHelpButton } from "./ResponseDeliveryHelpDialog";
+export { FormPurposeHelpButton } from "./FormPurposeHelpButton";
 export { toast } from "./Toast";
 export { EmailResponseSettings } from "./EmailResponseSettings";
 export { ConditionalIndicatorOption } from "./conditionals/ConditionalIndicatorOption";

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -546,14 +546,14 @@
       "nonAdminInfoList": "<li>Collecting an individual’s email to register for an event.</li><li>Collecting an individual’s age or gender for a survey.</li><li>Collecting a business's name or address to administer a grant or contribution (provided it is not an individual’s personal information).</li>",
       "contactCoordinator": "If you’re unsure, we recommend contacting your <a href=\"https://www.tbs-sct.canada.ca/ap/atip-aiprp/coord-eng.asp\">access to information and privacy coordinator.</a>"
     },
-    "personalInfoDetails": "Administrative purposes, such as:",
+    "personalInfoDetails": "<em>Administrative purposes</em>, such as:",
     "personalInfoDetailsVals": {
       "1": "applications for programs or benefits",
       "2": "eligibility determination",
       "3": "identity validation"
     },
     "nonAdminInfo": "Information not used to make a decision about an individual",
-    "nonAdminInfoDetails": "Non-administrative purposes, such as:",
+    "nonAdminInfoDetails": "<em>Non-administrative purposes</em>, such as:",
     "nonAdminInfoDetailsVals": {
       "1": "statistics",
       "2": "research",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -536,6 +536,16 @@
     "description": "We'll use this to inform the retention of responses in GC Forms beyond 45 days.",
     "personalInfo": "Personal information used to make a decision about an individual",
     "helpUs": "Help us understand how form responses will be used",
+    "learnMore": "Learn more about administrative purposes",
+    "learnMoreBox": {
+      "title": "More about administrative purpose",
+      "description": "The <a href='https://www.justice.gc.ca/eng/csj-sjc/pa-lprp/dp-dd/modern_3.html?wbdisable=true'>Privacy Act</a> defines administrative purpose as \"the use of [personal] information in a decision making process that directly affects that individual\".",
+      "personalInfo": "Examples of administrative use:",
+      "personalInfoList": "<li>Using an individual's SIN to verify identity.</li><li>Using an individual's annual income to assess eligibility.</li><li>Using an individual’s age to administer a benefit.</li>",
+      "nonAdminInfo": "Examples of non-administrative use:",
+      "nonAdminInfoList": "<li>Collecting an individual’s email to register for an event.</li><li>Collecting an individual’s age or gender for a survey.</li><li>Collecting a business's name or address to administer a grant or contribution (provided it is not an individual’s personal information).</li>",
+      "contactCoordinator": "If you’re unsure, we recommend contacting your <a href=\"https://www.tbs-sct.canada.ca/ap/atip-aiprp/coord-eng.asp\">access to information and privacy coordinator.</a>"
+    },
     "personalInfoDetails": "Administrative purposes, such as:",
     "personalInfoDetailsVals": {
       "1": "applications for programs or benefits",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -536,6 +536,16 @@
     "description": "Nous utiliserons cette information pour déterminer comment traiter les réponses qui sont dans Formulaires GC depuis plus de 45 jours.",
     "personalInfo": "Renseignements personnels servant à prendre une décision qui touche un individu",
     "helpUs": "Dites-nous comment vous prévoyez utiliser les réponses recueillies",
+    "learnMore": "En savoir plus sur les fins administratives",
+    "learnMoreBox": {
+      "title": "En savoir plus sur les fins administratives",
+      "description": "La <a href='https://www.justice.gc.ca/fra/sjc-csj/lprp-pa/dd-dp/modern_3.html?wbdisable=true'>Loi sur la protection des renseignements personnels</a> définit les fins administrative comme étant « l’usage de renseignements personnels concernant un individu dans le cadre d’une décision le touchant directement ».",
+      "personalInfo": "Exemples d’usages administratifs :",
+      "personalInfoList": "<li>Utiliser le numéro d’assurance sociale d'une personne pour vérifier son identité.</li><li>Utiliser le revenu annuel d’une personne pour évaluer son admissibilité.</li><li>Utiliser l’âge d'une personne pour administrer une prestation.</li>",
+      "nonAdminInfo": "Exemples d’usages non administratifs :",
+      "nonAdminInfoList": "<li>Recueillir l’adresse courriel d’une personne pour l’inscrire à un événement.</li><li>Recueillir l’âge ou l’identité de genre d’une personne pour un sondage.</li><li>Recueillir le nom ou l’adresse d’une entreprise pour administrer une subvention ou une contribution (tant qu’il ne s’agit pas des renseignements personnels d’une personne).</li>",
+      "contactCoordinator": "Si vous doutez, nous vous recommandons de contacter votre <a href='https://www.tbs-sct.canada.ca/ap/atip-aiprp/coord-fra.asp'>coordinateur·rice de l’accès à l’information et de la protection de la vie privée.</a>"
+    },
     "personalInfoDetails": "C’est-à-dire à des fins administratives, par exemple:",
     "personalInfoDetailsVals": {
       "1": "demandes ou candidatures",


### PR DESCRIPTION
Closes #3753 &  
Closes #3754 
--
Closes #3750

* Italics "Administrative purposes," "Non-administrative purposes,"
*  Help text for choosing a delivery option is missing
*  Help text for Administrative purposes reflects information for choosing a delivery option (the current info here should be for the missing help text in the point above^^)
