### PR TITLE
fix: Nested Addresses for AddressComplete

### DIFF
--- a/components/clientComponents/forms/AddressComplete/types.ts
+++ b/components/clientComponents/forms/AddressComplete/types.ts
@@ -6,8 +6,9 @@ export interface AddressCompleteChoice {
   Id: string;
   Text: string;
   Highlight: string;
+  Cursor: number;
   Description: string;
-  IsRetrievable: boolean;
+  Next: string;
 }
 
 // Address Lookup API returns an array of objects like:

--- a/components/clientComponents/forms/AddressComplete/utils.ts
+++ b/components/clientComponents/forms/AddressComplete/utils.ts
@@ -47,11 +47,33 @@ export const getSelectedAddress = async (
   });
 
   const responseData = await response.json(); //Todo #4341 - Error Handling
+
   const addressData = responseData.Items as AddressCompleteResult[];
 
   const addressComponents = await getAddressComponents(addressData, language);
 
   return addressComponents;
+};
+
+// Function returns the address set from a retreive.
+export const getAddressCompleteRetrieve = async (
+  addressCompleteKey: string,
+  query: string,
+  countryCode: string
+) => {
+  let params = "?";
+  params += "Key=" + encodeURIComponent(addressCompleteKey);
+  params += "&LastId=" + encodeURIComponent(query);
+  params += "&Country=" + encodeURIComponent(countryCode);
+
+  const response = await fetch(autoCompleteUrl + params, {
+    headers: { "content-Type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+
+  const responseData = await response.json(); //Todo #4341  - Error Handling
+
+  return responseData.Items as AddressCompleteChoice[];
 };
 
 // Helper function combines API component results into single address object.
@@ -125,3 +147,9 @@ export const getAddressAsAnswerElements = (
 
   return answerArray;
 };
+
+// Helper function to test if the address has multiple results.
+export function matchesAddressPattern(input: string): boolean {
+  const pattern = /^.+,\s+[A-Z]{2}(?:,\s+[A-Z0-9]+)?\s+-\s+\d+\s+Addresses$/;
+  return pattern.test(input);
+}


### PR DESCRIPTION
Closes #4417

Changes:
-> API structure is diff from v1 and v2, fixed that.
-> API decides "Retrieve" vs "Find" completely arbitrarily, adds a regex check to pick the right one when the API fails to define itself correctly.
-> Add lookup function for 'Find'.

WIP : The "choices" isn't being updated with the Find return. Working on the why atm.