### PR TITLE
fix: "Other" question field isn't showing up, so clicking the link "Other" takes you no where 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/conditionals/AddOther.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/conditionals/AddOther.tsx
@@ -7,6 +7,8 @@ import { FormElementWithIndex } from "@lib/types/form-builder-types";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { FormElementTypes } from "@lib/types";
 import { getTranslatedProperties } from "../../../actions";
+import { useGroupStore } from "@formBuilder/components/shared/right-panel/treeview/store/useGroupStore";
+import { allowGrouping } from "@formBuilder/components/shared/right-panel/treeview/util/allowGrouping";
 
 export const AddOther = ({ item }: { item: FormElementWithIndex }) => {
   const { t } = useTranslation("form-builder");
@@ -14,6 +16,8 @@ export const AddOther = ({ item }: { item: FormElementWithIndex }) => {
   const { add } = useTemplateStore((s) => ({
     add: s.add,
   }));
+
+  const groupId = useGroupStore((state) => state.id);
 
   const addOther = useCallback(async () => {
     if (!item.properties.choices) return;
@@ -41,7 +45,12 @@ export const AddOther = ({ item }: { item: FormElementWithIndex }) => {
       },
     };
 
-    add(item.index, FormElementTypes.textField, data);
+    const allowGroups = await allowGrouping();
+    if (allowGroups) {
+      add(item.index, FormElementTypes.textField, data, groupId);
+    } else {
+      add(item.index, FormElementTypes.textField, data);
+    }
   }, [add, item]);
 
   return (

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/conditionals/AddOther.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/conditionals/AddOther.tsx
@@ -51,7 +51,7 @@ export const AddOther = ({ item }: { item: FormElementWithIndex }) => {
     } else {
       add(item.index, FormElementTypes.textField, data);
     }
-  }, [add, item]);
+  }, [add, item, groupId]);
 
   return (
     <Button className="!m-0 !mt-4" theme="link" onClick={addOther}>


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/3793

Fixes issue for Other field when form is "grouped".

When using "groups" groupID was not passed so the field was not being added to the group.