### PR TITLE
chore: Removes the yup package

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "usehooks-ts": "2.9.1",
     "uuid": "9.0.1",
     "valibot": "^0.30.0",
-    "yup": "0.32.11",
     "zustand": "5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Summary | Résumé

Removes the yup package. We dropped it in favor of Valibot some time ago.
