### PR TITLE
fix: Departments dropdown language toggle on Preview

### DIFF
--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -241,6 +241,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
             name={`${id}`}
             ariaDescribedBy={description ? `desc-${id}` : undefined}
             choices={choices}
+            key={`${id}-${lang}`}
           />
         </div>
       );


### PR DESCRIPTION
# Summary | Résumé

Fixes #3803 

Added a key prop to the Combobox to force a refresh when toggling LanguagePriority on Preview.

To test:
- Create a form
- Add a Departments dropdown
- Go to Preview
- Check that the contents of the dropdown match the language of "Previewing in"
- Toggle the "Previewing in" language
- Check that the contents of the dropdown match the language of "Previewing in"
