### PR TITLE
fix: Updates save date with correct date conversion

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/SetClosingDate.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/close/SetClosingDate.tsx
@@ -99,7 +99,9 @@ export const SetClosingDate = ({
   const saveFormStatus = useCallback(async () => {
     // Check to see if the existing date is in the past when updating the toggle. If the date is in
     // the future we want to keep the existing value.
-    let closeDate = isFutureDate(String(closingDate)) ? closingDate : null;
+    let closeDate = isFutureDate(String(closingDate))
+      ? new Date(String(closingDate)).toISOString()
+      : null;
 
     if (status === "closed") {
       // Set date to now to close the form right away


### PR DESCRIPTION
# Summary | Résumé

Fixes a bug where the save date function was not first converting the date to an ISO date which caused a date miss-match in prisma etc

Here is the related [production thread chat](https://app.slack.com/client/T2G2S06PM/C05G766KW49?selected_team_id=T2G2S06PM).

Closes #4559 
