### PR TITLE
feat: Add Link to Logic View in Options Modal

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/Edit.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/Edit.tsx
@@ -147,7 +147,9 @@ export const Edit = ({ formId }: { formId: string }) => {
             if (element) {
               const questionNumber = getQuestionNumber(element, elementTypes);
               const item = { ...element, index, questionNumber };
-              return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
+              return (
+                <ElementPanel elements={sortedElements} item={item} key={item.id} formId={formId} />
+              );
             }
           })}
       </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -195,7 +195,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
           sortedElements.map((element, index) => {
             const questionNumber = 0;
             const item = { ...element, index, questionNumber };
-            return <ElementPanel elements={sortedElements} item={item} key={item.id} />;
+            return <ElementPanel elements={sortedElements} item={item} key={item.id} formId={id} />;
           })}
       </div>
       {/* Confirmation*/}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
@@ -15,9 +15,11 @@ import { useHandleAdd } from "@lib/hooks/form-builder/useHandleAdd";
 export const ElementPanel = ({
   item,
   elements,
+  formId,
 }: {
   item: FormElementWithIndex;
   elements: FormElement[];
+  formId: string;
 }) => {
   const { getFocusInput, setChangeKey, setFocusInput, remove, moveUp, moveDown, duplicateElement } =
     useTemplateStore((s) => ({
@@ -107,7 +109,7 @@ export const ElementPanel = ({
         }
       }}
     >
-      <PanelBodyRoot item={item} onChangeMade={forceRefresh} />
+      <PanelBodyRoot item={item} onChangeMade={forceRefresh} formId={formId} />
       <PanelActions
         isFirstItem={item.index === 0}
         isLastItem={item.index === elements.length - 1}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalFormRules.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalFormRules.tsx
@@ -31,6 +31,7 @@ export const ModalFormRules = ({
 }) => {
   const { t } = useTranslation("form-builder");
   const formId = `form-${Date.now()}`;
+  const [showLogicDetails, setShowLogicDetails] = useState(false);
 
   const { elements, form, groupsEnabled } = useTemplateStore((s) => ({
     elements: s.form.elements,
@@ -79,10 +80,7 @@ export const ModalFormRules = ({
   };
 
   const learnMoreAboutLogicView = () => {
-    const viewLogicDetails = document.getElementById("viewLogicDetails");
-    if (viewLogicDetails) {
-      viewLogicDetails.classList.toggle("hidden");
-    }
+    setShowLogicDetails(showLogicDetails ? false : true);
   };
 
   return (
@@ -126,7 +124,10 @@ export const ModalFormRules = ({
           <Button theme={"link"} onClick={learnMoreAboutLogicView}>
             {t("logic.tryitout.button")}
           </Button>
-          <div id="viewLogicDetails" className="hidden border-x-4 border-dark-gray px-5">
+          <div
+            id="viewLogicDetails"
+            className={`border-x-4 border-dark-gray px-5 ${showLogicDetails ? "" : "hidden"}`}
+          >
             <div className="mb-4 mt-4">
               <Markdown options={{ forceBlock: true }}>{t("logic.tryitout.text")}</Markdown>
             </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalFormRules.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalFormRules.tsx
@@ -12,6 +12,8 @@ import { ConditionalSelector } from "@formBuilder/components/shared/conditionals
 import { sortByGroups, sortByLayout } from "@lib/utils/form-builder";
 import { AddOther } from "@formBuilder/components/shared/conditionals/AddOther";
 
+import Markdown from "markdown-to-jsx";
+
 export const ModalFormRules = ({
   item,
   properties,
@@ -76,6 +78,13 @@ export const ModalFormRules = ({
     updateModalProperties(item.id, { ...properties, conditionalRules: rules });
   };
 
+  const learnMoreAboutLogicView = () => {
+    const viewLogicDetails = document.getElementById("viewLogicDetails");
+    if (viewLogicDetails) {
+      viewLogicDetails.classList.toggle("hidden");
+    }
+  };
+
   return (
     <form
       onSubmit={(e: React.FormEvent<HTMLFormElement>) => e.preventDefault()}
@@ -114,9 +123,17 @@ export const ModalFormRules = ({
           <AddOther item={item} onComplete={updateModalFromBase} />
         </div>
         <div>
-          <Button theme={"link"} onClick={tryLogicView}>
-            {t("logic.tryitout")}
+          <Button theme={"link"} onClick={learnMoreAboutLogicView}>
+            {t("logic.tryitout.button")}
           </Button>
+          <div id="viewLogicDetails" className="hidden border-x-4 border-dark-gray px-5">
+            <div className="mb-4 mt-4">
+              <Markdown options={{ forceBlock: true }}>{t("logic.tryitout.text")}</Markdown>
+            </div>
+            <Button theme={"primary"} onClick={tryLogicView}>
+              {t("logic.tryitout.open")}
+            </Button>
+          </div>
         </div>
       </div>
     </form>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalFormRules.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalFormRules.tsx
@@ -18,12 +18,14 @@ export const ModalFormRules = ({
   initialChoiceRules,
   updateModalProperties,
   descriptionId,
+  tryLogicView,
 }: {
   item: FormElementWithIndex;
   properties: ModalProperties;
   initialChoiceRules: ChoiceRule[];
   updateModalProperties: (id: number, properties: ModalProperties) => void;
   descriptionId?: string;
+  tryLogicView: () => void;
 }) => {
   const { t } = useTranslation("form-builder");
   const formId = `form-${Date.now()}`;
@@ -98,7 +100,7 @@ export const ModalFormRules = ({
         })}
       </div>
       <div className="mb-6">
-        <div>
+        <div className="mb-4">
           <Button
             className="mr-4"
             onClick={() => {
@@ -110,6 +112,11 @@ export const ModalFormRules = ({
             {t("addConditionalRules.addAnotherRule")}
           </Button>
           <AddOther item={item} onComplete={updateModalFromBase} />
+        </div>
+        <div>
+          <Button theme={"link"} onClick={tryLogicView}>
+            {t("logic.tryitout")}
+          </Button>
         </div>
       </div>
     </form>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalRules.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ModalRules.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect } from "react";
 import { useTranslation } from "@i18n/client";
+import { useRouter } from "next/navigation";
 
 import { Modal, ModalButton, ModalFormRules } from "./index";
 import { FormElementWithIndex } from "@lib/types/form-builder-types";
@@ -19,17 +20,30 @@ import useModalRulesStore from "@lib/store/useModalRulesStore";
 export const ModalRules = ({
   item,
   modalRef,
+  formId,
 }: {
   item: FormElementWithIndex;
   modalRef?: React.RefObject<HTMLDivElement> | undefined;
+  formId: string;
 }) => {
-  const { elements, updateField } = useTemplateStore((s) => ({
+  const {
+    elements,
+    updateField,
+    formId: storeId,
+  } = useTemplateStore((s) => ({
     updateField: s.updateField,
     elements: s.form.elements,
+    formId: s.id,
   }));
 
+  if (storeId && storeId !== formId) {
+    formId = storeId;
+  }
+
+  const router = useRouter();
+
   const { refs } = useRefsContext();
-  const { t } = useTranslation("form-builder");
+  const { t, i18n } = useTranslation("form-builder");
   const isRichText = item.type == "richText";
   const { modals, updateModalProperties } = useModalRulesStore();
   const descriptionId = `descriptionId-${Date.now()}`;
@@ -105,6 +119,10 @@ export const ModalRules = ({
     );
   };
 
+  const handletryLogicView = () => {
+    router.push(`/${i18n.language}/form-builder/${formId}/edit/logic`);
+  };
+
   return (
     <Modal
       modalRef={modalRef}
@@ -131,6 +149,7 @@ export const ModalRules = ({
             properties={modals[item.id]}
             updateModalProperties={updateModalProperties}
             descriptionId={descriptionId}
+            tryLogicView={handletryLogicView}
           />
         </>
       )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
@@ -19,11 +19,13 @@ export const PanelBody = ({
   elIndex = -1,
   onQuestionChange,
   onRequiredChange,
+  formId,
 }: {
   item: FormElementWithIndex;
   elIndex?: number;
   onQuestionChange: (itemId: number, val: string, lang: Language) => void;
   onRequiredChange: (itemId: number, checked: boolean) => void;
+  formId: string;
 }) => {
   const { t } = useTranslation("form-builder");
   const isRichText = item.type === "richText";
@@ -46,7 +48,7 @@ export const PanelBody = ({
       {isRichText || isDynamicRow ? (
         <div className="my-4">
           <Question item={item} onQuestionChange={onQuestionChange} />
-          <SelectedElement item={item} elIndex={elIndex} />
+          <SelectedElement item={item} elIndex={elIndex} formId={formId} />
         </div>
       ) : (
         <>
@@ -62,7 +64,7 @@ export const PanelBody = ({
           <div className="mb-4 flex gap-4 text-sm">
             <div className="w-1/2">
               <QuestionDescription item={item} describedById={describedById} />
-              <SelectedElement item={item} elIndex={elIndex} />
+              <SelectedElement item={item} elIndex={elIndex} formId={formId} />
               {maxLength && (
                 <div className="disabled">
                   {t("maxCharacterLength")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBodyRoot.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBodyRoot.tsx
@@ -12,9 +12,11 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 export const PanelBodyRoot = ({
   item,
   onChangeMade,
+  formId,
 }: {
   item: FormElementWithIndex;
   onChangeMade: () => void;
+  formId: string;
 }) => {
   const { updateField, propertyPath } = useTemplateStore((s) => ({
     propertyPath: s.propertyPath,
@@ -44,6 +46,7 @@ export const PanelBodyRoot = ({
         item={item}
         onQuestionChange={onQuestionChange}
         onRequiredChange={onRequiredChange}
+        formId={formId}
       />
     </div>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBodySub.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBodySub.tsx
@@ -9,11 +9,13 @@ export const PanelBodySub = ({
   elIndex,
   onQuestionChange,
   onRequiredChange,
+  formId,
 }: {
   item: FormElementWithIndex;
   elIndex: number;
   onQuestionChange: (itemId: number, val: string, lang: Language) => void;
   onRequiredChange: (subIndex: number, val: boolean) => void;
+  formId: string;
 }) => {
   return (
     <div className="py-5">
@@ -22,6 +24,7 @@ export const PanelBodySub = ({
         item={item}
         onQuestionChange={onQuestionChange}
         onRequiredChange={onRequiredChange}
+        formId={formId}
       />
     </div>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SelectedElement.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SelectedElement.tsx
@@ -67,9 +67,11 @@ const useGetSelectedOption = (item: FormElementWithIndex): ElementOption => {
 export const SelectedElement = ({
   item,
   elIndex = -1,
+  formId,
 }: {
   item: FormElementWithIndex;
   elIndex: number;
+  formId: string;
 }) => {
   const { t } = useTranslation("form-builder");
 
@@ -99,7 +101,7 @@ export const SelectedElement = ({
         element = (
           <>
             <ShortAnswer>{t("addElementDialog.radio.title")}</ShortAnswer>
-            <Options item={item} renderIcon={() => <RadioEmptyIcon />} />
+            <Options item={item} renderIcon={() => <RadioEmptyIcon />} formId={formId} />
           </>
         );
       }
@@ -118,7 +120,7 @@ export const SelectedElement = ({
                 <span className="ml-2 text-lg">{t("addElementDialog.checkbox.title")}</span>
               </div>
             </ShortAnswer>
-            <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} />
+            <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} formId={formId} />
           </>
         );
       }
@@ -133,7 +135,7 @@ export const SelectedElement = ({
           <>
             <ShortAnswer>{t("addElementDialog.dropdown.title")}</ShortAnswer>
             {!item.properties.managedChoices && (
-              <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} />
+              <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} formId={formId} />
             )}
           </>
         );
@@ -149,7 +151,7 @@ export const SelectedElement = ({
           <>
             <ShortAnswer>{t("addElementDialog.combobox.title")}</ShortAnswer>
             {!item.properties.managedChoices && (
-              <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} />
+              <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} formId={formId} />
             )}
           </>
         );
@@ -168,10 +170,10 @@ export const SelectedElement = ({
       element = <ShortAnswer data-testid="number">0123456789</ShortAnswer>;
       break;
     case "dynamicRow":
-      element = <SubElement item={item} elIndex={item.index} />;
+      element = <SubElement item={item} elIndex={item.index} formId={formId} />;
       break;
     case "attestation":
-      element = <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} />;
+      element = <Options item={item} renderIcon={() => <CheckBoxEmptyIcon />} formId={formId} />;
       break;
     default:
       element = null;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/Options.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/Options.tsx
@@ -59,9 +59,11 @@ type RenderIcon = (index: number) => ReactElement | string | undefined;
 export const Options = ({
   item,
   renderIcon,
+  formId,
 }: {
   item: FormElementWithIndex;
   renderIcon?: RenderIcon;
+  formId: string;
 }) => {
   const { elements, translationLanguagePriority } = useTemplateStore((s) => ({
     elements: s.form.elements,
@@ -135,7 +137,7 @@ export const Options = ({
         </div>
       </div>
       <div>
-        <ModalRules modalRef={modalContainer} item={item} />
+        <ModalRules modalRef={modalContainer} item={item} formId={formId} />
       </div>
     </div>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/sub-elements/SubElement.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/sub-elements/SubElement.tsx
@@ -18,7 +18,16 @@ import { Input, LockedBadge } from "@formBuilder/components/shared";
 import { getQuestionNumber } from "@lib/utils/form-builder";
 import { useHandleAdd } from "@lib/hooks/form-builder/useHandleAdd";
 
-export const SubElement = ({ item, elIndex, ...props }: { item: FormElement; elIndex: number }) => {
+export const SubElement = ({
+  item,
+  elIndex,
+  formId,
+  ...props
+}: {
+  item: FormElement;
+  elIndex: number;
+  formId: string;
+}) => {
   const { t } = useTranslation("form-builder");
 
   const {
@@ -135,6 +144,7 @@ export const SubElement = ({ item, elIndex, ...props }: { item: FormElement; elI
                 item={item}
                 onQuestionChange={onQuestionChange}
                 onRequiredChange={onRequiredChange}
+                formId={formId}
               />
             </PanelHightLight>
           </div>

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -920,6 +920,7 @@
         "buttonLabel": "Remove"
       }
     },
+    "tryitout": "Have a complex form? Try branching instead +",
     "exitBadge": "Exit",
     "exitButtonElement": {
       "description": "Help people exiting your form have a path forward.",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -920,7 +920,11 @@
         "buttonLabel": "Remove"
       }
     },
-    "tryitout": "Have a complex form? Try branching instead +",
+    "tryitout": {
+      "button": "Have a complex form? Try branching instead +",
+      "text": "<p class='mb-4'>Use branching logic to route people filling out the form toward different pages based on their answers. This helps create an experience where people only see what’s relevant to them.</p> <p> With this feature, visualize the form flow and configure branches in the form set-up panel located on the right, within the Branching tab.</p>",
+      "open": "Open the branching set-up tab"
+    },
     "exitBadge": "Exit",
     "exitButtonElement": {
       "description": "Help people exiting your form have a path forward.",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -920,6 +920,7 @@
         "buttonLabel": "Supprimer"
       }
     },
+    "tryitout": "Vous créez un formulaire complexe? Ajoutez des embranchements +",
     "exitBadge": "Sortie",
     "exitButtonElement": {
       "description": "Aidez les personnes qui quittent votre formulaires à avoir un moyen d'aller de l'avant.",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -920,7 +920,11 @@
         "buttonLabel": "Supprimer"
       }
     },
-    "tryitout": "Vous créez un formulaire complexe? Ajoutez des embranchements +",
+    "tryitout": {
+      "button": "Vous créez un formulaire complexe? Ajoutez des embranchements +",
+      "text": "<p class='mb-4'>Utilisez la logique d’embranchements pour diriger les personnes qui remplissent le formulaire vers différentes pages en fonction de leurs réponses. Cela permet de créer une expérience où les gens ne voient que ce qui les concerne.</p> <p>Avec cette fonctionnalité, vous pouvez visualiser le flux du formulaire et configurer les embranchements dans le panneau de configuration du formulaire situé à droite, dans l’onglet Embranchements.</p>",
+      "open": "Ouvrir l’onglet pour la configuration des embranchements"
+    },
     "exitBadge": "Sortie",
     "exitButtonElement": {
       "description": "Aidez les personnes qui quittent votre formulaires à avoir un moyen d'aller de l'avant.",


### PR DESCRIPTION
Closes #3976 

Passes the formId across the application to be able to route to the logic view - so just a quick test to make sure options don't return "undefined" in the URL at the top.

To test:
-> Open or Create a form.
-> Add a question that can have options.
-> Click an option to show "add rules"
-> Click the "add rules", and then click the "Have a complex form? Try branching instead +"

Double check the form has all the stuff you had, and the URL matches. eg: "en/form-builder/0000/edit" vs "en/form-builder/undefined/edit"