### PR TITLE
chore: increase next server maximum memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "yarn prisma:dev && yarn initialize && next dev --turbo",
     "dev:secure": "yarn prisma:dev && yarn initialize && next dev --turbo --experimental-https",
     "build": "DATABASE_URL=postgres://postgres:chummy@localhost:5432/formsDB next build --debug",
-    "start": "yarn prisma:deploy && yarn initialize && next start -p ${PORT:-3000}",
+    "start": "yarn prisma:deploy && yarn initialize && NODE_OPTIONS=\"--max-old-space-size=3584\" next start -p ${PORT:-3000}",
     "initialize": "yarn workspace flag_initialization initialize",
     "prisma:deploy": "prisma migrate deploy && tsx prisma/seeds/seed_cli.ts --environment=production",
     "prisma:dev": "prisma migrate dev --skip-seed && tsx prisma/seeds/seed_cli.ts --environment=development",


### PR DESCRIPTION
# Summary | Résumé

- Increases maximum allowed memory space for our Next server. Following recommendation from [Node documentation](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) I set it to 3.5 GB because our ECS is configured with 4 GB of memory.

After investigating on a recent Out of Memory issue in production I could not find any root cause that would explain it. Since it was the first time it happened I decided to just go with a simple change that was recommended on different online websites.

For reference, here is the Fatal error we got in production:
`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`