### PR TITLE
chore: Add legend to logic view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/Legend.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/Legend.tsx
@@ -1,0 +1,24 @@
+import { serverTranslation } from "@i18n";
+import { LogicSectionArrowIcon } from "@serverComponents/icons/LogicSectionArrowIcon";
+import { LogicOptionArrowIcon } from "@serverComponents/icons/LogicOptionArrowIcon";
+import { Language } from "@lib/types/form-builder-types";
+
+export const Legend = async ({ lang }: { lang: Language }) => {
+  const { t } = await serverTranslation("form-builder", { lang });
+  return (
+    <div className="my-6">
+      <div className="text-base italic">
+        <span className="inline-block pr-4">
+          <LogicSectionArrowIcon />
+        </span>
+        {t("logic.legend.section")}
+      </div>
+      <div className="text-base italic">
+        <span className="inline-block pr-4">
+          <LogicOptionArrowIcon className="inline-block" />
+        </span>
+        {t("logic.legend.option")}
+      </div>
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/page.tsx
@@ -6,6 +6,8 @@ import { Suspense } from "react";
 import { Loader } from "@clientComponents/globals/Loader";
 import { LogicNavigation } from "./components/LogicNavigation";
 import { SkipLinkReusable } from "@clientComponents/globals/SkipLinkReusable";
+import { Legend } from "./components/flow/Legend";
+import { Language } from "@lib/types/form-builder-types";
 
 export async function generateMetadata({
   params: { locale },
@@ -42,9 +44,9 @@ export default async function Page({
         {t("logic.heading")}
       </h2>
       <SkipLinkReusable anchor="#rightPanelTitle">{t("skipLink.logicSetup")}</SkipLinkReusable>
-      <p>{t("logic.description")}</p>
+      <Legend lang={locale as Language} />
       <LogicNavigation />
-      <div className="flow-container my-10 w-full border-1">
+      <div className="flow-container my-4 w-full border-1">
         <Suspense fallback={<Loading />}>
           <FlowWithProvider />
         </Suspense>

--- a/components/serverComponents/icons/LogicOptionArrowIcon.tsx
+++ b/components/serverComponents/icons/LogicOptionArrowIcon.tsx
@@ -1,0 +1,23 @@
+export const LogicOptionArrowIcon = ({
+  className,
+  title,
+}: {
+  className?: string;
+  title?: string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="16"
+    width="16"
+    className={className}
+    focusable="false"
+    aria-hidden={title ? false : true}
+    role={title ? "img" : "presentation"}
+  >
+    {title && <title>{title}</title>}
+    <path
+      fill="#047857"
+      d="M0 0v10.286A2.2 2.2 0 0 0 .671 11.9c.448.448.986.671 1.615.671h9.371L9.83 14.4l1.6 1.6L16 11.429l-4.571-4.572-1.6 1.6 1.828 1.829H2.286V0H0Z"
+    />
+  </svg>
+);

--- a/components/serverComponents/icons/LogicSectionArrowIcon.tsx
+++ b/components/serverComponents/icons/LogicSectionArrowIcon.tsx
@@ -1,0 +1,20 @@
+export const LogicSectionArrowIcon = ({
+  className,
+  title,
+}: {
+  className?: string;
+  title?: string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="16"
+    width="16"
+    className={className}
+    focusable="false"
+    aria-hidden={title ? false : true}
+    role={title ? "img" : "presentation"}
+  >
+    {title && <title>{title}</title>}
+    <path d="M12.175 9H0V7H12.175L6.575 1.4L8 0L16 8L8 16L6.575 14.6L12.175 9Z" fill="#4338CA" />b
+  </svg>
+);

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -866,7 +866,11 @@
       "default": "Select a section",
       "catchAllGroup": "Pour toute autre valeur"
     },
-    "actionsSaved": "Actions saved"
+    "actionsSaved": "Actions saved",
+    "legend": {
+      "section": "Apply a rule to a Section",
+      "option": "Apply conditional rules to radio buttons, checkboxes, and dropdown form elements. "
+    }
   },
   "groups": {
     "newSection": "New section",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -866,7 +866,11 @@
       "default": "Sélectionner une section",
       "catchAllGroup": "Pour toute autre valeur"
     },
-    "actionsSaved": "Actions enregistrées"
+    "actionsSaved": "Actions enregistrées",
+    "legend": {
+      "section": "[FR] Apply a rule to a Section",
+      "option": "[FR] Apply conditional rules to radio buttons, checkboxes, and dropdown form elements. "
+    }
   },
   "groups": {
     "newSection": "Nouvelle section",


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/3789

Adds some icons with descriptions for the meanings to the logic view. 

<img width="946" alt="Screenshot 2024-06-19 at 12 20 49 PM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/96a40f20-5320-4686-adf3-8ca46ccc0a57">
