### PR TITLE
chore: * Disable turbo for default dev, add turbo command for those that want.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "singleQuote": false
   },
   "scripts": {
-    "dev": "yarn prisma:dev && yarn initialize && next dev --turbo",
+    "dev": "yarn prisma:dev && yarn initialize && next dev",
+    "dev:turbo": "yarn prisma:dev && yarn initialize && next dev --turbo",
     "dev:secure": "yarn prisma:dev && yarn initialize && next dev --experimental-https",
     "build": "DATABASE_URL=postgres://postgres:chummy@localhost:5432/formsDB next build --debug",
     "start": "yarn prisma:deploy && yarn initialize && NODE_OPTIONS=\"--max-old-space-size=3584\" next start -p ${PORT:-3000}",


### PR DESCRIPTION
Just makes "dev" default not turbo, and gives a turbo option as well.

Turbo seems to cause issues with the auth module sometimes.