### PR TITLE
fix: use css rule vs inline style to set container height

### DIFF
--- a/.eslint-tailwindcss.js
+++ b/.eslint-tailwindcss.js
@@ -34,6 +34,7 @@ module.exports = {
         "example-text",
         "section",
         "maple-leaf-loader",
+        "flow-container",
       ],
     },
   },

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/page.tsx
@@ -44,7 +44,7 @@ export default async function Page({
       <SkipLinkReusable anchor="#rightPanelTitle">{t("skipLink.logicSetup")}</SkipLinkReusable>
       <p>{t("logic.description")}</p>
       <LogicNavigation />
-      <div className="my-10 w-full border-1" style={{ height: "calc(100vh - 300px)" }}>
+      <div className="flow-container my-10 w-full border-1">
         <Suspense fallback={<Loading />}>
           <FlowWithProvider />
         </Suspense>

--- a/styles/_form-builder.scss
+++ b/styles/_form-builder.scss
@@ -370,3 +370,7 @@
   padding: 0 !important;
   margin: 0;
 }
+
+.flow-container{
+  height: calc(100vh - 300px);
+}


### PR DESCRIPTION
# Summary | Résumé

- use css rule vs inline style to set container height