### PR TITLE
chore: update release please version

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -13,13 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@86576b355dd19da0519e0bdb63d8edb5bcf76a25 # v1.7.0
+      - uses: actions/create-github-app-token@c8f55efbd427e7465d6da1106e7979bc8aaee856 # v1.10.1
         id: sre_app_token
         with:
-          app_id: ${{ secrets.SRE_APP_ID }}
-          private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SRE_APP_ID }}
+          private-key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
 
-      - uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,7 @@
     { "type": "feature", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
-    { "type": "revert", "section": "Reverts", "hidden": true },
+    { "type": "revert", "section": "Reverts" },
     { "type": "docs", "section": "Documentation" },
     { "type": "style", "section": "Styles" },
     { "type": "chore", "section": "Miscellaneous Chores" },


### PR DESCRIPTION
# Summary | Résumé

Updates the Release Please action to the new action and repo.  The previous action and repo were decommissioned in May 2024 and is now read only.

Also updates the github-app-token action to the latest version and updates configuration to remove depreciation warnings.