### PR TITLE
fix: Fix for unsaved form Responses error

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -17,7 +17,7 @@ import {
 } from "@lib/responseDownloadFormats/types";
 import { getFullTemplateByID } from "@lib/templates";
 import { FormElementTypes, VaultStatus } from "@lib/types";
-import { isResponseId } from "@lib/validation/validation";
+import { isResponseId, isUUID } from "@lib/validation/validation";
 import { listAllSubmissions, retrieveSubmissions, updateLastDownloadedBy } from "@lib/vault";
 import { transform as csvTransform } from "@lib/responseDownloadFormats/csv";
 import { transform as htmlAggregatedTransform } from "@lib/responseDownloadFormats/html-aggregated";
@@ -63,6 +63,13 @@ export const fetchSubmissions = async ({
 
   if (!session) {
     throw new Error("User is not authenticated");
+  }
+
+  if (formId === "0000" || !isUUID(formId)) {
+    return {
+      submissions: [],
+      lastEvaluatedKey: null,
+    };
   }
 
   // get status from url params (default = new) and capitalize/cast to VaultStatus

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/page.tsx
@@ -38,21 +38,6 @@ export default async function Page({
     overdueAfter: Number(await getAppSetting("nagwarePhaseEncouraged")),
   };
 
-  // Handle the case where the user is not authenticated and the form ID is 0000
-  // In this case we know no responses will be returned, so we can skip the API call
-  if (isAuthenticated && id === "0000") {
-    return (
-      <Responses
-        initialForm={null}
-        nagwareResult={null}
-        lastEvaluatedKey={null}
-        overdueAfter={pageProps.overdueAfter}
-        responseDownloadLimit={pageProps.responseDownloadLimit}
-        vaultSubmissions={[]}
-      />
-    );
-  }
-
   try {
     if (isAuthenticated) {
       const initialForm = await fetchTemplate(id);


### PR DESCRIPTION
# Summary | Résumé

Reverts #3824 in favour of a better fix - catches at the actions layer, and checks for UUID as well.
