### PR TITLE
fix/form-schedule-remove-12-hour-time

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/ClosedDateBanner.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/ClosedDateBanner.tsx
@@ -12,7 +12,7 @@ export const ClosedDateBanner = ({ closingDate }: { closingDate?: string | null 
 
   const isPastClosingDate = dateHasPast(Date.parse(closingDate));
 
-  const { month, day, year, hour, minute, dayPeriod } = formClosingDateEst(closingDate);
+  const { month, day, year, hour, minute } = formClosingDateEst(closingDate);
 
   const closedText = t("closingDate.banner.text", {
     month,
@@ -20,7 +20,6 @@ export const ClosedDateBanner = ({ closingDate }: { closingDate?: string | null 
     year,
     hour,
     minute,
-    dayPeriod,
   });
 
   if (!isPastClosingDate) {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/ClosingDateDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/ClosingDateDialog.tsx
@@ -7,6 +7,7 @@ import { toast } from "@formBuilder/components/shared/Toast";
 import { WarningIcon } from "@serverComponents/icons";
 import { formClosingDateEst } from "@lib/utils/date/utcToEst";
 import { logMessage } from "@lib/logger";
+import { isFutureDate } from "@lib/utils/date/isFutureDate";
 
 export const ClosingDateDialog = ({
   showDateTimeDialog,
@@ -34,6 +35,9 @@ export const ClosingDateDialog = ({
   // Pre-populate the form with the closing date if it exists
   useEffect(() => {
     if (!closingDate) {
+      return;
+    }
+    if (!isFutureDate(closingDate)) {
       return;
     }
     try {
@@ -178,15 +182,18 @@ export const ClosingDateDialog = ({
               <label htmlFor="time-picker" className="mb-2 font-bold">
                 {t("scheduleClosingPage.dialog.timePicker.text1")}
               </label>
-              <p id="time-picker-description" className="mb-4">
+              <p id="time-picker-description" className="mb-2">
                 {t("scheduleClosingPage.dialog.timePicker.text2")}
+              </p>
+              <p id="time-picker-description2" className="mb-4 opacity-65">
+                {t("scheduleClosingPage.dialog.timePicker.text3")}
               </p>
               <input
                 className="!w-20"
                 id="time-picker"
                 name="time-picker"
                 role="time"
-                aria-describedby="time-picker-description"
+                aria-describedby="time-picker-description time-picker-description2"
                 minLength={5}
                 maxLength={5}
                 onChange={(e) => setTime(e.target.value)}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/ScheduledClosingDate.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/ScheduledClosingDate.tsx
@@ -29,16 +29,16 @@ export const ScheduledClosingDate = ({
     return null;
   }
 
-  let month, day, year, hour, minute, dayPeriod;
+  let month, day, year, hour, minute;
 
   try {
-    ({ month, day, year, hour, minute, dayPeriod } = formClosingDateEst(closingDate, language));
+    ({ month, day, year, hour, minute } = formClosingDateEst(closingDate, language));
   } catch (error) {
     logMessage.info("Unable to parse closing date", closingDate);
     return null;
   }
 
-  if (!month || !day || !year || !hour || !minute || !dayPeriod) {
+  if (!month || !day || !year || !hour || !minute) {
     return null;
   }
 
@@ -51,7 +51,6 @@ export const ScheduledClosingDate = ({
         year,
         hour,
         minute,
-        dayPeriod,
       })}
     </div>
   );

--- a/components/clientComponents/forms/ClosingNotice/ClosingNotice.tsx
+++ b/components/clientComponents/forms/ClosingNotice/ClosingNotice.tsx
@@ -31,16 +31,16 @@ export const ClosingNotice = ({
     return null;
   }
 
-  let month, day, year, hour, minute, dayPeriod;
+  let month, day, year, hour, minute;
 
   try {
-    ({ month, day, year, hour, minute, dayPeriod } = formClosingDateEst(closingDate, language));
+    ({ month, day, year, hour, minute } = formClosingDateEst(closingDate, language));
   } catch (error) {
     logMessage.info("Unable to parse closing date", closingDate);
     return null;
   }
 
-  if (!month || !day || !year || !hour || !minute || !dayPeriod) {
+  if (!month || !day || !year || !hour || !minute) {
     return null;
   }
 
@@ -56,7 +56,6 @@ export const ClosingNotice = ({
             year,
             hour,
             minute,
-            dayPeriod,
           })}
         </span>
       </p>

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -199,7 +199,7 @@
   "closingNotice": {
     "title": "Form closing",
     "text1": "Form accepting submissions until:",
-    "text2": "{{month}} {{day}}, {{year}} at {{hour}}:{{minute}} {{dayPeriod}} ET."
+    "text2": "{{month}} {{day}}, {{year}} at {{hour}}:{{minute}} ET."
   },
   "cancel": "Cancel"
 }

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -944,7 +944,7 @@
       }
     },
     "banner": {
-      "text": "Form closed on {{month}} {{day}}, {{year}} at {{hour}}:{{minute}} {{dayPeriod}} ET"
+      "text": "Form closed on {{month}} {{day}}, {{year}} at {{hour}}:{{minute}} ET"
     }
   },
   "errorSavingForm": {
@@ -1195,7 +1195,8 @@
       },
       "timePicker": {
         "text1": "Set a time",
-        "text2": "Provide the time using the 24-hour clock with timezone in Eastern Time"
+        "text2": "Provide the time using the 24-hour clock with timezone in Eastern Time.",
+        "text3": "For example 21:00"
       },
       "error": {
         "notFutureDate": "Date and time must be upcoming, in the future."

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -199,7 +199,7 @@
   "closingNotice": {
     "title": "Fermeture du formulaire",
     "text1": "Les soumissions sont acceptées jusqu'au :",
-    "text2": "{{day}} {{month}} {{year}} à {{hour}} h {{minute}} {{dayPeriod}} HE"
+    "text2": "{{day}} {{month}} {{year}} à {{hour}} h {{minute}} HE"
   },
   "cancel": "Annuler"
 }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -944,7 +944,7 @@
       }
     },
     "banner": {
-      "text": "Le formulaire a été fermé le {{day}} {{month}} {{year}} à {{hour}} h {{minute}} {{dayPeriod}} HE"
+      "text": "Le formulaire a été fermé le {{day}} {{month}} {{year}} à {{hour}} h {{minute}} HE"
     }
   },
   "errorSavingForm": {
@@ -1195,7 +1195,8 @@
       },
       "timePicker": {
         "text1": "Fixez l'heure de fermeture",
-        "text2": "Indiquez l'heure en utilisant l'horloge de 24 heures avec le fuseau horaire de l'heure de l'Est"
+        "text2": "Indiquez l'heure en utilisant l'horloge de 24 heures avec le fuseau horaire de l'heure de l'Est.",
+        "text3": "[FR]For example 21:00"
       },
       "error": {
         "notFutureDate": "[FR]Date and time must be upcoming, in the future."

--- a/lib/utils/date/utcToEst.ts
+++ b/lib/utils/date/utcToEst.ts
@@ -8,8 +8,8 @@ export const formClosingDateEst = (utcDate: string, lang: string = "en") => {
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: true,
-    hourCycle: "h12",
+    hour12: false,
+    // hourCycle: "h12", -- will be added in a future release
   };
 
   const locale = lang === "fr" ? "fr-CA" : "en-CA";
@@ -26,7 +26,7 @@ export const formClosingDateEst = (utcDate: string, lang: string = "en") => {
   const year = parts.find((part) => part.type === "year")?.value;
   const hour = parts.find((part) => part.type === "hour")?.value;
   const minute = parts.find((part) => part.type === "minute")?.value;
-  const dayPeriod = parts.find((part) => part.type === "dayPeriod")?.value;
+  // const dayPeriod = parts.find((part) => part.type === "dayPeriod")?.value;
 
   return {
     month,
@@ -34,6 +34,6 @@ export const formClosingDateEst = (utcDate: string, lang: string = "en") => {
     year,
     hour,
     minute,
-    dayPeriod,
+    // dayPeriod,
   };
 };

--- a/lib/utils/date/utcToEst.vitest.ts
+++ b/lib/utils/date/utcToEst.vitest.ts
@@ -12,7 +12,7 @@ describe('utcToEst', () => {
       "minute": "00",
       "month": "October",
       "year": "2023",
-      "dayPeriod": "a.m.",
+      // "dayPeriod": "a.m.",
     });
   });
 
@@ -26,7 +26,7 @@ describe('utcToEst', () => {
       "minute": "00",
       "month": "octobre",
       "year": "2023",
-      "dayPeriod": "a.m.",
+      // "dayPeriod": "a.m.",
     });
   });
 


### PR DESCRIPTION
# Summary | Résumé

Removes the 24-hour to 12-hour time conversion. We'll add this back in a future itteration.