### PR TITLE
feat: Conditional Input History - Forms-form

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -25,6 +25,7 @@ import {
   getInputHistoryValues,
 } from "@lib/utils/form-builder/groupsHistory";
 import { filterShownElements, filterValuesByShownElements } from "@lib/formContext";
+import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -348,11 +349,11 @@ export const Form = withFormik<FormProps, Responses>({
     // Needed so the Loader is displayed
     formikBag.setStatus("submitting");
     try {
-      const isGroupsCheck = formikBag.props.allowGrouping;
-      const isShowHideRules = (values.matchedIds as string[])?.length > 0;
-
+      const hasGroups =
+        formHasGroups(formikBag.props.formRecord.form) && formikBag.props.allowGrouping;
+      const hasShowHideRules = (values.matchedIds as string[])?.length > 0;
       const formValues =
-        isGroupsCheck && isShowHideRules
+        hasGroups && hasShowHideRules
           ? removeFormContextValues(getValuesForConditionalLogic())
           : removeFormContextValues(values);
 

--- a/lib/formContext.ts
+++ b/lib/formContext.ts
@@ -1,4 +1,4 @@
-import { FormElement, Responses } from "@lib/types";
+import { FormElement, Response, Responses } from "@lib/types";
 import { PublicFormRecord, ConditionalRule } from "@lib/types";
 
 export type Group = {
@@ -433,10 +433,11 @@ export const filterValuesByShownElements = (values: Responses, elementsShown: Fo
   if (!values || !Array.isArray(elementsShown)) {
     return values;
   }
-  const filteredValues: { [key: string]: string } = {};
+  const filteredValues: { [key: string]: Response } = {};
   Object.keys(values).forEach((key) => {
     if (elementsShown.find((el) => el.id === Number(key))) {
-      filteredValues[key] = String(values[key]);
+      // Note: want to keep original value type (e.g. Checkbox=Array) or Formik may get confused
+      filteredValues[key] = values[key];
     } else {
       filteredValues[key] = "";
     }


### PR DESCRIPTION
# Conditional Input History - Forms-form

Adds conditional input history to the forms-forms. 
This adda the logic from group history and show-hide to only include the data that follows a user's branching path.

**_High Risk PR as this touches forms-forms (how a user submits data)_**

## Testing

The main things to test are that nothing obvious is broken around form submissions. Also test that the correct data is submitted. See the below video for an example.

Also test that old forms work as they previously did. So a review page should not be displayed when submitting and submissions continue working as previously.

https://github.com/user-attachments/assets/9a994947-7d0f-4f20-8781-0e836c93bc0d


