### PR TITLE
fix : AddressComplete Country Select Stuck

### DIFF
--- a/components/clientComponents/forms/AddressComplete/ManagedCombobox.tsx
+++ b/components/clientComponents/forms/AddressComplete/ManagedCombobox.tsx
@@ -57,7 +57,9 @@ export const ManagedCombobox = React.forwardRef(
               useFilter ? choice.toLowerCase().includes(inputValue?.toLowerCase() || "") : true
             )
           );
-          setIsOpen(true);
+          if (!useFilter) {
+            setIsOpen(true);
+          }
         },
         items,
         onSelectedItemChange: ({ selectedItem }) => {


### PR DESCRIPTION
If the ManagedCombobox component is not active filtering elements, don't force the combobox open on selecting an element. (Basically, the combobox needs to be forced open if it's actively being filtered by the AddressComplete API, but if it's not, it uses the old behavior and shouldn't be forced open.)

Closes #4455