### PR TITLE
fix: Email Delivery Component was mistakenly async

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/DeliveryOptionEmail.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/DeliveryOptionEmail.tsx
@@ -1,10 +1,11 @@
+"use client";
 import React from "react";
 import Link from "next/link";
 import { EmailResponseSettings } from "@formBuilder/components/shared";
 import { ClosedBanner } from "@formBuilder/components/shared/ClosedBanner";
-import { serverTranslation } from "@i18n";
+import { useTranslation } from "@i18n/client";
 
-export const DeliveryOptionEmail = async ({
+export const DeliveryOptionEmail = ({
   email,
   emailSubject,
   isPublished,
@@ -18,7 +19,7 @@ export const DeliveryOptionEmail = async ({
   const {
     t,
     i18n: { language },
-  } = await serverTranslation("form-builder-responses");
+  } = useTranslation("form-builder-responses");
 
   return (
     <>


### PR DESCRIPTION
# Summary | Résumé

Fixes error when trying to access Responses page when delivery option is set to Email

![Screenshot 2024-07-05 at 10 57 30 AM](https://github.com/cds-snc/platform-forms-client/assets/25329319/c7ba1ec0-63d8-4299-98f8-66739e8a75c4)


# Test instructions | Instructions pour tester la modification

1. Go to unpublished form
2. Change delivery settings to email
3. Go to Responses page
4. The responses page should show that you have email delivery enabled.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
