### PR TITLE
Fix the "More" Modal Pushing Data up and Down

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
@@ -58,13 +58,17 @@ export const ElementPanel = ({
   const { focusWithinProps, isWithin } = useIsWithin();
   const { refs } = useRefsContext();
 
+  const handleMoreClose = () => {
+    setChangeKey(String(new Date().getTime())); //Force a re-render
+  };
+
   const moreButton =
     item.type !== "richText"
       ? {
           moreButtonRenderer: (
             moreButton: JSX.Element | undefined
           ): React.ReactElement | string | undefined => (
-            <MoreModal item={item} moreButton={moreButton} />
+            <MoreModal item={item} moreButton={moreButton} onClose={handleMoreClose} />
           ),
         }
       : {};
@@ -103,7 +107,7 @@ export const ElementPanel = ({
         }
       }}
     >
-      <PanelBodyRoot item={item} />
+      <PanelBodyRoot item={item} key={"panel-body-" + item.id} />
       <PanelActions
         isFirstItem={item.index === 0}
         isLastItem={item.index === elements.length - 1}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
@@ -58,7 +58,7 @@ export const ElementPanel = ({
   const { focusWithinProps, isWithin } = useIsWithin();
   const { refs } = useRefsContext();
 
-  const handleMoreClose = () => {
+  const forceRefresh = () => {
     setChangeKey(String(new Date().getTime())); //Force a re-render
   };
 
@@ -68,7 +68,7 @@ export const ElementPanel = ({
           moreButtonRenderer: (
             moreButton: JSX.Element | undefined
           ): React.ReactElement | string | undefined => (
-            <MoreModal item={item} moreButton={moreButton} onClose={handleMoreClose} />
+            <MoreModal item={item} moreButton={moreButton} onClose={forceRefresh} />
           ),
         }
       : {};
@@ -107,7 +107,7 @@ export const ElementPanel = ({
         }
       }}
     >
-      <PanelBodyRoot item={item} key={"panel-body-" + item.id} />
+      <PanelBodyRoot item={item} key={"panel-body-" + item.id} onChangeMade={forceRefresh} />
       <PanelActions
         isFirstItem={item.index === 0}
         isLastItem={item.index === elements.length - 1}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
@@ -107,7 +107,7 @@ export const ElementPanel = ({
         }
       }}
     >
-      <PanelBodyRoot item={item} key={"panel-body-" + item.id} onChangeMade={forceRefresh} />
+      <PanelBodyRoot item={item} onChangeMade={forceRefresh} />
       <PanelActions
         isFirstItem={item.index === 0}
         isLastItem={item.index === elements.length - 1}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementRequired.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementRequired.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "@i18n/client";
 
 import { Checkbox } from "@formBuilder/components/shared";
@@ -14,21 +14,20 @@ export const ElementRequired = ({
 }) => {
   const { t } = useTranslation("form-builder");
   const allRequired = item.properties.validation?.all;
-  const [checked, setChecked] = useState(item.properties.validation?.required);
+  const checked = item.properties.validation?.required;
 
   return (
     <div className="mt-5 [&>div>label]:!pt-[5px]">
       <Checkbox
         disabled={item.properties.validation?.all}
         id={`required-${item.id}-id`}
-        value={`required-${item.id}-value`}
+        value={`required-${item.id}-value-` + checked}
         defaultChecked={checked}
-        key={`required-${item.id}`}
+        key={`required-${item.id}` + checked}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           if (!e.target) {
             return;
           }
-          setChecked(e.target.checked);
           onRequiredChange(item.id, e.target.checked);
         }}
         label={allRequired ? t("allRequired") : t("required")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { useTranslation } from "@i18n/client";
 import { FormElementTypes, ElementProperties } from "@lib/types";
@@ -40,7 +40,7 @@ export const ModalForm = ({
   }));
 
   const autocompleteSelectedValue = properties.autoComplete || "";
-  const [checked, setChecked] = useState(item.properties.validation?.required);
+  const checked = item.properties.validation?.required;
 
   return (
     <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => e.preventDefault()}>
@@ -98,8 +98,8 @@ export const ModalForm = ({
       <div className="mb-2">
         <Checkbox
           id={`required-${item.index}-id-modal`}
-          value={`required-${item.index}-value-modal`}
-          key={`required-${item.index}-modal`}
+          value={`required-${item.index}-value-modal-` + checked}
+          key={`required-${item.index}-modal-` + checked}
           defaultChecked={checked}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             // clone the existing properties so that we don't overwrite other keys in "validation"
@@ -110,7 +110,6 @@ export const ModalForm = ({
               ...properties,
               ...{ validation },
             });
-            setChecked(e.target.checked);
           }}
           label={t("required")}
         ></Checkbox>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/MoreModal.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/MoreModal.tsx
@@ -13,9 +13,11 @@ import useModalStore from "@lib/store/useModalStore";
 export const MoreModal = ({
   item,
   moreButton,
+  onClose,
 }: {
   item: FormElementWithIndex;
   moreButton: JSX.Element | undefined;
+  onClose: () => void;
 }) => {
   const { elements, updateField } = useTemplateStore((s) => ({
     lang: s.lang,
@@ -43,6 +45,7 @@ export const MoreModal = ({
       e.preventDefault();
       // replace all of "properties" with the new properties set in the ModalForm
       updateField(getPathString(item.id, elements), properties);
+      onClose(); // Let the PanelBody know that the modal is closed so it can refresh.
     };
   };
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
@@ -98,7 +98,11 @@ export const PanelBody = ({
                   </Tooltip.Info>
                 </div>
               )}
-              <ElementRequired onRequiredChange={onRequiredChange} item={item} />
+              <ElementRequired
+                onRequiredChange={onRequiredChange}
+                item={item}
+                key={"element-required-" + item.id}
+              />
             </div>
           </div>
         </>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBodyRoot.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBodyRoot.tsx
@@ -9,7 +9,13 @@ import {
 } from "@lib/types/form-builder-types";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 
-export const PanelBodyRoot = ({ item }: { item: FormElementWithIndex }) => {
+export const PanelBodyRoot = ({
+  item,
+  onChangeMade,
+}: {
+  item: FormElementWithIndex;
+  onChangeMade: () => void;
+}) => {
   const { updateField, propertyPath } = useTemplateStore((s) => ({
     propertyPath: s.propertyPath,
     localizeField: s.localizeField,
@@ -29,6 +35,7 @@ export const PanelBodyRoot = ({ item }: { item: FormElementWithIndex }) => {
 
   const onRequiredChange = (itemId: number, checked: boolean) => {
     updateField(propertyPath(itemId, "validation.required"), checked);
+    onChangeMade();
   };
 
   return (

--- a/cypress/e2e/form-builder/form-builder.cy.ts
+++ b/cypress/e2e/form-builder/form-builder.cy.ts
@@ -22,7 +22,7 @@ describe("Test FormBuilder", () => {
     cy.get("button").contains("Add option").click();
     cy.typeInField("#option--1--2", "option 2");
     cy.typeInField(`[aria-label="Privacy statement"]`, "privacy statement");
-    //cy.typeInField(`[aria-label="Confirmation message"]`, "confirmation page");
+    cy.typeInField(`[aria-label="Confirmation message"]`, "confirmation page");
     cy.get("#item-1").click();
     cy.get("button").contains("More").click();
     // open modal
@@ -37,7 +37,7 @@ describe("Test FormBuilder", () => {
     cy.get("#item-1").scrollIntoView();
     cy.get("#item-1").should("have.value", "Question 1-1");
     cy.get("#item1-describedby").should("contain", "Question 1 description");
-    // cy.get("#required-1-id").should("be.checked"); -- not working : Modal needs to update main view.
+    cy.get("#required-1-id").should("be.checked");
 
     // preview form
     cy.get('[data-testid="preview"]').click();


### PR DESCRIPTION
Fixes #3867 

Learning : 

> Fully uncontrolled — in this case your custom <Input> would take defaultChecked as a prop, and pass it to DOM <input>. The state would be inside the <Input> component itself. The prop value would only ever be used once, when the component is first rendered, and then ignored. The parent would have no way to "force" that state to become something else. If you ever need to reset the input, you'd have to mount it with a different key.

TL;DR : If you want a checkbox to change across components, change it's "key" value (eg: key="{the things id}+{checked or not}"

---

To test: 
1. Create a form.
2. Add a Question
3. Edit the Title, and the Required checkbox.
4. Note the values, and then click the "More" modal. The values should be the same. Edit them in the Modal.
5. Click save in the Modal.
6. Note the values, they should match what you changed. Edit the values again. Open the Modal, they should match again.