### PR TITLE
fix: Use language property for review page label 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SelectNextAction.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SelectNextAction.tsx
@@ -80,6 +80,7 @@ export const SelectNextAction = ({
         {selectedGroupNextActions === "exit" && (
           <div className="bg-gray-50 p-3">
             <SingleActionSelect
+              lang={lang}
               key={`single-action-select-${selectedGroupId}`}
               nextAction={selectedGroupNextActions || "end"}
             />
@@ -92,6 +93,7 @@ export const SelectNextAction = ({
               <SectionName lang={lang} sectionName={sectionName} />
             </div>
             <SingleActionSelect
+              lang={lang}
               key={`single-action-select-${selectedGroupId}`}
               nextAction={selectedGroupNextActions || "end"}
             />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SingleActionSelect.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/logic/SingleActionSelect.tsx
@@ -10,6 +10,8 @@ import { useTranslation } from "@i18n/client";
 import { SaveNote } from "./SaveNote";
 import { toast } from "@formBuilder/components/shared/Toast";
 import { Checkbox } from "@formBuilder/components/shared";
+import { getReviewLabels } from "@lib/utils/form-builder/i18nHelpers";
+import { Language } from "@lib/types/form-builder-types";
 
 const ExitIcon = () => {
   return (
@@ -24,9 +26,11 @@ const ExitIcon = () => {
 
 export const SingleActionSelect = ({
   item,
+  lang,
   nextAction = "review",
 }: {
   item?: FormElement | null;
+  lang: Language;
   nextAction: string | undefined;
 }) => {
   const { flow } = useFlowRef();
@@ -40,7 +44,13 @@ export const SingleActionSelect = ({
   const formGroups: GroupsType = useTemplateStore((s) => s.form.groups) || {};
   let groupItems = Object.keys(formGroups).map((key) => {
     const item = formGroups[key];
-    return { label: item.name, value: key };
+    let label = item.name;
+
+    if (key === "review") {
+      label = getReviewLabels()[lang];
+    }
+
+    return { label, value: key };
   });
 
   // Filter out the current group


### PR DESCRIPTION
# Summary | Résumé


Updates the next action selector to use the current language for the review page label.

<img width="485" alt="Screenshot 2024-07-29 at 2 32 46 PM" src="https://github.com/user-attachments/assets/7edda6de-f892-4cf5-aaae-c847390ba7ec">

