### PR TITLE
chore: Move refs provider

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/Edit.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/Edit.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "@i18n/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Language, LocalizedFormProperties } from "@lib/types/form-builder-types";
 import { ElementPanel, ConfirmationDescription, PrivacyDescription } from ".";
-import { RefsProvider } from "./RefsContext";
 import { RichTextLocked } from "./elements";
 import { ExpandingInput } from "@formBuilder/components/shared";
 import { useRehydrate, useTemplateStore } from "@lib/store/useTemplateStore";
@@ -141,18 +140,16 @@ export const Edit = ({ formId }: { formId: string }) => {
         ariaLabel={t("richTextIntroTitle")}
       />
       <div className="form-builder-editor">
-        <RefsProvider>
-          {layout.length >= 1 &&
-            layout.map((id, index) => {
-              const element = sortedElements.find((element) => element.id === id);
+        {layout.length >= 1 &&
+          layout.map((id, index) => {
+            const element = sortedElements.find((element) => element.id === id);
 
-              if (element) {
-                const questionNumber = getQuestionNumber(element, elementTypes);
-                const item = { ...element, index, questionNumber };
-                return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
-              }
-            })}
-        </RefsProvider>
+            if (element) {
+              const questionNumber = getQuestionNumber(element, elementTypes);
+              const item = { ...element, index, questionNumber };
+              return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
+            }
+          })}
       </div>
       <>
         <div id="privacy-text">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -7,7 +7,6 @@ import { useSearchParams } from "next/navigation";
 import { Language, LocalizedFormProperties } from "@lib/types/form-builder-types";
 import { ElementPanel } from ".";
 import { ConfirmationDescriptionWithGroups } from "./ConfirmationDescriptionWithGroups";
-import { RefsProvider } from "./RefsContext";
 import { RichTextLockedWithGroups } from "./elements/RichTextLockedWithGroups";
 import { ExpandingInput } from "@formBuilder/components/shared";
 import { useRehydrate, useTemplateStore } from "@lib/store/useTemplateStore";
@@ -189,14 +188,12 @@ export const EditWithGroups = () => {
       <Section groupId={groupId} />
       {/* Form Elements */}
       <div className="form-builder-editor">
-        <RefsProvider>
-          {!["end"].includes(groupId) &&
-            sortedElements.map((element, index) => {
-              const questionNumber = 0;
-              const item = { ...element, index, questionNumber };
-              return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
-            })}
-        </RefsProvider>
+        {!["end"].includes(groupId) &&
+          sortedElements.map((element, index) => {
+            const questionNumber = 0;
+            const item = { ...element, index, questionNumber };
+            return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
+          })}
       </div>
       {/* Confirmation*/}
       {groupId === "end" && (

--- a/components/clientComponents/globals/ClientContexts.tsx
+++ b/components/clientComponents/globals/ClientContexts.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from "next-auth/react";
 import { Session } from "next-auth";
 import { AccessControlProvider } from "@lib/hooks/useAccessControl";
 import { LiveMessagePovider } from "@lib/hooks/useLiveMessage";
+import { RefsProvider } from "@formBuilder/[id]/edit/components/RefsContext";
 
 export const ClientContexts: React.FC<{ session: Session | null; children: React.ReactNode }> = ({
   session,
@@ -19,7 +20,9 @@ export const ClientContexts: React.FC<{ session: Session | null; children: React
       refetchOnWindowFocus={false}
     >
       <AccessControlProvider>
-        <LiveMessagePovider>{children}</LiveMessagePovider>
+        <RefsProvider>
+          <LiveMessagePovider>{children}</LiveMessagePovider>
+        </RefsProvider>
       </AccessControlProvider>
     </SessionProvider>
   );


### PR DESCRIPTION
# Summary | Résumé

Moves refs provider outside of edit so we can make use of it from elements such as the TreeView.