### PR TITLE
fix: Adds focus heading behavior for forms with pages (groups)

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/BackButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/BackButton.tsx
@@ -4,7 +4,13 @@ import { Button } from "@clientComponents/forms";
 import { Language } from "@lib/types/form-builder-types";
 
 // Must be placed withing context of the GCFormsContext.Provider
-export const BackButton = ({ language }: { language: Language }) => {
+export const BackButton = ({
+  language,
+  callback,
+}: {
+  language: Language;
+  callback?: () => void;
+}) => {
   const { t } = useTranslation("review");
   const { setGroup, previousGroup } = useGCFormsContext();
   return (
@@ -13,6 +19,7 @@ export const BackButton = ({ language }: { language: Language }) => {
       secondary={true}
       onClick={() => {
         setGroup(previousGroup);
+        callback && callback();
       }}
     >
       {t("goBack", { lng: language })}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/BackButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/BackButton.tsx
@@ -4,13 +4,7 @@ import { Button } from "@clientComponents/forms";
 import { Language } from "@lib/types/form-builder-types";
 
 // Must be placed withing context of the GCFormsContext.Provider
-export const BackButton = ({
-  language,
-  callback,
-}: {
-  language: Language;
-  callback?: () => void;
-}) => {
+export const BackButton = ({ language, onClick }: { language: Language; onClick?: () => void }) => {
   const { t } = useTranslation("review");
   const { setGroup, previousGroup } = useGCFormsContext();
   return (
@@ -19,7 +13,7 @@ export const BackButton = ({
       secondary={true}
       onClick={() => {
         setGroup(previousGroup);
-        callback && callback();
+        onClick && onClick();
       }}
     >
       {t("goBack", { lng: language })}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -43,6 +43,7 @@ export const Preview = ({
     getIsPublished: s.getIsPublished,
     getSecurityAttribute: s.getSecurityAttribute,
   }));
+  const headingRef = React.useRef<HTMLHeadingElement>(null);
 
   const formParsed = safeJSONParse<FormProperties>(getSchema());
   if (!formParsed) {
@@ -184,7 +185,7 @@ export const Preview = ({
           </div>
         ) : (
           <div className="gc-formview">
-            <h1 className="mt-4">
+            <h1 className="mt-4" ref={headingRef}>
               {formRecord.form[localizeField(LocalizedFormProperties.TITLE, language)] ||
                 t("gcFormsTest", { ns: "form-builder" })}
             </h1>
@@ -209,7 +210,12 @@ export const Preview = ({
                               return (
                                 <>
                                   {allowGrouping && isShowReviewPage && (
-                                    <BackButton language={language} />
+                                    <BackButton
+                                      language={language}
+                                      callback={() => {
+                                        headingRef.current?.scrollIntoView();
+                                      }}
+                                    />
                                   )}
                                   <Button
                                     type="submit"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -212,7 +212,7 @@ export const Preview = ({
                                   {allowGrouping && isShowReviewPage && (
                                     <BackButton
                                       language={language}
-                                      callback={() => focusElement("h2")}
+                                      onClick={() => focusElement("h2")}
                                     />
                                   )}
                                   <Button

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -27,7 +27,7 @@ import { ErrorSaving } from "@formBuilder/components/shared/ErrorSaving";
 import { toast } from "@formBuilder/components/shared";
 import { defaultForm } from "@lib/store/defaults";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { focusHeading } from "@lib/client/clientHelpers";
+import { focusElement } from "@lib/client/clientHelpers";
 
 export const Preview = ({
   disableSubmit = true,
@@ -212,7 +212,7 @@ export const Preview = ({
                                   {allowGrouping && isShowReviewPage && (
                                     <BackButton
                                       language={language}
-                                      callback={() => focusHeading("h2")}
+                                      callback={() => focusElement("h2")}
                                     />
                                   )}
                                   <Button

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -27,6 +27,7 @@ import { ErrorSaving } from "@formBuilder/components/shared/ErrorSaving";
 import { toast } from "@formBuilder/components/shared";
 import { defaultForm } from "@lib/store/defaults";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
+import { focusHeading } from "@lib/client/clientHelpers";
 
 export const Preview = ({
   disableSubmit = true,
@@ -43,7 +44,6 @@ export const Preview = ({
     getIsPublished: s.getIsPublished,
     getSecurityAttribute: s.getSecurityAttribute,
   }));
-  const headingRef = React.useRef<HTMLHeadingElement>(null);
 
   const formParsed = safeJSONParse<FormProperties>(getSchema());
   if (!formParsed) {
@@ -185,7 +185,7 @@ export const Preview = ({
           </div>
         ) : (
           <div className="gc-formview">
-            <h1 className="mt-4" ref={headingRef}>
+            <h1 className="mt-4">
               {formRecord.form[localizeField(LocalizedFormProperties.TITLE, language)] ||
                 t("gcFormsTest", { ns: "form-builder" })}
             </h1>
@@ -212,9 +212,7 @@ export const Preview = ({
                                   {allowGrouping && isShowReviewPage && (
                                     <BackButton
                                       language={language}
-                                      callback={() => {
-                                        headingRef.current?.scrollIntoView();
-                                      }}
+                                      callback={() => focusHeading("h2")}
                                     />
                                   )}
                                   <Button

--- a/components/clientComponents/forms/BackButtonGroup/BackButtonGroup.tsx
+++ b/components/clientComponents/forms/BackButtonGroup/BackButtonGroup.tsx
@@ -4,7 +4,13 @@ import { Button } from "@clientComponents/globals";
 import { LockedSections } from "@formBuilder/components/shared/right-panel/treeview/types";
 import { Language } from "@lib/types/form-builder-types";
 
-export const BackButtonGroup = ({ language }: { language: Language }) => {
+export const BackButtonGroup = ({
+  language,
+  callback,
+}: {
+  language: Language;
+  callback?: () => void;
+}) => {
   const { currentGroup, getGroupHistory, handlePreviousAction } = useGCFormsContext();
   const { t } = useTranslation("form-builder");
 
@@ -28,6 +34,7 @@ export const BackButtonGroup = ({ language }: { language: Language }) => {
         onClick={async (e) => {
           e.preventDefault();
           handlePreviousAction();
+          callback && callback();
         }}
         type="button"
         className="mr-4"

--- a/components/clientComponents/forms/BackButtonGroup/BackButtonGroup.tsx
+++ b/components/clientComponents/forms/BackButtonGroup/BackButtonGroup.tsx
@@ -6,10 +6,10 @@ import { Language } from "@lib/types/form-builder-types";
 
 export const BackButtonGroup = ({
   language,
-  callback,
+  onClick,
 }: {
   language: Language;
-  callback?: () => void;
+  onClick?: () => void;
 }) => {
   const { currentGroup, getGroupHistory, handlePreviousAction } = useGCFormsContext();
   const { t } = useTranslation("form-builder");
@@ -34,7 +34,7 @@ export const BackButtonGroup = ({
         onClick={async (e) => {
           e.preventDefault();
           handlePreviousAction();
-          callback && callback();
+          onClick && onClick();
         }}
         type="button"
         className="mr-4"

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -27,7 +27,6 @@ import {
 import { filterShownElements, filterValuesByShownElements } from "@lib/formContext";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { scrollToElement } from "@lib/client/clientHelpers";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -159,6 +158,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const isGroupsCheck = groupsCheck(props.allowGrouping);
   const isShowReviewPage = showReviewPage(form);
   const showIntro = isGroupsCheck ? currentGroup === LockedSections.START : true;
+  const groupsHeadingRef = useRef<HTMLHeadingElement>(null);
 
   const { t } = useTranslation();
 
@@ -256,7 +256,9 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               isShowReviewPage &&
               currentGroup !== LockedSections.REVIEW &&
               currentGroup !== LockedSections.START && (
-                <h2 className="pb-8">{getGroupTitle(currentGroup, language as Language)}</h2>
+                <h2 className="pb-8" tabIndex={-1} ref={groupsHeadingRef}>
+                  {getGroupTitle(currentGroup, language as Language)}
+                </h2>
               )}
 
             {children}
@@ -275,7 +277,10 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
 
             <div className="flex">
               {isGroupsCheck && isShowReviewPage && (
-                <BackButtonGroup language={language as Language} callback={scrollToElement} />
+                <BackButtonGroup
+                  language={language as Language}
+                  callback={() => groupsHeadingRef.current?.focus()}
+                />
               )}
               {props.renderSubmit ? (
                 props.renderSubmit({
@@ -288,7 +293,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
                           currentGroup === LockedSections.REVIEW && (
                             <BackButton
                               language={language as Language}
-                              callback={scrollToElement}
+                              callback={() => groupsHeadingRef.current?.focus()}
                             />
                           )}
                         <div className="inline-block">

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -279,7 +279,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               {isGroupsCheck && isShowReviewPage && (
                 <BackButtonGroup
                   language={language as Language}
-                  callback={() => groupsHeadingRef.current?.focus()}
+                  onClick={() => groupsHeadingRef.current?.focus()}
                 />
               )}
               {props.renderSubmit ? (
@@ -293,7 +293,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
                           currentGroup === LockedSections.REVIEW && (
                             <BackButton
                               language={language as Language}
-                              callback={() => groupsHeadingRef.current?.focus()}
+                              onClick={() => groupsHeadingRef.current?.focus()}
                             />
                           )}
                         <div className="inline-block">

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -27,6 +27,7 @@ import {
 import { filterShownElements, filterValuesByShownElements } from "@lib/formContext";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
+import { scrollToElement } from "@lib/client/clientHelpers";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -274,7 +275,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
 
             <div className="flex">
               {isGroupsCheck && isShowReviewPage && (
-                <BackButtonGroup language={language as Language} />
+                <BackButtonGroup language={language as Language} callback={scrollToElement} />
               )}
               {props.renderSubmit ? (
                 props.renderSubmit({
@@ -285,7 +286,10 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
                         {isGroupsCheck &&
                           isShowReviewPage &&
                           currentGroup === LockedSections.REVIEW && (
-                            <BackButton language={language as Language} />
+                            <BackButton
+                              language={language as Language}
+                              callback={scrollToElement}
+                            />
                           )}
                         <div className="inline-block">
                           <SubmitButton

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -13,7 +13,7 @@ import { Language } from "@lib/types/form-builder-types";
 
 import { getLocalizedProperty } from "@lib/utils";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { scrollToElement } from "@lib/client/clientHelpers";
+import { focusHeading } from "@lib/client/clientHelpers";
 
 export const NextButton = ({
   validateForm,
@@ -91,7 +91,7 @@ export const NextButton = ({
           e.preventDefault();
           if (await handleValidation()) {
             handleNextAction();
-            scrollToElement();
+            focusHeading("h2");
           }
         }}
         type="button"

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -13,7 +13,7 @@ import { Language } from "@lib/types/form-builder-types";
 
 import { getLocalizedProperty } from "@lib/utils";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { focusHeading } from "@lib/client/clientHelpers";
+import { focusElement } from "@lib/client/clientHelpers";
 
 export const NextButton = ({
   validateForm,
@@ -91,7 +91,7 @@ export const NextButton = ({
           e.preventDefault();
           if (await handleValidation()) {
             handleNextAction();
-            focusHeading("h2");
+            focusElement("h2");
           }
         }}
         type="button"

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -13,6 +13,7 @@ import { Language } from "@lib/types/form-builder-types";
 
 import { getLocalizedProperty } from "@lib/utils";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
+import { scrollToElement } from "@lib/client/clientHelpers";
 
 export const NextButton = ({
   validateForm,
@@ -90,6 +91,7 @@ export const NextButton = ({
           e.preventDefault();
           if (await handleValidation()) {
             handleNextAction();
+            scrollToElement();
           }
         }}
         type="button"

--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -14,7 +14,7 @@ import {
   getElementIdsAsNumber,
   Group,
 } from "@lib/formContext";
-import { randomId } from "@lib/client/clientHelpers";
+import { randomId, scrollToElement } from "@lib/client/clientHelpers";
 
 type ReviewItem = {
   id: string;
@@ -246,6 +246,7 @@ const EditButton = ({
       onClick={() => {
         setGroup(reviewItem.id);
         clearHistoryAfterId(reviewItem.id);
+        scrollToElement();
       }}
     >
       {children}

--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -14,7 +14,7 @@ import {
   getElementIdsAsNumber,
   Group,
 } from "@lib/formContext";
-import { randomId, scrollToElement } from "@lib/client/clientHelpers";
+import { randomId } from "@lib/client/clientHelpers";
 
 type ReviewItem = {
   id: string;
@@ -109,8 +109,9 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
   const { groups, getValues, formRecord, getGroupHistory, getGroupTitle, matchedIds } =
     useGCFormsContext();
 
-  const headingRef = useRef(null);
-  useFocusIt({ elRef: headingRef });
+  const groupsHeadingRef = useRef<HTMLHeadingElement>(null);
+  // Focus heading on load
+  useFocusIt({ elRef: groupsHeadingRef });
 
   const reviewItems: ReviewItem[] = useMemo(() => {
     const formValues: void | FormValues = getValues();
@@ -146,7 +147,9 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
 
   return (
     <>
-      <h2 ref={headingRef}>{t("reviewForm", { lng: language })}</h2>
+      <h2 ref={groupsHeadingRef} tabIndex={-1}>
+        {t("reviewForm", { lng: language })}
+      </h2>
       <div className="my-16">
         {Array.isArray(reviewItems) &&
           reviewItems.map((reviewItem) => {
@@ -159,14 +162,26 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
                 className="mb-10 rounded-lg border-2 border-slate-400 px-6 py-4"
               >
                 <h3 className="text-slate-700">
-                  <EditButton reviewItem={reviewItem} theme="link">
+                  <EditButton
+                    reviewItem={reviewItem}
+                    theme="link"
+                    callback={() => {
+                      groupsHeadingRef.current?.focus();
+                    }}
+                  >
                     {title}
                   </EditButton>
                 </h3>
                 <div className="mb-10 ml-1">
                   <QuestionsAnswersList reviewItem={reviewItem} />
                 </div>
-                <EditButton reviewItem={reviewItem} theme="secondary">
+                <EditButton
+                  reviewItem={reviewItem}
+                  theme="secondary"
+                  callback={() => {
+                    groupsHeadingRef.current?.focus();
+                  }}
+                >
                   {t("edit", { lng: language })}
                 </EditButton>
               </div>
@@ -233,10 +248,12 @@ const EditButton = ({
   reviewItem,
   theme,
   children,
+  callback,
 }: {
   reviewItem: ReviewItem;
   theme: Theme;
   children: React.ReactElement | string;
+  callback?: () => void;
 }): React.ReactElement => {
   const { setGroup, clearHistoryAfterId } = useGCFormsContext();
   return (
@@ -246,7 +263,8 @@ const EditButton = ({
       onClick={() => {
         setGroup(reviewItem.id);
         clearHistoryAfterId(reviewItem.id);
-        scrollToElement();
+        // Focus groups heading on navigation
+        callback && callback();
       }}
     >
       {children}

--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -165,7 +165,7 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
                   <EditButton
                     reviewItem={reviewItem}
                     theme="link"
-                    callback={() => {
+                    onClick={() => {
                       groupsHeadingRef.current?.focus();
                     }}
                   >
@@ -178,7 +178,7 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
                 <EditButton
                   reviewItem={reviewItem}
                   theme="secondary"
-                  callback={() => {
+                  onClick={() => {
                     groupsHeadingRef.current?.focus();
                   }}
                 >
@@ -248,12 +248,12 @@ const EditButton = ({
   reviewItem,
   theme,
   children,
-  callback,
+  onClick,
 }: {
   reviewItem: ReviewItem;
   theme: Theme;
   children: React.ReactElement | string;
-  callback?: () => void;
+  onClick?: () => void;
 }): React.ReactElement => {
   const { setGroup, clearHistoryAfterId } = useGCFormsContext();
   return (
@@ -264,7 +264,7 @@ const EditButton = ({
         setGroup(reviewItem.id);
         clearHistoryAfterId(reviewItem.id);
         // Focus groups heading on navigation
-        callback && callback();
+        onClick && onClick();
       }}
     >
       {children}

--- a/lib/client/clientHelpers.ts
+++ b/lib/client/clientHelpers.ts
@@ -21,6 +21,18 @@ export const scrollToBottom = (containerEl: HTMLElement) => {
 };
 
 /**
+ * Allows scrolling to an element without having access to the element (ref) itself when called.
+ * @param elementName element name to scroll to. Defaults to H1
+ * @returns undefined
+ */
+export const scrollToElement = (elementName = "H1") => {
+  const NEXT_TICK = 0;
+  setTimeout(() => {
+    document.getElementsByTagName(elementName)?.[0].scrollIntoView();
+  }, NEXT_TICK);
+};
+
+/**
  * Like a UUID but smaller and not as unique. So best to append this to the element name.
  * e.g. id = `myElementName-${randomId()}`
  *

--- a/lib/client/clientHelpers.ts
+++ b/lib/client/clientHelpers.ts
@@ -21,14 +21,17 @@ export const scrollToBottom = (containerEl: HTMLElement) => {
 };
 
 /**
- * Allows scrolling to an element without having access to the element (ref) itself when called.
- * @param elementName element name to scroll to. Defaults to H1
+ * Focusses and announces to AT a element. Use this when there is no access to a element (ref)
+ * from the caller. For example see NextButton.tsx in the Form wrapper that has no access to the
+ * Form groups heading.
+ * Use as a last resort. Prefer using a react ref over this when possible.
+ * @param elementName element name to scroll to. Defaults to H1 (element must have a tabIndex)
  * @returns undefined
  */
-export const scrollToElement = (elementName = "H1") => {
+export const focusHeading = (elementName = "H1") => {
   const NEXT_TICK = 0;
   setTimeout(() => {
-    document.getElementsByTagName(elementName)?.[0].scrollIntoView();
+    (document.getElementsByTagName(elementName)?.[0] as HTMLElement)?.focus();
   }, NEXT_TICK);
 };
 

--- a/lib/client/clientHelpers.ts
+++ b/lib/client/clientHelpers.ts
@@ -21,17 +21,18 @@ export const scrollToBottom = (containerEl: HTMLElement) => {
 };
 
 /**
- * Focusses and announces to AT a element. Use this when there is no access to a element (ref)
- * from the caller. For example see NextButton.tsx in the Form wrapper that has no access to the
- * Form groups heading.
- * Use as a last resort. Prefer using a react ref over this when possible.
- * @param elementName element name to scroll to. Defaults to H1 (element must have a tabIndex)
+ * When a function does not have access to an element (ref), use the DOM to get an element and
+ * after the next tick (after the current event loop), focus the element. This moves the page to
+ * the element location and announces the text in the element to AT. Use a react ref over this to
+ * get and focus an element when possible.
+ * @param elementSelector selector to get the DOM element (first one found). Defaults to H1. Must
+ * have a tabIndex.
  * @returns undefined
  */
-export const focusHeading = (elementName = "H1") => {
+export const focusElement = (elementSelector = "H1") => {
   const NEXT_TICK = 0;
   setTimeout(() => {
-    (document.getElementsByTagName(elementName)?.[0] as HTMLElement)?.focus();
+    (document.querySelector(elementSelector) as HTMLElement)?.focus();
   }, NEXT_TICK);
 };
 


### PR DESCRIPTION
# Summary | Résumé

Adds focus header behavior for forms with lengthy pages. Focussing the group header (H2) navigates the page to the top and also announces the change (heading title) for AT users.

## Test

Create a form with a few pages that have a lot of form elements. I found adding a few address component sets helpful for this. Then try navigating back and forth through the form. For each page navigation, the focus should start at the top of the form.
