### PR TITLE
fix: adds additional check / set for active group 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -316,7 +316,13 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
 
           setId(item.isFolder ? String(item.index) : String(parent?.index));
         }}
-        onExpandItem={(item) => setExpandedItems([...expandedItems, item.index])}
+        onExpandItem={(item) => {
+          if (item.index !== groupId) {
+            setId(String(item.index));
+          }
+
+          setExpandedItems([...expandedItems, item.index]);
+        }}
         onCollapseItem={(item) =>
           setExpandedItems(
             expandedItems.filter((expandedItemIndex) => expandedItemIndex !== item.index)


### PR DESCRIPTION
# Summary | Résumé

This fixes and issue where the ` onFocusItem` event does not trigger.

This adds an additional check under `onExpandItem` to ensure the correct active group is set. 


Fix: https://github.com/cds-snc/platform-forms-client/issues/4027
