### PR TITLE
chore: use section name for logic view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
@@ -159,7 +159,7 @@ export const useFlowData = (lang: Language = "en") => {
 
       const newEdges = getEdges(key as string, prevNodeId, group, formGroups);
 
-      const titleKey = lang === "en" ? "titleEn" : "titleFr";
+      const titleKey = "name" as keyof typeof treeItem.data;
 
       const isOffBoardSection = treeItem.data.nextAction === "exit";
 
@@ -191,7 +191,7 @@ export const useFlowData = (lang: Language = "en") => {
     nodes.push({ ...endNode });
 
     return { edges, nodes };
-  }, [treeItems, reviewNode, endNode, formGroups, lang, startElements]);
+  }, [treeItems, reviewNode, endNode, formGroups, startElements]);
 
   const { edges, nodes } = getData();
 


### PR DESCRIPTION
# Summary | Résumé

Update to use name vs section title 

<img width="1083" alt="Screenshot 2024-07-11 at 9 27 29 AM" src="https://github.com/cds-snc/platform-forms-client/assets/62242/a4dd8ba4-c91a-4ca2-8946-17deb9bc17cd">
