### PR TITLE
fix: shows Review page and related for multi-group forms

### DIFF
--- a/__fixtures__/testDataWithGroups.json
+++ b/__fixtures__/testDataWithGroups.json
@@ -1,234 +1,360 @@
 {
-  "titleEn": "Test Form",
-  "titleFr": "Formulaire de test",
+  "titleEn": "show-hide-groups-test",
+  "titleFr": "[FR]show-hide-groups-test",
   "introduction": {
     "descriptionEn": "",
     "descriptionFr": ""
   },
   "privacyPolicy": {
     "descriptionEn": "Privacy statement",
-    "descriptionFr": "Avis de confidentialité"
+    "descriptionFr": "[FR]Privacy statement"
   },
   "confirmation": {
-    "descriptionEn": "",
-    "descriptionFr": "",
-    "referrerUrlEn": "https://digital.canada.ca/",
-    "referrerUrlFr": "https://numerique.canada.ca/"
+    "descriptionEn": "Confirmation message",
+    "descriptionFr": "[FR]Confirmation message",
+    "referrerUrlEn": "",
+    "referrerUrlFr": ""
   },
-  "layout": [1, 2, 3, 4, 5, 6, 8],
+  "layout": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
   "elements": [
     {
-      "id": 1,
-      "type": "textField",
+      "id": 8,
+      "type": "radio",
       "properties": {
-        "titleEn": "What is your full name?",
-        "titleFr": "Quel est votre nom complet?",
-        "placeholderEn": "I wish I knew",
-        "placeholderFr": "Je ne sais pas",
-        "descriptionEn": "This is a description",
-        "descriptionFr": "Voice une description",
-        "validation": {
-          "required": true
-        }
-      }
-    },
-    {
-      "id": 2,
-      "type": "textArea",
-      "properties": {
-        "titleEn": "What is the problem you are facing",
-        "titleFr": "Quel est le problème auquel vous êtes confronté?",
-        "placeholderEn": "Something difficult",
-        "placeholderFr": "Quelque chose difficile",
-        "descriptionEn": "Here be a description",
-        "descriptionFr": "Pour décrire, ou pas décire..",
-        "validation": {
-          "required": true
-        }
-      }
-    },
-    {
-      "id": 3,
-      "type": "richText",
-      "properties": {
-        "titleEn": "",
-        "titleFr": "",
-        "descriptionEn": "Thank you so much for your interest in the Canadian Digital Service’s Forms product. \n\r\n\r Please provide your information below so CDS can contact you about improving, updating, or digitizing a form.",
-        "descriptionFr": "Merci beaucoup de l’intérêt que vous portez au produit de Formulaire du Service Numérique Canadien. \n\r\n\r Veuillez fournir vos renseignements ci-dessous afin que le SNC puisse vous contacter pour discuter davantage l'amélioration, la mise à jour ou la numérisation d'un formulaire.",
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          }
+        ],
+        "titleEn": "P3-Q1",
+        "titleFr": "[FR]P3-Q1",
         "validation": {
           "required": false
-        }
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
       }
     },
     {
-      "id": 4,
-      "type": "dropdown",
+      "id": 9,
+      "type": "textField",
       "properties": {
-        "titleEn": "Province or territory",
-        "titleFr": "Province ou territoire",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "descriptionEn": "",
-        "descriptionFr": "",
         "choices": [
           {
             "en": "",
             "fr": ""
-          },
-          {
-            "en": "Alberta",
-            "fr": "Alberta"
-          },
-          {
-            "en": "British Columbia",
-            "fr": "Colombie-Britannique"
-          },
-          {
-            "en": "Manitoba",
-            "fr": "Manitoba"
-          },
-          {
-            "en": "New Brunswick",
-            "fr": "Nouveau-Brunswick"
-          },
-          {
-            "en": "Newfoundland and Labrador",
-            "fr": "Terre-Neuve-et-Labrador"
-          },
-          {
-            "en": "Northwest Territories",
-            "fr": "Territoires du Nord-Ouest"
-          },
-          {
-            "en": "Nova Scotia",
-            "fr": "Nouvelle-Écosse"
-          },
-          {
-            "en": "Nunavut",
-            "fr": "Nunavut"
-          },
-          {
-            "en": "Ontario",
-            "fr": "Ontario"
-          },
-          {
-            "en": "Prince Edward Island",
-            "fr": "Île-du-Prince-Édouard"
-          },
-          {
-            "en": "Quebec",
-            "fr": "Québec"
-          },
-          {
-            "en": "Saskatchewan",
-            "fr": "Saskatchewan"
-          },
-          {
-            "en": "Yukon",
-            "fr": "Yukon"
           }
         ],
+        "titleEn": "P3-Q1-A",
+        "titleFr": "[FR]P3-Q1-A",
         "validation": {
           "required": false
-        }
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "8.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P3-Q1-B",
+        "titleFr": "[FR]P3-Q1-B",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "8.1"
+          }
+        ]
       }
     },
     {
       "id": 5,
       "type": "radio",
       "properties": {
-        "titleEn": "Status",
-        "titleFr": "Statut",
-        "description": "",
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          }
+        ],
+        "titleEn": "P2-Q1",
+        "titleFr": "[FR]P2-Q1",
         "validation": {
           "required": false
         },
