### PR TITLE
fix: Ensure trusted host also uses nextauth_url

### DIFF
--- a/lib/auth/nextAuth.ts
+++ b/lib/auth/nextAuth.ts
@@ -114,7 +114,7 @@ export const {
     updateAge: 30 * 60, // 30 minutes
   },
   // Only trust the host if we don't explicitly have a AUTH_URL set
-  trustHost: process.env.AUTH_URL ? false : true,
+  trustHost: process.env.AUTH_URL || process.env.NEXTAUTH_URL ? false : true,
   debug: process.env.NODE_ENV !== "production",
   logger: {
     error(error) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,7 +34,7 @@ const { auth } = NextAuth({
   // When building the app use a random UUID as the token secret
   secret: process.env.TOKEN_SECRET ?? crypto.randomUUID(),
   debug: process.env.NODE_ENV !== "production",
-  trustHost: process.env.AUTH_URL ? false : true,
+  trustHost: process.env.AUTH_URL || process.env.NEXTAUTH_URL ? false : true,
   session: {
     strategy: "jwt",
     // Seconds - How long until an idle session expires and is no longer valid.


### PR DESCRIPTION
# Summary | Résumé
Ensure that NEXTAUTH_URL is also used for the trusted host setting of Auth.js until infrastructure is updated to ensure AUTH_URL is available.