### PR TITLE
chore: fix margin for filename input

### DIFF
--- a/components/clientComponents/globals/Header/FileName.tsx
+++ b/components/clientComponents/globals/Header/FileName.tsx
@@ -93,7 +93,7 @@ export const FileNameInput = () => {
         style={widthStyle}
         ref={fileNameInput}
         className={cn(
-          "border-1 border-[#1B00C2] rounded-md px-2 py-1 min-w-[220px] max-w-[200px] laptop:min-w-[250px] laptop:max-w-[500px] text-base font-bold text-ellipsis placeholder-slate-500",
+          "border-1 border-[#1B00C2] rounded-md px-2 py-1 min-w-[220px] max-w-[200px] laptop:min-w-[250px] laptop:max-w-[500px] text-base font-bold text-ellipsis placeholder-slate-500 mt-3",
           !isPublished && "hover:border-1 hover:border-gray-default"
         )}
         name="filename"


### PR DESCRIPTION
# Summary | Résumé

Fixes minor issue with Filename input styling.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="682" alt="Screenshot 2024-10-09 at 2 56 03 PM" src="https://github.com/user-attachments/assets/a5674123-8e4d-47a9-9c43-50ade39bda53"> | <img width="611" alt="fixed" src="https://github.com/user-attachments/assets/c55607c1-a7b8-4b2d-a8c7-a192c7bea097">
 |


