### PR TITLE
chore: Remove gray bg from Button icon theme and only apply selectively

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/Option.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/Option.tsx
@@ -128,7 +128,7 @@ export const Option = ({
       />
       <Button
         theme="icon"
-        className="group"
+        className="group bg-gray-selected hover:bg-gray-600"
         id={`remove--${id}--${index + 1}`}
         icon={<Close className="group-focus:fill-white-default" />}
         aria-label={`${t("removeOption")} ${value}`}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOption.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOption.tsx
@@ -113,7 +113,9 @@ export const SubOption = ({
         theme="icon"
         className="group"
         id={`remove--${id}--${index + 1}`}
-        icon={<Close className="group-focus:fill-white-default" />}
+        icon={
+          <Close className="group-focus:fill-white-default bg-gray-selected hover:bg-gray-600" />
+        }
         aria-label={`${t("removeOption")} ${value}`}
         onClick={() => {
           removeSubChoice(elIndex, subIndex, index);

--- a/components/clientComponents/globals/Buttons/themes.ts
+++ b/components/clientComponents/globals/Buttons/themes.ts
@@ -8,7 +8,7 @@ export const themes = {
   destructive:
     "border-gcds-red-700 bg-gcds-red-700 text-white-default hover:border-gcds-red-900 hover:bg-gcds-red-900 active:border-black",
   link: "!border-none bg-transparent !p-0 text-gcds-blue-800 underline hover:no-underline focus:!text-white-default",
-  icon: "ml-1.5 max-h-9 !rounded-full !border-none bg-gray-selected !p-1.5 hover:bg-gray-600",
+  icon: "ml-1.5 max-h-9 !rounded-full !border-none !p-1.5",
   disabled: "cursor-not-allowed border-none bg-gcds-gray-100 text-gcds-gray-800",
 } as const;
 


### PR DESCRIPTION
# Summary | Résumé

Just a bit of cleanup to make it easier to work with Button icon theme
