### PR TITLE
fix: Unstuck AddressComplete Dropdown

### DIFF
--- a/components/clientComponents/forms/AddressComplete/ManagedCombobox.tsx
+++ b/components/clientComponents/forms/AddressComplete/ManagedCombobox.tsx
@@ -79,6 +79,7 @@ export const ManagedCombobox = React.forwardRef(
 
     const changeInputValue = (value: string) => {
       setInputValue(value);
+      setIsOpen(false);
     };
 
     // Use useImperativeHandle to expose the method


### PR DESCRIPTION
Closes #4313

Dropdown will now close when new address is set instead of staying open because a new addresscomplete lookup occured.