### PR TITLE
fix: overlapping element menus

### DIFF
--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -49,6 +49,11 @@ export const useHandleAdd = () => {
       treeView?.current?.addItem(String(id));
 
       const el = document.getElementById(`item-${id}`);
+
+      // Close all panel menus
+      const closeAll = new CustomEvent("close-all-panel-menus");
+      window.dispatchEvent(closeAll);
+
       if (!el) return;
       el?.focus();
     },

--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -52,7 +52,7 @@ export const useHandleAdd = () => {
 
       // Close all panel menus
       const closeAll = new CustomEvent("close-all-panel-menus");
-      window.dispatchEvent(closeAll);
+      window && window.dispatchEvent(closeAll);
 
       if (!el) return;
       el?.focus();

--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -50,11 +50,12 @@ export const useHandleAdd = () => {
 
       const el = document.getElementById(`item-${id}`);
 
-      // Close all panel menus
+      if (!el) return;
+
+      // Close all panel menus before focussing on the new element
       const closeAll = new CustomEvent("close-all-panel-menus");
       window && window.dispatchEvent(closeAll);
 
-      if (!el) return;
       el?.focus();
     },
     [add, create, groupId, treeView]

--- a/lib/hooks/form-builder/useIsWithin.tsx
+++ b/lib/hooks/form-builder/useIsWithin.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useFocusWithin } from "react-aria";
 
 export const useIsWithin = () => {
@@ -12,6 +12,22 @@ export const useIsWithin = () => {
       !dialogExists && setFocusWithin(isFocusWithin);
     },
   });
+
+  // Add event listener for a custom close-all-panel-menus event
+  // This fixes an issue where the panel menu would still be open
+  // after adding and focusing on a new element
+  useEffect(() => {
+    window &&
+      window.addEventListener("close-all-panel-menus", () => {
+        setFocusWithin(false);
+      });
+
+    return () => {
+      window.removeEventListener("close-all-panel-menus", () => {
+        setFocusWithin(false);
+      });
+    };
+  }, []);
 
   const isWithin = isFocusWithin ? true : false;
 


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where element panel menus overlap when using add element button

<img width="1132" alt="Screenshot 2024-07-12 at 12 26 40 PM" src="https://github.com/user-attachments/assets/5efdfcb5-b6e0-4086-bf53-3d965b364b9c">
