### PR TITLE
chore: Temporarily trust host for Auth.js

### DIFF
--- a/lib/auth/nextAuth.ts
+++ b/lib/auth/nextAuth.ts
@@ -114,7 +114,7 @@ export const {
     updateAge: 30 * 60, // 30 minutes
   },
   // Only trust the host if we don't explicitly have a AUTH_URL set
-  trustHost: process.env.AUTH_URL || process.env.NEXTAUTH_URL ? false : true,
+  trustHost: true,
   debug: process.env.NODE_ENV !== "production",
   logger: {
     error(error) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,7 +34,7 @@ const { auth } = NextAuth({
   // When building the app use a random UUID as the token secret
   secret: process.env.TOKEN_SECRET ?? crypto.randomUUID(),
   debug: process.env.NODE_ENV !== "production",
-  trustHost: process.env.AUTH_URL || process.env.NEXTAUTH_URL ? false : true,
+  trustHost: true,
   session: {
     strategy: "jwt",
     // Seconds - How long until an idle session expires and is no longer valid.


### PR DESCRIPTION
# Summary | Résumé
Temporarily trust the  x-forwarded-for header for Auth.js to stop issue with setting headers after the response is already sent to the client.