### PR TITLE
fix: * Add a check for legacy forms to use layout object instead.

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -219,8 +219,8 @@ export const getSubmissionsByFormat = async ({
         }
       );
       let sorted: Answer[];
-      const formGroups = fullFormTemplate.form.groups ?? [];
-      if (allowGroupsFlag && formGroups.length !== 0) {
+      const formGroups = fullFormTemplate.form.groups ?? {};
+      if (allowGroupsFlag && Object.keys(formGroups).length > 0) {
         sorted = sortByGroups({ form: fullFormTemplate.form, elements: submission });
       } else {
         sorted = sortByLayout({ layout: fullFormTemplate.form.layout, elements: submission });

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -32,6 +32,7 @@ import { FormProperties } from "@lib/types";
 import { getLayoutFromGroups } from "@lib/utils/form-builder/groupedFormHelpers";
 import { allowGrouping } from "@formBuilder/components/shared/right-panel/treeview/util/allowGrouping";
 import { orderGroups } from "@lib/utils/form-builder/orderUsingGroupsLayout";
+import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 
 export const fetchSubmissions = async ({
   formId,
@@ -219,8 +220,7 @@ export const getSubmissionsByFormat = async ({
         }
       );
       let sorted: Answer[];
-      const formGroups = fullFormTemplate.form.groups ?? {};
-      if (allowGroupsFlag && Object.keys(formGroups).length > 0) {
+      if (allowGroupsFlag && formHasGroups(fullFormTemplate.form)) {
         sorted = sortByGroups({ form: fullFormTemplate.form, elements: submission });
       } else {
         sorted = sortByLayout({ layout: fullFormTemplate.form.layout, elements: submission });

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -219,7 +219,8 @@ export const getSubmissionsByFormat = async ({
         }
       );
       let sorted: Answer[];
-      if (allowGroupsFlag) {
+      const formGroups = fullFormTemplate.form.groups ?? [];
+      if (allowGroupsFlag && formGroups.length !== 0) {
         sorted = sortByGroups({ form: fullFormTemplate.form, elements: submission });
       } else {
         sorted = sortByLayout({ layout: fullFormTemplate.form.layout, elements: submission });


### PR DESCRIPTION
Adds a check for if a form is legacy and has no groups to resort to the old layout for downloading responses.