### PR TITLE
chore: Update error handling for 2fa

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/processFormData.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/processFormData.ts
@@ -26,8 +26,6 @@ export const processFormData = async (
       throw new MissingFormDataError("No form submitted with request");
     }
 
-    logMessage.info(`Form ID: ${reqFields ? reqFields.formID : "No form attached"}`);
-
     const form = await getPublicTemplateByID(reqFields.formID as string);
 
     if (!form) {
@@ -90,6 +88,7 @@ export const processFormData = async (
         contentLanguage ? contentLanguage : "en",
         reqFields.securityAttribute ? (reqFields.securityAttribute as string) : "Protected A"
       );
+      logMessage.info(`Submitting Response for Form ID: ${form.id}`);
       return true;
     } catch (err) {
       logMessage.error(err as Error);

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/actions.ts
@@ -4,7 +4,7 @@ import { serverTranslation } from "@i18n";
 import { redirect } from "next/navigation";
 import { requestNew2FAVerificationCode } from "@lib/auth";
 import { signIn } from "@lib/auth";
-import { handleErrorById } from "@lib/auth/cognito";
+import { handleErrorById, Missing2FASession } from "@lib/auth/cognito";
 import { cookies } from "next/headers";
 import { prisma } from "@lib/integration/prismaConnector";
 import { CredentialsSignin } from "next-auth";
@@ -149,18 +149,27 @@ export const resendVerificationCode = async (
   language: string,
   email: string,
   authenticationFlowToken: string
-): Promise<void> => {
-  const newCode = await requestNew2FAVerificationCode(authenticationFlowToken, email);
-  cookies().set(
-    "authenticationFlow",
-    JSON.stringify({
-      authenticationFlowToken: newCode,
-      email,
-    }),
-    { secure: true, sameSite: "strict", maxAge: 60 * 15 }
-  );
+): Promise<void | { error: string }> => {
+  try {
+    const newCode = await requestNew2FAVerificationCode(authenticationFlowToken, email);
+    cookies().set(
+      "authenticationFlow",
+      JSON.stringify({
+        authenticationFlowToken: newCode,
+        email,
+      }),
+      { secure: true, sameSite: "strict", maxAge: 60 * 15 }
+    );
 
-  redirect(`/${language}/auth/mfa`);
+    redirect(`/${language}/auth/mfa`);
+  } catch (e) {
+    if (e instanceof Missing2FASession) {
+      redirect(`/${language}/auth/login`);
+    } else {
+      logMessage.error(e);
+      return { error: "Internal Error" };
+    }
+  }
 };
 
 export const getErrorText = async (language: string, errorID: string) => {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/resend/components/client/ReVerify.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/resend/components/client/ReVerify.tsx
@@ -6,7 +6,6 @@ import { Button } from "@clientComponents/globals";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { getErrorText, resendVerificationCode } from "../../../actions";
 
-import { hasError } from "@lib/hasError";
 import { Alert } from "../../../../../components/client/forms/Alert";
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
 import Link from "next/link";
@@ -34,24 +33,17 @@ export const ReVerify = (): ReactElement => {
   }
 
   const handleReVerify = async () => {
-    try {
-      setResending(true);
-      if (!email || !authenticationFlowToken) {
-        router.push(`/${language}/auth/login`);
-        return;
-      }
-      await resendVerificationCode(language, email, authenticationFlowToken);
-    } catch (err) {
-      if (hasError(["Missing 2FA session"], err)) {
-        // Missing 2FA session so have the user try signing in again
-        router.push(`/${language}/auth/login`);
-        router.refresh();
-      } else {
-        // Internal Error
-        const errorText = await getErrorText(language, "InternalServiceException");
-        setAuthErrorState(errorText);
-        setResending(false);
-      }
+    setResending(true);
+    if (!email || !authenticationFlowToken) {
+      router.push(`/${language}/auth/login`);
+      return;
+    }
+    const result = await resendVerificationCode(language, email, authenticationFlowToken);
+
+    if (result?.error) {
+      const errorText = await getErrorText(language, "InternalServiceException");
+      setAuthErrorState(errorText);
+      setResending(false);
     }
   };
 

--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -192,6 +192,9 @@ export const requestNew2FAVerificationCode = async (
     return verificationCode;
   } catch (error) {
     if (error instanceof Missing2FASession) {
+      logMessage.warn(
+        `Failed to send new verification code. Reason: Missing 2FA session for user ${email}.`
+      );
       throw error;
     } else {
       throw new Error(`Failed to send new verification code. Reason: ${(error as Error).message}.`);


### PR DESCRIPTION
# Summary | Résumé
Updates the handling of 2fa "resend code" path errors. 

- Adds a log entry that identifies the email address trying to request a new token `{"level":"warn","time":1718129549075,"msg":"Failed to send new verification code. Reason: Missing 2FA session for user bryan.robitaille@cds-snc.ca."}`
- Fixes the error path to ensure the server redirects the user to `/auth/login` if a session does not exist instead of relying on the browser.  In NODE_ENV Production the error was being sanitized and wasn't being properly handled client side.


Also modifies the "form submission" event log to identify that it is a form submission and not just listing the form ID.