### PR TITLE
Fix: Ensure the correct id is being used in RightPanel

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -12,7 +12,7 @@ import { useActivePathname } from "@lib/hooks/form-builder";
 import { DownloadCSVWithGroups } from "@formBuilder/[id]/edit/translate/components/DownloadCSVWithGroups";
 import { useTreeRef } from "./treeview/provider/TreeRefProvider";
 import { TreeView } from "./treeview/TreeView";
-import { useRehydrate } from "@lib/store/useTemplateStore";
+import { useRehydrate, useTemplateStore } from "@lib/store/useTemplateStore";
 
 import { SelectNextAction } from "./logic/SelectNextAction";
 import { useGroupStore } from "./treeview/store/useGroupStore";
@@ -58,6 +58,15 @@ export const RightPanel = ({ id }: { id: string }) => {
   const [open, setOpen] = useState(false);
   const router = useRouter();
   const { t, i18n } = useTranslation("form-builder");
+
+  const { id: storeId } = useTemplateStore((s) => ({
+    id: s.id,
+  }));
+
+  if (storeId && storeId !== id) {
+    id = storeId;
+  }
+
   const { activePathname } = useActivePathname();
   const { treeView } = useTreeRef();
   const getElement = useGroupStore((s) => s.getElement);


### PR DESCRIPTION
# Summary | Résumé

Updates Right Panel tabs to use ID from template store if it's different than the possibly stale ID coming in from props.