### PR TITLE
Fix: Profile page showing incorrect status for publishing permission

### DIFF
--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/page.tsx
@@ -28,7 +28,11 @@ export default async function Page({
 
   if (
     checkPrivilegesAsBoolean(ability, [
-      { action: "update", subject: "FormRecord", field: "isPublished" },
+      {
+        action: "update",
+        subject: { type: "FormRecord", object: { users: [{ id: session.user.id }] } },
+        field: "isPublished",
+      },
     ])
   ) {
     redirect(`/${locale}/forms`, RedirectType.replace);

--- a/app/(gcforms)/[locale]/(user authentication)/profile/page.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/profile/page.tsx
@@ -20,7 +20,11 @@ export default async function Page({ params: { locale } }: { params: { locale: s
   const { session, ability } = await authCheckAndRedirect();
 
   const hasPublishPrivilege = checkPrivilegesAsBoolean(ability, [
-    { action: "update", subject: "FormRecord", field: "isPublished" },
+    {
+      action: "update",
+      subject: { type: "FormRecord", object: { users: [{ id: session.user.id }] } },
+      field: "isPublished",
+    },
   ]);
 
   const [userQuestions, allQuestions] = await Promise.all([


### PR DESCRIPTION
# Summary | Résumé

A change in how server side permissions were checked introduced an error where a user with publishing permissions was shown to not have publishing permissions.


# Test instructions | Instructions pour tester la modification

Go to Admin and set publishing permissions to True.
Go to profile page
Permissions should show as unlocked.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