-        "choices": [
-          {
-            "en": "Citizen",
-            "fr": "Cityoen"
-          },
-          {
-            "en": "Permanent Resident",
-            "fr": "Permanent Resident"
-          },
-          {
-            "en": "Student",
-            "fr": "Student"
-          },
-          {
-            "en": "Visitor",
-            "fr": "Visitor"
-          },
-          {
-            "en": "Other",
-            "fr": "Autre"
-          }
-        ]
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
       }
     },
     {
       "id": 6,
-      "type": "checkbox",
+      "type": "textField",
       "properties": {
-        "titleEn": "Will the project or any of its activities involve or benefit people in English or French linguistic minority communities in Canada, in some way?",
-        "titleFr": " Le projet ou les activités connexes impliquent-ils ou s’adressent-ils d’une façon ou d’une autre aux minorités francophones et anglophones du Canada?",
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P2-Q1-A",
+        "titleFr": "[FR]P2-Q1-A",
         "validation": {
           "required": false
         },
-        "choices": [
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
           {
-            "en": "Yes",
-            "fr": "Oui"
-          },
-          {
-            "en": "No",
-            "fr": "Non"
-          },
-          {
-            "en": "Not Applicable",
-            "fr": "Non applicable"
+            "choiceId": "5.0"
           }
         ]
       }
     },
     {
-      "id": 8,
+      "id": 7,
       "type": "textField",
       "properties": {
-        "titleEn": "This Answer is empty?",
-        "titleFr": "Ce reponse est vide?",
-        "placeholderEn": "yuppers",
-        "placeholderFr": "oui",
-        "descriptionEn": "This is a description",
-        "descriptionFr": "Voice une description",
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P2-Q1-B",
+        "titleFr": "[FR]P2-Q1-B",
         "validation": {
           "required": false
-        }
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "5.1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "type": "radio",
+      "properties": {
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          }
+        ],
+        "titleEn": "P1-Q1",
+        "titleFr": "[FR]P1-Q1",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P1-Q1-A",
+        "titleFr": "[FR]P1-Q1-A",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "2.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P1-Q1-B",
+        "titleFr": "[FR]P1-Q1-B",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "2.1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "type": "radio",
+      "properties": {
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          },
+          {
+            "en": "C",
+            "fr": "[FR]C"
+          }
+        ],
+        "titleEn": "Q1",
+        "titleFr": "[FR]Q1",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
       }
     }
   ],
