### PR TITLE
fix: Add key for next action

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SelectNextAction.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SelectNextAction.tsx
@@ -43,7 +43,10 @@ export const SelectNextAction = ({ item, lang }: { item: FormElement | null; lan
           <SectionName lang={lang} sectionName={sectionName} />
         </div>
         <div className="p-4">
-          <SingleActionSelect nextAction={selectedGroupNextActions || "end"} />
+          <SingleActionSelect
+            key={`single-action-select-${selectedGroupId}`}
+            nextAction={selectedGroupNextActions || "end"}
+          />
         </div>
       </div>
     );
@@ -72,6 +75,7 @@ export const SelectNextAction = ({ item, lang }: { item: FormElement | null; lan
           no - => section 2
         */
         <MultiActionSelector
+          key={`multi-action-select-${selectedGroupId}`}
           lang={lang}
           sectionName={sectionName}
           item={item}


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where the next action selector was ending up using a previously selected value from stale state.