### PR TITLE
Update product strings to clarify conditional logic features and align with guidance

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -118,7 +118,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
     <>
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="flex w-[800px]">
-        <h2 id="questionsTitle" tabIndex={-1}>
+        <h2 id="editPages" tabIndex={-1}>
           {t("editPages")}
         </h2>
         <div className="ml-5 mt-2">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -22,7 +22,6 @@ import { PrivacyDescriptionBefore } from "./PrivacyDescriptionBefore";
 import { PrivacyDescriptionBody } from "./PrivacyDescriptionBody";
 import { ConfirmationTitle } from "./ConfirmationTitle";
 import { SkipLinkReusable } from "@clientComponents/globals/SkipLinkReusable";
-
 import { AddPageButton } from "./AddPageButton";
 import { AddBranchingButton } from "./AddBranchingButton";
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -118,8 +118,8 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
     <>
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="flex w-[800px]">
-        <h2 id="editPages" tabIndex={-1}>
-          {t("editPages")}
+        <h2 id="editPagesHeading" tabIndex={-1}>
+          {t("editPagesHeading")}
         </h2>
         <div className="ml-5 mt-2">
           <SaveButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -119,7 +119,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="flex w-[800px]">
         <h2 id="editPagesHeading" tabIndex={-1}>
-          {t("editPagesHeading")}
+          {t("groups.editPagesHeading")}
         </h2>
         <div className="ml-5 mt-2">
           <SaveButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -120,13 +120,13 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="flex w-[800px]">
         <h2 id="questionsTitle" tabIndex={-1}>
-          {t("questions")}
+          {t("editPages")}
         </h2>
         <div className="ml-5 mt-2">
           <SaveButton />
         </div>
       </div>
-      <SkipLinkReusable anchor="#rightPanelTitle">{t("skipLink.questionsSetup")}</SkipLinkReusable>
+      <SkipLinkReusable anchor="#rightPanelTitle">{t("skipLink.pagesSetup")}</SkipLinkReusable>
       <div className="flex max-w-[800px] justify-between">
         <SectionNameInput value={groupName} groupId={groupId} updateGroupName={updateGroupName} />
         <LangSwitcher descriptionLangKey="editingIn" />
@@ -226,7 +226,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
         <AddBranchingButton id={id} locale={locale} />
       </div>
 
