### PR TITLE
fix: Users Cursor stuck in AddressComplete Input

### DIFF
--- a/components/clientComponents/forms/AddressComplete/ManagedCombobox.tsx
+++ b/components/clientComponents/forms/AddressComplete/ManagedCombobox.tsx
@@ -99,6 +99,12 @@ export const ManagedCombobox = React.forwardRef(
             required,
             "aria-describedby": ariaDescribedBy,
             onFocus: () => setIsOpen(true),
+            onChange: (e) => {
+              setInputValue((e.target as HTMLInputElement).value);
+            },
+            // Prevents a double input refresh from being fired, this is a workaround for a downshift bug
+            // https://github.com/downshift-js/downshift/issues/1108
+            // Downshift won't be updated to fix this issue, so we need to handle it ourselves
           })}
           data-testid="combobox-input"
           placeholder={placeholderText}


### PR DESCRIPTION
Closes #4504 

Downshift has a 'bug'/'designflaw'/'intended'? way of behaving that causes a double render when you handle the input value of the component yourself. There's a small and simple work around in simply calling the onChange yourself through the event handler instead of letting Downshift do it all.