### PR TITLE
chore: Improve French content, fix typos and improve clarity of concepts

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -57,7 +57,7 @@
       "other": "Other"
     },
     "checkbox": {
-      "description": "A set of options for multiple selections.",
+      "description": "A set of options for a single or multiple selections.",
       "title": "Checkboxes",
       "chooseItems": "Question",
       "selectAllThatApply": "Select all that apply."
@@ -850,7 +850,7 @@
   "addConditionalRules": {
     "modalTitle": "Add a display rule",
     "modalTitleEdit": "Edit display rules",
-    "modalDescription": "Allow an option in your question to show an additional short or long answer input field when selected. Only radio buttons, checkboxes, and dropdowns can apply a rule.",
+    "modalDescription": "Displays a new question in response to a previously selected answer. Only questions with a choice of answers can have a rule applied.",
     "warning": "Options and questions must exist before adding a display rule.",
     "optionTitle": "If option selected is:",
     "questionTitle": "Show question:",
@@ -886,7 +886,7 @@
     "translateTitle": "Page title",
     "addRule": "Add rule",
     "saveRule": "Save",
-    "saveNote": "Branching turns off linear autoflow between pages.",
+    "saveNote": "Adding branches deactivates the linear flow that links form pages.",
     "resetRules": "Reset to linear flow",
     "resetRulesHelp": "Reset help",
     "resetRulesDescription": "This will remove branching logic and reset the progression between pages to a simple linear flow, overriding any existing rules that were applied.",
@@ -912,46 +912,46 @@
     },
     "actionsSaved": "Actions saved",
     "legend": {
-      "page": "Change how pages are ordered and connected",
-      "option": "Apply branching based on questions with selectable options"
-    },
-    "exit": {
-      "convertText": "Convert to:",
-      "checkboxLabel": "Exit page",
-      "nodeIconLabel": "Exit",
-      "offboardNodeContent": {
-        "content": "Exits the form",
-        "exitButton": "Back to the start"
-      },
-      "exitPanel": {
-        "title1": "Exit page",
-        "title2": "Ineligible to continue filling out the form",
-        "description": "Exit pages link people filling out the form back to the start of the form.",
-        "buttonLabel": "Remove"
-      }
-    },
-    "tryitout": {
-      "button": "Have a complex form? Try branching instead +",
-      "text": "<p class='mb-4'>Use branching logic to route people filling out the form toward different pages based on their answers. This helps create an experience where people only see what’s relevant to them.</p> <p> With this feature, visualize the form flow and configure branches in the form set-up panel located on the right, within the Branching tab.</p>",
-      "open": "Open the branching set-up tab"
-    },
-    "exitBadge": "Exit",
-    "exitButtonElement": {
-      "description": "Help people exiting your form have a path forward.",
-      "list": {
-        "title": "What to include in an exit page",
-        "item1": "Links to other relevant forms or web pages",
-        "item2": "Next steps in the process or guidance on form requirements",
-        "item3": "Contact information to follow up or learn more about the form"
-      },
-      "buttonDescription": "An exit button takes people to the organization website corresponding to the branding of the form.",
-      "buttonLabel": "Customize the button destination by copy-pasting a more relevant link below:"
-    },
-    "noPages": {
-      "text1": "Add a <strong>New page</strong> from the",
-      "text2": "Pages tab",
-      "text3": "before adding a branch."
+      "page": "To change how pages are ordered and connected",
+      "option": "To take a specific path depending on a selected option"
     }
+  },
+  "exit": {
+    "convertText": "Convert to:",
+    "checkboxLabel": "Exit page",
+    "nodeIconLabel": "Exit",
+    "offboardNodeContent": {
+      "content": "Exits the form",
+      "exitButton": "Back to the start"
+    },
+    "exitPanel": {
+      "title1": "Exit page",
+      "title2": "Ineligible to continue filling out the form",
+      "description": "Exit pages link people filling out the form back to the start of the form.",
+      "buttonLabel": "Remove"
+    }
+  },
+  "tryitout": {
+    "button": "Have a complex form? Try branching instead +",
+    "text": "<p class='mb-4'>Use branching logic to route people filling out the form toward different pages based on their answers. This helps create an experience where people only see what’s relevant to them.</p> <p> With this feature, visualize the form flow and configure branches in the form set-up panel located on the right, within the Branching tab.</p>",
+    "open": "Open the branching set-up tab"
+  },
+  "exitBadge": "Exit",
+  "exitButtonElement": {
+    "description": "Help people exiting your form have a path forward.",
+    "list": {
+      "title": "What to include in an exit page",
+      "item1": "Links to other relevant forms or web pages",
+      "item2": "Next steps in the process or guidance on form requirements",
+      "item3": "Contact information to follow up or learn more about the form"
+    },
+    "buttonDescription": "An exit button takes people to the organization website corresponding to the branding of the form.",
+    "buttonLabel": "Customize the button destination by copy-pasting a more relevant link below:"
+  },
+  "noPages": {
+    "text1": "Add a <strong>New page</strong> from the",
+    "text2": "Pages tab",
+    "text3": "before adding a branch."
   },
   "groups": {
     "newPage": "New page",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -57,7 +57,7 @@
       "other": "Autre"
     },
     "checkbox": {
-      "description": "Un ensemble d’option en vue de sélection multiple.",
+      "description": "Un ensemble d’options en vue de sélection unique ou multiple.",
       "title": "Cases à cocher",
       "chooseItems": "Question",
       "selectAllThatApply": "Sélectionnez toutes les options pertinentes."
@@ -163,7 +163,7 @@
     },
     "questionElement": "Éléments",
     "radio": {
-      "description": "Un petit ensemble d’option en vue de sélection unique.",
+      "description": "Un petit ensemble d’options en vue d'une sélection unique.",
       "title": "Boutons radio",
       "chooseAnOption": "Question",
       "selectOnlyOne": "Sélectionnez une option."
@@ -850,7 +850,7 @@
   "addConditionalRules": {
     "modalTitle": "Ajouter une règle d'affichage",
     "modalTitleEdit": "Modifier les règles d'affichage",
-    "modalDescription": "Permet à une option de votre question d'afficher un champ de saisie supplémentaire pour la réponse courte ou longue lorsqu'elle est sélectionnée. Seuls les boutons radios, les cases à cocher et les listes déroulantes permettent d'appliquer une règle.",
+    "modalDescription": "Permet de faire afficher une nouvelle question en réaction à une réponse précédemment choisie. Seules les questions à choix de réponses peuvent se faire appliquer une règle.",
     "warning": "Des options et des questions doivent exister avant d'ajouter une règle d'affichage.",
     "optionTitle": "Si l'option sélectionnée est :",
     "questionTitle": "Afficher la question :",
@@ -884,12 +884,12 @@
     "questionTitle": "Question :",
     "pageTitle": "Page :",
     "translateTitle": "Titre de la page",
-    "addRule": "Ajouter une régle",
+    "addRule": "Ajouter une règle",
     "saveRule": "Enregistrer",
-    "saveNote": "Les embranchements désactivent l'enchaînement linéaire automatique entre les pages.",
+    "saveNote": "L'ajout d'embranchements désactive l'enchaînement linéaire des pages du formulaire.",
     "resetRules": "Réinitialiser l'enchaînement linéaire",
     "resetRulesHelp": "Aide pour la réinitialisation",
-    "resetRulesDescription": "Cette fonction réinitialisera la progression entre les pages en un flux linéaire simple, remplaçant ainsi toute la logique d'embranchement qui s'applique.",
+    "resetRulesDescription": "Cette fonction réinitialisera la progression entre les pages en une séquence linéaire simple, remplaçant ainsi toute la logique d'embranchement qui s'applique.",
     "resetRulesDialog": {
       "title": "Réinitialiser l'enchaînement linéaire?",
       "areYouSure": "Êtes-vous sûr de vouloir réinitialiser le flux du formulaire? ",
@@ -912,8 +912,8 @@
     },
     "actionsSaved": "Actions enregistrées",
     "legend": {
-      "page": "Modifier la façon dont les pages sont ordonnées et connectées",
-      "option": "Appliquer des règles d'embranchement basé sur des questions ayant des options à sélectionner"
+      "page": "Pour modifier la façon dont les pages sont ordonnées et connectées",
+      "option": "Pour faire emprunter un chemin précis en fonction d'une réponse choisie."
     },
     "exit": {
       "convertText": "Convertir en :",
@@ -978,7 +978,7 @@
       "beforeText": "<p>C’est votre responsabilité de bien connaître les exigences de votre ministère ou organisme en matière de renseignements personnels. Si vous ne savez pas comment procéder, nous vous recommandons de contacter votre <a href=\"https://www.tbs-sct.canada.ca/ap/atip-aiprp/coord-fra.asp\" target=\"_blank\">coordinateur·rice de l'accès à l'information et de la protection de la vie privée</a>.</p>",
       "body": "<p className=\"mb-4\">Aidez les personnes qui remplissent le formulaire à comprendre comment vous traitez leurs renseignements personnels, comme énoncé à la section 4.2.10 de la <a href=\"https://www.tbs-sct.canada.ca/pol/doc-fra.aspx?id=18309\" target=\"_blank\">Directive sur les pratiques relatives à la protection de la vie privée</a>.</p><p><strong>Ce qu'il faut préciser dans un avis de confidentialité</strong></p><ul><li>Les renseignements personnels qui sont recueillis et les fins de la collecte.</li><li>Les autorisations légales ou de programmes dont vous disposez.</li><li>Les façons dont les reseignements seront utilisés, partagés, stockés et conservés.</li><li>Les droits d’accès ou de correction des renseignements personnels et les droits de déposer une plainte.</li></ul>",
       "description": "Ce qu'il faut préciser dans une déclaration de confidentialité :",
-      "summary": "Ajouter un avis de confidentialité pour expliquer comment vous traitez les renseignmenets personnels"
+      "summary": "Ajouter un avis de confidentialité pour expliquer comment vous traitez les renseignements personnels"
     },
     "confirmation": {
       "beforeText": "Le message de confirmation s’affichera sur une nouvelle page une fois le formulaire soumis.",


### PR DESCRIPTION
# Changes based on localization feedback

Elise found a few product copy issues while translating the Guidance articles.

## Documented review:
https://docs.google.com/spreadsheets/d/1bhcNoEFnvHL7k-UUAjAndIMsLqNXcQnZySlvxb1Z8T0/edit?gid=1844769255#gid=1844769255

## Includes:

- Clarifying legacy concepts
- Fixing typos
- Ensuring consistency in what is active/passive
- Making autoflow clear/concise where possible