### PR TITLE
fix: Repeating set sub element panel actions

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/sub-elements/SubElement.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/sub-elements/SubElement.tsx
@@ -16,6 +16,7 @@ import { useHandleAdd } from "@lib/hooks/form-builder/useHandleAdd";
 import { CustomizeSetButton } from "../CustomizeSetButton";
 import { AddToSetButton } from "../AddToSetButton";
 import { FormElementWithIndex } from "@lib/types/form-builder-types";
+import { useRefsContext } from "../../RefsContext";
 
 export const SubElement = ({
   item,
@@ -27,24 +28,18 @@ export const SubElement = ({
   elIndex: number;
   formId: string;
 }) => {
-  const {
-    updateField,
-    subMoveUp,
-    subMoveDown,
-    subDuplicateElement,
-    removeSubItem,
-    propertyPath,
-    setChangeKey,
-  } = useTemplateStore((s) => ({
-    updateField: s.updateField,
-    subMoveUp: s.subMoveUp,
-    subMoveDown: s.subMoveDown,
-    subDuplicateElement: s.subDuplicateElement,
-    removeSubItem: s.removeSubItem,
-    getLocalizationAttribute: s.getLocalizationAttribute,
-    propertyPath: s.propertyPath,
-    setChangeKey: s.setChangeKey,
-  }));
+  const { updateField, subMoveUp, subMoveDown, removeSubItem, propertyPath, setChangeKey } =
+    useTemplateStore((s) => ({
+      updateField: s.updateField,
+      subMoveUp: s.subMoveUp,
+      subMoveDown: s.subMoveDown,
+      removeSubItem: s.removeSubItem,
+      getLocalizationAttribute: s.getLocalizationAttribute,
+      propertyPath: s.propertyPath,
+      setChangeKey: s.setChangeKey,
+    }));
+
+  const { refs } = useRefsContext();
 
   const subElements = item.properties.subElements;
 
@@ -63,17 +58,25 @@ export const SubElement = ({
     return elements.filter((element) => !notAllowed.includes(element.id));
   };
 
-  const forceRefresh = () => {
+  const focusSubElement = (id: number) => {
+    // Add delay to wait for the new element to be rendered
+    setTimeout(() => {
+      refs && refs.current && refs.current[id].focus();
+    }, 200);
+  };
+
+  const forceRefresh = (id?: number) => {
     setChangeKey(String(new Date().getTime())); //Force a re-render
+    id && focusSubElement(id);
   };
 
   if (!subElements || subElements.length < 1)
     return (
       <div className="ml-4 mt-10">
         <AddToSetButton
-          handleAdd={(type?: FormElementTypes) => {
-            handleAddSubElement(elIndex, 0, type);
-            forceRefresh();
+          handleAdd={async (type?: FormElementTypes) => {
+            const id = await handleAddSubElement(elIndex, 0, type);
+            forceRefresh(id);
           }}
           filterElements={elementFilter}
         />
@@ -94,25 +97,22 @@ export const SubElement = ({
                   isFirstItem={subIndex === 0}
                   isLastItem={subIndex === subElements.length - 1}
                   totalItems={subElements.length}
-                  handleAdd={(type?: FormElementTypes) => {
-                    handleAddSubElement(elIndex, subIndex, type);
-                    forceRefresh();
+                  handleAdd={async (type?: FormElementTypes) => {
+                    const id = await handleAddSubElement(elIndex, subIndex, type);
+                    forceRefresh(id);
                   }}
                   handleRemove={() => {
-                    removeSubItem(elIndex, item.id);
+                    removeSubItem(item.id, item.id);
                     forceRefresh();
                   }}
+                  handleDuplicate={() => {}} // no duplicate for sub elements
                   handleMoveUp={() => {
-                    subMoveUp(elIndex, subIndex);
-                    forceRefresh();
+                    subMoveUp(item.id, subIndex);
+                    forceRefresh(item.id);
                   }}
                   handleMoveDown={() => {
-                    subMoveDown(elIndex, subIndex);
-                    forceRefresh();
-                  }}
-                  handleDuplicate={() => {
-                    subDuplicateElement(elIndex, subIndex);
-                    forceRefresh();
+                    subMoveDown(item.id, subIndex);
+                    forceRefresh(item.id);
                   }}
                   moreButtonRenderer={(moreButton) => {
                     return (
@@ -145,8 +145,9 @@ export const SubElement = ({
       {subElements.length >= 1 && (
         <div className="mb-2 ml-4 mt-4">
           <AddToSetButton
-            handleAdd={(type?: FormElementTypes) => {
-              handleAddSubElement(elIndex, subElements.length, type);
+            handleAdd={async (type?: FormElementTypes) => {
+              const id = await handleAddSubElement(elIndex, subElements.length, type);
+              forceRefresh(id);
             }}
             filterElements={elementFilter}
           />

--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -39,24 +39,26 @@ export const useHandleAdd = () => {
   /* Note this callback is also in ElementPanel */
   const handleAddElement = useCallback(
     async (index: number, type?: FormElementTypes) => {
+      let id;
+
       if (allowedTemplates.includes(type as LoaderType)) {
         blockLoader(type as LoaderType, index, async (data, position) => {
           // Note add() returns the element id -- we're not using it yet
-          await add(position, data.type, data, groupId);
+          id = await add(position, data.type, data, groupId);
         });
-        return;
+        return id;
       }
 
       const item = await create(type as FormElementTypes);
       if (item.type === "dynamicRow") {
         item.properties.dynamicRow = await getTranslatedDynamicRowProperties();
       }
-      const id = await add(index, item.type, item, groupId);
+      id = await add(index, item.type, item, groupId);
       treeView?.current?.addItem(String(id));
 
       const el = document.getElementById(`item-${id}`);
 
-      if (!el) return;
+      if (!el) return id;
 
       // Close all panel menus before focussing on the new element
       const closeAll = new CustomEvent("close-all-panel-menus");
@@ -69,18 +71,26 @@ export const useHandleAdd = () => {
 
   const handleAddSubElement = useCallback(
     async (elIndex: number, subIndex: number, type?: FormElementTypes) => {
+      let id;
+
+      // Close all panel menus before focussing on the new element
+      const closeAll = new CustomEvent("close-all-panel-menus");
+      window && window.dispatchEvent(closeAll);
+
       if (allowedTemplates.includes(type as LoaderType)) {
         blockLoader(type as LoaderType, subIndex, (data, position) => {
-          addSubItem(elIndex, position, data.type, data);
+          id = addSubItem(elIndex, position, data.type, data);
           setChangeKey(String(new Date().getTime())); //Force a re-render
         });
-        return;
+        return id;
       }
 
       const item = await create(type as FormElementTypes);
-      addSubItem(elIndex, subIndex, item.type, item);
+      id = addSubItem(elIndex, subIndex, item.type, item);
 
       setChangeKey(String(new Date().getTime())); //Force a re-render
+
+      return id;
     },
     [addSubItem, create, setChangeKey]
   );

--- a/lib/store/types.ts
+++ b/lib/store/types.ts
@@ -15,9 +15,9 @@ export interface TemplateStoreState extends TemplateStoreProps {
   setHasHydrated: () => void;
   getFocusInput: () => boolean;
   moveUp: (index: number, groupId?: string) => void;
-  subMoveUp: (elIndex: number, subIndex?: number) => void;
+  subMoveUp: (id: number, subIndex: number) => void;
   moveDown: (index: number, groupId?: string) => void;
-  subMoveDown: (elIndex: number, subIndex?: number) => void;
+  subMoveDown: (id: number, subIndex?: number) => void;
   localizeField: {
     <LocalizedProperty extends string>(
       arg: LocalizedProperty,
@@ -39,18 +39,18 @@ export interface TemplateStoreState extends TemplateStoreProps {
     groupId?: string
   ) => Promise<number>;
   addSubItem: (
-    elIndex: number,
+    elId: number,
     subIndex?: number,
     type?: FormElementTypes,
     data?: FormElement
-  ) => void;
+  ) => Promise<number>;
   remove: (id: number, groupId?: string) => void;
   removeSubItem: (elIndex: number, id: number) => void;
   addChoice: (elIndex: number) => void;
   addLabeledChoice: (elIndex: number, label: { en: string; fr: string }) => Promise<number>;
   addSubChoice: (elIndex: number, subIndex: number) => void;
   removeChoice: (elIndex: number, choiceIndex: number) => void;
-  removeSubChoice: (elIndex: number, subIndex: number, choiceIndex: number) => void;
+  removeSubChoice: (elId: number, subIndex: number, choiceIndex: number) => void;
   getChoice: (elIndex: number, choiceIndex: number) => { en: string; fr: string } | undefined;
   updateField: (
     path: string,
@@ -60,7 +60,6 @@ export interface TemplateStoreState extends TemplateStoreProps {
   propertyPath: (id: number, field: string, lang?: Language) => string;
   unsetField: (path: string) => void;
   duplicateElement: (id: number, groupId?: string) => void;
-  subDuplicateElement: (elIndex: number, subIndex: number) => void;
   importTemplate: (jsonConfig: FormProperties) => void;
   getSchema: () => string;
   getIsPublished: () => boolean;

--- a/lib/utils/form-builder/getPath.ts
+++ b/lib/utils/form-builder/getPath.ts
@@ -50,6 +50,18 @@ export const getElementIndexes = <T extends Element>(id: number, elements: T[]):
   return [elIndex, null];
 };
 
+export const getParentIndex = (id: number, elements: Element[]) => {
+  const parentIndexes = getElementIndexes(id, elements);
+
+  if (!parentIndexes || parentIndexes[0] === null) {
+    return;
+  }
+
+  const parentIndex = parentIndexes[0];
+
+  return parentIndex;
+};
+
 export const indexesToPath = <T extends Form>(indexes: Indexes, form: T) => {
   const [elIndex, subIndex] = indexes;
 


### PR DESCRIPTION
# Summary | Résumé

Updates to fix issues caused by using `indexes` vs `ids`.

- Fixes issue with moving up / down after the parent has been re-indexed.
- Fixes focus issues 
  - Re-focuses sub element when an item is moved up / down
  - Focus sub-element when adding an item
  
  **Before**
  
  When moving a parent up or down the sub-elements would try to use the wrong parent index and in turn the button action wouldn't do anything.
Example:
https://github.com/user-attachments/assets/b8a02ecf-682e-4cf5-a243-6dd68d64f2b2


  