### PR TITLE
fix: Permissions on Admin pages

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/upload/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/upload/page.tsx
@@ -20,9 +20,13 @@ export default async function Page() {
 
   const { ability } = await authCheckAndRedirect();
 
-  checkPrivilegesAsBoolean(ability, [{ action: "create", subject: "FormRecord" }], {
-    redirect: true,
-  });
+  checkPrivilegesAsBoolean(
+    ability,
+    [{ action: "create", subject: { type: "FormRecord", object: {} } }],
+    {
+      redirect: true,
+    }
+  );
   return (
     <>
       <h1>{t("upload.title")}</h1>

--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/upload/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/upload/page.tsx
@@ -22,7 +22,7 @@ export default async function Page() {
 
   checkPrivilegesAsBoolean(
     ability,
-    [{ action: "create", subject: { type: "FormRecord", object: {} } }],
+    [{ action: "update", subject: { type: "FormRecord", object: {} } }],
     {
       redirect: true,
     }

--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/view-templates/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/view-templates/page.tsx
@@ -21,11 +21,8 @@ export default async function Page() {
 
   checkPrivilegesAsBoolean(
     ability,
-    [
-      { action: "view", subject: "FormRecord" },
-      { action: "update", subject: "FormRecord" },
-    ],
-    { logic: "one", redirect: true }
+    [{ action: "update", subject: { type: "FormRecord", object: {} } }],
+    { redirect: true }
   );
 
   const templates = (await getAllTemplates(ability)).map((template) => {


### PR DESCRIPTION
# Summary | Résumé

Ensures that only users with "manage all forms" privilege can view the "upload" and "view-templates" pages.  Previously the page would start to load and then throw an Access Control Error.  These changes now short circuit the page load.

![Screenshot 2024-07-05 at 8 37 12 AM](https://github.com/cds-snc/platform-forms-client/assets/25329319/98a35735-0885-4f96-91b8-dac6bc82a471)


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
