### PR TITLE
fix: Add a max width to the warning alert for logic publish

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/Publish.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/Publish.tsx
@@ -213,7 +213,7 @@ export const Publish = ({ id }: { id: string }) => {
       )}
 
       {userCanPublish && (
-        <Alert.Warning className="my-5">
+        <Alert.Warning className="my-5 max-w-4xl">
           <Alert.Title headingTag="h2">{t("logicPublishWarning.header")}</Alert.Title>
           <p className="mb-5">{t("logicPublishWarning.text")}</p>
         </Alert.Warning>


### PR DESCRIPTION
Closes #4067

To test simply open a publishable form and resize the window. It should no longer push the left hand bar off weirdly, instead only doing so when it hits mobile widths and then pushes it down as per previously.