### PR TITLE
fix: Deleting a template without and associated API key

### DIFF
--- a/lib/serviceAccount.ts
+++ b/lib/serviceAccount.ts
@@ -1,6 +1,5 @@
 import crypto from "crypto";
-import { prisma } from "@lib/integration/prismaConnector";
-import { Prisma } from "@prisma/client";
+import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
 import { logMessage } from "@lib/logger";
 import { logEvent } from "@lib/auditLogs";
 import { authCheckAndThrow } from "@lib/actions";
@@ -85,19 +84,12 @@ export const deleteKey = async (templateId: string) => {
   }
 
   await prisma.apiServiceAccount
-    .delete({
+    .deleteMany({
       where: {
         templateId: templateId,
       },
     })
-    .catch((e) => {
-      // Ignore the error if the record does not exist.
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
-        return;
-      }
-      // continue to throw if it is a different type of error
-      throw e;
-    });
+    .catch((e) => prismaErrors(e, null));
 
   logEvent(
     ability.userID,


### PR DESCRIPTION
# Summary | Résumé

When deleting a Template the code also attempts to delete any associated API Service Account that may be associated with the template.  The current prisma invocation throws and error, although it it handled, and logs the output to console.  This can create additional noise in the application logs.  
![Screenshot 2024-11-04 at 1 04 51 PM](https://github.com/user-attachments/assets/a4d93f39-0ef5-4aeb-8428-c756809e6cc2)

Solution:
Swap the prisma `delete` invocation for a `deleteMany`.  This way if no record exists the prisma command does not fail and throw an error.  The `deleteMany` uses a filter of the `templateId` to remove any associated accounts.


# Test instructions | Instructions pour tester la modification
Setup:
- Create a form
Test:
- Delete a form
- No error should be visible in the console.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
