### PR TITLE
fix: Updates the review page start title 

### DIFF
--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -232,9 +232,9 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
         {Array.isArray(reviewItems) &&
           reviewItems.map((reviewItem) => {
             const title =
-              reviewItem.id !== "start"
-                ? reviewItem.title
-                : t("start", { ns: "common", lng: language });
+              reviewItem.id === "start"
+                ? t("logic.start", { ns: "common", lng: language })
+                : reviewItem.title;
             return (
               <div
                 key={reviewItem.id}

--- a/components/clientComponents/forms/Review/Review.tsx
+++ b/components/clientComponents/forms/Review/Review.tsx
@@ -231,9 +231,10 @@ export const Review = ({ language }: { language: Language }): React.ReactElement
       <div className="my-16">
         {Array.isArray(reviewItems) &&
           reviewItems.map((reviewItem) => {
-            const title = reviewItem.title
-              ? reviewItem.title
-              : t("start", { ns: "common", lng: language });
+            const title =
+              reviewItem.id !== "start"
+                ? reviewItem.title
+                : t("start", { ns: "common", lng: language });
             return (
               <div
                 key={reviewItem.id}


### PR DESCRIPTION
# Summary | Résumé

Updates review page start title to use the correct language. Previously a check was done on whether the group was undefined, that was the "flag" for whether it was a start group or not. The check was updated to look at the group Id instead.

## Test

Load up a group form. Switch the language to French. The Review page Start group should now be in French (the remaining group titles should be unchanged).

EXPECTED
![Screenshot 2024-10-28 at 12 23 55 PM](https://github.com/user-attachments/assets/667afa10-be23-4565-aa0e-8d787cd70c89)



