### PR TITLE
Improved error message for server-side file validation errors

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -28,7 +28,6 @@ import {
 import { filterShownElements, filterValuesByShownElements } from "@lib/formContext";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { t } from "i18next";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -170,7 +169,12 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const errorList = props.errors ? getErrorList(props) : null;
   const errorId = "gc-form-errors";
   const serverErrorId = `${errorId}-server`;
-  const formStatusError = props.status === "Error" ? props.errors.form || t("server-error") : null;
+  const formStatusError =
+    props.status === "FileError"
+      ? t("input-validation.file-submission")
+      : props.status === "Error"
+      ? t("server-error")
+      : null;
 
   //  If there are errors on the page, set focus the first error field
   useEffect(() => {
@@ -391,12 +395,7 @@ export const Form = withFormik<FormProps, Responses>({
       );
 
       if (result.error) {
-        formikBag.setStatus("Error");
-        if (result.error.message.includes("FileValidationResult")) {
-          formikBag.setErrors({
-            form: t("input-validation.file-submission"),
-          });
-        }
+        formikBag.setStatus("FileError");
       } else {
         formikBag.props.onSuccess(result.id);
       }

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -28,6 +28,7 @@ import {
 import { filterShownElements, filterValuesByShownElements } from "@lib/formContext";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
+import { t } from "i18next";
 
 interface SubmitButtonProps {
   numberOfRequiredQuestions: number;
@@ -169,7 +170,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const errorList = props.errors ? getErrorList(props) : null;
   const errorId = "gc-form-errors";
   const serverErrorId = `${errorId}-server`;
-  const formStatusError = props.status === "Error" ? t("server-error") : null;
+  const formStatusError = props.status === "Error" ? props.errors.form || t("server-error") : null;
 
   //  If there are errors on the page, set focus the first error field
   useEffect(() => {
@@ -388,8 +389,14 @@ export const Form = withFormik<FormProps, Responses>({
         formikBag.props.language,
         formikBag.props.formRecord
       );
+
       if (result.error) {
         formikBag.setStatus("Error");
+        if (result.error.message.includes("FileValidationResult")) {
+          formikBag.setErrors({
+            form: t("input-validation.file-submission"),
+          });
+        }
       } else {
         formikBag.props.onSuccess(result.id);
       }

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -43,6 +43,7 @@
     "regex": "Enter the correct format.",
     "file-size-too-large": "Select a smaller file.",
     "file-size-too-large-all-files": "Files exceed the 3.5 MB maximum. Upload smaller files.",
+    "file-submission": "There was a problem with the file submitted. Try uploading a different file format, such as PDF.",
     "file-type-invalid": "Select a different file type.",
     "too-many-characters": "Shorten the response.",
     "all-checkboxes-required": "Read and check all boxes to confirm the items in this section.",

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -43,6 +43,7 @@
     "regex": "Veuillez utiliser le bon format.",
     "file-size-too-large": "Sélectionner un fichier plus petit.",
     "file-size-too-large-all-files": "Les fichiers dépassent le maximum de 3.5 Mo. Téléversez des fichiers plus petits.",
+    "file-submission": "Il y a eu un problème avec le fichier soumis. Essayez de téléverser un autre format de fichier, tel que PDF.",
     "file-type-invalid": "Sélectionner un autre type de fichier.",
     "too-many-characters": "Raccourcir la réponse.",
     "all-checkboxes-required": "Lisez et cochez toutes les cases pour confirmer les éléments de cette section.",


### PR DESCRIPTION
# Summary | Résumé

Partial fix for #4362 
Adds an improved error message for server-side file validation errors.
The problem with this solution is that it just throws a generic error at the top of the form with no link/association to the input that caused the problem, as a normal validation error would do.
A future PR should attempt to address this shortfall.