-      <SkipLinkReusable anchor="#rightPanelTitle">{t("skipLink.questionsSetup")}</SkipLinkReusable>
+      <SkipLinkReusable anchor="#rightPanelTitle">{t("skipLink.pagesSetup")}</SkipLinkReusable>
     </>
   );
 };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -118,7 +118,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
     <>
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="flex w-[800px]">
-        <h2 id="editPagesHeading" tabIndex={-1}>
+        <h2 id="editPagesHeading" className="whitespace-nowrap" tabIndex={-1}>
           {t("groups.editPagesHeading")}
         </h2>
         <div className="ml-5 mt-2">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -199,7 +199,7 @@ export const TranslateWithGroups = () => {
       <div className="mr-10">
         <div className="flex w-[800px]">
           <h2 id="translateTitle" tabIndex={-1}>
-            {t("translateTitle")}
+            {t("editTranslations")}
           </h2>
           <div className="ml-5 mt-2">
             <SaveButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -198,7 +198,7 @@ export const TranslateWithGroups = () => {
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="mr-10">
         <div className="flex w-[800px]">
-          <h2 id="translateTitle" tabIndex={-1}>
+          <h2 id="editTranslations" tabIndex={-1}>
             {t("editTranslations")}
           </h2>
           <div className="ml-5 mt-2">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -198,8 +198,8 @@ export const TranslateWithGroups = () => {
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="mr-10">
         <div className="flex w-[800px]">
-          <h2 id="editTranslations" tabIndex={-1}>
-            {t("editTranslations")}
+          <h2 id="editTranslationsHeading" tabIndex={-1}>
+            {t("editTranslationsHeading")}
           </h2>
           <div className="ml-5 mt-2">
             <SaveButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -199,7 +199,7 @@ export const TranslateWithGroups = () => {
       <div className="mr-10">
         <div className="flex w-[800px]">
           <h2 id="editTranslationsHeading" tabIndex={-1}>
-            {t("editTranslationsHeading")}
+            {t("groups.editTranslationsHeading")}
           </h2>
           <div className="ml-5 mt-2">
             <SaveButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -198,7 +198,7 @@ export const TranslateWithGroups = () => {
       <h1 className="sr-only">{t("edit")}</h1>
       <div className="mr-10">
         <div className="flex w-[800px]">
-          <h2 id="editTranslationsHeading" tabIndex={-1}>
+          <h2 id="editTranslationsHeading" className="whitespace-nowrap" tabIndex={-1}>
             {t("groups.editTranslationsHeading")}
           </h2>
           <div className="ml-5 mt-2">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -224,7 +224,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                       </Tab.Panel>
                       <Tab.Panel>
                         {/* Translate */}
-                        <SkipLinkReusable anchor="#translateTitle">
+                        <SkipLinkReusable anchor="#editTranslations">
                           {t("skipLink.translate")}
                         </SkipLinkReusable>
                         <div className="m-0 mt-1 w-full p-4" aria-live="polite">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -208,7 +208,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                     <Tab.Panels>
                       <Tab.Panel>
                         {/* Tree */}
-                        <SkipLinkReusable anchor="#questionsTitle">
+                        <SkipLinkReusable anchor="#pagesTitle">
                           {t("skipLink.pages")}
                         </SkipLinkReusable>
                         <div className="m-0 w-full" aria-live="polite">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -185,7 +185,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                   <Tab.Group selectedIndex={selectedIndex}>
                     <Tab.List className={"flex justify-between border-b border-gray-200"}>
                       <TabButton
-                        text={t("rightPanel.questions")}
+                        text={t("rightPanel.pages")}
                         onClick={() => {
                           router.push(`/${i18n.language}/form-builder/${id}/edit`);
                         }}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -189,7 +189,6 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                         onClick={() => {
                           router.push(`/${i18n.language}/form-builder/${id}/edit`);
                         }}
-                        className="justify-start px-6"
                       />
                       <TabButton
                         text={t("rightPanel.translation")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -224,7 +224,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                       </Tab.Panel>
                       <Tab.Panel>
                         {/* Translate */}
-                        <SkipLinkReusable anchor="#editTranslations">
+                        <SkipLinkReusable anchor="#editTranslationsHeading">
                           {t("skipLink.translate")}
                         </SkipLinkReusable>
                         <div className="m-0 mt-1 w-full p-4" aria-live="polite">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -210,7 +210,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                       <Tab.Panel>
                         {/* Tree */}
                         <SkipLinkReusable anchor="#questionsTitle">
-                          {t("skipLink.questions")}
+                          {t("skipLink.pages")}
                         </SkipLinkReusable>
                         <div className="m-0 w-full" aria-live="polite">
                           <TreeView

--- a/components/clientComponents/globals/SkipLinkReusable.tsx
+++ b/components/clientComponents/globals/SkipLinkReusable.tsx
@@ -7,7 +7,7 @@
     <span className="bg-blue">{t("linkTitle")}</span>
   </SkipLinkReusable>
  */
-export const SkipLinkReusable = ({
+export const Reusable = ({
   children,
   anchor,
 }: {

--- a/components/clientComponents/globals/SkipLinkReusable.tsx
+++ b/components/clientComponents/globals/SkipLinkReusable.tsx
@@ -7,7 +7,7 @@
     <span className="bg-blue">{t("linkTitle")}</span>
   </SkipLinkReusable>
  */
-export const Reusable = ({
+export const SkipLinkReusable = ({
   children,
   anchor,
 }: {

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1013,7 +1013,7 @@
   },
   "next": "Continue",
   "skipLink": {
-    "questions": "Skip to edit Pages",
+    "pages": "Skip to edit Pages",
     "translate": "Skip to edit Translations",
     "logic": "Skip to edit Branching",
     "pagesSetup": "Skip to Pages set-up",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -221,8 +221,8 @@
     "url": "Website address"
   },
   "autocompleteWhenNotToUse": {
-    "text1": "Auto complete attributes may not work well for information the form filler does not enter regularly. Things like historical or business information may not fill in correctly.",
-    "text2": "Usability testing is a good way to understand if the rules you set cause problems with filling in forms.",
+    "text1": "Autocomplete attributes may not work well for information the form filler does not enter regularly. Things like historical or business information may not fill in correctly.",
+    "text2": "Usability testing is a good way to understand if the parameters you set for questions cause problems while filling out forms.",
     "title": "When not to use autocomplete"
   },
   "backToForm": "Back to form",
@@ -848,10 +848,10 @@
     "failedLink": "Saving failed - Contact support"
   },
   "addConditionalRules": {
-    "modalTitle": "Add a rule to a question",
-    "modalTitleEdit": "Edit conditional rules",
-    "modalDescription": "Allow an option in your question to show an additional short or long answer input field when selected. Only drop downs, single choice, and multi-select blocks can apply a rule.",
-    "warning": "Options and questions must exist before adding a conditional rule.",
+    "modalTitle": "Add a display rule",
+    "modalTitleEdit": "Edit display rules",
+    "modalDescription": "Allow an option in your question to show an additional short or long answer input field when selected. Only radio buttons, checkboxes, and dropdowns can apply a rule.",
+    "warning": "Options and questions must exist before adding a display rule.",
     "optionTitle": "If option selected is:",
     "questionTitle": "Show question:",
     "addCustomRules": "Add a rule",
@@ -865,10 +865,10 @@
   "saved": "Saved",
   "opensInNewTab": "opens in a new tab",
   "rightPanel": {
-    "title": "Right panel",
+    "title": "Form set-up panel",
     "openPanel": "Form set-up",
     "closePanel": "Close panel",
-    "questions": "Questions",
+    "pages": "Pages",
     "logic": "Branching",
     "translation": "Translations",
     "treeView": {
@@ -877,8 +877,8 @@
     "loadTab": "Loaded {{tabPanelLabel}} editor"
   },
   "logic": {
-    "heading": "Branching",
-    "description": "Apply branching logic between form pages with questions that have radio buttons, checkboxes, or a dropdown.",
+    "heading": "Edit branching",
+    "description": "Add logic to form pages with questions that have radio buttons, checkboxes, or a dropdown.",
     "clear": "Remove",
     "gotoPage": "Go to page",
     "questionTitle": "Question:",
@@ -886,7 +886,7 @@
     "translateTitle": "Page title",
     "addRule": "Add rule",
     "saveRule": "Save",
-    "saveNote": "Adding branching turns off linear autoflow between form pages.",
+    "saveNote": "Branching turns off linear autoflow between pages.",
     "resetRules": "Reset to linear flow",
     "resetRulesHelp": "Reset help",
     "resetRulesDescription": "This will remove branching logic and reset the progression between pages to a simple linear flow, overriding any existing rules that were applied.",
@@ -957,9 +957,9 @@
     "newPage": "New page",
     "pageNameInput": "Page name",
     "addPage": "Add page",
-    "addNewPage": "Add a new page",
-    "addBranch": "Add a branch",
-    "addPagePlaceholder": "Add a page name",
+    "addNewPage": "Add new page",
+    "addBranch": "Add branch",
+    "addPagePlaceholder": "Add page name",
     "treeAriaLabel": "GC Forms pages",
     "addElement": {
       "empty": {
@@ -969,8 +969,10 @@
     },
     "pageTitle": "Page title",
     "groupDeleted": "Page deleted",
+    "editPages": "Edit page",
+    "editTranslations": "Edit translations",
     "editPage": "Edit page {{name}}",
-    "editRules": "Edit rules for page {{name}}",
+    "editRules": "Edit branching for page {{name}}",
     "groupSuccessfullyDeleted": "{{group}} successfully deleted",
     "privacy": {
       "beforeText": "<p>You’re responsible for understanding your department or agency's responsibilities related to personal information. If you’re unsure how to proceed, we recommend contacting your <a href=\"https://www.tbs-sct.canada.ca/ap/atip-aiprp/coord-eng.asp\" target=\"_blank\">access to information and privacy coordinator.</a></p>",
@@ -1011,10 +1013,10 @@
   },
   "next": "Continue",
   "skipLink": {
-    "questions": "Skip to Questions editor",
-    "translate": "Skip to Translations editor",
-    "logic": "Skip to Branching editor",
-    "questionsSetup": "Skip to Questions set-up",
+    "questions": "Skip to edit Pages",
+    "translate": "Skip to edit Translations",
+    "logic": "Skip to edit Branching",
+    "pagesSetup": "Skip to Pages set-up",
     "translateSetup": "Skip to Translations set-up",
     "logicSetup": "Skip to Branching set-up"
   },

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -949,7 +949,7 @@
     },
     "noPages": {
       "text1": "Add a <strong>New page</strong> from the",
-      "text2": "Questions tab",
+      "text2": "Pages tab",
       "text3": "before adding a branch."
     }
   },

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -891,7 +891,7 @@
     "resetRulesHelp": "Reset help",
     "resetRulesDescription": "This will remove branching logic and reset the progression between pages to a simple linear flow, overriding any existing rules that were applied.",
     "resetRulesDialog": {
-      "title": "Reset to linear flow",
+      "title": "Reset to linear flow?",
       "areYouSure": "Are you sure you want to reset the form flow?",
       "text": "This will remove all branching logic that was applied and reset the flow to a simple linear path. <strong>This action cannot be undone.</strong>",
       "reset": "Reset"
@@ -969,8 +969,8 @@
     },
     "pageTitle": "Page title",
     "groupDeleted": "Page deleted",
-    "editPages": "Edit page",
-    "editTranslations": "Edit translations",
+    "editPagesHeading": "Edit page",
+    "editTranslationsHeading": "Edit translations",
     "editPage": "Edit page {{name}}",
     "editRules": "Edit branching for page {{name}}",
     "groupSuccessfullyDeleted": "{{group}} successfully deleted",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -222,7 +222,7 @@
   },
   "autocompleteWhenNotToUse": {
     "text1": "Les attributs de remplissage automatique pourraient ne pas fonctionner correctement pour les informations que les personnes qui ne saisissent pas régulièrement. Des informations historiques ou commerciales risquent d'être erronées.",
-    "text2": "Les tests d'utilisabilité sont un bon moyen de comprendre si les règles que vous fixez posent des problèmes pour les personnes qui remplissent le formulaire.",
+    "text2": "Les tests d'utilisabilité sont un bon moyen de comprendre si les paramètres que vous fixez aux questions posent des problèmes pour les personnes qui remplissent le formulaire.",
     "title": "Quand ne pas utiliser le remplissage automatique"
   },
   "backToForm": "Retourner au formulaire",
@@ -848,10 +848,10 @@
     "failedLink": "L'enregistrement a échoué - Contacter l'équipe de soutien"
   },
   "addConditionalRules": {
-    "modalTitle": "Ajouter une règle à une question",
-    "modalTitleEdit": "Modifier les règles conditionnelles",
-    "modalDescription": "Permet à une option de votre question d'afficher un champ de saisie supplémentaire pour la réponse courte ou longue lorsqu'elle est sélectionnée. Seuls les menus déroulants, les blocs à choix unique et les blocs à sélection multiple peuvent appliquer une règle.",
-    "warning": "Des options et des questions doivent exister avant d'ajouter une règle conditionnelle.",
+    "modalTitle": "Ajouter une règle d'affichage",
+    "modalTitleEdit": "Modifier les règles d'affichage",
+    "modalDescription": "Permet à une option de votre question d'afficher un champ de saisie supplémentaire pour la réponse courte ou longue lorsqu'elle est sélectionnée. Seuls les boutons radios, les cases à cocher et les listes déroulantes permettent d'appliquer une règle.",
+    "warning": "Des options et des questions doivent exister avant d'ajouter une règle d'affichage.",
     "optionTitle": "Si l'option sélectionnée est :",
     "questionTitle": "Afficher la question :",
     "addCustomRules": "Ajouter une règle",
@@ -865,10 +865,10 @@
   "saved": "Enregistré",
   "opensInNewTab": "ouvre un nouvel onglet",
   "rightPanel": {
-    "title": "Panneau de droite",
+    "title": "Panneau de configuration du formulaire",
     "openPanel": "Configuration du formulaire",
     "closePanel": "Fermer le panneau",
-    "questions": "Questions",
+    "pages": "Pages",
     "logic": "Embranchements",
     "translation": "Traductions",
     "treeView": {
@@ -877,8 +877,8 @@
     "loadTab": "Éditeur de {{tabPanelLabel}}"
   },
   "logic": {
-    "heading": "Embranchements",
-    "description": "Appliquer de la logic d'embranchement entre les pages du formulaire ayant des questions avec des boutons radio, des cases à cocher ou une liste déroulante.",
+    "heading": "Modifier les embranchements",
+    "description": "Ajouter de la logic aux pages du formulaire ayant des questions avec des boutons radio, des cases à cocher ou une liste déroulante.",
     "clear": "Enlever",
     "gotoPage": "Aller à la page",
     "questionTitle": "Question :",
@@ -886,19 +886,19 @@
     "translateTitle": "Titre de la page",
     "addRule": "Ajouter une régle",
     "saveRule": "Enregistrer",
-    "saveNote": "Ajouter des embranchements désactive la fonction de flux linéaire automatique entre les pages du formulaire.",
-    "resetRules": "Réinitialisation au flux linéaire",
+    "saveNote": "Les embranchements désactivent l'enchaînement linéaire automatique entre les pages.",
+    "resetRules": "Réinitialiser l'enchaînement linéaire",
     "resetRulesHelp": "Aide pour la réinitialisation",
     "resetRulesDescription": "Cette fonction réinitialisera la progression entre les pages en un flux linéaire simple, remplaçant ainsi toute la logique d'embranchement qui s'applique.",
     "resetRulesDialog": {
-      "title": "Réinitialisation au flux linéaire",
+      "title": "Réinitialiser l'enchaînement linéaire?",
       "areYouSure": "Êtes-vous sûr de vouloir réinitialiser le flux du formulaire? ",
       "text": "Cela supprimera tous les embranchements qui ont été appliqués et ramènera le formulaire à une trajectoire linéaire simple. <strong>Cette action est irréversible.</strong>",
       "reset": "Réinitialiser"
     },
-    "toastSuccess": "Flux linéaire appliqué",
+    "toastSuccess": "Enchaînement linéaire appliqué",
     "multiRulesWarning": {
-      "text1": "L'ordre et le flux sont définis en fonction des règles appliquées.",
+      "text1": "L'ordre et le l'enchaînement sont définis en fonction des règles appliquées.",
       "text2": "Relier les pages :",
       "text3": "Pour relier ces pages, vous devez enlever les règles appliquées aux éléments du formulaire."
     },
@@ -932,7 +932,7 @@
     },
     "tryitout": {
       "button": "Vous créez un formulaire complexe? Ajoutez des embranchements +",
-      "text": "<p class='mb-4'>Utilisez la logique d’embranchements pour diriger les personnes qui remplissent le formulaire vers différentes pages en fonction de leurs réponses. Cela permet de créer une expérience où les gens ne voient que ce qui les concerne.</p> <p>Avec cette fonctionnalité, vous pouvez visualiser le flux du formulaire et configurer les embranchements dans le panneau de configuration du formulaire situé à droite, dans l’onglet Embranchements.</p>",
+      "text": "<p class='mb-4'>Utilisez la logique d’embranchement pour diriger les personnes qui remplissent le formulaire vers différentes pages en fonction de leurs réponses. Cela permet de créer une expérience où les gens ne voient que ce qui les concerne.</p> <p>Avec cette fonctionnalité, vous pouvez visualiser l'enchaînement du formulaire et configurer les embranchements dans le panneau de configuration du formulaire situé à droite, dans l’onglet Embranchements.</p>",
       "open": "Ouvrir l’onglet pour la configuration des embranchements"
     },
     "exitBadge": "Sortie",
@@ -970,8 +970,10 @@
     "pageTitle": "Titre de la page",
     "groupDeleted": "Page supprimée",
     "groupSuccessfullyDeleted": "{{group}} a été supprimé",
+    "editPages": "Modifier la page",
+    "editTranslations": "Modifier les traductions",
     "editPage": "Modifier la page {{name}}",
-    "editRules": "Modifier les règles de la page {{name}}",
+    "editRules": "Modifier les embranchements de la page {{name}}",
     "privacy": {
       "beforeText": "<p>C’est votre responsabilité de bien connaître les exigences de votre ministère ou organisme en matière de renseignements personnels. Si vous ne savez pas comment procéder, nous vous recommandons de contacter votre <a href=\"https://www.tbs-sct.canada.ca/ap/atip-aiprp/coord-fra.asp\" target=\"_blank\">coordinateur·rice de l'accès à l'information et de la protection de la vie privée</a>.</p>",
       "body": "<p className=\"mb-4\">Aidez les personnes qui remplissent le formulaire à comprendre comment vous traitez leurs renseignements personnels, comme énoncé à la section 4.2.10 de la <a href=\"https://www.tbs-sct.canada.ca/pol/doc-fra.aspx?id=18309\" target=\"_blank\">Directive sur les pratiques relatives à la protection de la vie privée</a>.</p><p><strong>Ce qu'il faut préciser dans un avis de confidentialité</strong></p><ul><li>Les renseignements personnels qui sont recueillis et les fins de la collecte.</li><li>Les autorisations légales ou de programmes dont vous disposez.</li><li>Les façons dont les reseignements seront utilisés, partagés, stockés et conservés.</li><li>Les droits d’accès ou de correction des renseignements personnels et les droits de déposer une plainte.</li></ul>",
@@ -1000,7 +1002,7 @@
     },
     "confirmMoveGroup": {
       "title": "Remplacer les règles?",
-      "description": " Il semble que des éléments déplacés comportent des règles conditionnelles. Souhaitez-vous remplacer ces règles par un flux automatique linéaire?",
+      "description": " Il semble que des éléments déplacés comportent des règles conditionnelles. Souhaitez-vous remplacer ces règles par un enchaînement linéaire automatique?",
       "cancel": "Non, déplacer sans modifier les règles",
       "confirm": "Oui, appliquer un flux automatique"
     }
@@ -1011,10 +1013,10 @@
   },
   "next": "Continuer",
   "skipLink": {
-    "questions": "Passer à l'éditeur de questions",
-    "translate": "Passer à l'éditeur de traductions",
-    "logic": "Passer à l'éditeur d'embranchements",
-    "questionsSetup": "Passer à la configuration des questions",
+    "questions": "Passer à modifier la page",
+    "translate": "Passer à modifier les traductions",
+    "logic": "Passer à modifier les embranchements",
+    "pagesSetup": "Passer à la configuration des pages",
     "translateSetup": "Passer à la configuration des traductions",
     "logicSetup": "Passer à la configuration d'embranchements'"
   },

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -949,7 +949,7 @@
     },
     "noPages": {
       "text1": "Ajoutez une <strong>Nouvelle page</strong> dans",
-      "text2": "l'onglet Questions",
+      "text2": "l'onglet Pages",
       "text3": "avant d'ajouter un embranchement."
     }
   },

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1013,7 +1013,7 @@
   },
   "next": "Continuer",
   "skipLink": {
-    "questions": "Passer à modifier la page",
+    "pages": "Passer à modifier la page",
     "translate": "Passer à modifier les traductions",
     "logic": "Passer à modifier les embranchements",
     "pagesSetup": "Passer à la configuration des pages",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -970,8 +970,8 @@
     "pageTitle": "Titre de la page",
     "groupDeleted": "Page supprimée",
     "groupSuccessfullyDeleted": "{{group}} a été supprimé",
-    "editPages": "Modifier la page",
-    "editTranslations": "Modifier les traductions",
+    "editPagesHeading": "Modifier la page",
+    "editTranslationsHeading": "Modifier les traductions",
     "editPage": "Modifier la page {{name}}",
     "editRules": "Modifier les embranchements de la page {{name}}",
     "privacy": {


### PR DESCRIPTION
# Content changes, including:

## Logical hierarchy (pages, questions)

- Carrying through change in terminology of "pages" throughout the app
- Having "questions" as a logical subset of "pages" instead of the reverse, to clarify the structure of objects
- Not introducing "questions" as a concept unnecessarily --> form element
- Ensuring tab menu is plural for pages, translations, branching // pages, traductions, embranchements

## Deduplicate and decipher similar concepts (rules, display logic, branching logic, right panel)

- Update the "rules" modal title to be more concise for dynamic fields
- Distinguish between question "rules" or "parameters" for questions in the "More" modal to avoid confusion
- Decipher "display rules" (hide/show based on X) and branching rules (go to page Y based on Z)
- Differentiate left edit zone from right panel configuration for non-sighted users and help non-sighted users navigate

## Refinement (autoflow, form element names)
- Change "autoflow" in French to "enchaînement linéaire [automatique]"
- Ensure consistent use of radio buttons, checkboxes and dropdowns as components rather than single-choice / multiselect/dropdown menu
- Make nav labels and buttons tighter and more concise when possible

# Link to Guidance

https://docs.google.com/document/d/1wH6v57cjAmdNV1TTf6NVwolbXGo0POgVpyDdA_Nja5s/edit