### PR TITLE
Hide section title when grouping is off

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ConfirmationTitle.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ConfirmationTitle.tsx
@@ -2,9 +2,12 @@
 
 import React from "react";
 import { useTranslation } from "@i18n/client";
+import { useTemplateStore } from "@lib/store/useTemplateStore";
 
 export const ConfirmationTitle = () => {
   const { t } = useTranslation("form-builder");
+  const getGroupsEnabled = useTemplateStore((s) => s.getGroupsEnabled);
+
   return (
     <div className="mb-8 text-[1rem]">
       <div
@@ -15,9 +18,12 @@ export const ConfirmationTitle = () => {
           backgroundRepeat: "repeat-x",
         }}
       ></div>
-      <div className="mb-2 inline-block rounded-md border-1 border-slate-500 bg-slate-50 px-2 py-1 text-slate-500">
-        {t("confirmation.sectionTitle")}
-      </div>
+
+      {getGroupsEnabled() && (
+        <div className="mb-2 inline-block rounded-md border-1 border-slate-500 bg-slate-50 px-2 py-1 text-slate-500">
+          {t("confirmation.sectionTitle")}
+        </div>
+      )}
       <h2 className="mt-0 text-2xl text-slate-500 laptop:mt-0">{t("confirmation.title")}</h2>
     </div>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -20,6 +20,7 @@ import { FormElement } from "@lib/types";
 import { LangSwitcher } from "@formBuilder/components/shared/LangSwitcher";
 import { PrivacyDescriptionBefore } from "./PrivacyDescriptionBefore";
 import { PrivacyDescriptionBody } from "./PrivacyDescriptionBody";
+import { ConfirmationTitle } from "./ConfirmationTitle";
 
 export const EditWithGroups = () => {
   const { t } = useTranslation("form-builder");
@@ -194,6 +195,7 @@ export const EditWithGroups = () => {
           detailsText={
             <div className="mt-4">
               <ConfirmationDescriptionWithGroups />
+              <ConfirmationTitle />
             </div>
           }
           hydrated={hasHydrated}


### PR DESCRIPTION
# Summary | Résumé

Fixes #3755

**Groups off**
<img width="949" alt="Screenshot 2024-06-10 at 7 48 46 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/665b0f88-3f34-4e4c-b4df-0f842ef45473">

**Groups on**
<img width="875" alt="Screenshot 2024-06-10 at 7 51 00 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/a1fb5cfe-909d-49ba-aa6a-cdbe8850f7c6">



