### PR TITLE
fix: trusted host check and NEXTAUTH_URL

### DIFF
--- a/lib/auth/nextAuth.ts
+++ b/lib/auth/nextAuth.ts
@@ -113,7 +113,7 @@ export const {
     maxAge: 2 * 60 * 60, // 2 hours
     updateAge: 30 * 60, // 30 minutes
   },
-  // Only trust the host if we don't explicitly have a AUTH_URL set
+  // Elastic Load Balancer safely sets the host header and ignores the incoming request headers
   trustHost: true,
   debug: process.env.NODE_ENV !== "production",
   logger: {

--- a/lib/origin.ts
+++ b/lib/origin.ts
@@ -1,22 +1,15 @@
 import { headers } from "next/headers";
 
 /**
- * Extract the origin from either `AUTH_URL` or `NEXTAUTH_URL` environment variables,
- * or the request's headers option.
+ * Extract the origin from the request's headers.
  */
 export function getOrigin(): string {
-  const envUrl = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
   const h = headers();
 
-  let url: URL;
-  if (envUrl) {
-    url = new URL(envUrl);
-  } else {
-    const detectedHost = h.get("x-forwarded-host") ?? h.get("host");
-    const detectedProtocol = h.get("x-forwarded-proto") ?? "https";
+  const detectedHost = h.get("host");
+  const detectedProtocol = h.get("x-forwarded-proto") ?? "https";
 
-    url = new URL(`${detectedProtocol}://${detectedHost}`);
-  }
+  const url = new URL(`${detectedProtocol}://${detectedHost}`);
 
   // remove trailing slash
   const sanitizedUrl = url.toString().replace(/\/$/, "");

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,6 +34,7 @@ const { auth } = NextAuth({
   // When building the app use a random UUID as the token secret
   secret: process.env.TOKEN_SECRET ?? crypto.randomUUID(),
   debug: process.env.NODE_ENV !== "production",
+  // Elastic Load Balancer safely sets the host header and ignores the incoming request headers
   trustHost: true,
   session: {
     strategy: "jwt",
@@ -142,33 +143,19 @@ const setCORS = (req: NextRequest, pathname: string) => {
   if (pathname.startsWith("/api") || reqHeaders.get("next-action")) {
     debugLogger(`Middleware: API / Server Action path = ${pathname}`);
     const response = NextResponse.next();
-    const origin = req.headers.get("origin") ?? "";
+    const host = reqHeaders.get("host");
 
-    const allowedOrigins = [
-      // These are hardcoded and set in Staging and Production
-      process.env.NEXTAUTH_URL,
-      process.env.AUTH_URL,
-      // If we're running in local development or E2E testing use localhost as origin
-      process.env.NODE_ENV !== "production" || process.env.APP_ENV === "test"
-        ? "http://localhost:3000"
-        : undefined,
-      // If we're in a PR Review environment use the passed in origin as there is currently no way to get the existing origin from the container
-      process.env.REVIEW_ENV ? origin : undefined,
-    ].filter((origin: string | undefined) => origin);
-
-    // Allowed origins check
-    if (allowedOrigins.includes(origin)) {
-      response.headers.set("Access-Control-Allow-Origin", origin);
-    } else {
-      response.headers.set(
-        "Access-Control-Allow-Origin",
-        process.env.NEXTAUTH_URL ?? process.env.APP_ENV !== "test"
-          ? "MISSING ORIGIN URL IN .env FILE!"
-          : "localhost:3000"
+    // If host header is not set something is seriously wrong.
+    if (!host) {
+      throw new Error(
+        `HOST header is missing from request to ${pathname} from ${req.headers.get(
+          "x-forwarded-for"
+        )}`
       );
     }
 
-    // Set default CORS headers
+    // Set CORS headers
+    response.headers.set("Access-Control-Allow-Origin", host);
     response.headers.set("Access-Control-Allow-Credentials", "true");
     response.headers.set("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS");
     response.headers.set(


### PR DESCRIPTION
# Summary | Résumé
Removes any remaining reference to NEXTAUTH_URL in the codebase as we can implicitly trust that the Elastic Load Balancer safely sets the Host header and ignores any header provided in the original request.

Confirmed here: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#host-header-preservation

It would also appear that Auth.js guidance is now that the `trusted_host` should always be set to true: https://authjs.dev/reference/core#trusthost