### PR TITLE
fix: Grab the right language for AddressComplete SubLabels (Responses)

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -192,7 +192,8 @@ export const getSubmissionsByFormat = async ({
       throw new AccessControlError("User is not authenticated");
     }
 
-    const { t } = await serverTranslation("form-builder-responses");
+    const { t: tEn } = await serverTranslation("form-builder-responses", { lang: "en" });
+    const { t: tFr } = await serverTranslation("form-builder-responses", { lang: "fr" });
 
     const responseConfirmLimit = Number(await getAppSetting("responseDownloadLimit"));
 
@@ -276,24 +277,24 @@ export const getSubmissionsByFormat = async ({
 
             const extraTranslations = {
               streetAddress: {
-                en: t("addressComponents.streetAddress", { lang: "en" }),
-                fr: t("addressComponents.streetAddress", { lang: "fr" }),
+                en: tEn("addressComponents.streetAddress"),
+                fr: tFr("addressComponents.streetAddress"),
               },
               city: {
-                en: t("addressComponents.city", { lang: "en" }),
-                fr: t("addressComponents.city", { lang: "fr" }),
+                en: tEn("addressComponents.city"),
+                fr: tFr("addressComponents.city"),
               },
               province: {
-                en: t("addressComponents.province", { lang: "en" }),
-                fr: t("addressComponents.province", { lang: "fr" }),
+                en: tEn("addressComponents.province"),
+                fr: tFr("addressComponents.province"),
               },
               postalCode: {
-                en: t("addressComponents.postalCode", { lang: "en" }),
-                fr: t("addressComponents.postalCode", { lang: "fr" }),
+                en: tEn("addressComponents.postalCode"),
+                fr: tFr("addressComponents.postalCode"),
               },
               country: {
-                en: t("addressComponents.country", { lang: "en" }),
-                fr: t("addressComponents.country", { lang: "fr" }),
+                en: tEn("addressComponents.country"),
+                fr: tFr("addressComponents.country"),
               },
             };
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -276,19 +276,25 @@ export const getSubmissionsByFormat = async ({
 
             const extraTranslations = {
               streetAddress: {
-                en: t("addressComponents.streetAddress"),
-                fr: t("addressComponents.streetAddress"),
+                en: t("addressComponents.streetAddress", { lang: "en" }),
+                fr: t("addressComponents.streetAddress", { lang: "fr" }),
               },
-              city: { en: t("addressComponents.city"), fr: t("addressComponents.city") },
+              city: {
+                en: t("addressComponents.city", { lang: "en" }),
+                fr: t("addressComponents.city", { lang: "fr" }),
+              },
               province: {
-                en: t("addressComponents.province"),
-                fr: t("addressComponents.province"),
+                en: t("addressComponents.province", { lang: "en" }),
+                fr: t("addressComponents.province", { lang: "fr" }),
               },
               postalCode: {
-                en: t("addressComponents.postalCode"),
-                fr: t("addressComponents.postalCode"),
+                en: t("addressComponents.postalCode", { lang: "en" }),
+                fr: t("addressComponents.postalCode", { lang: "fr" }),
               },
-              country: { en: t("addressComponents.country"), fr: t("addressComponents.country") },
+              country: {
+                en: t("addressComponents.country", { lang: "en" }),
+                fr: t("addressComponents.country", { lang: "fr" }),
+              },
             };
 
             const reviewElements = getAddressAsAnswerElements(


### PR DESCRIPTION
Closes #4535