### PR TITLE
chore: add timeout to Freshdesk API call

### DIFF
--- a/lib/integration/freshdesk.ts
+++ b/lib/integration/freshdesk.ts
@@ -100,6 +100,7 @@ export const createTicket = async ({
       Authorization: "Basic " + btoa(username + ":" + password),
     },
     body: JSON.stringify(data),
+    signal: AbortSignal.timeout(5000), // 5 seconds timeout to make sure this operation is not blocking
   });
 
   if (response?.ok === false) {


### PR DESCRIPTION
# Summary | Résumé

- Added 5 seconds timeout to the Freshdesk API call. While investigating on the recent fuzzy attack we discovered that the API call to Freshdesk was missing a simple timeout. It will prevent server actions from being blocked because of an unresponsive API server.