### PR TITLE
fix: allow generate SBOM step to fail

### DIFF
--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -69,6 +69,7 @@ jobs:
           dockerfile_path: "Dockerfile"
           sbom_name: "forms-client"
           token: "${{ secrets.GITHUB_TOKEN }}"
+        continue-on-error: true # TODO: remove once Trivy ECR has been setup
 
       - name: Logout of Staging Amazon ECR
         if: always()


### PR DESCRIPTION
# Summary
Update the Staging ECR push workflow to allow the generate SBOM step to fail.  This step is intermittently failing because the public Trivy Docker image that contains the vulnerability database is being rate limited.

SRE is working on setting up a dedicated ECR for CDS projects to fix this rate limiting in the future.

# Test instructions | Instructions pour tester la modification

Expect the generate SBOM step to no longer fail the Staging Docker image build/push workflow.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

n/a

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
