### PR TITLE
Update logic view nav and remove React flow default a11y

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/FlowWithProvider.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/FlowWithProvider.tsx
@@ -85,6 +85,9 @@ const Flow: ForwardRefRenderFunction<unknown, FlowProps> = ({ children }, ref) =
   return (
     <>
       <ReactFlow
+        disableKeyboardA11y={true}
+        nodesFocusable={false}
+        edgesFocusable={false}
         proOptions={{ hideAttribution: true }}
         nodesDraggable={false}
         nodes={nodes}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -56,6 +56,7 @@ export const RightPanel = ({ id }: { id: string }) => {
   const hasHydrated = useRehydrate();
 
   const selectedElementId = useGroupStore((s) => s.selectedElementId);
+  const setId = useGroupStore((state) => state.setId);
   const item = (selectedElementId && getElement(selectedElementId)) || null;
 
   useEffect(() => {
@@ -173,6 +174,8 @@ export const RightPanel = ({ id }: { id: string }) => {
                       <TabButton
                         text={t("rightPanel.logic")}
                         onClick={() => {
+                          // Set the active group to the start group before navigating to the logic tab
+                          setId("start");
                           router.push(`/${i18n.language}/form-builder/${id}/edit/logic`);
                         }}
                       />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/MultiActionSelector.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/MultiActionSelector.tsx
@@ -19,6 +19,7 @@ import { ensureChoiceId } from "@lib/formContext";
 import { LocalizedElementProperties } from "@lib/types/form-builder-types";
 import { SaveNote } from "./SaveNote";
 import { toast } from "@formBuilder/components/shared/Toast";
+import { SectionName } from "./SectionName";
 
 export const GroupAndChoiceSelect = ({
   groupId,
@@ -130,10 +131,12 @@ export const GroupAndChoiceSelect = ({
 
 export const MultiActionSelector = ({
   item,
+  sectionName,
   descriptionId,
   initialNextActionRules,
 }: {
   item: FormElement;
+  sectionName: string | null;
   descriptionId?: string;
   initialNextActionRules: NextActionRule[];
 }) => {
@@ -198,26 +201,29 @@ export const MultiActionSelector = ({
 
   return (
     <>
-      <div className="p-4">
-        <h3 className="block text-sm font-normal">
-          <strong>{t("logic.questionTitle")}</strong> {title}
-        </h3>
+      <div className="flex justify-between border-b-2 border-black bg-gray-50 p-3 align-middle">
+        <div>
+          <SectionName sectionName={sectionName} />
+          <h3 className="mb-6 ml-2 mt-2 block text-sm font-normal">
+            {t("logic.questionTitle")} <strong> {title}</strong>
+          </h3>
+
+          <label className="flex items-center hover:fill-white hover:underline">
+            <span className="mr-2 pl-3 text-sm">{t("logic.addRule")}</span>
+            <Button
+              theme="secondary"
+              className="p-0 hover:!bg-indigo-500 hover:!fill-white focus:!fill-white"
+              disabled={disableAdd}
+              onClick={() => {
+                setNextActions([...nextActions, { groupId: "", choiceId: String(item.id) }]);
+              }}
+            >
+              <AddIcon className="hover:fill-white focus:fill-white" title={t("logic.addRule")} />
+            </Button>
+          </label>
+        </div>
       </div>
 
-      <div className="flex items-center border-b-2 border-black bg-slate-50 p-3">
-        <span className="mr-2 inline-block pl-3">{t("logic.addRule")}</span>
-        <Button
-          disabled={disableAdd}
-          onClick={() => {
-            setNextActions([...nextActions, { groupId: "", choiceId: String(item.id) }]);
-          }}
-          theme={"secondary"}
-          className="p-1 focus:fill-white"
-          aria-controls={formId}
-        >
-          <AddIcon className="active:fill-white " title={t("logic.addRule")} />
-        </Button>
-      </div>
       <form
         onSubmit={(e: React.FormEvent<HTMLFormElement>) => e.preventDefault()}
         id={formId}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SectionName.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SectionName.tsx
@@ -1,0 +1,9 @@
+import { useTranslation } from "@i18n/client";
+export const SectionName = ({ sectionName }: { sectionName: string | null }) => {
+  const { t } = useTranslation("form-builder");
+  return sectionName ? (
+    <h3 className="mb-0 ml-2 block text-sm font-normal">
+      {t("logic.sectionTitle")} <strong> {sectionName}</strong>
+    </h3>
+  ) : null;
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SelectNextAction.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SelectNextAction.tsx
@@ -9,16 +9,7 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { SingleActionSelect } from "./SingleActionSelect";
 import { MultiActionSelector } from "./MultiActionSelector";
 import { ClearMultiRules } from "./ClearMultiRules";
-import { useTranslation } from "@i18n/client";
-
-const SectionName = ({ sectionName }: { sectionName: string | null }) => {
-  const { t } = useTranslation("form-builder");
-  return sectionName ? (
-    <h3 className="block text-sm font-normal">
-      <strong>{t("logic.sectionTitle")}</strong> {sectionName}
-    </h3>
-  ) : null;
-};
+import { SectionName } from "./SectionName";
 
 export const SelectNextAction = ({ item }: { item: FormElement | null }) => {
   const typesWithOptions = ["radio", "checkbox", "select", "dropdown"];
@@ -31,7 +22,11 @@ export const SelectNextAction = ({ item }: { item: FormElement | null }) => {
   const sectionName = selectedGroupId ? selectedGroup?.name : null;
 
   if (selectedGroupId === "end" || selectedGroupId === "review") {
-    return <SectionName sectionName={sectionName} />;
+    return (
+      <div className="flex justify-between border-b-2 border-black bg-gray-50 p-3 align-middle">
+        <SectionName sectionName={sectionName} />
+      </div>
+    );
   }
 
   if (!selectedGroup) {
@@ -42,9 +37,13 @@ export const SelectNextAction = ({ item }: { item: FormElement | null }) => {
   // section 1 => section 2
   if (!item && !Array.isArray(selectedGroupNextActions)) {
     return (
-      <div className="p-4">
-        <SectionName sectionName={sectionName} />
-        <SingleActionSelect nextAction={selectedGroupNextActions || "end"} />
+      <div>
+        <div className="flex justify-between border-b-2 border-black bg-gray-50 p-3 align-middle">
+          <SectionName sectionName={sectionName} />
+        </div>
+        <div className="p-4">
+          <SingleActionSelect nextAction={selectedGroupNextActions || "end"} />
+        </div>
       </div>
     );
   }
@@ -62,9 +61,6 @@ export const SelectNextAction = ({ item }: { item: FormElement | null }) => {
   // If we have an item a question is selected
   return (
     <div>
-      <div className="px-4 pt-4">
-        <SectionName sectionName={sectionName} />
-      </div>
       {typesWithOptions.includes(item.type) ? (
         /* 
           If the item (form element) has options 
@@ -75,6 +71,7 @@ export const SelectNextAction = ({ item }: { item: FormElement | null }) => {
           no - => section 2
         */
         <MultiActionSelector
+          sectionName={sectionName}
           item={item}
           initialNextActionRules={
             Array.isArray(selectedGroupNextActions) ? selectedGroupNextActions : [] // Default to end


### PR DESCRIPTION
# Summary | Résumé

- Updates styling for Logic view nav under the tab buttons
- Updates React flow to remove default keyboard a11y --- we'll just tab to each button.
- Fixes bug where when the active ID was set to "end" - end would be selected when you visit the logic tab which shouldn't be possible. 



https://github.com/cds-snc/platform-forms-client/assets/62242/7b51b12e-df60-4cbc-aa3a-ac95e5733b2a


