### PR TITLE
fix: Improved Drag target indicator and DragImage

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/Item.tsx
@@ -83,6 +83,24 @@ export const Item = ({
         <div
           {...context.itemContainerWithoutChildrenProps}
           {...context.interactiveElementProps}
+          onDragStart={(e) => {
+            context.interactiveElementProps.onDragStart &&
+              context.interactiveElementProps.onDragStart(e);
+
+            // Customize dragging image for form elements
+            if (isFormElement) {
+              // Get the box inside the element being dragged
+              const el = e.currentTarget.children[0];
+
+              // Get the position of the cursor inside the box for the offset
+              const rect = el.getBoundingClientRect();
+              const x = e.clientX - rect.left;
+              const y = e.clientY - rect.top;
+
+              // Use the inner box for the drag image
+              e.dataTransfer.setDragImage(el, x, y);
+            }
+          }}
           className={cn(
             "text-left group relative w-full overflow-hidden truncate cursor-pointer h-[60px]",
             isSection && isSectionClasses,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -177,15 +177,12 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
         renderItemTitle={({ title }) => <Item.Title title={title} />}
         renderItemArrow={({ item, context }) => <Item.Arrow item={item} context={context} />}
         renderLiveDescriptorContainer={() => null}
-        renderDragBetweenLine={({ draggingPosition, lineProps }) => {
+        renderDragBetweenLine={({ lineProps }) => {
           return (
-            <div
-              {...lineProps}
-              className={cn(
-                "w-full border-b-2 border-blue-focus",
-                draggingPosition.depth > 0 && "ml-10"
-              )}
-            />
+            <div {...lineProps}>
+              <div className="absolute left-0 -ml-2 -mt-2 size-0 border-y-8 border-l-8 border-y-transparent border-l-blue-focus" />
+              <div className={cn("w-full border-b-1 border-blue-focus")} />
+            </div>
           );
         }}
         renderItemsContainer={({ children, containerProps }) => {


### PR DESCRIPTION
# Summary | Résumé

- Render custom DragBetweenLine with arrow indicator
- Customize DragImage for form elements


| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="460" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/a3fadc68-bdec-4972-88ff-0ce74826d0d0"> | <img width="456" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/6ce2ce26-aea9-43d9-b472-e3e6cd7b1520"> |
| <img width="437" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/c41533c0-48ef-48e1-bafa-bba0dcb7a93b"> | <img width="451" alt="image" src="https://github.com/cds-snc/platform-forms-client/assets/1187115/ef1d7fe0-f6a3-4c5d-93b4-8cc4e2ea1e0a"> |

