### PR TITLE
feat: Campaign Banner

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -61,7 +61,7 @@ const TabButton = ({
 
 export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
   const router = useRouter();
-  const { t, i18n } = useTranslation("form-builder");
+  const { t, i18n } = useTranslation(["form-builder", "common"]);
 
   const { id: storeId } = useTemplateStore((s) => ({
     id: s.id,
@@ -91,6 +91,16 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
   }
 
   const [isIntersecting, setIsIntersecting] = useState(false);
+  const isBannerEnabled = t("campaignBanner.enabled");
+
+  //If Intersecting fixed-20 else fixed-0, but if BannerEnabled fixed-40 else fixed-20
+  const fixedRange = isBannerEnabled
+    ? isIntersecting
+      ? "top-30"
+      : "top-10"
+    : isIntersecting
+    ? "top-20"
+    : "top-0";
 
   // Observe if the header is offscreen
   // Used to determine the position of the right panel button "toggle" button
@@ -123,7 +133,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
 
   return (
     <section className="relative" aria-labelledby="rightPanelTitle">
-      <div className={cn("fixed right-0", isIntersecting ? "top-20" : "top-0", open && "hidden")}>
+      <div className={cn("fixed right-0", fixedRange, open && "hidden")}>
         <Button
           theme="link"
           className="mr-8 mt-5 whitespace-nowrap [&_svg]:focus:fill-white"

--- a/components/clientComponents/globals/Header/Header.tsx
+++ b/components/clientComponents/globals/Header/Header.tsx
@@ -11,6 +11,7 @@ import { ShareDropdown } from "./ShareDropdown";
 import LanguageToggle from "./LanguageToggle";
 import { YourAccountDropdown } from "./YourAccountDropdown";
 import { LiveMessage } from "@lib/hooks/useLiveMessage";
+import Markdown from "markdown-to-jsx";
 
 type HeaderParams = {
   context?: "admin" | "formBuilder" | "default";
@@ -25,67 +26,83 @@ export const Header = ({ context = "default", className }: HeaderParams) => {
     i18n: { language },
   } = useTranslation(["common", "form-builder", "admin-login"]);
 
+  const isBannerEnabled = t("campaignBanner.enabled");
+
   return (
-    <header
-      className={cn("mb-5 border-b-1 border-gray-500 bg-white px-0 py-2 relative", className)}
-    >
-      <div className="grid w-full grid-flow-col">
-        <div className="flex">
-          <Link
-            href={`/${language}/form-builder`}
-            prefetch={false}
-            id="logo"
-            className="mr-7 flex border-r-1 pr-[14px] text-3xl font-semibold !text-black no-underline focus:bg-white"
-          >
-            <div className="inline-block h-[45px] w-[46px] p-2">
-              <SiteLogo title={t("title")} />
-            </div>
-          </Link>
-
-          {context === "default" && (
-            <div className="mt-3 box-border block h-[40px] px-2 py-1 text-xl font-semibold">
-              {t("title", { ns: "common" })}
-            </div>
-          )}
-
-          {status === "authenticated" && (
-            <>
-              <div className="mt-3 box-border block h-[40px] px-2 py-1 font-semibold">
-                <Link href={`/${language}/forms`}>{t("adminNav.allForms", { ns: "common" })}</Link>
-                {isFormBuilder && <span className="mx-2 inline-block"> / </span>}
-              </div>
-            </>
-          )}
-          {isFormBuilder && <FileNameInput />}
+    <>
+      {isBannerEnabled && (
+        <div className="bg-slate-800 text-white px-4 py-4">
+          <div className="inline-block border-2 border-gray-500 px-1 py-1 mr-4">
+            {t("campaignBanner.type")}
+          </div>
+          <div className="inline-block">
+            <Markdown options={{ forceBlock: true }}>{t("campaignBanner.message")}</Markdown>
+          </div>
         </div>
-        <nav className="justify-self-end" aria-label={t("mainNavAriaLabel", { ns: "common" })}>
-          <ul className="mt-2 flex list-none px-0 text-base">
-            {status !== "authenticated" && (
-              <li className="mr-2 py-2 text-base tablet:mr-4">
-                <Link href={`/${language}/auth/login`} prefetch={false}>
-                  {t("loginMenu.login")}
-                </Link>
-              </li>
+      )}
+      <header
+        className={cn("mb-5 border-b-1 border-gray-500 bg-white px-0 py-2 relative", className)}
+      >
+        <div className="grid w-full grid-flow-col">
+          <div className="flex">
+            <Link
+              href={`/${language}/form-builder`}
+              prefetch={false}
+              id="logo"
+              className="mr-7 flex border-r-1 pr-[14px] text-3xl font-semibold !text-black no-underline focus:bg-white"
+            >
+              <div className="inline-block h-[45px] w-[46px] p-2">
+                <SiteLogo title={t("title")} />
+              </div>
+            </Link>
+
+            {context === "default" && (
+              <div className="mt-3 box-border block h-[40px] px-2 py-1 text-xl font-semibold">
+                {t("title", { ns: "common" })}
+              </div>
             )}
-            {
-              <li className="mr-2 py-2 tablet:mr-4">
-                <LanguageToggle />
-              </li>
-            }
-            {isFormBuilder && (
-              <li className="mr-2 text-base tablet:mr-4">
-                <ShareDropdown />
-              </li>
+
+            {status === "authenticated" && (
+              <>
+                <div className="mt-3 box-border block h-[40px] px-2 py-1 font-semibold">
+                  <Link href={`/${language}/forms`}>
+                    {t("adminNav.allForms", { ns: "common" })}
+                  </Link>
+                  {isFormBuilder && <span className="mx-2 inline-block"> / </span>}
+                </div>
+              </>
             )}
-            {
-              <li className="mr-5 text-base">
-                <YourAccountDropdown isAuthenticated={status === "authenticated"} />
-              </li>
-            }
-          </ul>
-        </nav>
-      </div>
-      <LiveMessage />
-    </header>
+            {isFormBuilder && <FileNameInput />}
+          </div>
+          <nav className="justify-self-end" aria-label={t("mainNavAriaLabel", { ns: "common" })}>
+            <ul className="mt-2 flex list-none px-0 text-base">
+              {status !== "authenticated" && (
+                <li className="mr-2 py-2 text-base tablet:mr-4">
+                  <Link href={`/${language}/auth/login`} prefetch={false}>
+                    {t("loginMenu.login")}
+                  </Link>
+                </li>
+              )}
+              {
+                <li className="mr-2 py-2 tablet:mr-4">
+                  <LanguageToggle />
+                </li>
+              }
+              {isFormBuilder && (
+                <li className="mr-2 text-base tablet:mr-4">
+                  <ShareDropdown />
+                </li>
+              )}
+              {
+                <li className="mr-5 text-base">
+                  <YourAccountDropdown isAuthenticated={status === "authenticated"} />
+                </li>
+              }
+            </ul>
+          </nav>
+        </div>
+        <LiveMessage />
+      </header>
+    </>
   );
 };

--- a/components/clientComponents/globals/Header/Header.tsx
+++ b/components/clientComponents/globals/Header/Header.tsx
@@ -27,22 +27,26 @@ export const Header = ({ context = "default", className }: HeaderParams) => {
   } = useTranslation(["common", "form-builder", "admin-login"]);
 
   const isBannerEnabled = t("campaignBanner.enabled");
+  const paddingTop = isBannerEnabled ? "py-0" : "py-2";
 
   return (
     <>
-      {isBannerEnabled && (
-        <div className="bg-slate-800 text-white px-4 py-4">
-          <div className="inline-block border-2 border-gray-500 px-1 py-1 mr-4">
-            {t("campaignBanner.type")}
-          </div>
-          <div className="inline-block">
-            <Markdown options={{ forceBlock: true }}>{t("campaignBanner.message")}</Markdown>
-          </div>
-        </div>
-      )}
       <header
-        className={cn("mb-5 border-b-1 border-gray-500 bg-white px-0 py-2 relative", className)}
+        className={cn(
+          "mb-5 border-b-1 border-gray-500 bg-white px-0 " + paddingTop + " relative",
+          className
+        )}
       >
+        {isBannerEnabled && (
+          <div className="bg-slate-800 text-white px-4 py-4">
+            <div className="inline-block border-2 border-gray-500 px-1 py-1 mr-4">
+              {t("campaignBanner.type")}
+            </div>
+            <div className="inline-block">
+              <Markdown options={{ forceBlock: true }}>{t("campaignBanner.message")}</Markdown>
+            </div>
+          </div>
+        )}
         <div className="grid w-full grid-flow-col">
           <div className="flex">
             <Link

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -162,5 +162,10 @@
     "confirmation": "Confirmation message",
     "privacy": "Privacy statement"
   },
-  "exit": "Exit"
+  "exit": "Exit",
+  "campaignBanner": {
+    "enabled": true,
+    "type": "COMING SOON",
+    "message": "<strong>In August</strong>: Build multi-page forms with branching logic. <a href='/en/contact' className='text-white hover:text-white'>Subscribe for updates</a>"
+  }
 }

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -167,6 +167,6 @@
   "campaignBanner": {
     "enabled": true,
     "type": "À VENIR",
-    "message": "<strong>En août</strong> : Créez des formulaires multipages avec logique d’embranchement. <a href='/en/contact' className='text-white hover:text-white'>S’abonner aux mises à jour</a>"
+    "message": "<strong>En août</strong> : Créez des formulaires multipages avec logique d’embranchement. <a href='/fr/contact' className='text-white hover:text-white'>S’abonner aux mises à jour</a>"
   }
 }

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -163,5 +163,10 @@
     "confirmation": "Message de confirmation",
     "privacy": "Avis de confidentialité"
   },
-  "exit": "Sortie"
+  "exit": "Sortie",
+  "campaignBanner": {
+    "enabled": true,
+    "type": "À VENIR",
+    "message": "<strong>En août</strong> : Créez des formulaires multipages avec logique d’embranchement. <a href='/en/contact' className='text-white hover:text-white'>S’abonner aux mises à jour</a>"
+  }
 }


### PR DESCRIPTION
Adds a toggable banner for campaigns/alerts that can be easily customized.

Closes #3849 

To test:
-> Open app!~ Hooray.

To edit:
-> i18n/translations/en/common.json // i18n/translations/fr/common.json -> "campaignBanner".

To enable/disable.
^ as above, just swap the enabled setting.

Alert tweaks the position of the "Form Setup" right panel to accomdate.