### PR TITLE
fix: logic view group node outline styling

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node
-          target-branch: main
+          target-branch: develop

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
@@ -82,7 +82,9 @@ export const GroupNode = (node: NodeProps) => {
         {node.id !== "end" && node.id !== "review" && (
           <button
             {...handleClick}
-            className="absolute right-[-20px] top-[-20px] cursor-pointer outline-2 outline-violet-800 hover:scale-125"
+            className={cn(
+              "absolute right-[-20px] top-[-20px] cursor-pointer outline-offset-8 outline-slate-800 hover:scale-125 rounded-full"
+            )}
           >
             <QuestionRuleSvg title={t("linkGroup")} />
           </button>
@@ -140,12 +142,16 @@ export const GroupNode = (node: NodeProps) => {
                 setId(node.id);
                 setSelectedElementId(Number(child.index));
               }}
-              className={cn(nodeClassName, selected, "focus:border-violet-800")}
+              className={cn(
+                nodeClassName,
+                selected,
+                "focus:border-violet-800 outline-offset-8 outline-slate-800 hover:scale-125 rounded-full"
+              )}
             >
               <div className="line-clamp-2 truncate text-wrap">
                 {getTitle(child.data as ElementProperties).substring(0, 300)}
               </div>
-              <div className="absolute right-[10px] top-[10px] cursor-pointer hover:scale-125">
+              <div className="absolute right-[10px] top-[10px] cursor-pointer hover:scale-125 ">
                 <OptionRuleSvg title={t("linkGroup")} />
               </div>
             </button>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
@@ -151,7 +151,7 @@ export const GroupNode = (node: NodeProps) => {
               <div className="line-clamp-2 truncate text-wrap">
                 {getTitle(child.data as ElementProperties).substring(0, 300)}
               </div>
-              <div className="absolute right-[10px] top-[10px] cursor-pointer hover:scale-125 ">
+              <div className="absolute right-[10px] top-[10px] cursor-pointer hover:scale-125">
                 <OptionRuleSvg title={t("linkGroup")} />
               </div>
             </button>


### PR DESCRIPTION
# Summary | Résumé

Updates group node outlines for better a11y

<img width="464" alt="Screenshot 2024-06-10 at 9 09 02 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/93af0b48-691d-42c3-b398-ef2ca4dfdc71">


<img width="450" alt="Screenshot 2024-06-10 at 9 09 48 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/df253bff-3b2f-47be-ad6e-dfe87c79b50a">


<img width="486" alt="Screenshot 2024-06-10 at 9 10 16 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/a6ad7501-24f6-4301-9094-93bb89c3726e">

Before

<img width="359" alt="Screenshot 2024-06-10 at 9 13 05 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/bcd59acd-1ee9-4e7b-a3c3-388b9adb79db">

<img width="337" alt="Screenshot 2024-06-10 at 9 13 17 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/45556aba-6f04-48c0-8223-5084fddaf8be">

