### PR TITLE
fix: Import with groups

### DIFF
--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -70,7 +70,13 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
       ...initProps?.form,
     };
 
-    initProps.form.groups = orderGroups(initProps.form.groups, initProps.form.groupsLayout);
+    // Ensure order by groups layout
+    if (!initProps.form.groupsLayout) {
+      /* No need to order as the groups layout does not exist */
+      initProps.form.groupsLayout = [];
+    } else {
+      initProps.form.groups = orderGroups(initProps.form.groups, initProps.form.groupsLayout);
+    }
   }
 
   return createStore<TemplateStoreState>()(
@@ -401,8 +407,15 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
                 state.lang = language as Language;
                 state.translationLanguagePriority = language as Language;
                 state.form = initializeGroups({ ...defaultForm }, allowGroups);
+
                 // Ensure order by groups layout
-                state.form.groups = orderGroups(state.form.groups, state.form.groupsLayout);
+                if (!state.form.groupsLayout) {
+                  /* No need to order as the groups layout does not exist */
+                  state.form.groupsLayout = [];
+                } else {
+                  state.form.groups = orderGroups(state.form.groups, state.form.groupsLayout);
+                }
+
                 state.isPublished = false;
                 state.name = "";
                 state.deliveryOption = undefined;
@@ -419,8 +432,15 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
                 state.id = "";
                 state.lang = "en";
                 state.form = initializeGroups({ ...defaultForm, ...jsonConfig }, allowGroups);
+
                 // Ensure order by groups layout
-                state.form.groups = orderGroups(state.form.groups, state.form.groupsLayout);
+                if (!state.form.groupsLayout) {
+                  /* No need to order as the groups layout does not exist */
+                  state.form.groupsLayout = [];
+                } else {
+                  state.form.groups = orderGroups(state.form.groups, state.form.groupsLayout);
+                }
+
                 state.isPublished = false;
                 state.name = "";
                 state.securityAttribute = "Protected A";

--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -70,6 +70,8 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
       ...initProps?.form,
     };
 
+    initProps.form = initializeGroups(initProps.form, initProps?.allowGroupsFlag || false);
+
     // Ensure order by groups layout
     if (!initProps.form.groupsLayout) {
       /* No need to order as the groups layout does not exist */


### PR DESCRIPTION
# Summary | Résumé

See: https://github.com/cds-snc/platform-forms-client/issues/4007

Adjusts initialization code for groups when a form is imported without a groups layout property. 

### Testing 
Import the attached form which has no groups or group layout with the grouping feature on.
[my-form.json](https://github.com/user-attachments/files/16264914/my-form.json)

Note that the elements should end up under the Start page.
