### PR TITLE
chore: add https support for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ package-lock.json
 responses.csv
 
 tsconfig.tsbuildinfo
+certificates

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "dev": "yarn prisma:dev && yarn initialize && next dev --turbo",
+    "dev:secure": "yarn prisma:dev && yarn initialize && next dev --turbo --experimental-https",
     "build": "DATABASE_URL=postgres://postgres:chummy@localhost:5432/formsDB next build --debug",
     "start": "yarn prisma:deploy && yarn initialize && next start -p ${PORT:-3000}",
     "initialize": "yarn workspace flag_initialization initialize",


### PR DESCRIPTION
# Summary | Résumé

Adds yarn command for `dev:secure` 

This runs next the `experimental-https` flag allowing us to use https for our localhost

<img width="921" alt="Screenshot 2024-06-18 at 11 57 25 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/90f20a57-06f1-412f-911c-30ce966241e5">

