### PR TITLE
fix: remove initial initializeGroups on default form

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -55,14 +55,15 @@ const DebugNamedGroupLayout = () => {
   if (!groups) {
     return null;
   }
-  const groupLayoutNames = groupsLayout
-    ? groupsLayout
-        .map((id: string) => groups[id]?.name)
-        .filter(Boolean)
-        .map((name, i) => {
-          return <div key={i}>{name}</div>;
-        })
-    : [];
+  const groupLayoutNames =
+    groupsLayout && groupsLayout.length >= 1
+      ? groupsLayout
+          .map((id: string) => groups[id]?.name)
+          .filter(Boolean)
+          .map((name, i) => {
+            return <div key={i}>{name}</div>;
+          })
+      : [];
 
   return groupLayoutNames;
 };

--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -50,7 +50,7 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
     translationLanguagePriority: (initProps?.locale as Language) || "en",
     focusInput: false,
     hasHydrated: false,
-    form: initializeGroups(defaultForm, initProps?.allowGroupsFlag || false),
+    form: defaultForm,
     isPublished: false,
     name: "",
     securityAttribute: "Protected A",


### PR DESCRIPTION
# Summary | Résumé

File for testing - has no groups property

[v2-accessibility-feedback-template-gc-forms-2023-07-21-1 (1).json](https://github.com/user-attachments/files/16268218/v2-accessibility-feedback-template-gc-forms-2023-07-21-1.1.json)
