### PR TITLE
chore: add loading state to submit button

### DIFF
--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
@@ -8,12 +8,12 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
-import { ButtonSubmit } from "@clientComponents/globals/Buttons/ButtonSubmit";
+import { SubmitButton } from "@clientComponents/globals/Buttons/SubmitButton";
 
-const SubmitButton = () => {
+const ButtonSubmit = () => {
   const { t } = useTranslation("login");
   const { pending } = useFormStatus();
-  return <ButtonSubmit loading={pending}>{t("continueButton")}</ButtonSubmit>;
+  return <SubmitButton loading={pending}>{t("continueButton")}</SubmitButton>;
 };
 
 export const LoginForm = () => {
@@ -118,7 +118,7 @@ export const LoginForm = () => {
             {t("resetPasswordText")}
           </Link>
         </p>
-        <SubmitButton />
+        <ButtonSubmit />
       </form>
     </>
   );

--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
@@ -2,22 +2,18 @@
 
 import { useFormStatus, useFormState } from "react-dom";
 import { Alert, ErrorListItem, Label, TextInput } from "../../../../components/client/forms";
-import { Button } from "@clientComponents/globals";
 import { useTranslation } from "@i18n/client";
 import { login, ErrorStates } from "../../actions";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
+import { ButtonSubmit } from "@clientComponents/globals/Buttons/ButtonSubmit";
 
 const SubmitButton = () => {
   const { t } = useTranslation("login");
   const { pending } = useFormStatus();
-  return (
-    <Button theme="primary" type="submit" disabled={pending} aria-disabled={pending}>
-      {t("continueButton")}
-    </Button>
-  );
+  return <ButtonSubmit loading={pending}>{t("continueButton")}</ButtonSubmit>;
 };
 
 export const LoginForm = () => {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/components/client/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useFormStatus, useFormState } from "react-dom";
+import { useFormState } from "react-dom";
 import { Alert, ErrorListItem, Label, TextInput } from "../../../../components/client/forms";
 import { useTranslation } from "@i18n/client";
 import { login, ErrorStates } from "../../actions";
@@ -8,13 +8,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
-import { SubmitButton } from "@clientComponents/globals/Buttons/SubmitButton";
-
-const ButtonSubmit = () => {
-  const { t } = useTranslation("login");
-  const { pending } = useFormStatus();
-  return <SubmitButton loading={pending}>{t("continueButton")}</SubmitButton>;
-};
+import { SubmitButtonAction } from "@clientComponents/globals/Buttons/SubmitButton";
 
 export const LoginForm = () => {
   const {
@@ -118,7 +112,7 @@ export const LoginForm = () => {
             {t("resetPasswordText")}
           </Link>
         </p>
-        <ButtonSubmit />
+        <SubmitButtonAction>{t("continueButton")}</SubmitButtonAction>
       </form>
     </>
   );

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
@@ -8,7 +8,7 @@ import { Expired2faSession } from "./Expired2faSession";
 import { Locked2fa } from "./Locked2fa";
 import Link from "next/link";
 import { ErrorStatus } from "@clientComponents/forms/Alert/Alert";
-import { Button } from "@clientComponents/globals";
+import { SubmitButton } from "@clientComponents/globals/Buttons/SubmitButton";
 import { ToastContainer } from "@formBuilder/components/shared/Toast";
 import { useFocusIt } from "@lib/hooks/useFocusIt";
 import { Loader } from "@clientComponents/globals/Loader";
@@ -179,14 +179,12 @@ export const MFAForm = () => {
               }
             />
           </div>
-          <Button
-            theme="primary"
-            type="submit"
-            dataTestId="verify-submit"
-            disabled={isSubmittingStep1}
-          >
+
+          {/* TODO ask design about keeping submit button visible on loading to reduce "surprise! I'm hiding this botton.." */}
+          <SubmitButton loading={isSubmittingStep1} dataTestId="verify-submit">
             {t("verify.confirmButton")}
-          </Button>
+          </SubmitButton>
+
           <div className="mt-12 flex">
             <Link className="mr-8" href={`/${language}/auth/mfa/resend`}>
               {t("verify.resendConfirmationCodeButton")}

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
@@ -180,7 +180,6 @@ export const MFAForm = () => {
             />
           </div>
 
-          {/* TODO ask design about keeping submit button visible on loading to reduce "surprise! I'm hiding this botton.." */}
           <SubmitButton loading={isSubmittingStep1} dataTestId="verify-submit">
             {t("verify.confirmButton")}
           </SubmitButton>

--- a/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { useState } from "react";
 import { useSession } from "next-auth/react";
-import { ButtonSubmit } from "@clientComponents/globals/Buttons/ButtonSubmit";
+import { SubmitButton } from "@clientComponents/globals/Buttons/SubmitButton";
 
 export const AcceptButton = () => {
   const router = useRouter();
@@ -37,8 +37,8 @@ export const AcceptButton = () => {
   };
 
   return (
-    <ButtonSubmit loading={isLoading} onClick={agree}>
+    <SubmitButton loading={isLoading} onClick={agree}>
       {t("acceptableUsePage.agree")}
-    </ButtonSubmit>
+    </SubmitButton>
   );
 };

--- a/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
@@ -3,11 +3,13 @@
 import { useTranslation } from "@i18n/client";
 import { useRouter } from "next/navigation";
 
-import { Button } from "@clientComponents/globals";
+import { useState } from "react";
 import { useSession } from "next-auth/react";
+import { ButtonSubmit } from "@clientComponents/globals/Buttons/ButtonSubmit";
 
 export const AcceptButton = () => {
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
 
   const {
     t,
@@ -15,9 +17,13 @@ export const AcceptButton = () => {
   } = useTranslation("common");
   const defaultRoute = `/${language}/forms`;
 
-  const { status, update } = useSession();
+  const { /*status,*/ update } = useSession();
 
   const agree = async () => {
+    // status from useSession will jump back and forth between authenticated and loading,
+    // using state instead for reliability. TODO see if "fixed" in future versions of next-auth?
+    setIsLoading(true);
+
     // Update the session to reflect the user has accepted the terms of use.
     const session = await update({
       user: { acceptableUse: true },
@@ -31,8 +37,8 @@ export const AcceptButton = () => {
   };
 
   return (
-    <Button id="acceptableUse" onClick={agree} disabled={status !== "authenticated"}>
+    <ButtonSubmit loading={isLoading} onClick={agree}>
       {t("acceptableUsePage.agree")}
-    </Button>
+    </ButtonSubmit>
   );
 };

--- a/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
@@ -37,7 +37,7 @@ export const AcceptButton = () => {
   };
 
   return (
-    <SubmitButton id="acceptableUse" loading={isLoading} onClick={agree}>
+    <SubmitButton id="acceptableUse" type="button" loading={isLoading} onClick={agree}>
       {t("acceptableUsePage.agree")}
     </SubmitButton>
   );

--- a/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/policy/components/client/AcceptButton.tsx
@@ -37,7 +37,7 @@ export const AcceptButton = () => {
   };
 
   return (
-    <SubmitButton loading={isLoading} onClick={agree}>
+    <SubmitButton id="acceptableUse" loading={isLoading} onClick={agree}>
       {t("acceptableUsePage.agree")}
     </SubmitButton>
   );

--- a/components/clientComponents/globals/Buttons/ButtonSubmit.tsx
+++ b/components/clientComponents/globals/Buttons/ButtonSubmit.tsx
@@ -1,0 +1,83 @@
+"use client";
+import React, { ReactElement } from "react";
+import { themes, Theme } from "./themes";
+import { cn } from "@lib/utils";
+import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
+
+/**
+ * TODO add to auth related pages like 2FA
+ * TODO note why disabling a submit button is confusing for AT users
+ * TODO add active focus hover state for button
+ * TODO look into aria-disabled
+ */
+
+interface ButtonSubmitProps {
+  children?: JSX.Element | string;
+  id?: string;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (e: React.MouseEvent<HTMLElement>) => void;
+  icon?: ReactElement;
+  className?: string;
+  "aria-label"?: string;
+  theme?: Theme;
+  buttonRef?: (el: HTMLButtonElement) => void;
+  dataTestId?: string;
+  loading: boolean;
+  describeLoading?: string;
+}
+
+export const ButtonSubmit = ({
+  children,
+  onClick,
+  onKeyDown,
+  className,
+  icon,
+  "aria-label": ariaLabel = undefined,
+  theme = "primary",
+  buttonRef,
+  dataTestId,
+  loading,
+  describeLoading,
+  ...rest
+}: ButtonSubmitProps & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  return (
+    <button
+      type="submit"
+      onClick={(e) => {
+        if (!loading && onClick) {
+          onClick(e);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (!loading && onClick && e.key === "Enter") {
+          e.preventDefault(); // Stops browser from also calling on click
+          onKeyDown ? onKeyDown(e) : onClick(e);
+        }
+      }}
+      className={
+        loading
+          ? cn(themes["base"], themes.disabled, className)
+          : cn(themes["base"], themes[theme], className)
+      }
+      aria-label={ariaLabel}
+      ref={buttonRef}
+      data-testid={dataTestId}
+      // TODO do more testing on aria-disabled, doesn't seem to do much with AT...
+      aria-disabled={loading}
+      {...rest}
+    >
+      {icon && <div className={cn(theme !== "icon" && "-ml-2 mr-2 w-8")}>{icon}</div>}
+      {children}
+      {loading && (
+        <SpinnerIcon className="ml-2 h-7 w-7 animate-spin fill-blue-600 text-white dark:text-white" />
+      )}
+      <div aria-live="polite" className="sr-only">
+        {loading && `${describeLoading ? describeLoading : "Loading"}`}
+      </div>
+    </button>
+  );
+};
+
+export const RoundedButtonSubmit = ({ className, ...props }: ButtonSubmitProps) => (
+  <ButtonSubmit {...props} className={cn(className, "rounded-[100px]")} />
+);

--- a/components/clientComponents/globals/Buttons/ButtonSubmit.tsx
+++ b/components/clientComponents/globals/Buttons/ButtonSubmit.tsx
@@ -6,7 +6,7 @@ import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
 
 /**
  * TODO add to auth related pages like 2FA
- * TODO note why disabling a submit button is confusing for AT users
+ * TODO note why disabling a submit button is confusing for AT users e.g. https://adrianroselli.com/2024/02/dont-disable-form-controls.html
  * TODO add active focus hover state for button
  * TODO look into aria-disabled
  */
@@ -15,7 +15,6 @@ interface ButtonSubmitProps {
   children?: JSX.Element | string;
   id?: string;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
-  onKeyDown?: (e: React.MouseEvent<HTMLElement>) => void;
   icon?: ReactElement;
   className?: string;
   "aria-label"?: string;
@@ -29,7 +28,6 @@ interface ButtonSubmitProps {
 export const ButtonSubmit = ({
   children,
   onClick,
-  onKeyDown,
   className,
   icon,
   "aria-label": ariaLabel = undefined,
@@ -43,15 +41,12 @@ export const ButtonSubmit = ({
   return (
     <button
       type="submit"
+      // Note: no need to add onKeyDown also, keying enter also triggers onClick. More info see
+      // https://html.spec.whatwg.org/#implicit-submission
       onClick={(e) => {
+        // Simulate a disabled state by blocking the callback when loading
         if (!loading && onClick) {
           onClick(e);
-        }
-      }}
-      onKeyDown={(e) => {
-        if (!loading && onClick && e.key === "Enter") {
-          e.preventDefault(); // Stops browser from also calling on click
-          onKeyDown ? onKeyDown(e) : onClick(e);
         }
       }}
       className={
@@ -69,6 +64,7 @@ export const ButtonSubmit = ({
       {icon && <div className={cn(theme !== "icon" && "-ml-2 mr-2 w-8")}>{icon}</div>}
       {children}
       {loading && (
+        // TODO run this spinner by design
         <SpinnerIcon className="ml-2 h-7 w-7 animate-spin fill-blue-600 text-white dark:text-white" />
       )}
       <div aria-live="polite" className="sr-only">

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -40,7 +40,7 @@ interface ButtonProps {
   buttonRef?: (el: HTMLButtonElement) => void;
   dataTestId?: string;
   describeLoading?: string;
-  type?: "button" | "submit" | "reset";
+  type?: "submit" | "button";
 }
 
 interface SubmitButtonProps extends ButtonProps {

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -26,8 +26,8 @@ export const SubmitButtonAction = (props: ButtonProps) => {
  * https://adrianroselli.com/2024/02/dont-disable-form-controls.html
  *
  * Note about above Note:
- * I think it is weird that AT do not work more with a html buttons DOM state switching to disabled
- * or with aria-disabled (announcing change) but this is what we have to work with..
+ * I think it is weird that AT do not do more with an html buttons DOM state switching to disabled
+ * or with aria-disabled but this is what we have to work with.
  */
 
 interface ButtonProps {
@@ -79,7 +79,7 @@ export const SubmitButton = ({
         if (!loading && onClick) {
           onClick(e);
         } else if (loading) {
-          // Prevent form submit while loading in the case of a user keying a form submit
+          // Prevent form submit while loading in the case of a user keying a submit in a form.
           e.preventDefault();
         }
       }}

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from "react";
 import { themes, Theme } from "./themes";
 import { cn } from "@lib/utils";
 import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
+import { useTranslation } from "@i18n/client";
 
 /**
  * Adds an accessible submit button that has a spinner when loading.
@@ -18,7 +19,7 @@ import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
  * https://adrianroselli.com/2024/02/dont-disable-form-controls.html
  */
 
-// TODO could add a button wrapper to work with server actions use useformStatus
+// TODO could add a button wrapper to work with server actions useformStatus status
 
 interface SubmitButtonProps {
   children?: JSX.Element | string;
@@ -32,6 +33,7 @@ interface SubmitButtonProps {
   dataTestId?: string;
   loading: boolean;
   describeLoading?: string;
+  type?: "button" | "submit" | "reset";
 }
 
 export const SubmitButton = ({
@@ -45,8 +47,10 @@ export const SubmitButton = ({
   dataTestId,
   loading,
   describeLoading,
+  type = "submit",
   ...rest
 }: SubmitButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const { t } = useTranslation("common");
   const disabledClass = `
     focus:bg-[#e2e8ef] focus:text-[#748094] focus:border-none focus:outline-offset-0 focus:outline-0
     active:bg-[#e2e8ef] active:text-[#748094] active:border-none active:outline-offset-0 active:outline-0
@@ -54,7 +58,8 @@ export const SubmitButton = ({
 
   return (
     <button
-      type="submit"
+      // "type" because a "submit" button may no longer be in a form element with the new server action patterns
+      type={type}
       // Note: no need to add onKeyDown also, keying enter also triggers onClick. More info see
       // https://html.spec.whatwg.org/#implicit-submission
       onClick={(e) => {
@@ -82,7 +87,7 @@ export const SubmitButton = ({
         <SpinnerIcon className="ml-2 h-7 w-7 animate-spin fill-blue-600 text-white dark:text-white" />
       )}
       <div aria-live="polite" className="sr-only">
-        {loading && `${describeLoading ? describeLoading : "Loading"}`}
+        {loading && `${describeLoading ? describeLoading : t("loadingResult")}`}
       </div>
     </button>
   );

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -5,10 +5,12 @@ import { cn } from "@lib/utils";
 import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
 
 /**
- * TODO add to auth related pages like 2FA
- * TODO note why disabling a submit button is confusing for AT users e.g. https://adrianroselli.com/2024/02/dont-disable-form-controls.html
- * TODO add active active hover state for button
- * TODO look into aria-disabled
+ * TODO could add a button wrapper to work with server actions use useformStatus
+ *
+ * TODO note why disabling a submit button is confusing for AT users
+ * e.g. https://adrianroselli.com/2024/02/dont-disable-form-controls.html
+ *
+ * TODO look into if aria-disabled has better support now
  */
 
 interface SubmitButtonProps {

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -11,7 +11,7 @@ import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
  * TODO look into aria-disabled
  */
 
-interface ButtonSubmitProps {
+interface SubmitButtonProps {
   children?: JSX.Element | string;
   id?: string;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
@@ -25,7 +25,7 @@ interface ButtonSubmitProps {
   describeLoading?: string;
 }
 
-export const ButtonSubmit = ({
+export const SubmitButton = ({
   children,
   onClick,
   className,
@@ -37,7 +37,7 @@ export const ButtonSubmit = ({
   loading,
   describeLoading,
   ...rest
-}: ButtonSubmitProps & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+}: SubmitButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   return (
     <button
       type="submit"
@@ -74,6 +74,6 @@ export const ButtonSubmit = ({
   );
 };
 
-export const RoundedButtonSubmit = ({ className, ...props }: ButtonSubmitProps) => (
-  <ButtonSubmit {...props} className={cn(className, "rounded-[100px]")} />
+export const RoundedSubmitButton = ({ className, ...props }: SubmitButtonProps) => (
+  <SubmitButton {...props} className={cn(className, "rounded-[100px]")} />
 );

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -36,7 +36,6 @@ interface ButtonProps {
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   icon?: ReactElement;
   className?: string;
-  "aria-label"?: string;
   theme?: Theme;
   buttonRef?: (el: HTMLButtonElement) => void;
   dataTestId?: string;
@@ -53,7 +52,6 @@ export const SubmitButton = ({
   onClick,
   className,
   icon,
-  "aria-label": ariaLabel = undefined,
   theme = "primary",
   buttonRef,
   dataTestId,
@@ -88,7 +86,6 @@ export const SubmitButton = ({
           ? cn(themes["base"], themes.disabled, disabledClass, className)
           : cn(themes["base"], themes[theme], className)
       }
-      aria-label={ariaLabel}
       ref={buttonRef}
       data-testid={dataTestId}
       // TODO do more testing on aria-disabled, doesn't seem to do much with AT... worth even

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -4,6 +4,13 @@ import { themes, Theme } from "./themes";
 import { cn } from "@lib/utils";
 import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
 import { useTranslation } from "@i18n/client";
+import { useFormStatus } from "react-dom";
+
+// Convenience for server actions
+export const SubmitButtonAction = (props: ButtonProps) => {
+  const { pending } = useFormStatus();
+  return <SubmitButton loading={pending} {...props} />;
+};
 
 /**
  * Adds an accessible submit button that has a spinner when loading.
@@ -19,9 +26,7 @@ import { useTranslation } from "@i18n/client";
  * https://adrianroselli.com/2024/02/dont-disable-form-controls.html
  */
 
-// TODO could add a button wrapper to work with server actions useformStatus status
-
-interface SubmitButtonProps {
+interface ButtonProps {
   children?: JSX.Element | string;
   id?: string;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
@@ -31,9 +36,12 @@ interface SubmitButtonProps {
   theme?: Theme;
   buttonRef?: (el: HTMLButtonElement) => void;
   dataTestId?: string;
-  loading: boolean;
   describeLoading?: string;
   type?: "button" | "submit" | "reset";
+}
+
+interface SubmitButtonProps extends ButtonProps {
+  loading: boolean;
 }
 
 export const SubmitButton = ({

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -5,13 +5,20 @@ import { cn } from "@lib/utils";
 import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
 
 /**
- * TODO could add a button wrapper to work with server actions use useformStatus
+ * Adds an accessible submit button that has a spinner when loading.
  *
- * TODO note why disabling a submit button is confusing for AT users
- * e.g. https://adrianroselli.com/2024/02/dont-disable-form-controls.html
+ * The difference between this and the "standard" Button is this does not disable the submit button
+ * when loading. The main reason for this is that it is confusing for AT users to have a button
+ * that is suddenly out of the tab order (not focussable or activateable). Instead the button
+ * gives a visual and AT accessible indication that it is loading.
+ * I think it is weird that AT do not work more with a html buttons DOM state switch to disabled or
+ * with aria-disabled (announcing change) but this is what we have to work with..
  *
- * TODO look into if aria-disabled has better support now
+ * Here's a helpful article on the topic:
+ * https://adrianroselli.com/2024/02/dont-disable-form-controls.html
  */
+
+// TODO could add a button wrapper to work with server actions use useformStatus
 
 interface SubmitButtonProps {
   children?: JSX.Element | string;
@@ -64,14 +71,14 @@ export const SubmitButton = ({
       aria-label={ariaLabel}
       ref={buttonRef}
       data-testid={dataTestId}
-      // TODO do more testing on aria-disabled, doesn't seem to do much with AT...
+      // TODO do more testing on aria-disabled, doesn't seem to do much with AT... worth even
+      // using with a submit button?
       aria-disabled={loading}
       {...rest}
     >
       {icon && <div className={cn(theme !== "icon" && "-ml-2 mr-2 w-8")}>{icon}</div>}
       {children}
       {loading && (
-        // TODO run this spinner by design
         <SpinnerIcon className="ml-2 h-7 w-7 animate-spin fill-blue-600 text-white dark:text-white" />
       )}
       <div aria-live="polite" className="sr-only">
@@ -80,7 +87,3 @@ export const SubmitButton = ({
     </button>
   );
 };
-
-export const RoundedSubmitButton = ({ className, ...props }: SubmitButtonProps) => (
-  <SubmitButton {...props} className={cn(className, "rounded-[100px]")} />
-);

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -15,15 +15,19 @@ export const SubmitButtonAction = (props: ButtonProps) => {
 /**
  * Adds an accessible submit button that has a spinner when loading.
  *
+ * Note:
  * The difference between this and the "standard" Button is this does not disable the submit button
  * when loading. The main reason for this is that it is confusing for AT users to have a button
- * that is suddenly out of the tab order (not focussable or activateable). Instead the button
- * gives a visual and AT accessible indication that it is loading.
- * I think it is weird that AT do not work more with a html buttons DOM state switch to disabled or
- * with aria-disabled (announcing change) but this is what we have to work with..
+ * that changes suddenly to be out of the tab order (not focussable or activateable). Instead this
+ * button gives a visual and AT accessible indication that it is loading. The button also
+ * programmatically disables a form submit while loading just like a disabled button would.
  *
  * Here's a helpful article on the topic:
  * https://adrianroselli.com/2024/02/dont-disable-form-controls.html
+ *
+ * Note about above Note:
+ * I think it is weird that AT do not work more with a html buttons DOM state switching to disabled
+ * or with aria-disabled (announcing change) but this is what we have to work with..
  */
 
 interface ButtonProps {
@@ -74,6 +78,9 @@ export const SubmitButton = ({
         // Simulate a disabled state by blocking the callback when loading
         if (!loading && onClick) {
           onClick(e);
+        } else if (loading) {
+          // Prevent form submit while loading in the case of a user keying a form submit
+          e.preventDefault();
         }
       }}
       className={

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -7,7 +7,7 @@ import { SpinnerIcon } from "@serverComponents/icons/SpinnerIcon";
 /**
  * TODO add to auth related pages like 2FA
  * TODO note why disabling a submit button is confusing for AT users e.g. https://adrianroselli.com/2024/02/dont-disable-form-controls.html
- * TODO add active focus hover state for button
+ * TODO add active active hover state for button
  * TODO look into aria-disabled
  */
 
@@ -38,6 +38,11 @@ export const SubmitButton = ({
   describeLoading,
   ...rest
 }: SubmitButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const disabledClass = `
+    focus:bg-[#e2e8ef] focus:text-[#748094] focus:border-none focus:outline-offset-0 focus:outline-0
+    active:bg-[#e2e8ef] active:text-[#748094] active:border-none active:outline-offset-0 active:outline-0
+  `;
+
   return (
     <button
       type="submit"
@@ -51,7 +56,7 @@ export const SubmitButton = ({
       }}
       className={
         loading
-          ? cn(themes["base"], themes.disabled, className)
+          ? cn(themes["base"], themes.disabled, disabledClass, className)
           : cn(themes["base"], themes[theme], className)
       }
       aria-label={ariaLabel}

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -75,11 +75,11 @@ export const SubmitButton = ({
       // Note: no need to add onKeyDown also, keying enter also triggers onClick. More info see
       // https://html.spec.whatwg.org/#implicit-submission
       onClick={(e) => {
-        // Simulate a disabled state by blocking the callback when loading
         if (!loading && onClick) {
           onClick(e);
         } else if (loading) {
           // Prevent form submit while loading in the case of a user keying a submit in a form.
+          // This is needed since the onClick is also called for a form submit.
           e.preventDefault();
         }
       }}

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -152,5 +152,6 @@
   "mainNavAriaLabel": "Main",
   "yourAccount": "Your account",
   "dateModified": "Date modified",
-  "start": "Start"
+  "start": "Start",
+  "loadingResult": "Loading..."
 }

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -153,5 +153,6 @@
   "mainNavAriaLabel": "Navigation principale",
   "yourAccount": "Votre compte",
   "dateModified": "Date de modification ",
-  "start": "Début"
+  "start": "Début",
+  "loadingResult": "[FR]Loading..."
 }

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -154,5 +154,5 @@
   "yourAccount": "Votre compte",
   "dateModified": "Date de modification ",
   "start": "Début",
-  "loadingResult": "[FR]Loading..."
+  "loadingResult": "Chargement en cours..."
 }


### PR DESCRIPTION
# Summary | Résumé

The original issue was the Agree button would toggle between disabled and back to enabled when the Agree form was submitted.

This fix adds:
-  a new button focussed on submitting with related accessible loading status etc.
- a new button that wraps the above button but for use with server actions (convenience)

Pages updated to use these buttons:
- login
- mfa
- policy (agree page)

Demo of impacted pages
https://github.com/cds-snc/platform-forms-client/assets/107579368/fc0c7491-90f1-4119-954d-4f7ccd530614

Todo:
Add to remain auth related pages?





