### PR TITLE
feat: client feature flags

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -15,6 +15,8 @@ import { TemplateStoreProvider } from "@lib/store/useTemplateStore";
 import { Language } from "@lib/types/form-builder-types";
 import { FormRecord } from "@lib/types";
 import { logMessage } from "@lib/logger";
+import { FeatureFlagsProvider } from "@lib/hooks/useFeatureFlags";
+import { getAllFlags } from "@lib/cache/flags";
 
 export default async function Layout({
   children,
@@ -49,39 +51,41 @@ export default async function Layout({
   }
 
   return (
-    <TemplateStoreProvider {...{ ...initialForm, locale, allowGroupsFlag }}>
-      <SaveTemplateProvider>
-        <RefStoreProvider>
-          <div>
-            {/* @TODO: Backlink?? */}
-            <div className="flex flex-col">
-              <SkipLink />
-              <Header context="formBuilder" className="mb-0" />
-              <div className="shrink-0 grow basis-auto bg-gray-soft">
-                <ToastContainer containerId="default" />
-                <ToastContainer limit={1} containerId="wide" autoClose={false} width="600px" />
-                <div className="flex h-full flex-row gap-7">
-                  <div id="left-nav" className="z-10 border-r border-slate-200 bg-white">
-                    <div className="sticky top-0">
-                      <LeftNavigation id={id} />
+    <FeatureFlagsProvider featureFlags={await getAllFlags()}>
+      <TemplateStoreProvider {...{ ...initialForm, locale, allowGroupsFlag }}>
+        <SaveTemplateProvider>
+          <RefStoreProvider>
+            <div>
+              {/* @TODO: Backlink?? */}
+              <div className="flex flex-col">
+                <SkipLink />
+                <Header context="formBuilder" className="mb-0" />
+                <div className="shrink-0 grow basis-auto bg-gray-soft">
+                  <ToastContainer containerId="default" />
+                  <ToastContainer limit={1} containerId="wide" autoClose={false} width="600px" />
+                  <div className="flex h-full flex-row gap-7">
+                    <div id="left-nav" className="z-10 border-r border-slate-200 bg-white">
+                      <div className="sticky top-0">
+                        <LeftNavigation id={id} />
+                      </div>
                     </div>
+                    <GroupStoreProvider>
+                      <main
+                        id="content"
+                        className="form-builder my-7 w-full min-h-[calc(100vh-300px)]"
+                      >
+                        {children}
+                      </main>
+                      {allowGroupsFlag && <RightPanel id={id} lang={locale as Language} />}
+                    </GroupStoreProvider>
                   </div>
-                  <GroupStoreProvider>
-                    <main
-                      id="content"
-                      className="form-builder my-7 w-full min-h-[calc(100vh-300px)]"
-                    >
-                      {children}
-                    </main>
-                    {allowGroupsFlag && <RightPanel id={id} lang={locale as Language} />}
-                  </GroupStoreProvider>
                 </div>
               </div>
+              <Footer displayFormBuilderFooter className="mt-0 lg:mt-0" />
             </div>
-            <Footer displayFormBuilderFooter className="mt-0 lg:mt-0" />
-          </div>
-        </RefStoreProvider>
-      </SaveTemplateProvider>
-    </TemplateStoreProvider>
+          </RefStoreProvider>
+        </SaveTemplateProvider>
+      </TemplateStoreProvider>
+    </FeatureFlagsProvider>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/Preview.tsx
@@ -28,14 +28,9 @@ import { toast } from "@formBuilder/components/shared";
 import { defaultForm } from "@lib/store/defaults";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
 import { focusElement } from "@lib/client/clientHelpers";
+import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
 
-export const Preview = ({
-  disableSubmit = true,
-  allowGrouping = false,
-}: {
-  disableSubmit?: boolean;
-  allowGrouping?: boolean;
-}) => {
+export const Preview = ({ disableSubmit = true }: { disableSubmit?: boolean }) => {
   const { status } = useSession();
   const { i18n } = useTranslation(["common", "confirmation"]);
   const { id, getSchema, getIsPublished, getSecurityAttribute } = useTemplateStore((s) => ({
@@ -44,6 +39,9 @@ export const Preview = ({
     getIsPublished: s.getIsPublished,
     getSecurityAttribute: s.getSecurityAttribute,
   }));
+
+  const { getFlag } = useFeatureFlags();
+  const allowGrouping = getFlag("conditionalLogic");
 
   const formParsed = safeJSONParse<FormProperties>(getSchema());
   if (!formParsed) {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/page.tsx
@@ -3,7 +3,6 @@ import { Metadata } from "next";
 import { authCheckAndThrow } from "@lib/actions";
 import { notFound } from "next/navigation";
 import { Preview } from "./Preview";
-import { allowGrouping } from "@formBuilder/components/shared/right-panel/treeview/util/allowGrouping";
 import { ClientContainer } from "./ClientContainer";
 
 export async function generateMetadata({
@@ -24,8 +23,6 @@ export default async function Page({ params: { id } }: { params: { id: string } 
   }));
   const disableSubmit = id === "0000" || !session?.user;
 
-  const isAllowGrouping = await allowGrouping();
-
   const formID = id;
 
   if (!session?.user && formID !== "0000") {
@@ -33,7 +30,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
   }
   return (
     <ClientContainer>
-      <Preview disableSubmit={disableSubmit} allowGrouping={isAllowGrouping} />
+      <Preview disableSubmit={disableSubmit} />
     </ClientContainer>
   );
 }

--- a/lib/cache/flags.ts
+++ b/lib/cache/flags.ts
@@ -108,3 +108,13 @@ const checkMulti = async (keys: string[]): Promise<{ [k: string]: boolean }> => 
 
   return Object.fromEntries(mapped);
 };
+
+export type Flags = {
+  [k: string]: boolean;
+};
+
+// NOTE: Is there any security risk in accessing all our feature flags?
+// Alternatively this could become a static "safe list" of public feature flags that is updated manually.
+export async function getAllFlags(): Promise<Flags> {
+  return checkMulti(await getKeys());
+}

--- a/lib/hooks/useFeatureFlags.tsx
+++ b/lib/hooks/useFeatureFlags.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Flags } from "@lib/cache/flags";
+import { createContext, useContext, useState } from "react";
+
+const featureFlagsContext = createContext({
+  flags: {} as Flags,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setFlags: (flags: Flags) => {},
+  getFlag: () => {},
+});
+
+export const FeatureFlagsProvider = ({
+  children,
+  featureFlags,
+}: {
+  children: React.ReactNode;
+  featureFlags: Flags;
+}) => {
+  const [flags, setFlags] = useState(featureFlags);
+  return (
+    <featureFlagsContext.Provider value={{ flags, setFlags, getFlag: () => {} }}>
+      {children}
+    </featureFlagsContext.Provider>
+  );
+};
+
+export const useFeatureFlags = () => {
+  const { flags, setFlags } = useContext(featureFlagsContext);
+  return {
+    getFlag: (key: string) => {
+      return flags[key as keyof typeof flags];
+    },
+    setFlag: (key: string, value: boolean) => {
+      setFlags({ ...flags, [key]: value });
+    },
+  };
+};


### PR DESCRIPTION
# Summary | Résumé

Adds a React context provider to allow the client (components) to access feature flags without having to do prop drilling. 

Currently the getFlags() util method is only used in form-builder. A follow up commit could be to use this in other similar areas.

I also have a few ideas to make this a little more fancy but I'd rather keep this as simple as possible for the first iteration.
