### PR TITLE
fix: add back devcontainer db and redis services

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,3 +12,26 @@ services:
       - 3000:3000
     expose: 
       - 3000
+
+  db:
+    image: postgres:13.12@sha256:ced3ba927f4cf06e03eac7760f426a95367076fb31fe4e31b679f82d119a3519
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: chummy
+    ports:
+      - "5432:5432"
+    expose:
+      - 5432
+    command:
+      - "postgres"
+      - "-c"
+      - "listen_addresses=*"
+    restart: unless-stopped
+
+  redis:
+    restart: unless-stopped
+    image: redis:latest@sha256:2976bc0437deff693af2dcf081a1d1758de8b413e6de861151a5a136c25eb9e4
+    ports:
+      - "6379:6379"
+    expose:
+      - 6379


### PR DESCRIPTION
# Summary
Add the `db` and `redis` services back to the devcontainer's docker-compose file to support localhost environments without a LocalStack license.

# Test instructions | Instructions pour tester la modification

1. Remove all running docker containers.
2. Build the devcontainer.
3. Setup your local `.env` to connect to the `db` and `redis` services.
```env
DATABASE_URL=postgres://postgres:chummy@db:5432/forms
REDIS_URL=redis
```
4. Run `yarn dev` and expect the app to load at `http://localhost:3000`.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

None.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [x] Have you modified the change log and updated any relevant documentation?
- [x] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
