### PR TITLE
fix: PR Review Environment not handling complex secrets

### DIFF
--- a/bin/pr-review-entrypoint.sh
+++ b/bin/pr-review-entrypoint.sh
@@ -32,8 +32,8 @@ load_non_existing_envs() {
     if echo "$line" | grep -Eq "$_isBlank"; then # Ignore blank line
       continue
     fi
-    key=$(echo "$line" | cut -d '=' -f 1)
-    value=$(echo "$line" | cut -d '=' -f 2-)
+    key="${line%%=*}"
+    value="${line#*=}" 
 
     if [ -z "$(var_expand "$key")" ] && [ $key != "NEXTAUTH_URL" ]; then # Check if environment variable doesn't exist
       export "${key}=${value}"


### PR DESCRIPTION
# Summary | Résumé

The current `cut` command in the pr-review-entrypoint.sh was using `=` as a delimiter.  As more and more of our secrets become complex or handle base64 encoding this delimiter can appear naturally and wreck havoc on the secret parsing.

To fix the `cut` command has been replaced with the same scripting parsing command that is used in pr-review-sync-vars.sh that leverages the first instance of `=` instead of parsing the whole string into multiple sections.


# Test instructions | Instructions pour tester la modification
Blind faith

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Are there any related issues or tangent features you consider out of scope for
this issue that could be addressed in the future? If so please create issues and provide
links in this section

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
