### PR TITLE
Fix: Add Group Ordering to response download.

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -31,6 +31,7 @@ import { FormBuilderError } from "./exceptions";
 import { FormProperties } from "@lib/types";
 import { getLayoutFromGroups } from "@lib/utils/form-builder/groupedFormHelpers";
 import { allowGrouping } from "@formBuilder/components/shared/right-panel/treeview/util/allowGrouping";
+import { orderGroups } from "@lib/utils/form-builder/orderUsingGroupsLayout";
 
 export const fetchSubmissions = async ({
   formId,
@@ -95,7 +96,7 @@ const sortByLayout = ({ layout, elements }: { layout: number[]; elements: Answer
 };
 
 const sortByGroups = ({ form, elements }: { form: FormProperties; elements: Answer[] }) => {
-  const groups = form.groups || {};
+  const groups = orderGroups(form.groups, form.groupsLayout) ?? {};
   const layout = getLayoutFromGroups(form, groups);
   return sortByLayout({ layout, elements });
 };


### PR DESCRIPTION
Closes #4146

Test JSON file:
[testing-the-high-risk-pr-2024-08-06.json](https://github.com/user-attachments/files/16512709/testing-the-high-risk-pr-2024-08-06.json)

To test:
-> Import
-> Click Test Form
-> Fill it Out to an End that can Submit
-> Submit
-> Check responses tab.
-> Validate order matches. 