### PR TITLE
feat: treat technical-failure as permanent when receiving callback from GCNotify

### DIFF
--- a/app/api/notify-callback/route.ts
+++ b/app/api/notify-callback/route.ts
@@ -136,9 +136,9 @@ export const POST = middleware([validAuthorizationHeader()], async (req, props) 
     });
   }
 
-  if (deliveryStatus === "permanent-failure") {
+  if (deliveryStatus === "technical-failure" || deliveryStatus === "permanent-failure") {
     logMessage.warn(
-      `HealthCheck Notify Callback: Form submission ${submissionID} will never be delivered because of a permanent failure (GC Notify)`
+      `HealthCheck Notify Callback: Form submission ${submissionID} will never be delivered because of a ${deliveryStatus} (GC Notify)`
     );
     await removeProcessedMark(submissionID);
     return NextResponse.json({


### PR DESCRIPTION
closes https://github.com/cds-snc/platform-forms-client/issues/2214 (see comments for more information)

# Summary | Résumé

- Adds `technical-failure` status (from GCNotify callback) to the list of statuses we should not try to reprocess submission for