### PR TITLE
fix: Remove the uneditable group section.

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -380,14 +380,6 @@ export const TranslateWithGroups = () => {
         {/* END PRIVACY */}
 
         <div key={"start"}>
-          {groups && (
-            <GroupSection
-              group={groups["start"]}
-              groupId={"start"}
-              primaryLanguage={primaryLanguage}
-              secondaryLanguage={secondaryLanguage}
-            />
-          )}
           {groups &&
             sortGroup({ form, group: groups["start"] }).map((element, index) => {
               return (


### PR DESCRIPTION
Closes #4028

To test:
-> Open Form, Go to Translations!~
"Start" Page Title should no longer appear, as it is not editable in the first place.