### PR TITLE
fix: use CDS Trivy vulnerability database

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -31,8 +31,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@8308922cec0e5e898b1f51cf0908258552976578
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
+        uses: cds-snc/security-tools/.github/actions/docker-scan@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
         env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
           ECR_REGISTRY: ${{ steps.login-ecr-staging.outputs.registry }}
         with:
           docker_image: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest"

--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -61,8 +61,9 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
         env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
           ECR_REGISTRY: ${{ steps.login-ecr-staging.outputs.registry }}
         with:
           docker_image: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.GITHUB_SHA }}"


### PR DESCRIPTION
# Summary | Résumé
Update the Docker scan actions to use a self-hosted Trivy vulnerability database. This is being done to address the rate limiting of the publicly hosted database.

# Test instructions | Instructions pour tester la modification

After merge, expect the generate SBOM and docker scan actions to no longer intermittently fail with rate limiting errors.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

n/a

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?

# Related
- https://github.com/cds-snc/platform-core-services/issues/597
