### PR TITLE
chore: Move types for flags

### DIFF
--- a/app/(gcforms)/[locale]/layout.tsx
+++ b/app/(gcforms)/[locale]/layout.tsx
@@ -1,7 +1,8 @@
 import { authCheckAndThrow } from "@lib/actions";
 import { ClientContexts } from "@clientComponents/globals/ClientContexts";
 import { ReactHydrationCheck } from "@clientComponents/globals";
-import { FeatureFlags, getSomeFlags } from "@lib/cache/flags";
+import { getSomeFlags } from "@lib/cache/flags";
+import { FeatureFlags } from "@lib/cache/types";
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const { session } = await authCheckAndThrow().catch(() => ({ session: null }));

--- a/components/clientComponents/globals/ClientContexts.tsx
+++ b/components/clientComponents/globals/ClientContexts.tsx
@@ -6,7 +6,7 @@ import { AccessControlProvider } from "@lib/hooks/useAccessControl";
 import { LiveMessagePovider } from "@lib/hooks/useLiveMessage";
 import { RefsProvider } from "@formBuilder/[id]/edit/components/RefsContext";
 import { FeatureFlagsProvider } from "@lib/hooks/useFeatureFlags";
-import { Flags } from "@lib/cache/flags";
+import { Flags } from "@lib/cache/types";
 
 export const ClientContexts: React.FC<{
   session: Session | null;

--- a/lib/cache/flags.ts
+++ b/lib/cache/flags.ts
@@ -3,6 +3,7 @@ import flagInitialSettings from "../../flag_initialization/default_flag_settings
 import { AccessControlError, checkPrivileges } from "@lib/privileges";
 import { logEvent } from "@lib/auditLogs";
 import { UserAbility } from "@lib/types";
+import { FeatureFlagKeys, FeatureFlags, PickFlags } from "./types";
 
 /**
  * Enables an Application Setting Flag
@@ -108,23 +109,6 @@ const checkMulti = async <T extends FeatureFlagKeys[]>(keys: T): Promise<PickFla
   }, new Map<string, boolean>());
 
   return Object.fromEntries(mapped) as PickFlags<T>;
-};
-
-// TODO: in the future these could pulled in from default_flag_settings.json
-export const FeatureFlags = {
-  addressComplete: "addressComplete",
-  repeatingSets: "repeatingSets",
-} as const;
-
-export type FeatureFlagKeys = keyof typeof FeatureFlags;
-
-export type Flags = {
-  [K in FeatureFlagKeys]: boolean;
-};
-
-// Utility type to pick only the keys provided in the flags array
-export type PickFlags<T extends FeatureFlagKeys[]> = {
-  [K in T[number]]: boolean;
 };
 
 export async function getSomeFlags<T extends FeatureFlagKeys[]>(flags: T): Promise<PickFlags<T>> {

--- a/lib/cache/types.ts
+++ b/lib/cache/types.ts
@@ -1,0 +1,16 @@
+// TODO: in the future these could pulled in from default_flag_settings.json
+export const FeatureFlags = {
+  addressComplete: "addressComplete",
+  repeatingSets: "repeatingSets",
+} as const;
+
+export type FeatureFlagKeys = keyof typeof FeatureFlags;
+
+export type Flags = {
+  [K in FeatureFlagKeys]: boolean;
+};
+
+// Utility type to pick only the keys provided in the flags array
+export type PickFlags<T extends FeatureFlagKeys[]> = {
+  [K in T[number]]: boolean;
+};

--- a/lib/hooks/useFeatureFlags.tsx
+++ b/lib/hooks/useFeatureFlags.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Flags } from "@lib/cache/flags";
+import { Flags } from "@lib/cache/types";
 import { createContext, useContext, useState } from "react";
 
 const FeatureFlagsContext = createContext({


### PR DESCRIPTION
# Summary | Résumé

Moves flags to standalone file to avoid issue with Server functions / components 