-  "brand": {
-    "name": "cds-snc",
-    "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
-    "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
-    "logoTitleEn": "Canadian Digital Service",
-    "logoTitleFr": "Service numérique canadien",
-    "urlEn": "https://digital.canada.ca/",
-    "urlFr": "https://numerique.canada.ca/"
-  },
   "groups": {
     "start": {
       "name": "Start",
-      "titleEn": "",
-      "titleFr": "",
-      "elements": ["1", "2", "3", "5", "6", "8"]
+      "titleEn": "Beginning",
+      "titleFr": "Beginning",
+      "autoFlow": false,
+      "elements": ["1"],
+      "nextAction": [
+        {
+          "groupId": "84b36e7b-2c6c-40be-ad22-1abd24c38019",
+          "choiceId": "1.0"
+        },
+        {
+          "groupId": "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f",
+          "choiceId": "1.1"
+        },
+        {
+          "groupId": "1231e20c-080e-4119-9774-33d829f290da",
+          "choiceId": "1.2"
+        }
+      ]
     },
-    "9d1b6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed": {
-      "name": "Group 1",
-      "titleEn": "",
-      "titleFr": "",
-      "elements": ["4"]
+    "84b36e7b-2c6c-40be-ad22-1abd24c38019": {
+      "name": "P1",
+      "titleEn": "P1",
+      "titleFr": "[FR]P1",
+      "autoFlow": false,
+      "elements": ["2", "3", "4"],
+      "nextAction": "review"
+    },
+    "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f": {
+      "name": "P2",
+      "titleEn": "P2",
+      "titleFr": "[FR]P2",
+      "autoFlow": false,
+      "elements": ["5", "6", "7"],
+      "nextAction": "review"
+    },
+    "1231e20c-080e-4119-9774-33d829f290da": {
+      "name": "P3",
+      "titleEn": "P3",
+      "titleFr": "[FR]P3",
+      "autoFlow": true,
+      "elements": ["8", "9", "10"],
+      "nextAction": "review"
+    },
+    "review": {
+      "name": "Review",
+      "titleEn": "Review",
+      "titleFr": "Review",
+      "elements": [],
+      "nextAction": "end"
+    },
+    "end": {
+      "name": "End",
+      "titleEn": "End",
+      "titleFr": "End",
+      "elements": []
     }
-  }
+  },
+  "groupsLayout": [
+    "84b36e7b-2c6c-40be-ad22-1abd24c38019",
+    "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f",
+    "1231e20c-080e-4119-9774-33d829f290da"
+  ]
 }

