### PR TITLE
Clearer terminology around exit pages and review page

### DIFF
--- a/__fixtures__/sections-out-of-order.json
+++ b/__fixtures__/sections-out-of-order.json
@@ -305,7 +305,7 @@
     "review": {
       "name": "Review",
       "titleEn": "Review page",
-      "titleFr": "Page de révision",
+      "titleFr": "Page récapitulative",
       "autoFlow": true,
       "elements": [],
       "nextAction": "9a8c1cf4-001f-4cd2-91df-e3804e45c53a"

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -912,11 +912,11 @@
       "option": "Apply branching based on questions with selectable options"
     },
     "exit": {
-      "convertText": "Convert page",
-      "checkboxLabel": "Exit the form",
+      "convertText": "Convert to:",
+      "checkboxLabel": "Exit page",
       "nodeIconLabel": "Exit",
       "offboardNodeContent": {
-        "content": "Exit page content",
+        "content": "Exits the form",
         "exitButton": "Back to the start"
       },
       "exitPanel": {

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -158,7 +158,7 @@
   "logic": {
     "start": "Page de départ",
     "end": "Page de confirmation",
-    "review": "Page de révision",
+    "review": "Page récapitulative",
     "introduction": "Introduction du formulaire",
     "confirmation": "Message de confirmation",
     "privacy": "Avis de confidentialité"

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -912,11 +912,11 @@
       "option": "Appliquer des règles d'embranchement basé sur des questions ayant des options à sélectionner"
     },
     "exit": {
-      "convertText": "Convertir la page",
-      "checkboxLabel": "Quitter le formulaire",
+      "convertText": "Convertir en :",
+      "checkboxLabel": "Page de sortie",
       "nodeIconLabel": "Sortie",
       "offboardNodeContent": {
-        "content": "Contenu de la page de sortie",
+        "content": "Quitte le formulaire",
         "exitButton": "Retourner au départ"
       },
       "exitPanel": {


### PR DESCRIPTION
Small content tweaks to clean up the conditional logic feature to match guidance:

- In French, switching `Page de révision` to `Page récapitulative`.
- In English and French, clarifying the action of turning a page into an `Exit page`.

