### PR TITLE
chore: add translations for dialogs

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/confirm/ConfirmDeleteSectionDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/confirm/ConfirmDeleteSectionDialog.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@clientComponents/globals";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
+import { useTranslation } from "@i18n/client";
+import Markdown from "markdown-to-jsx";
 
 export type handleCloseType = (value: boolean) => void;
 
@@ -10,35 +12,30 @@ export const ConfirmDeleteSectionDialog = ({
   open: boolean;
   handleClose: handleCloseType;
 }) => {
+  const { t } = useTranslation("form-builder");
+
   return (
     <AlertDialog.Root open={open}>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className="fixed inset-0 z-[200] h-screen w-screen bg-gray-500/70" />
         <AlertDialog.Content className="absolute left-1/2 top-1/2 z-[201] w-full max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-4 shadow-2xl">
           <AlertDialog.Title className="text-2xl font-extrabold leading-tight">
-            Delete this group?
+            {t("groups.confirmDeleteGroup.title")}
           </AlertDialog.Title>
           <AlertDialog.Description className="pb-6">
-            <p>
-              <strong>Questions will also be deleted</strong>
-              <br />
-              Elements within the group will also be deleted.
-            </p>
-            <p>
-              <strong>Move questions </strong>
-              <br />
-              Move all elements that you would like to keep to another group.
-            </p>
+            <Markdown options={{ forceBlock: true }}>
+              {t("groups.confirmDeleteGroup.description")}
+            </Markdown>
           </AlertDialog.Description>
           <div style={{ display: "flex", gap: 25, justifyContent: "flex-end" }}>
             <AlertDialog.Cancel asChild>
               <Button onClick={() => handleClose(false)} theme="secondary">
-                Cancel
+                {t("groups.confirmDeleteGroup.cancel")}
               </Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
               <Button onClick={() => handleClose(true)} theme="destructive">
-                Delete group and elements
+                {t("groups.confirmDeleteGroup.delete")}
               </Button>
             </AlertDialog.Action>
           </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/confirm/ConfirmMoveSectionDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/confirm/ConfirmMoveSectionDialog.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@clientComponents/globals";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
-
 import { useTranslation } from "@i18n/client";
+import Markdown from "markdown-to-jsx";
 
 export type handleCloseType = (value: boolean) => void;
 
@@ -19,20 +19,22 @@ export const ConfirmMoveSectionDialog = ({
         <AlertDialog.Overlay className="fixed inset-0 z-[200] h-screen w-screen bg-gray-500/70" />
         <AlertDialog.Content className="absolute left-1/2 top-1/2 z-[201] w-full max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-4 shadow-2xl">
           <AlertDialog.Title className="text-2xl font-extrabold leading-tight">
-            {t("groups.confirmDeleteGroup.title")}
+            {t("groups.confirmMoveGroup.title")}
           </AlertDialog.Title>
           <AlertDialog.Description className="pb-6">
-            {t("groups.confirmDeleteGroup.description")}
+            <Markdown options={{ forceBlock: true }}>
+              {t("groups.confirmMoveGroup.description")}
+            </Markdown>
           </AlertDialog.Description>
           <div style={{ display: "flex", gap: 25, justifyContent: "flex-end" }}>
             <AlertDialog.Cancel asChild>
               <Button onClick={() => handleClose(false)} theme="secondary">
-                {t("groups.confirmDeleteGroup.cancel")}
+                {t("groups.confirmMoveGroup.cancel")}
               </Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
               <Button onClick={() => handleClose(true)} theme="primary">
-                {t("groups.confirmDeleteGroup.confirm")}
+                {t("groups.confirmMoveGroup.confirm")}
               </Button>
             </AlertDialog.Action>
           </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/confirm/ConfirmMoveSectionDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/confirm/ConfirmMoveSectionDialog.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@clientComponents/globals";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
 
+import { useTranslation } from "@i18n/client";
+
 export type handleCloseType = (value: boolean) => void;
 
 export const ConfirmMoveSectionDialog = ({
@@ -10,27 +12,27 @@ export const ConfirmMoveSectionDialog = ({
   open: boolean;
   handleClose: handleCloseType;
 }) => {
+  const { t } = useTranslation("form-builder");
   return (
     <AlertDialog.Root open={open}>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className="fixed inset-0 z-[200] h-screen w-screen bg-gray-500/70" />
         <AlertDialog.Content className="absolute left-1/2 top-1/2 z-[201] w-full max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-4 shadow-2xl">
           <AlertDialog.Title className="text-2xl font-extrabold leading-tight">
-            Rewrite rules?
+            {t("groups.confirmDeleteGroup.title")}
           </AlertDialog.Title>
           <AlertDialog.Description className="pb-6">
-            It seems the item(s) you are moving have one or more custom rules. Would you like to
-            overwrite those rules with autoflow?
+            {t("groups.confirmDeleteGroup.description")}
           </AlertDialog.Description>
           <div style={{ display: "flex", gap: 25, justifyContent: "flex-end" }}>
             <AlertDialog.Cancel asChild>
               <Button onClick={() => handleClose(false)} theme="secondary">
-                No, move without changing rules
+                {t("groups.confirmDeleteGroup.cancel")}
               </Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
               <Button onClick={() => handleClose(true)} theme="primary">
-                Yes, autoflow
+                {t("groups.confirmDeleteGroup.confirm")}
               </Button>
             </AlertDialog.Action>
           </div>

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -977,16 +977,16 @@
       }
     },
     "confirmDeleteGroup": {
-      "title": "Delete this group?",
-      "description": "<span className='inline-block mb-4'><strong>Questions will also be deleted</strong><br />Elements within the group will also be deleted.</span><span className='inline-block mb-4'><strong>Move questions </strong><br />Move all elements that you would like to keep to another group.</span>",
+      "title": "Delete this page?",
+      "description": "<span className='inline-block mb-4'><strong>Page content will also be deleted</strong><br />All form elements on this page will be deleted.</span><span className='inline-block mb-4'><strong>You can move content before deleting</strong><br />Move all form elements that you would like to keep to another page.</span>",
       "cancel": "Cancel",
-      "delete": "Delete group and elements"
+      "delete": "Delete page and its contents"
     },
     "confirmMoveGroup": {
-      "title": "Rewrite rules?",
-      "description": " It seems the item(s) you are moving have one or more custom rules. Would you like to overwrite those rules with autoflow?",
+      "title": "Overwrite rules?",
+      "description": " It seems the items you are moving may have custom rules applied. Would you like to overwrite those rules and apply linear autoflow?",
       "cancel": "No, move without changing rules",
-      "confirm": "Yes, autoflow"
+      "confirm": "Yes, apply linear autoflow"
     }
   },
   "confirmation": {

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -975,6 +975,18 @@
         "label": "Keyboard shortcuts",
         "body": "<p className=\"mb-4\">Navigate the questions and pages using the arrow keys.</p><p><strong>Drag and drop:</strong></p>\n<ul><li>control + D to pick up an item</li><li>arrow keys to drag the item</li><li>enter key to drop the item</li></ul>"
       }
+    },
+    "confirmDeleteGroup": {
+      "title": "Delete this group?",
+      "description": "<p><strong>Questions will also be deleted</strong><br />Elements within the group will also be deleted.</p><p><strong>Move questions </strong><br />Move all elements that you would like to keep to another group.</p>",
+      "cancel": "Cancel",
+      "delete": "Delete group and elements"
+    },
+    "confirmMoveGroup": {
+      "title": "Rewrite rules?",
+      "description": " It seems the item(s) you are moving have one or more custom rules. Would you like to overwrite those rules with autoflow?",
+      "cancel": "No, move without changing rules",
+      "confirm": "Yes, autoflow"
     }
   },
   "confirmation": {

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -978,7 +978,7 @@
     },
     "confirmDeleteGroup": {
       "title": "Delete this group?",
-      "description": "<p><strong>Questions will also be deleted</strong><br />Elements within the group will also be deleted.</p><p><strong>Move questions </strong><br />Move all elements that you would like to keep to another group.</p>",
+      "description": "<span className='inline-block mb-4'><strong>Questions will also be deleted</strong><br />Elements within the group will also be deleted.</span><span className='inline-block mb-4'><strong>Move questions </strong><br />Move all elements that you would like to keep to another group.</span>",
       "cancel": "Cancel",
       "delete": "Delete group and elements"
     },

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -984,7 +984,7 @@
     },
     "confirmMoveGroup": {
       "title": "Overwrite rules?",
-      "description": " It seems the items you are moving may have custom rules applied. Would you like to overwrite those rules and apply linear autoflow?",
+      "description": " It seems the items you are moving have conditional rules applied. Would you like to overwrite those rules and apply linear autoflow?",
       "cancel": "No, move without changing rules",
       "confirm": "Yes, apply linear autoflow"
     }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -975,6 +975,18 @@
         "label": "Raccourcis clavier",
         "body": "<p className=\"mb-4\">Naviguer les questions et les pages à l'aide des touches fléchées.</p><p><strong>Glisser-déposer :</strong></p>\n<ul><li>Contrôle + D pour prendre un élément</li><li>touches fléchées pour faire glisser l'élément</li><li>Appuyer Entrée pour déposer l'élément</li></ul>"
       }
+    },
+    "confirmDeleteGroup": {
+      "title": "Delete this group? [FR]",
+      "description": "<p><strong>Questions will also be deleted</strong><br />Elements within the group will also be deleted.</p><p><strong>Move questions </strong><br />Move all elements that you would like to keep to another group.</p> [FR]",
+      "cancel": "Cancel [FR]",
+      "delete": "Delete group and elements [FR]"
+    },
+    "confirmMoveGroup": {
+      "title": "Rewrite rules? [FR]",
+      "description": " It seems the item(s) you are moving have one or more custom rules. Would you like to overwrite those rules with autoflow? [FR]",
+      "cancel": "No, move without changing rules [FR]",
+      "confirm": "Yes, autoflow [FR]"
     }
   },
   "confirmation": {

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -977,16 +977,16 @@
       }
     },
     "confirmDeleteGroup": {
-      "title": "Delete this group? [FR]",
-      "description": "<p><strong>Questions will also be deleted</strong><br />Elements within the group will also be deleted.</p><p><strong>Move questions </strong><br />Move all elements that you would like to keep to another group.</p> [FR]",
-      "cancel": "Cancel [FR]",
-      "delete": "Delete group and elements [FR]"
+      "title": "Supprimer cette page?",
+      "description": "<p><strong>Le contenu de la page sera supprimé</strong><br />Tous les éléments de cette page seront également supprimés.</p><p><strong>Vous pouvez déplacer le contenu </strong><br />Déplacez tous les éléments de formulaire que vous souhaitez conserver vers une autre page.</p>",
+      "cancel": "Annuler",
+      "delete": "Supprimer la page et son contenu"
     },
     "confirmMoveGroup": {
-      "title": "Rewrite rules? [FR]",
-      "description": " It seems the item(s) you are moving have one or more custom rules. Would you like to overwrite those rules with autoflow? [FR]",
-      "cancel": "No, move without changing rules [FR]",
-      "confirm": "Yes, autoflow [FR]"
+      "title": "Remplacer les règles",
+      "description": " Il semble que les éléments déplacés comportent des règles conditionnelles. Souhaitez-vous remplacer ces règles par un flux automatique linéaire?",
+      "cancel": "Non, déplacer sans modifier les règles",
+      "confirm": "Oui, appliquer un flux automatique"
     }
   },
   "confirmation": {

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -978,13 +978,13 @@
     },
     "confirmDeleteGroup": {
       "title": "Supprimer cette page?",
-      "description": "<p><strong>Le contenu de la page sera supprimé</strong><br />Tous les éléments de cette page seront également supprimés.</p><p><strong>Vous pouvez déplacer le contenu </strong><br />Déplacez tous les éléments de formulaire que vous souhaitez conserver vers une autre page.</p>",
+      "description": "<p><strong>Le contenu de la page sera également supprimé</strong><br />Tous les éléments de cette page seront supprimés.</p><p><strong>Vous pouvez déplacer le contenu avant de supprimer</strong><br />Déplacez tous les éléments de formulaire que vous souhaitez conserver vers une autre page.</p>",
       "cancel": "Annuler",
       "delete": "Supprimer la page et son contenu"
     },
     "confirmMoveGroup": {
-      "title": "Remplacer les règles",
-      "description": " Il semble que les éléments déplacés comportent des règles conditionnelles. Souhaitez-vous remplacer ces règles par un flux automatique linéaire?",
+      "title": "Remplacer les règles?",
+      "description": " Il semble que des éléments déplacés comportent des règles conditionnelles. Souhaitez-vous remplacer ces règles par un flux automatique linéaire?",
       "cancel": "Non, déplacer sans modifier les règles",
       "confirm": "Oui, appliquer un flux automatique"
     }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -978,7 +978,7 @@
     },
     "confirmDeleteGroup": {
       "title": "Supprimer cette page?",
-      "description": "<p><strong>Le contenu de la page sera également supprimé</strong><br />Tous les éléments de cette page seront supprimés.</p><p><strong>Vous pouvez déplacer le contenu avant de supprimer</strong><br />Déplacez tous les éléments de formulaire que vous souhaitez conserver vers une autre page.</p>",
+      "description": "<span className='inline-block mb-4'><strong>Le contenu de la page sera également supprimé</strong><br />Tous les éléments de cette page seront supprimés.</span><span className='inline-block mb-4'><strong>Vous pouvez déplacer le contenu avant de supprimer</strong><br />Déplacez tous les éléments de formulaire que vous souhaitez conserver vers une autre page.</span>",
       "cancel": "Annuler",
       "delete": "Supprimer la page et son contenu"
     },


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/3996

Adds translation strings for 

1) Deleting a page from the Tree View

2) Confirm moving a page when custom rules are set

For this go to logic page --- add some custom rules to a page
Go to Tree View and attempt to move that page
