### PR TITLE
fix: update start page name for logic view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
@@ -160,7 +160,6 @@ export const useFlowData = (lang: Language = "en") => {
 
       if (key === LockedSections.START) {
         // Ensure start label is displayed in the correct language
-        // The "name" gets set when the template is created
         label = getStartLabels()[lang];
       }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/useFlowData.tsx
@@ -7,6 +7,8 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { Group, GroupsType, NextActionRule } from "@lib/formContext";
 import { Language } from "@lib/types/form-builder-types";
 import { getReviewNode, getStartElements, getEndNode } from "@lib/utils/form-builder/i18nHelpers";
+import { getStartLabels } from "@lib/utils/form-builder/i18nHelpers";
+import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
 
 interface CustomEdge {
   id: string;
@@ -34,15 +36,6 @@ const lineStyle = {
   strokeWidth: 2,
   stroke: "#6366F1",
 };
-
-/*
-const arrowStyle = {
-  type: MarkerType.ArrowClosed,
-  width: 18,
-  height: 18,
-  color: "#6366F1",
-};
-*/
 
 const arrowStyle = {
   type: "1__type=gc-arrow-closed",
@@ -131,7 +124,7 @@ export const useFlowData = (lang: Language = "en") => {
 
     const x_pos = 0;
     const y_pos = 0;
-    let prevNodeId: string = "start";
+    let prevNodeId: string = LockedSections.START;
 
     if (!treeIndexes) {
       return { edges, nodes: [] };
@@ -144,7 +137,7 @@ export const useFlowData = (lang: Language = "en") => {
       const group: Group | undefined = formGroups && formGroups[key] ? formGroups[key] : undefined;
       let elements: TreeItem[] = [];
 
-      if (key === "start") {
+      if (key === LockedSections.START) {
         // Add "default" start elements
         // introduction, privacy
         elements = startElements;
@@ -163,11 +156,19 @@ export const useFlowData = (lang: Language = "en") => {
 
       const isOffBoardSection = treeItem.data.nextAction === "exit";
 
+      let label = treeItem.data[titleKey];
+
+      if (key === LockedSections.START) {
+        // Ensure start label is displayed in the correct language
+        // The "name" gets set when the template is created
+        label = getStartLabels()[lang];
+      }
+
       const flowNode = {
         id: key as string,
         position: { x: x_pos, y: y_pos },
         data: {
-          label: treeItem.data[titleKey],
+          label,
           children: elements,
           nextAction: treeItem.data.nextAction,
         },
@@ -177,7 +178,7 @@ export const useFlowData = (lang: Language = "en") => {
       edges.push(...(newEdges as CustomEdge[]));
       prevNodeId = key as string;
 
-      if (key === "review" || key === "end") {
+      if (key === LockedSections.REVIEW || key === LockedSections.END) {
         return;
       }
       nodes.push(flowNode);
@@ -191,7 +192,7 @@ export const useFlowData = (lang: Language = "en") => {
     nodes.push({ ...endNode });
 
     return { edges, nodes };
-  }, [treeItems, reviewNode, endNode, formGroups, startElements]);
+  }, [treeItems, reviewNode, endNode, formGroups, startElements, lang]);
 
   const { edges, nodes } = getData();
 


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where start page wasn't receiving the updated translation name.

See: https://github.com/cds-snc/platform-forms-client/issues/4018

Noting the start group is unique as it's name gets setup when the template is created given we need a place for store existing form elements.

In this case we can replace the name when we're creating nodes for the logic view.

<img width="478" alt="Screenshot 2024-07-18 at 1 09 22 PM" src="https://github.com/user-attachments/assets/a7dc98bc-9502-4d05-a5aa-192480e4790c">

<img width="450" alt="Screenshot 2024-07-18 at 1 09 08 PM" src="https://github.com/user-attachments/assets/e5163bd2-8f7b-499a-93f7-50210e5efabf">


