### PR TITLE
fix: content - clarify limitations with reordering pages if branching is applied

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -907,9 +907,9 @@
     },
     "toastSuccess": "Linear flow applied",
     "multiRulesWarning": {
-      "text1": "The order and flow is set based on the rules applied.",
-      "text2": "Connecting pages:",
-      "text3": "To connect these pages, you must remove the rules applied to form elements."
+      "text1": "This page has branching applied.",
+      "text2": "Remove branching logic",
+      "text3": "To connect these pages, remove branches."
     },
     "choiceSelect": {
       "selectOption": "Select an option",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -907,9 +907,9 @@
     },
     "toastSuccess": "Enchaînement linéaire appliqué",
     "multiRulesWarning": {
-      "text1": "L'ordre et le l'enchaînement de page sont définis en fonction des règles appliquées.",
-      "text2": "Relier les pages :",
-      "text3": "Pour relier ces pages, vous devez enlever les règles appliquées aux éléments du formulaire."
+      "text1": "Cette page a des embranchements appliqués.",
+      "text2": "Enlever la logique d'embranchement",
+      "text3": "Pour relier ces pages, vous devez supprimer les branches."
     },
     "choiceSelect": {
       "selectOption": "Sélectionner une option",


### PR DESCRIPTION
## Problem to solve

Small section where we refer to rules instead of branches, text doesn't make a lot of sense:

![image](https://github.com/user-attachments/assets/d72332e9-f53b-4be3-8e02-0f94a983189b)

When clicking on the page flow icon in branching, already have branches applied to the page, get this message,

"This page has branching applied to options
Remove the branches to create a simple page to page connection"
