### PR TITLE
fix: Updates sectionTitle to use form lang as default vs English

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SectionTitle.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SectionTitle.tsx
@@ -12,8 +12,8 @@ export const SectionTitle = ({ groupTitle, groupId }: { groupTitle: string; grou
     getLocalizationAttribute: s.getLocalizationAttribute,
     translationLanguagePriority: s.translationLanguagePriority,
   }));
-  // Defaulting to form language (vs "en") to handle case of getLocalizationAttribute returning
-  // undefined and defaulting to English. Want French when French page + French form. See #4040
+  // Defaulting to form language to handle case of getLocalizationAttribute returning undefined and
+  // defaulting to English. Instead we want e.g. French when French page + French form. See #4040
   const language = (getLocalizationAttribute()?.lang as Language) || translationLanguagePriority;
 
   const { t } = useTranslation("form-builder");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SectionTitle.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SectionTitle.tsx
@@ -12,8 +12,8 @@ export const SectionTitle = ({ groupTitle, groupId }: { groupTitle: string; grou
     getLocalizationAttribute: s.getLocalizationAttribute,
     translationLanguagePriority: s.translationLanguagePriority,
   }));
-  // Because undefined is returned for matching page vs form language, do not default to "en".
-  // Instead use the form language as the default or a French page + French form will get English.
+  // Defaulting to form language (vs "en") to handle case of getLocalizationAttribute returning
+  // undefined and defaulting to English. Want French when French page + French form. See #4040
   const language = (getLocalizationAttribute()?.lang as Language) || translationLanguagePriority;
 
   const { t } = useTranslation("form-builder");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SectionTitle.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SectionTitle.tsx
@@ -8,10 +8,13 @@ import { useTranslation } from "@i18n/client";
 import { useTreeRef } from "@formBuilder/components/shared/right-panel/treeview/provider/TreeRefProvider";
 
 export const SectionTitle = ({ groupTitle, groupId }: { groupTitle: string; groupId: string }) => {
-  const { getLocalizationAttribute } = useTemplateStore((s) => ({
+  const { getLocalizationAttribute, translationLanguagePriority } = useTemplateStore((s) => ({
     getLocalizationAttribute: s.getLocalizationAttribute,
+    translationLanguagePriority: s.translationLanguagePriority,
   }));
-  const language = getLocalizationAttribute()?.lang as Language;
+  // Because undefined is returned for matching page vs form language, do not default to "en".
+  // Instead use the form language as the default or a French page + French form will get English.
+  const language = (getLocalizationAttribute()?.lang as Language) || translationLanguagePriority;
 
   const { t } = useTranslation("form-builder");
   const { tree } = useTreeRef();
@@ -28,7 +31,7 @@ export const SectionTitle = ({ groupTitle, groupId }: { groupTitle: string; grou
   };
 
   const saveGroupTitle = (groupTitle: string) => {
-    updateGroupTitle({ id: groupId, locale: language || "en", title: groupTitle });
+    updateGroupTitle({ id: groupId, locale: language, title: groupTitle });
 
     const sectionTitleKey = `section-title-${groupId}`;
     tree?.current?.renameItem(sectionTitleKey, groupTitle);


### PR DESCRIPTION
# Summary | Résumé

The issue was when both the page language and the form language match, the language would default to English. So a user with a French page language and a French form would receive English as the language and the app would set the English field even though the French field was active.
To solve this I set the default (if page language equals form language) to the form language.

# Test

Follow the steps in #4040
