### PR TITLE
(fix): Update groupsLayout when deleting a group

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -212,12 +212,13 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
                   deleteGroup(String(item.index));
 
                   // When deleting a group, we need to select the previous group
-                  const pages = Object.keys(items);
-                  const itemIndex = pages.indexOf(String(item.index));
-                  const previousItem = itemIndex > 0 ? pages[itemIndex - 1] : "start";
-                  setSelectedItems([previousItem]);
-                  setExpandedItems([previousItem]);
-                  setId(previousItem);
+                  const itemsArray = Object.keys(items);
+                  const deletedItemIndex = itemsArray.indexOf(String(item.index));
+                  const previousItemId =
+                    deletedItemIndex > 0 ? itemsArray[deletedItemIndex - 1] : "start";
+                  setSelectedItems([previousItemId]);
+                  setExpandedItems([previousItemId]);
+                  setId(previousItemId);
 
                   // And update the groups layout
                   await updateGroupsLayout();

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/TreeView.tsx
@@ -210,6 +210,18 @@ const ControlledTree: ForwardRefRenderFunction<unknown, TreeDataProviderProps> =
                     });
 
                   deleteGroup(String(item.index));
+
+                  // When deleting a group, we need to select the previous group
+                  const pages = Object.keys(items);
+                  const itemIndex = pages.indexOf(String(item.index));
+                  const previousItem = itemIndex > 0 ? pages[itemIndex - 1] : "start";
+                  setSelectedItems([previousItem]);
+                  setExpandedItems([previousItem]);
+                  setId(previousItem);
+
+                  // And update the groups layout
+                  await updateGroupsLayout();
+
                   autoFlowAll();
                   setOpenConfirmDeleteDialog(false);
                   toast.success(

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/useUpdateGroupLayout.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/treeview/util/useUpdateGroupLayout.ts
@@ -11,7 +11,7 @@ export const useUpdateGroupLayout = () => {
 
   const updateGroupsLayout = async () => {
     // Add a delay to ensure the tree from previous actions updates before this is called
-    sleep(3000);
+    await sleep(2);
 
     const rootItems = environment?.current?.items.root.children as string[];
 


### PR DESCRIPTION
# Summary | Résumé

Update `groupsLayout` when deleting a group (page).

Previously, when you deleted a page, the `groupsLayout` would not update.
You would also end up in a strange view where no page was selected, so the editor view was a blank/empty page.

We have an `updateGroupsLayout()` hook that is helpful in this regard, but it relies on the layout of the Tree itself. So we have to force the Tree to update before calling it. We can do this by setting a selected/expanded item in the tree.

To achieve this, we need to:
- find the previous page (default to Start)
- `setSelected(previousPage)`
- `setExpanded(previousPage)` - actually triggers the Tree refresh
- `setId(previousPage)` - so we don't have a blank/empty page in the editor
- `updateGroupsLayout()`
