### PR TITLE
fix: nested check for response 

### DIFF
--- a/app/api/templates/route.ts
+++ b/app/api/templates/route.ts
@@ -53,12 +53,11 @@ export const GET = middleware(
       const response = templates.map((template) => onlyIncludePublicProperties(template));
 
       if (!response)
-        if (!response)
-          throw new Error(
-            `Template API response was null. Request information: method = ${
-              req.method
-            } ; query = ${JSON.stringify(props.params)} ; body = ${JSON.stringify(props.body)}`
-          );
+        throw new Error(
+          `Template API response was null. Request information: method = ${
+            req.method
+          } ; query = ${JSON.stringify(props.params)} ; body = ${JSON.stringify(props.body)}`
+        );
       return NextResponse.json(response);
     } catch (e) {
       const error = e as Error;

--- a/app/api/templates/route.ts
+++ b/app/api/templates/route.ts
@@ -116,13 +116,13 @@ export const POST = middleware(
           deliveryOption: deliveryOption,
           securityAttribute: securityAttribute,
         });
-        if (!response)
-          if (!response)
-            throw new Error(
-              `Template API response was null. Request information: method = ${
-                req.method
-              } ; query = ${JSON.stringify(props.params)} ; body = ${JSON.stringify(props.body)}`
-            );
+        if (!response) {
+          throw new Error(
+            `Template API response was null. Request information: method = ${
+              req.method
+            } ; query = ${JSON.stringify(props.params)} ; body = ${JSON.stringify(props.body)}`
+          );
+        }
         return NextResponse.json(response);
       } else {
         throw new MalformedAPIRequest("Missing formConfig");

--- a/app/api/templates/route.ts
+++ b/app/api/templates/route.ts
@@ -52,12 +52,13 @@ export const GET = middleware(
       const templates = await getAllTemplatesForUser(ability);
       const response = templates.map((template) => onlyIncludePublicProperties(template));
 
-      if (!response)
+      if (!response) {
         throw new Error(
           `Template API response was null. Request information: method = ${
             req.method
           } ; query = ${JSON.stringify(props.params)} ; body = ${JSON.stringify(props.body)}`
         );
+      }
       return NextResponse.json(response);
     } catch (e) {
       const error = e as Error;


### PR DESCRIPTION
# Summary | Résumé

Fixes small issues with a nested !response found while reviewing some other code.

Prior to PR:

```javascript
if (!response)
          if (!response)
```