### PR TITLE
Fix: mfa resend when no session

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/processFormData.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/processFormData.ts
@@ -26,8 +26,6 @@ export const processFormData = async (
       throw new MissingFormDataError("No form submitted with request");
     }
 
-    logMessage.info(`Form ID: ${reqFields ? reqFields.formID : "No form attached"}`);
-
     const form = await getPublicTemplateByID(reqFields.formID as string);
 
     if (!form) {
@@ -90,8 +88,10 @@ export const processFormData = async (
         contentLanguage ? contentLanguage : "en",
         reqFields.securityAttribute ? (reqFields.securityAttribute as string) : "Protected A"
       );
+      logMessage.info(`Response submitted for Form ID: ${form.id}`);
       return true;
     } catch (err) {
+      logMessage.info(`Attempted response submission for Form ID: ${form.id} failed`);
       logMessage.error(err as Error);
       throw err;
     }

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/resend/components/client/ReVerify.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/resend/components/client/ReVerify.tsx
@@ -6,7 +6,6 @@ import { Button } from "@clientComponents/globals";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { getErrorText, resendVerificationCode } from "../../../actions";
 
-import { hasError } from "@lib/hasError";
 import { Alert } from "../../../../../components/client/forms/Alert";
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
 import Link from "next/link";
@@ -34,24 +33,18 @@ export const ReVerify = (): ReactElement => {
   }
 
   const handleReVerify = async () => {
-    try {
-      setResending(true);
-      if (!email || !authenticationFlowToken) {
-        router.push(`/${language}/auth/login`);
-        return;
-      }
-      await resendVerificationCode(language, email, authenticationFlowToken);
-    } catch (err) {
-      if (hasError(["Missing 2FA session"], err)) {
-        // Missing 2FA session so have the user try signing in again
-        router.push(`/${language}/auth/login`);
-        router.refresh();
-      } else {
-        // Internal Error
-        const errorText = await getErrorText(language, "InternalServiceException");
-        setAuthErrorState(errorText);
-        setResending(false);
-      }
+    setResending(true);
+    if (!email || !authenticationFlowToken) {
+      router.push(`/${language}/auth/login`);
+      return;
+    }
+    const result = await resendVerificationCode(language, email, authenticationFlowToken);
+
+    if (result?.error) {
+      // Internal Error
+      const errorText = await getErrorText(language, "InternalServiceException");
+      setAuthErrorState(errorText);
+      setResending(false);
     }
   };
 

--- a/lib/auth/cognito.ts
+++ b/lib/auth/cognito.ts
@@ -192,6 +192,9 @@ export const requestNew2FAVerificationCode = async (
     return verificationCode;
   } catch (error) {
     if (error instanceof Missing2FASession) {
+      logMessage.warn(
+        `Failed to send new verificaiton code. User ${email} does not have an existing authentication flow token`
+      );
       throw error;
     } else {
       throw new Error(`Failed to send new verification code. Reason: ${(error as Error).message}.`);


### PR DESCRIPTION
# Summary | Résumé

take 2 of #3801 

Updates the handling of 2fa "resend code" path errors.

    Adds a log entry that identifies the email address trying to request a new token {"level":"warn","time":1718129549075,"msg":"Failed to send new verification code. Reason: Missing 2FA session for user bryan.robitaille@cds-snc.ca."}
    Fixes the error path to ensure the server redirects the user to /auth/login if a session does not exist instead of relying on the browser. In NODE_ENV Production the error was being sanitized and wasn't being properly handled client side.

Also modifies the "form submission" event log to identify that it is a form submission and not just listing the form ID.