--- a/__fixtures__/testDataWithGroups.json
+++ b/__fixtures__/testDataWithGroups.json
@@ -1,360 +1,234 @@
 {
-  "titleEn": "show-hide-groups-test",
-  "titleFr": "[FR]show-hide-groups-test",
+  "titleEn": "Test Form",
+  "titleFr": "Formulaire de test",
   "introduction": {
     "descriptionEn": "",
     "descriptionFr": ""
   },
   "privacyPolicy": {
     "descriptionEn": "Privacy statement",
-    "descriptionFr": "[FR]Privacy statement"
+    "descriptionFr": "Avis de confidentialité"
   },
   "confirmation": {
-    "descriptionEn": "Confirmation message",
-    "descriptionFr": "[FR]Confirmation message",
-    "referrerUrlEn": "",
-    "referrerUrlFr": ""
+    "descriptionEn": "",
+    "descriptionFr": "",
+    "referrerUrlEn": "https://digital.canada.ca/",
+    "referrerUrlFr": "https://numerique.canada.ca/"
   },
-  "layout": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  "layout": [1, 2, 3, 4, 5, 6, 8],
   "elements": [
     {
-      "id": 8,
-      "type": "radio",
+      "id": 1,
+      "type": "textField",
       "properties": {
+        "titleEn": "What is your full name?",
+        "titleFr": "Quel est votre nom complet?",
+        "placeholderEn": "I wish I knew",
+        "placeholderFr": "Je ne sais pas",
+        "descriptionEn": "This is a description",
+        "descriptionFr": "Voice une description",
+        "validation": {
+          "required": true
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "textArea",
+      "properties": {
+        "titleEn": "What is the problem you are facing",
+        "titleFr": "Quel est le problème auquel vous êtes confronté?",
+        "placeholderEn": "Something difficult",
+        "placeholderFr": "Quelque chose difficile",
+        "descriptionEn": "Here be a description",
+        "descriptionFr": "Pour décrire, ou pas décire..",
+        "validation": {
+          "required": true
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "richText",
+      "properties": {
+        "titleEn": "",
+        "titleFr": "",
+        "descriptionEn": "Thank you so much for your interest in the Canadian Digital Service’s Forms product. \n\r\n\r Please provide your information below so CDS can contact you about improving, updating, or digitizing a form.",
+        "descriptionFr": "Merci beaucoup de l’intérêt que vous portez au produit de Formulaire du Service Numérique Canadien. \n\r\n\r Veuillez fournir vos renseignements ci-dessous afin que le SNC puisse vous contacter pour discuter davantage l'amélioration, la mise à jour ou la numérisation d'un formulaire.",
+        "validation": {
+          "required": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "dropdown",
+      "properties": {
+        "titleEn": "Province or territory",
+        "titleFr": "Province ou territoire",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "descriptionEn": "",
+        "descriptionFr": "",
         "choices": [
           {
-            "en": "A",
-            "fr": "[FR]A"
+            "en": "",
+            "fr": ""
           },
           {
-            "en": "B",
-            "fr": "[FR]B"
+            "en": "Alberta",
+            "fr": "Alberta"
+          },
+          {
+            "en": "British Columbia",
+            "fr": "Colombie-Britannique"
+          },
+          {
+            "en": "Manitoba",
+            "fr": "Manitoba"
+          },
+          {
+            "en": "New Brunswick",
+            "fr": "Nouveau-Brunswick"
+          },
+          {
+            "en": "Newfoundland and Labrador",
+            "fr": "Terre-Neuve-et-Labrador"
+          },
+          {
+            "en": "Northwest Territories",
+            "fr": "Territoires du Nord-Ouest"
+          },
+          {
+            "en": "Nova Scotia",
+            "fr": "Nouvelle-Écosse"
+          },
+          {
+            "en": "Nunavut",
+            "fr": "Nunavut"
+          },
+          {
+            "en": "Ontario",
+            "fr": "Ontario"
+          },
+          {
+            "en": "Prince Edward Island",
+            "fr": "Île-du-Prince-Édouard"
+          },
+          {
+            "en": "Quebec",
+            "fr": "Québec"
+          },
+          {
+            "en": "Saskatchewan",
+            "fr": "Saskatchewan"
+          },
+          {
+            "en": "Yukon",
+            "fr": "Yukon"
           }
         ],
-        "titleEn": "P3-Q1",
-        "titleFr": "[FR]P3-Q1",
         "validation": {
           "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": []
-      }
-    },
-    {
-      "id": 9,
-      "type": "textField",
-      "properties": {
-        "choices": [
-          {
-            "en": "",
-            "fr": ""
-          }
-        ],
-        "titleEn": "P3-Q1-A",
-        "titleFr": "[FR]P3-Q1-A",
-        "validation": {
-          "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": [
-          {
-            "choiceId": "8.0"
-          }
-        ]
-      }
-    },
-    {
-      "id": 10,
-      "type": "textField",
-      "properties": {
-        "choices": [
-          {
-            "en": "",
-            "fr": ""
-          }
-        ],
-        "titleEn": "P3-Q1-B",
-        "titleFr": "[FR]P3-Q1-B",
-        "validation": {
-          "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": [
-          {
-            "choiceId": "8.1"
-          }
-        ]
+        }
       }
     },
     {
       "id": 5,
       "type": "radio",
       "properties": {
-        "choices": [
-          {
-            "en": "A",
-            "fr": "[FR]A"
-          },
-          {
-            "en": "B",
-            "fr": "[FR]B"
-          }
-        ],
-        "titleEn": "P2-Q1",
-        "titleFr": "[FR]P2-Q1",
+        "titleEn": "Status",
+        "titleFr": "Statut",
+        "description": "",
         "validation": {
           "required": false
         },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": []
+        "choices": [
+          {
+            "en": "Citizen",
+            "fr": "Cityoen"
+          },
+          {
+            "en": "Permanent Resident",
+            "fr": "Permanent Resident"
+          },
+          {
+            "en": "Student",
+            "fr": "Student"
+          },
+          {
+            "en": "Visitor",
+            "fr": "Visitor"
+          },
+          {
+            "en": "Other",
+            "fr": "Autre"
+          }
+        ]
       }
     },
     {
       "id": 6,
-      "type": "textField",
+      "type": "checkbox",
       "properties": {
-        "choices": [
-          {
-            "en": "",
-            "fr": ""
-          }
-        ],
-        "titleEn": "P2-Q1-A",
-        "titleFr": "[FR]P2-Q1-A",
+        "titleEn": "Will the project or any of its activities involve or benefit people in English or French linguistic minority communities in Canada, in some way?",
+        "titleFr": " Le projet ou les activités connexes impliquent-ils ou s’adressent-ils d’une façon ou d’une autre aux minorités francophones et anglophones du Canada?",
         "validation": {
           "required": false
         },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": [
-          {
-            "choiceId": "5.0"
-          }
-        ]
-      }
-    },
-    {
-      "id": 7,
-      "type": "textField",
-      "properties": {
         "choices": [
           {
-            "en": "",
-            "fr": ""
-          }
-        ],
-        "titleEn": "P2-Q1-B",
-        "titleFr": "[FR]P2-Q1-B",
-        "validation": {
-          "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": [
-          {
-            "choiceId": "5.1"
-          }
-        ]
-      }
-    },
-    {
-      "id": 2,
-      "type": "radio",
-      "properties": {
-        "choices": [
-          {
-            "en": "A",
-            "fr": "[FR]A"
+            "en": "Yes",
+            "fr": "Oui"
           },
           {
-            "en": "B",
-            "fr": "[FR]B"
-          }
-        ],
-        "titleEn": "P1-Q1",
-        "titleFr": "[FR]P1-Q1",
-        "validation": {
-          "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": []
-      }
-    },
-    {
-      "id": 3,
-      "type": "textField",
-      "properties": {
-        "choices": [
+            "en": "No",
+            "fr": "Non"
+          },
           {
-            "en": "",
-            "fr": ""
-          }
-        ],
-        "titleEn": "P1-Q1-A",
-        "titleFr": "[FR]P1-Q1-A",
-        "validation": {
-          "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": [
-          {
-            "choiceId": "2.0"
+            "en": "Not Applicable",
+            "fr": "Non applicable"
           }
         ]
       }
     },
     {
-      "id": 4,
+      "id": 8,
       "type": "textField",
       "properties": {
-        "choices": [
-          {
-            "en": "",
-            "fr": ""
-          }
-        ],
-        "titleEn": "P1-Q1-B",
-        "titleFr": "[FR]P1-Q1-B",
+        "titleEn": "This Answer is empty?",
+        "titleFr": "Ce reponse est vide?",
+        "placeholderEn": "yuppers",
+        "placeholderFr": "oui",
+        "descriptionEn": "This is a description",
+        "descriptionFr": "Voice une description",
         "validation": {
           "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": [
-          {
-            "choiceId": "2.1"
-          }
-        ]
-      }
-    },
-    {
-      "id": 1,
-      "type": "radio",
-      "properties": {
-        "choices": [
-          {
-            "en": "A",
-            "fr": "[FR]A"
-          },
-          {
-            "en": "B",
-            "fr": "[FR]B"
-          },
-          {
-            "en": "C",
-            "fr": "[FR]C"
-          }
-        ],
-        "titleEn": "Q1",
-        "titleFr": "[FR]Q1",
-        "validation": {
-          "required": false
-        },
-        "subElements": [],
-        "descriptionEn": "",
-        "descriptionFr": "",
-        "placeholderEn": "",
-        "placeholderFr": "",
-        "conditionalRules": []
+        }
       }
     }
   ],
+  "brand": {
+    "name": "cds-snc",
+    "logoEn": "https://digital.canada.ca/img/cds/cds-lockup-ko-en.svg",
+    "logoFr": "https://numerique.canada.ca/img/cds/cds-lockup-ko-fr.svg",
+    "logoTitleEn": "Canadian Digital Service",
+    "logoTitleFr": "Service numérique canadien",
+    "urlEn": "https://digital.canada.ca/",
+    "urlFr": "https://numerique.canada.ca/"
+  },
   "groups": {
     "start": {
       "name": "Start",
-      "titleEn": "Beginning",
-      "titleFr": "Beginning",
-      "autoFlow": false,
-      "elements": ["1"],
-      "nextAction": [
-        {
-          "groupId": "84b36e7b-2c6c-40be-ad22-1abd24c38019",
-          "choiceId": "1.0"
-        },
-        {
-          "groupId": "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f",
-          "choiceId": "1.1"
-        },
-        {
-          "groupId": "1231e20c-080e-4119-9774-33d829f290da",
-          "choiceId": "1.2"
-        }
-      ]
+      "titleEn": "",
+      "titleFr": "",
+      "elements": ["1", "2", "3", "5", "6", "8"]
     },
-    "84b36e7b-2c6c-40be-ad22-1abd24c38019": {
-      "name": "P1",
-      "titleEn": "P1",
-      "titleFr": "[FR]P1",
-      "autoFlow": false,
-      "elements": ["2", "3", "4"],
-      "nextAction": "review"
-    },
-    "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f": {
-      "name": "P2",
-      "titleEn": "P2",
-      "titleFr": "[FR]P2",
-      "autoFlow": false,
-      "elements": ["5", "6", "7"],
-      "nextAction": "review"
-    },
-    "1231e20c-080e-4119-9774-33d829f290da": {
-      "name": "P3",
-      "titleEn": "P3",
-      "titleFr": "[FR]P3",
-      "autoFlow": true,
-      "elements": ["8", "9", "10"],
-      "nextAction": "review"
-    },
-    "review": {
-      "name": "Review",
-      "titleEn": "Review",
-      "titleFr": "Review",
-      "elements": [],
-      "nextAction": "end"
-    },
-    "end": {
-      "name": "End",
-      "titleEn": "End",
-      "titleFr": "End",
-      "elements": []
+    "9d1b6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed": {
+      "name": "Group 1",
+      "titleEn": "",
+      "titleFr": "",
+      "elements": ["4"]
     }
-  },
-  "groupsLayout": [
-    "84b36e7b-2c6c-40be-ad22-1abd24c38019",
-    "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f",
-    "1231e20c-080e-4119-9774-33d829f290da"
-  ]
+  }
 }

--- a/__fixtures__/testDataWithGroupsLayout.json
+++ b/__fixtures__/testDataWithGroupsLayout.json
@@ -1,0 +1,360 @@
+{
+  "titleEn": "show-hide-groups-test",
+  "titleFr": "[FR]show-hide-groups-test",
+  "introduction": {
+    "descriptionEn": "",
+    "descriptionFr": ""
+  },
+  "privacyPolicy": {
+    "descriptionEn": "Privacy statement",
+    "descriptionFr": "[FR]Privacy statement"
+  },
+  "confirmation": {
+    "descriptionEn": "Confirmation message",
+    "descriptionFr": "[FR]Confirmation message",
+    "referrerUrlEn": "",
+    "referrerUrlFr": ""
+  },
+  "layout": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  "elements": [
+    {
+      "id": 8,
+      "type": "radio",
+      "properties": {
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          }
+        ],
+        "titleEn": "P3-Q1",
+        "titleFr": "[FR]P3-Q1",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 9,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P3-Q1-A",
+        "titleFr": "[FR]P3-Q1-A",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "8.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P3-Q1-B",
+        "titleFr": "[FR]P3-Q1-B",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "8.1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "type": "radio",
+      "properties": {
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          }
+        ],
+        "titleEn": "P2-Q1",
+        "titleFr": "[FR]P2-Q1",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P2-Q1-A",
+        "titleFr": "[FR]P2-Q1-A",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "5.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P2-Q1-B",
+        "titleFr": "[FR]P2-Q1-B",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "5.1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "type": "radio",
+      "properties": {
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          }
+        ],
+        "titleEn": "P1-Q1",
+        "titleFr": "[FR]P1-Q1",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P1-Q1-A",
+        "titleFr": "[FR]P1-Q1-A",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "2.0"
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "type": "textField",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "P1-Q1-B",
+        "titleFr": "[FR]P1-Q1-B",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [
+          {
+            "choiceId": "2.1"
+          }
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "type": "radio",
+      "properties": {
+        "choices": [
+          {
+            "en": "A",
+            "fr": "[FR]A"
+          },
+          {
+            "en": "B",
+            "fr": "[FR]B"
+          },
+          {
+            "en": "C",
+            "fr": "[FR]C"
+          }
+        ],
+        "titleEn": "Q1",
+        "titleFr": "[FR]Q1",
+        "validation": {
+          "required": false
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    }
+  ],
+  "groups": {
+    "start": {
+      "name": "Start",
+      "titleEn": "Beginning",
+      "titleFr": "Beginning",
+      "autoFlow": false,
+      "elements": ["1"],
+      "nextAction": [
+        {
+          "groupId": "84b36e7b-2c6c-40be-ad22-1abd24c38019",
+          "choiceId": "1.0"
+        },
+        {
+          "groupId": "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f",
+          "choiceId": "1.1"
+        },
+        {
+          "groupId": "1231e20c-080e-4119-9774-33d829f290da",
+          "choiceId": "1.2"
+        }
+      ]
+    },
+    "84b36e7b-2c6c-40be-ad22-1abd24c38019": {
+      "name": "P1",
+      "titleEn": "P1",
+      "titleFr": "[FR]P1",
+      "autoFlow": false,
+      "elements": ["2", "3", "4"],
+      "nextAction": "review"
+    },
+    "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f": {
+      "name": "P2",
+      "titleEn": "P2",
+      "titleFr": "[FR]P2",
+      "autoFlow": false,
+      "elements": ["5", "6", "7"],
+      "nextAction": "review"
+    },
+    "1231e20c-080e-4119-9774-33d829f290da": {
+      "name": "P3",
+      "titleEn": "P3",
+      "titleFr": "[FR]P3",
+      "autoFlow": true,
+      "elements": ["8", "9", "10"],
+      "nextAction": "review"
+    },
+    "review": {
+      "name": "Review",
+      "titleEn": "Review",
+      "titleFr": "Review",
+      "elements": [],
+      "nextAction": "end"
+    },
+    "end": {
+      "name": "End",
+      "titleEn": "End",
+      "titleFr": "End",
+      "elements": []
+    }
+  },
+  "groupsLayout": [
+    "84b36e7b-2c6c-40be-ad22-1abd24c38019",
+    "6365ee9b-1caa-4a08-b53d-ecfc2a9dd08f",
+    "1231e20c-080e-4119-9774-33d829f290da"
+  ]
+}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -26,6 +26,7 @@ import { safeJSONParse } from "@lib/utils";
 import { ErrorSaving } from "@formBuilder/components/shared/ErrorSaving";
 import { toast } from "@formBuilder/components/shared";
 import { defaultForm } from "@lib/store/defaults";
+import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
 
 export const Preview = ({
   disableSubmit = true,
@@ -93,6 +94,8 @@ export const Preview = ({
   const isPastClosingDate = useIsFormClosed();
 
   const hasHydrated = useRehydrate();
+
+  const isShowReviewPage = showReviewPage(formRecord.form);
 
   if (isPastClosingDate) {
     return (
@@ -205,7 +208,9 @@ export const Preview = ({
                             fallBack={() => {
                               return (
                                 <>
-                                  {allowGrouping && <BackButton language={language} />}
+                                  {allowGrouping && isShowReviewPage && (
+                                    <BackButton language={language} />
+                                  )}
                                   <Button
                                     type="submit"
                                     id="SubmitButton"

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -20,6 +20,7 @@ import { LockedSections } from "@formBuilder/components/shared/right-panel/treev
 import { BackButton } from "@formBuilder/[id]/preview/BackButton";
 import { Language } from "@lib/types/form-builder-types";
 import { BackButtonGroup } from "../BackButtonGroup/BackButtonGroup";
+import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -149,6 +150,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
 
   const { currentGroup, groupsCheck, getGroupTitle } = useGCFormsContext();
   const isGroupsCheck = groupsCheck(props.allowGrouping);
+  const isShowReviewPage = showReviewPage(form);
   const showIntro = isGroupsCheck ? currentGroup === LockedSections.START : true;
 
   const { t } = useTranslation();
@@ -225,7 +227,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
             onSubmit={(e) => {
               e.preventDefault();
               // For groups enabled forms only allow submitting on the Review page
-              if (isGroupsCheck && currentGroup !== LockedSections.REVIEW) {
+              if (isGroupsCheck && isShowReviewPage && currentGroup !== LockedSections.REVIEW) {
                 return;
               }
               handleSubmit(e);
@@ -235,6 +237,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
             aria-live="polite"
           >
             {isGroupsCheck &&
+              isShowReviewPage &&
               currentGroup !== LockedSections.REVIEW &&
               currentGroup !== LockedSections.START && (
                 <h2 className="pb-8">{getGroupTitle(currentGroup, language as Language)}</h2>
@@ -249,21 +252,25 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               </RichText>
             )}
 
-            {isGroupsCheck && currentGroup === LockedSections.REVIEW && (
+            {isGroupsCheck && isShowReviewPage && currentGroup === LockedSections.REVIEW && (
               <Review language={language as Language} />
             )}
 
             <div className="flex">
-              {isGroupsCheck && <BackButtonGroup language={language as Language} />}
+              {isGroupsCheck && isShowReviewPage && (
+                <BackButtonGroup language={language as Language} />
+              )}
               {props.renderSubmit ? (
                 props.renderSubmit({
                   validateForm: props.validateForm,
                   fallBack: () => {
                     return (
                       <div>
-                        {isGroupsCheck && currentGroup === LockedSections.REVIEW && (
-                          <BackButton language={language as Language} />
-                        )}
+                        {isGroupsCheck &&
+                          isShowReviewPage &&
+                          currentGroup === LockedSections.REVIEW && (
+                            <BackButton language={language as Language} />
+                          )}
                         <div className="inline-block">
                           <SubmitButton
                             numberOfRequiredQuestions={numberOfRequiredQuestions}

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -12,6 +12,7 @@ import { ArrowRightNav } from "@serverComponents/icons/ArrowRightNav";
 import { Language } from "@lib/types/form-builder-types";
 
 import { getLocalizedProperty } from "@lib/utils";
+import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
 
 export const NextButton = ({
   validateForm,
@@ -40,7 +41,8 @@ export const NextButton = ({
     !currentGroup ||
     currentGroup === LockedSections.REVIEW ||
     currentGroup === LockedSections.END ||
-    !hasNextAction(currentGroup)
+    !hasNextAction(currentGroup) ||
+    !showReviewPage(formRecord.form)
   ) {
     return fallBack ? fallBack() : <></>;
   }

--- a/lib/utils/form-builder/showReviewPage.ts
+++ b/lib/utils/form-builder/showReviewPage.ts
@@ -1,0 +1,7 @@
+import { FormProperties } from "@lib/types";
+import { formHasGroups } from "./formHasGroups";
+
+export function showReviewPage(form: FormProperties) {
+  if (!formHasGroups(form)) return false;
+  return Array.isArray(form.groupsLayout) && form.groupsLayout.length > 1;
+}

--- a/lib/utils/form-builder/showReviewPage.ts
+++ b/lib/utils/form-builder/showReviewPage.ts
@@ -3,5 +3,5 @@ import { formHasGroups } from "./formHasGroups";
 
 export function showReviewPage(form: FormProperties) {
   if (!formHasGroups(form)) return false;
-  return Array.isArray(form.groupsLayout) && form.groupsLayout.length > 1;
+  return Array.isArray(form.groupsLayout) && form.groupsLayout.length > 0;
 }

--- a/lib/vitests/formHasGroups.test.ts
+++ b/lib/vitests/formHasGroups.test.ts
@@ -1,6 +1,6 @@
 import { FormProperties } from "@lib/types";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
-import validFormTemplate from "../../__fixtures__/testDataWithGroups.json";
+import validFormTemplate from "../../__fixtures__/testDataWithGroupsLayout.json";
 describe("formHasGroups function", () => {
   it("Has valid groups", () => {
     const form = validFormTemplate as FormProperties;

--- a/lib/vitests/showReviewPage.test.ts
+++ b/lib/vitests/showReviewPage.test.ts
@@ -1,6 +1,6 @@
 import { FormProperties } from "@lib/types";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import form from "../../__fixtures__/testDataWithGroups.json";
+import form from "../../__fixtures__/testDataWithGroupsLayout.json";
 
 describe("showReviewPage function", () => {
   it("Handles undefined", () => {

--- a/lib/vitests/showReviewPage.test.ts
+++ b/lib/vitests/showReviewPage.test.ts
@@ -1,0 +1,29 @@
+import { FormProperties } from "@lib/types";
+import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
+import form from "../../__fixtures__/testDataWithGroups.json";
+
+describe("showReviewPage function", () => {
+  it("Handles undefined", () => {
+    const form = undefined as unknown as FormProperties;
+    expect(showReviewPage(form)).toBe(false);
+  });
+
+  it("Handles null", () => {
+    const form = null as unknown as FormProperties;
+    expect(showReviewPage(form)).toBe(false);
+  });
+
+  it("Handles non array", () => {
+    const form = {} as FormProperties;
+    expect(showReviewPage(form)).toBe(false);
+  });
+
+  it("Handles form with empty groupsLayout", () => {
+    const emptyGroupsLayout = { groupsLayout: [] as string[] } as FormProperties;
+    expect(showReviewPage(emptyGroupsLayout)).toBe(false);
+  });
+
+  it("Handles form with Ids in groupsLayout", () => {
+    expect(showReviewPage(form as FormProperties)).toBe(true);
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

This feature/fix updates the Preview and Forms-Forms to only show a Review page if a form has multiple pages (groups).

## Test

I tested by checking there was *no* Review page on a single-page form in Preview and published in a Forms-form.
Then also checking there was a Review page on a multi-page form in Preview and published in a Forms-form.

For example:

https://github.com/user-attachments/assets/db09531a-8a24-4ee1-94a1-44a55b03c482


