### PR TITLE
chore: Check for unsaved forms when checking for API key

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/page.tsx
@@ -24,13 +24,7 @@ export default async function Page({
   let keyId: string | false = false;
 
   if (process.env.APP_ENV !== "test") {
-    try {
-      if (id && id !== "0000") {
-        keyId = await checkKeyExists(id);
-      }
-    } catch (e) {
-      // no-op
-    }
+    keyId = await checkKeyExists(id);
   }
 
   return (

--- a/lib/serviceAccount.ts
+++ b/lib/serviceAccount.ts
@@ -116,6 +116,10 @@ export const checkMachineUserExists = async (templateId: string) => {
 };
 
 export const checkKeyExists = async (templateId: string) => {
+  if (templateId === "0000") {
+    return false;
+  }
+
   const { ability } = await authCheckAndThrow();
   await checkUserHasTemplateOwnership(ability, templateId);
 


### PR DESCRIPTION
# Summary | Résumé

Don't throw on unsaved forms.

Should quiet this noise 
<img width="428" alt="image" src="https://github.com/user-attachments/assets/bb58a8bc-0a5b-43a4-bdea-c27a66018213">
