### PR TITLE
fix: Ensure user is owner on form when setting closing form date and message

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1496,6 +1496,21 @@ export const updateClosedData = async (
   closingDate: string | null,
   details?: ClosedDetails
 ) => {
+  const templateWithAssociatedUsers = await _unprotectedGetTemplateWithAssociatedUsers(formID);
+  if (!templateWithAssociatedUsers) return null;
+
+  checkPrivileges(ability, [
+    {
+      action: "update",
+      subject: {
+        type: "FormRecord",
+        object: {
+          ...templateWithAssociatedUsers.formRecord,
+          users: templateWithAssociatedUsers.users,
+        },
+      },
+    },
+  ]);
   let detailsData: ClosedDetails | null = null;
 
   // Add the closed details if they exist


### PR DESCRIPTION
# Summary | Résumé
Add an ability check before the prisma call to ensure the user is an owner of the form.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
