### PR TITLE
fix: ElementDialog example component styles

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Address.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Address.tsx
@@ -14,26 +14,26 @@ export const Address = () => {
 
       <ExampleWrapper className="mt-4">
         <h4 className="mb-4">{t("addElementDialog.address.whatIsYourAddress")}</h4>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="street" className="gc-label">
             {t("addElementDialog.address.street.label")}
           </Label>
           <Description>{t("addElementDialog.address.street.description")}</Description>
           <TextInput type="text" id="street" name="street" autoComplete="address-line1" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="city" className="gc-label">
             {t("addElementDialog.address.city")}
           </Label>
           <TextInput type="text" id="city" name="city" autoComplete="address-level2" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="province" className="gc-label">
             {t("addElementDialog.address.province")}
           </Label>
           <TextInput type="text" id="province" name="province" autoComplete="address-level1" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="postal" className="gc-label">
             {t("addElementDialog.address.postal")}
           </Label>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Attestation.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Attestation.tsx
@@ -17,7 +17,7 @@ export const Attestation = () => {
           <span className="text-red-default">({t("addElementDialog.allRequired")})</span>
         </Label>
 
-        <div className="overflow-hidden">
+        <div className="overflow-hidden p-2">
           <Checkbox id="one" label={t("addElementDialog.condition1")} name={"nameOne"} />
           <Checkbox id="two" label={t("addElementDialog.condition2")} name={"nameTwo"} />
           <Checkbox id="three" label={t("addElementDialog.condition3")} name={"nameThree"} />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Contact.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Contact.tsx
@@ -14,23 +14,23 @@ export const Contact = () => {
 
       <ExampleWrapper className="mt-4">
         <h4 className="mb-4">{t("addElementDialog.contact.howCanWeContactYou")}</h4>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="phone" className="gc-label">
             {t("addElementDialog.contact.phone.label")}
           </Label>
           <TextInput type="text" id="phone" name="phone" autoComplete="tel" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="email" className="gc-label">
             {t("addElementDialog.contact.email.label")}
           </Label>
           <TextInput type="text" id="email" name="email" autoComplete="email" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="radio-english" className="gc-label">
             {t("addElementDialog.contact.language.label")}
           </Label>
-          <div className="overflow-hidden">
+          <div className="overflow-hidden p-2">
             <RadioComponent
               id="radio-english"
               label={t("addElementDialog.contact.language.english")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/DropDown.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/DropDown.tsx
@@ -16,7 +16,7 @@ export const DropDown = () => {
           {t("addElementDialog.dropdown.selectOption")}
         </Label>
         <Description>{t("addElementDialog.dropdown.selectOne")}</Description>
-        <div className="overflow-hidden">
+        <div className="overflow-hidden p-2">
           <Dropdown
             name="name"
             id="dropdown"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/FirstMiddleLastName.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/FirstMiddleLastName.tsx
@@ -14,19 +14,19 @@ export const FirstMiddleLastName = () => {
 
       <ExampleWrapper className="mt-4">
         <h4 className="mb-4">{t("addElementDialog.firstMiddleLastName.whatIsYourName")}</h4>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="first" className="gc-label">
             {t("addElementDialog.firstMiddleLastName.first.label")}
           </Label>
           <TextInput id="first" type="text" name="first" autoComplete="given-name" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="middle" className="gc-label">
             {t("addElementDialog.firstMiddleLastName.middle.label")}
           </Label>
           <TextInput id="middle" type="text" name="middle" autoComplete="additional-name" />
         </div>
-        <div className="mb-6">
+        <div className="gcds-input-wrapper mb-6">
           <Label htmlFor="last" className="gc-label">
             {t("addElementDialog.firstMiddleLastName.last.label")}
           </Label>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Name.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Name.tsx
@@ -12,7 +12,7 @@ export const Name = () => {
       <h3 className="mb-0">{t("addElementDialog.name.title")}</h3>
       <p>{t("addElementDialog.name.description")}</p>
 
-      <ExampleWrapper className="mt-4">
+      <ExampleWrapper className="gcds-input-wrapper mt-4">
         <Label htmlFor="name" className="gc-label">
           {t("addElementDialog.name.label")}
         </Label>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Number.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/Number.tsx
@@ -12,7 +12,7 @@ export const Number = () => {
       <h3 className="mb-0">{t("addElementDialog.number.title")}</h3>
       <p>{t("addElementDialog.number.description")}</p>
 
-      <ExampleWrapper className="mt-4">
+      <ExampleWrapper className="gcds-input-wrapper mt-4">
         <Label htmlFor="name" className="gc-label">
           {t("addElementDialog.number.amount")}
         </Label>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/TextArea.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/TextArea.tsx
@@ -12,7 +12,7 @@ export const TextArea = () => {
       <h3 className="mb-0">{t("addElementDialog.textArea.title")}</h3>
       <p>{t("addElementDialog.textArea.description")}</p>
 
-      <ExampleWrapper className="mt-4">
+      <ExampleWrapper className="gcds-textarea-wrapper mt-4">
         <Label htmlFor="textarea" className="gc-label">
           {t("addElementDialog.textArea.enterAnswer")}
         </Label>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/TextField.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/TextField.tsx
@@ -11,7 +11,7 @@ export const TextField = () => {
       <h3 className="mb-0">{t("addElementDialog.textField.title")}</h3>
       <p>{t("addElementDialog.textField.description")}</p>
 
-      <ExampleWrapper className="mt-4">
+      <ExampleWrapper className="gcds-input-wrapper mt-4">
         <Label htmlFor="name" className="gc-label">
           {t("addElementDialog.textField.enterAnswer")}
         </Label>


### PR DESCRIPTION
# Summary | Résumé

Follow-up fix related to gcds-styles - updated example components in the ElementDialog
