### PR TITLE
fix: move marker off screen for logic view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/EndMarker.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/EndMarker.tsx
@@ -1,6 +1,9 @@
 export const EndMarker = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" style={{ position: "absolute", top: 0, left: 0 }}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ position: "absolute", top: "-200px", left: "-200px" }}
+    >
       <defs>
         <marker
           id="1__type=1__type=gc-arrow-closed"


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/3872

Fixes issue where "hidden" svg marker was covering the logo and part of the form filename input on the logic page


https://github.com/cds-snc/platform-forms-client/assets/62242/747434b2-5a86-4803-90e7-144969ea603f


