### PR TITLE
fix: Add early return for responses page when a form hasn't been saved yet 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
@@ -38,6 +38,21 @@ export default async function Page({
     overdueAfter: Number(await getAppSetting("nagwarePhaseEncouraged")),
   };
 
+  // Handle the case where the user is not authenticated and the form ID is 0000
+  // In this case we know no responses will be returned, so we can skip the API call
+  if (isAuthenticated && id === "0000") {
+    return (
+      <Responses
+        initialForm={null}
+        nagwareResult={null}
+        lastEvaluatedKey={null}
+        overdueAfter={pageProps.overdueAfter}
+        responseDownloadLimit={pageProps.responseDownloadLimit}
+        vaultSubmissions={[]}
+      />
+    );
+  }
+
   try {
     if (isAuthenticated) {
       const initialForm = await fetchTemplate(id);


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where a user could land on the responses page with a form that has never been saved (doesn't have form responses).

Adds early return to avoid API lookup which throws

 ```
 Forms
 - Template 0000 must have associated owners to access responses
 ```