### PR TITLE
chore: Move key generation to inside modal / download 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "@i18n/client";
 
 import { cn } from "@lib/utils";
 import { Button } from "@clientComponents/globals";
-import { Dialog as BaseDialog, useDialogRef } from "@formBuilder/components/shared/Dialog";
+import { Dialog, useDialogRef } from "@formBuilder/components/shared/Dialog";
 import { EventKeys, useCustomEvent } from "@lib/hooks/useCustomEvent";
 
 import { ResponsibilityList } from "./ResponsibilityList";
@@ -17,7 +17,7 @@ type APIKeyCustomEventDetails = {
   id: string;
 };
 
-export const Dialog = () => {
+export const ApiKeyDialog = () => {
   const dialog = useDialogRef();
   const { Event } = useCustomEvent();
   const { t } = useTranslation("form-builder");
@@ -26,6 +26,7 @@ export const Dialog = () => {
   const [id, setId] = useState<string>("");
   const [isOpen, setIsOpen] = useState(false);
 
+  // Handle loading state for download button
   const [generating, setGenerating] = useState(false);
 
   const handleOpen = useCallback((detail: APIKeyCustomEventDetails) => {
@@ -54,7 +55,7 @@ export const Dialog = () => {
   };
 
   // Actions
-  const handleCancel = () => {
+  const handleClose = () => {
     dialog.current?.close();
     setIsOpen(false);
   };
@@ -70,7 +71,7 @@ export const Dialog = () => {
 
   const actions = (
     <>
-      <Button theme="secondary" onClick={handleCancel}>
+      <Button theme="secondary" onClick={handleClose}>
         {t("settings.api.dialog.cancelButton")}
       </Button>
       <DownloadButton
@@ -89,8 +90,8 @@ export const Dialog = () => {
   return (
     <>
       {isOpen && (
-        <BaseDialog
-          handleClose={handleCancel}
+        <Dialog
+          handleClose={handleClose}
           dialogRef={dialog}
           actions={actions}
           title={t("settings.api.dialog.title")}
@@ -101,7 +102,7 @@ export const Dialog = () => {
             <ConfirmationAgreement handleAgreement={hasAgreed} />
             <Note />
           </div>
-        </BaseDialog>
+        </Dialog>
       )}
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/Dialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/Dialog.tsx
@@ -10,10 +10,11 @@ import { EventKeys, useCustomEvent } from "@lib/hooks/useCustomEvent";
 import { ResponsibilityList } from "./ResponsibilityList";
 import { ConfirmationAgreement } from "./ConfirmationAgreement";
 import { Note } from "./Note";
+import { downloadKey, _createKey } from "@formBuilder/[id]/settings/api/utils";
+import { SubmitButton as DownloadButton } from "@clientComponents/globals/Buttons/SubmitButton";
 
 type APIKeyCustomEventDetails = {
-  download: () => void;
-  cancel: () => void;
+  id: string;
 };
 
 export const Dialog = () => {
@@ -22,12 +23,14 @@ export const Dialog = () => {
   const { t } = useTranslation("form-builder");
 
   // Setup + Open dialog
-  const [handler, setHandler] = useState<APIKeyCustomEventDetails | null>(null);
+  const [id, setId] = useState<string>("");
   const [isOpen, setIsOpen] = useState(false);
+
+  const [generating, setGenerating] = useState(false);
 
   const handleOpen = useCallback((detail: APIKeyCustomEventDetails) => {
     if (detail) {
-      setHandler(detail);
+      detail.id && setId(detail.id);
       setIsOpen(true);
     }
   }, []);
@@ -52,13 +55,15 @@ export const Dialog = () => {
 
   // Actions
   const handleCancel = () => {
-    handler?.cancel();
     dialog.current?.close();
     setIsOpen(false);
   };
 
-  const handleSave = () => {
-    handler?.download();
+  const handleSave = async () => {
+    setGenerating(true);
+    const key = await _createKey(id);
+    downloadKey(JSON.stringify(key), id);
+    setGenerating(false);
     dialog.current?.close();
     setIsOpen(false);
   };
@@ -68,15 +73,16 @@ export const Dialog = () => {
       <Button theme="secondary" onClick={handleCancel}>
         {t("settings.api.dialog.cancelButton")}
       </Button>
-      <Button
+      <DownloadButton
+        loading={generating}
         className={cn("ml-5")}
         theme="primary"
-        disabled={!agreed}
+        disabled={!agreed || generating}
         onClick={handleSave}
         dataTestId="confirm-download"
       >
         {t("settings.api.dialog.downloadButton")}
-      </Button>
+      </DownloadButton>
     </>
   );
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/components/ApiKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/components/ApiKeyButton.tsx
@@ -37,7 +37,7 @@ export const ApiKeyButton = ({
           loading={false}
           theme="primary"
           disabled={Boolean(keyId)}
-          onClick={async () => {
+          onClick={() => {
             openDialog();
           }}
         >

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/components/ApiKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/components/ApiKeyButton.tsx
@@ -1,12 +1,8 @@
 "use client";
-import { useState } from "react";
 import { useParams } from "next/navigation";
 import { useTranslation } from "@i18n/client";
 
 import { EventKeys, useCustomEvent } from "@lib/hooks/useCustomEvent";
-import { ApiKeyType } from "@lib/types/form-builder-types";
-import { deleteServiceAccountKey } from "../actions";
-import { downloadKey, _createKey } from "../utils";
 import { DeleteKeyButton } from "./DeleteKeyButton";
 import { SubmitButton as GenerateApiKeyButton } from "@clientComponents/globals/Buttons/SubmitButton";
 
@@ -25,43 +21,23 @@ export const ApiKeyButton = ({
   const { id } = useParams();
 
   const { Event } = useCustomEvent();
-  const [pendingKey, setPendingKey] = useState<ApiKeyType | null>(null);
-  const [generatingKey, setGeneratingKey] = useState(false);
-  const [deletingKey, setDeletingKey] = useState(false);
+
+  const openDialog = () => {
+    Event.fire(EventKeys.openApiKeyDialog, { id });
+  };
 
   if (Array.isArray(id)) return null;
 
-  const openDialog = () => {
-    Event.fire(EventKeys.openApiKeyDialog, {
-      download: () => {
-        downloadKey(JSON.stringify(pendingKey), id);
-        setPendingKey(null);
-      },
-      cancel: async () => {
-        setPendingKey(null);
-        setDeletingKey(true);
-        // Note this will revalidate the page
-        // and remove the key from the UI
-        await deleteServiceAccountKey(id);
-        setDeletingKey(false);
-      },
-    });
-  };
-
   return (
     <div className="mb-4">
-      {showDelete && keyId && !deletingKey && !pendingKey ? (
+      {showDelete && keyId ? (
         <DeleteKeyButton id={id} keyId={keyId} />
       ) : (
         <GenerateApiKeyButton
-          loading={generatingKey}
+          loading={false}
           theme="primary"
-          disabled={Boolean(keyId) || pendingKey !== null}
+          disabled={Boolean(keyId)}
           onClick={async () => {
-            setGeneratingKey(true);
-            const key = await _createKey(id);
-            setPendingKey(key);
-            setGeneratingKey(false);
             openDialog();
           }}
         >

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/components/DeleteKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/components/DeleteKeyButton.tsx
@@ -1,20 +1,31 @@
+import React, { useState } from "react";
 import { useTranslation } from "@i18n/client";
-
-import { Button } from "@clientComponents/globals";
 import { ApiTooltip } from "./ApiTooltip";
 import { deleteServiceAccountKey } from "../actions";
 
+import { SubmitButton as DeleteApiKeyButton } from "@clientComponents/globals/Buttons/SubmitButton";
+
 export const DeleteKeyButton = ({ id, keyId }: { id: string; keyId: string }) => {
   const { t } = useTranslation("form-builder");
+  const [deleting, setDeleting] = useState(false);
   return (
     <>
       <div className="mb-4">
         <div className="font-bold">{t("settings.api.keyId")}</div>
         {keyId} <ApiTooltip />
       </div>
-      <Button theme="destructive" className="mr-4" onClick={() => deleteServiceAccountKey(id)}>
+      <DeleteApiKeyButton
+        loading={deleting}
+        theme="destructive"
+        className="mr-4"
+        onClick={async () => {
+          setDeleting(true);
+          await deleteServiceAccountKey(id);
+          setDeleting(false);
+        }}
+      >
         {t("settings.api.deleteKey")}
-      </Button>
+      </DeleteApiKeyButton>
     </>
   );
 };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api/page.tsx
@@ -6,7 +6,7 @@ import { redirect } from "next/navigation";
 import { checkPrivilegesAsBoolean } from "@lib/privileges";
 import { isProductionEnvironment } from "@lib/origin";
 import { ApiKeyButton } from "./components/ApiKeyButton";
-import { Dialog as ApiKeyDialog } from "../../components/dialogs/ApiKeyDialog/Dialog";
+import { ApiKeyDialog } from "../../components/dialogs/ApiKeyDialog/ApiKeyDialog";
 
 export async function generateMetadata({
   params: { locale },


### PR DESCRIPTION
# Summary | Résumé

Update API key generation step to happen when the user presses download after agreeing.