### PR TITLE
chore: FileValidation error vs Server error

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -399,7 +399,11 @@ export const Form = withFormik<FormProps, Responses>({
       );
 
       if (result.error) {
-        formikBag.setStatus("FileError");
+        if (result.error.message.includes("FileValidationResult")) {
+          formikBag.setStatus("FileError");
+        } else {
+          formikBag.setStatus("Error");
+        }
       } else {
         formikBag.props.onSuccess(result.id);
       }


### PR DESCRIPTION
# Summary | Résumé

Fixes #4478 

A previous fix (#4374) caused all errors from the serverAction to be caught as FileValidation errors.
This will specifically catch those and render appropriately, and let everything else fall through to a generic Server error.
