### PR TITLE
chore: Add customEvent hook for pub/sub pattern

### DIFF
--- a/lib/hooks/useCustomEvent.tsx
+++ b/lib/hooks/useCustomEvent.tsx
@@ -1,0 +1,55 @@
+import { useRef } from "react";
+
+/**
+ *  @TODO: Define unique payload types for each CustomEvent and add
+ *         to CustomEventDetails instead of using generic object
+ */
+export type CustomEventDetails = object | undefined;
+
+export const useCustomEvent = () => {
+  // Attach listeners to a documentRef instead of document directly
+  // https://www.preciousorigho.com/articles/a-better-way-to-create-event-listeners-in-react
+  const documentRef = useRef<Document | null>(null);
+
+  if (typeof window !== "undefined") {
+    documentRef.current = window.document;
+  }
+
+  const Event = {
+    /**
+     * Fire an event, pass an optional payload
+     * @param eventName string
+     * @param data CustomEventDetails
+     */
+    fire: (eventName: string, data: CustomEventDetails = undefined) => {
+      const event = new CustomEvent(eventName, { detail: data });
+      documentRef.current && documentRef.current.dispatchEvent(event);
+    },
+
+    /**
+     * Register an event listener
+     * @param eventName string
+     * @param callback (data: CustomEventDetails) => void
+     */
+    on: (eventName: string, callback: (data: CustomEventDetails) => void) => {
+      documentRef.current &&
+        documentRef.current.addEventListener(eventName, (event: Event) => {
+          callback((event as CustomEvent).detail);
+        });
+    },
+
+    /**
+     * Remove an event listener
+     * @param eventName string
+     * @param callback (data: CustomEventDetails) => void
+     */
+    off: (eventName: string, callback: (data: CustomEventDetails) => void) => {
+      documentRef.current &&
+        documentRef.current.removeEventListener(eventName, (event: Event) => {
+          callback((event as CustomEvent).detail);
+        });
+    },
+  };
+
+  return { Event };
+};

--- a/lib/hooks/useCustomEvent.tsx
+++ b/lib/hooks/useCustomEvent.tsx
@@ -1,8 +1,14 @@
 import { useRef } from "react";
 
 /**
- *  @TODO: Define unique payload types for each CustomEvent and add
+ * @TODO: Define unique payload types for each CustomEvent and add
  *         to CustomEventDetails instead of using generic object
+ *
+ * Example: a MoreDialog listener might accept a payload like:
+ *
+ * type MoreDialogEventDetails = {
+ *   item: FormElementWithIndex;
+ * }
  */
 export type CustomEventDetails = object | undefined;
 
@@ -21,17 +27,17 @@ export const useCustomEvent = () => {
      * @param eventName string
      * @param data CustomEventDetails
      */
-    fire: (eventName: string, data: CustomEventDetails = undefined) => {
-      const event = new CustomEvent(eventName, { detail: data });
+    fire: (eventName: string, detail: CustomEventDetails = undefined) => {
+      const event = new CustomEvent(eventName, { detail });
       documentRef.current && documentRef.current.dispatchEvent(event);
     },
 
     /**
      * Register an event listener
      * @param eventName string
-     * @param callback (data: CustomEventDetails) => void
+     * @param callback (detail: CustomEventDetails) => void
      */
-    on: (eventName: string, callback: (data: CustomEventDetails) => void) => {
+    on: (eventName: string, callback: (detail: CustomEventDetails) => void) => {
       documentRef.current &&
         documentRef.current.addEventListener(eventName, (event: Event) => {
           callback((event as CustomEvent).detail);
@@ -41,9 +47,9 @@ export const useCustomEvent = () => {
     /**
      * Remove an event listener
      * @param eventName string
-     * @param callback (data: CustomEventDetails) => void
+     * @param callback (detail: CustomEventDetails) => void
      */
-    off: (eventName: string, callback: (data: CustomEventDetails) => void) => {
+    off: (eventName: string, callback: (detail: CustomEventDetails) => void) => {
       documentRef.current &&
         documentRef.current.removeEventListener(eventName, (event: Event) => {
           callback((event as CustomEvent).detail);


### PR DESCRIPTION
# Summary | Résumé

Adds a customEvent hook for use as a pub/sub implementation across the app.
Intent is to provide an easy way of communicating across components, ie a Button and a Dialog component.

See the MoreDialog as an example of a problem in this regard.
The Dialog and Button are wrapped together and must be inserted into the app code together. This becomes problematic when you have many dialogs on the screen - you end up with many duplicate components, and you get potential for css/style bleed as the dialog becomes wrapped in whatever context the button needs to be visible.

This pub/sub hook will enable splitting the button and dialog components.
The button can appear many times on the screen.
A single dialog can be inserted at a higher/common level and listens for a custom event to toggle open.
The button can fire the event and pass in whatever data the dialog needs.

## Usage

Add the listener and handler (ensure to remove the listener on unload)
```
useEffect(() => {
    Event.on("open-form-access-dialog", handleOpenDialog);

    return () => {
      Event.off("open-form-access-dialog", handleOpenDialog);
    };
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [handleOpenDialog]);
```

Fire event to trigger the listener
```
const openManageFormAccessDialog = () => {
    Event.fire("open-form-access-dialog");
  };
```

Fire the event with a custom payload
```
const openMoreDialog = () => {
  Event.fire("open-more-dialog", {
      item: {
        ...item,
        index,
        questionNumber: index,
      } as FormElementWithIndex,
    } as FormElementWithIndex
  );