### PR TITLE
chore:  fix group node spacing

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/GroupNode.tsx
@@ -56,7 +56,7 @@ export const GroupNode = (node: NodeProps) => {
   };
 
   const nodeClassName =
-    "relative flex w-[100%] min-w-[200px] max-w-[450px] rounded-sm bg-slate-50 p-2 py-3 text-sm text-slate-600 border-red";
+    "relative flex w-[100%] min-w-[200px] max-w-[200px] rounded-sm bg-slate-50 p-2 py-3 text-sm text-slate-600 border-red";
 
   return (
     <div>
@@ -149,7 +149,7 @@ export const GroupNode = (node: NodeProps) => {
               )}
             >
               <div className="w-full truncate pr-8">
-                {getTitle(child.data as ElementProperties).substring(0, 300)}
+                {getTitle(child.data as ElementProperties).substring(0, 200)}
               </div>
               <div className="absolute right-[10px] top-[6px] cursor-pointer hover:scale-125">
                 <OptionRuleSvg title={t("groups.editRules", { name: node.data.label.name })} />


### PR DESCRIPTION
# Summary | Résumé

Small updating to fix spacing + truncating text.

<img width="481" alt="Screenshot 2024-06-24 at 2 19 49 PM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/985c7491-5985-4290-85b3-0fc4c7cc4828">

Fixes issue where text was not truncating properly and was covered by arrows

![image_720](https://github.com/cds-snc/platform-forms-client/assets/62242/62025331-423a-4d6e-be48-1672d3440c67)

