### PR TITLE
Fix: countries with single language only for international addresses.

### DIFF
--- a/components/clientComponents/forms/AddressComplete/utils.ts
+++ b/components/clientComponents/forms/AddressComplete/utils.ts
@@ -63,7 +63,10 @@ export const getAddressComponents = async (
   const frenchResult = addressCompleteResult.find((result) => result.Language === "FRE");
 
   // Pick ENG or FRE based on language. (en vs fr)
-  const resultData = language === "en" ? englishResult : frenchResult;
+  let resultData = language === "en" ? englishResult : frenchResult;
+  if (resultData === undefined) {
+    resultData = addressCompleteResult[0];
+  }
 
   const streetAddress =
     (resultData?.SubBuilding ? resultData?.SubBuilding + "-" : "") +


### PR DESCRIPTION
Fixes part of #4430 , it can be closed and #4417 used for the other part.

Essentially this fix makes it so if a country only provides a single language for it's addresses it doesn't try to force it to grab ENG/FRE entries, instead taking the only option available.