### PR TITLE
* Form Purpose w/ Delivery Option Email - Fix : Save Disabled

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -133,7 +133,9 @@ export const ResponseDelivery = () => {
       if (!completeEmailAddressRegex.test(inputEmailValue)) {
         return false;
       }
-      return isValidDeliveryOption && emailDeliveryOptionsChanged;
+      return (
+        isValidDeliveryOption && (emailDeliveryOptionsChanged || purposeOption !== formPurpose)
+      );
     }
 
     if (deliveryOptionValue === initialDeliveryOption && purposeOption === formPurpose) {


### PR DESCRIPTION
Resolves #3891 

To test, go to settings page of a form, and set delivery option to email. You should now be able to change form purpose and as long as it's a new value the save button enables.