### PR TITLE
chore: Translate dynamic row props

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
@@ -121,7 +121,7 @@ export const TranslateCustomizeSet = ({
             <textarea
               className="size-full p-4 focus:outline-blue-focus"
               id={`remove-button-text-french-${element.id}`}
-              aria-describedby={`remove-button-text-english-${element.id}`}
+              aria-describedby={`remove-button-text-english-desc-${element.id}`}
               value={removeButtonEnValue}
               onChange={(e) => {
                 updateField(
@@ -144,7 +144,7 @@ export const TranslateCustomizeSet = ({
             <textarea
               className="size-full p-4 focus:outline-blue-focus"
               id={`remove-button-text-french-${element.id}`}
-              aria-describedby={`remove-button-text-french-${element.id}`}
+              aria-describedby={`remove-button-text-french-desc-${element.id}`}
               value={removeButtonFrValue}
               onChange={(e) => {
                 updateField(

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
@@ -1,0 +1,141 @@
+import { Language } from "@lib/types/form-builder-types";
+import { FieldsetLegend } from ".";
+import { LanguageLabel } from "./LanguageLabel";
+import { useTranslation } from "@i18n/client";
+import { useTemplateStore } from "@lib/store/useTemplateStore";
+import { FormElement } from "@lib/types";
+
+export const TranslateCustomizeSet = ({
+  element,
+  primaryLanguage,
+  secondaryLanguage,
+}: {
+  element: FormElement;
+  primaryLanguage: Language;
+  secondaryLanguage: Language;
+}) => {
+  const { t } = useTranslation("form-builder");
+
+  const { updateField, localizeField, propertyPath } = useTemplateStore((s) => ({
+    updateField: s.updateField,
+    localizeField: s.localizeField,
+    propertyPath: s.propertyPath,
+  }));
+
+  const dynamicRowProps = element.properties.dynamicRow;
+
+  if (!dynamicRowProps) {
+    return null;
+  }
+
+  // Add button
+  const addButtonText = "addButtonText";
+
+  const addButtonPropEn = localizeField(addButtonText, primaryLanguage);
+  const addButtonEnValue = dynamicRowProps[addButtonPropEn];
+  const addButtonPropFr = localizeField(addButtonText, secondaryLanguage);
+  const addButtonFrValue = dynamicRowProps[addButtonPropFr];
+
+  // Remove button
+  const removeButtonText = "removeButtonText";
+
+  const removeButtonPropEn = localizeField(removeButtonText, primaryLanguage);
+  const removeButtonEnValue = dynamicRowProps[removeButtonPropEn];
+  const removeButtonPropFr = localizeField(removeButtonText, secondaryLanguage);
+  const removeButtonFrValue = dynamicRowProps[removeButtonPropFr];
+
+  return (
+    <>
+      {/* Start add button inputs */}
+      <fieldset>
+        <FieldsetLegend>
+          {t("dynamicRow.translate.repeatingSet")} {":"} {t("dynamicRow.translate.addButtonText")}
+        </FieldsetLegend>
+        {/* English */}
+        <div className="mb-10 flex gap-px divide-x-2 border border-gray-300" key={primaryLanguage}>
+          <div className="relative w-1/2 flex-1">
+            <LanguageLabel id="add-button-text-english" lang={primaryLanguage}>
+              <>{primaryLanguage}</>
+            </LanguageLabel>
+            <textarea
+              className="size-full p-4 focus:outline-blue-focus"
+              id="add-button-text-english-input"
+              aria-describedby="add-button-text-english"
+              value={addButtonEnValue}
+              onChange={(e) => {
+                updateField(
+                  propertyPath(element.id, `dynamicRow.${addButtonText}`, primaryLanguage),
+                  e.target.value
+                );
+              }}
+            />
+          </div>
+          {/* French */}
+          <div className="relative w-1/2 flex-1">
+            <LanguageLabel id="add-button-text-french" lang={secondaryLanguage}>
+              <>{secondaryLanguage}</>
+            </LanguageLabel>
+            <textarea
+              className="size-full p-4 focus:outline-blue-focus"
+              id="add-button-text-french-input"
+              aria-describedby="add-button-text-french"
+              value={addButtonFrValue}
+              onChange={(e) => {
+                updateField(
+                  propertyPath(element.id, `dynamicRow.${addButtonText}`, secondaryLanguage),
+                  e.target.value
+                );
+              }}
+            />
+          </div>
+        </div>
+      </fieldset>
+      {/* End add button inputs */}
+
+      {/* Start remove button inputs */}
+      <fieldset>
+        <FieldsetLegend>
+          {t("dynamicRow.translate.repeatingSet")} {":"}{" "}
+          {t("dynamicRow.translate.removeButtonText")}
+        </FieldsetLegend>
+        <div className="mb-10 flex gap-px divide-x-2 border border-gray-300" key={primaryLanguage}>
+          <div className="relative w-1/2 flex-1">
+            <LanguageLabel id="remove-button-text-english" lang={primaryLanguage}>
+              <>{primaryLanguage}</>
+            </LanguageLabel>
+            <textarea
+              className="size-full p-4 focus:outline-blue-focus"
+              id="remove-button-text-french-input"
+              aria-describedby="remove-button-text-english"
+              value={removeButtonEnValue}
+              onChange={(e) => {
+                updateField(
+                  propertyPath(element.id, `dynamicRow.${removeButtonText}`, primaryLanguage),
+                  e.target.value
+                );
+              }}
+            />
+          </div>
+          <div className="relative w-1/2 flex-1">
+            <LanguageLabel id="remove-button-text-french" lang={secondaryLanguage}>
+              <>{secondaryLanguage}</>
+            </LanguageLabel>
+            <textarea
+              className="size-full p-4 focus:outline-blue-focus"
+              id="remove-button-text-french-input"
+              aria-describedby="remove-button-text-french"
+              value={removeButtonFrValue}
+              onChange={(e) => {
+                updateField(
+                  propertyPath(element.id, `dynamicRow.${removeButtonText}`, secondaryLanguage),
+                  e.target.value
+                );
+              }}
+            />
+          </div>
+        </div>
+      </fieldset>
+      {/* End remove button inputs */}
+    </>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
@@ -75,13 +75,19 @@ export const TranslateCustomizeSet = ({
           </div>
           {/* French */}
           <div className="relative w-1/2 flex-1">
-            <LanguageLabel id="add-button-text-french" lang={secondaryLanguage}>
+            <label htmlFor={`add-button-text-french-${element.id}`} className="sr-only">
+              <>{secondaryLanguage}</>
+            </label>
+            <LanguageLabel
+              id={`add-button-text-french-desc-${element.id}`}
+              lang={secondaryLanguage}
+            >
               <>{secondaryLanguage}</>
             </LanguageLabel>
             <textarea
               className="size-full p-4 focus:outline-blue-focus"
-              id="add-button-text-french-input"
-              aria-describedby="add-button-text-french"
+              id={`add-button-text-french-${element.id}`}
+              aria-describedby={`add-button-text-french-desc-${element.id}`}
               value={addButtonFrValue}
               onChange={(e) => {
                 updateField(
@@ -103,13 +109,19 @@ export const TranslateCustomizeSet = ({
         </FieldsetLegend>
         <div className="mb-10 flex gap-px divide-x-2 border border-gray-300" key={primaryLanguage}>
           <div className="relative w-1/2 flex-1">
-            <LanguageLabel id="remove-button-text-english" lang={primaryLanguage}>
+            <label htmlFor={`remove-button-text-english-${element.id}`} className="sr-only">
+              <>{primaryLanguage}</>
+            </label>
+            <LanguageLabel
+              id={`remove-button-text-english-desc-${element.id}`}
+              lang={primaryLanguage}
+            >
               <>{primaryLanguage}</>
             </LanguageLabel>
             <textarea
               className="size-full p-4 focus:outline-blue-focus"
-              id="remove-button-text-french-input"
-              aria-describedby="remove-button-text-english"
+              id={`remove-button-text-french-${element.id}`}
+              aria-describedby={`remove-button-text-english-${element.id}`}
               value={removeButtonEnValue}
               onChange={(e) => {
                 updateField(
@@ -120,13 +132,19 @@ export const TranslateCustomizeSet = ({
             />
           </div>
           <div className="relative w-1/2 flex-1">
-            <LanguageLabel id="remove-button-text-french" lang={secondaryLanguage}>
+            <label htmlFor={`remove-button-text-french-${element.id}`} className="sr-only">
+              <>{secondaryLanguage}</>
+            </label>
+            <LanguageLabel
+              id={`remove-button-text-french-desc-${element.id}`}
+              lang={secondaryLanguage}
+            >
               <>{secondaryLanguage}</>
             </LanguageLabel>
             <textarea
               className="size-full p-4 focus:outline-blue-focus"
-              id="remove-button-text-french-input"
-              aria-describedby="remove-button-text-french"
+              id={`remove-button-text-french-${element.id}`}
+              aria-describedby={`remove-button-text-french-${element.id}`}
               value={removeButtonFrValue}
               onChange={(e) => {
                 updateField(

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateCustomizeSet.tsx
@@ -53,14 +53,17 @@ export const TranslateCustomizeSet = ({
         </FieldsetLegend>
         {/* English */}
         <div className="mb-10 flex gap-px divide-x-2 border border-gray-300" key={primaryLanguage}>
+          <label htmlFor={`add-button-text-english-${element.id}`} className="sr-only">
+            <>{primaryLanguage}</>
+          </label>
           <div className="relative w-1/2 flex-1">
-            <LanguageLabel id="add-button-text-english" lang={primaryLanguage}>
+            <LanguageLabel id={`add-button-text-english-desc-${element.id}`} lang={primaryLanguage}>
               <>{primaryLanguage}</>
             </LanguageLabel>
             <textarea
               className="size-full p-4 focus:outline-blue-focus"
-              id="add-button-text-english-input"
-              aria-describedby="add-button-text-english"
+              id={`add-button-text-english-${element.id}`}
+              aria-describedby={`add-button-text-english-desc-${element.id}`}
               value={addButtonEnValue}
               onChange={(e) => {
                 updateField(

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -22,6 +22,7 @@ import { SkipLinkReusable } from "@clientComponents/globals/SkipLinkReusable";
 import { alphabet } from "@lib/utils/form-builder";
 import { sortGroup } from "@lib/utils/form-builder/groupedFormHelpers";
 import { Group } from "@lib/formContext";
+import { TranslateCustomizeSet } from "./TranslateCustomizeSet";
 
 const GroupSection = ({
   groupId,
@@ -99,11 +100,13 @@ const Element = ({
   element,
   index,
   primaryLanguage,
+  secondaryLanguage,
   questionNumber,
 }: {
   element: FormElement;
   index: number;
   primaryLanguage: Language;
+  secondaryLanguage: Language;
   questionNumber?: string;
 }) => {
   let subElements;
@@ -126,6 +129,7 @@ const Element = ({
           index={subElement.id}
           questionNumber={questionNumber}
           primaryLanguage={primaryLanguage}
+          secondaryLanguage={secondaryLanguage}
         />
       );
     });
@@ -169,6 +173,16 @@ const Element = ({
             <Description primaryLanguage={primaryLanguage} element={element} />
           )}
           {subElements}
+        </>
+      )}
+      {element.type === "dynamicRow" && (
+        <>
+          <TranslateCustomizeSet
+            element={element}
+            primaryLanguage={primaryLanguage}
+            secondaryLanguage={secondaryLanguage}
+          />
+          <div>here</div>
         </>
       )}
     </>
@@ -384,7 +398,12 @@ export const TranslateWithGroups = () => {
             sortGroup({ form, group: groups["start"] }).map((element, index) => {
               return (
                 <div className="section" id={`section-${index}`} key={element.id}>
-                  <Element index={index} element={element} primaryLanguage={primaryLanguage} />
+                  <Element
+                    index={index}
+                    element={element}
+                    primaryLanguage={primaryLanguage}
+                    secondaryLanguage={secondaryLanguage}
+                  />
                 </div>
               );
             })}
@@ -418,6 +437,7 @@ export const TranslateWithGroups = () => {
                           index={index}
                           element={element}
                           primaryLanguage={primaryLanguage}
+                          secondaryLanguage={secondaryLanguage}
                         />
                       </div>
                     );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -182,7 +182,6 @@ const Element = ({
             primaryLanguage={primaryLanguage}
             secondaryLanguage={secondaryLanguage}
           />
-          <div>here</div>
         </>
       )}
     </>

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1076,6 +1076,11 @@
     "removeButtonText": "Remove",
     "removeButtonTextA11yEn": "Remove button text (english)",
     "removeButtonTextA11yFr": "Remove button text (french)",
+    "translate": {
+      "repeatingSet": "Repeating set",
+      "addButtonText": "Button label - Add to set",
+      "removeButtonText": "Button label - Remove from set"
+    },
     "dialog": {
       "customizeElement": "Customize element",
       "title": "Customize set",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1076,6 +1076,11 @@
     "removeButtonText": "Remove [FR]",
     "removeButtonTextA11yEn": "Remove button text (english) [FR] ",
     "removeButtonTextA11yFr": "Remove button text (french) [FR] ",
+    "translate": {
+      "repeatingSet": "Repeating set [FR]",
+      "addButtonText": "Button label - Add to set [FR]",
+      "removeButtonText": "Button label - Remove from set [FR]"
+    },
     "dialog": {
       "customizeElement": "Customize element [FR]",
       "title": "Customize set [FR]",


### PR DESCRIPTION
# Summary | Résumé

Adds inputs to translate screen for dynamic row properties.

<img width="600" alt="Screenshot 2024-09-11 at 11 54 04 AM" src="https://github.com/user-attachments/assets/3dbf709a-7026-482e-a0d1-3351c82738c4">

