### PR TITLE
chore: Remove barrel file for form-builder hooks

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditNavigation.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditNavigation.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { useTranslation } from "@i18n/client";
 import { SubNavLink } from "@clientComponents/globals/SubNavLink";
-import { useActivePathname } from "@lib/hooks/form-builder";
+import { useActivePathname } from "@lib/hooks/form-builder/useActivePathname";
 import { LangSwitcher } from "@formBuilder/components/shared/LangSwitcher";
 import { QuestionsIcon, TranslateIcon } from "@serverComponents/icons";
 import { useTemplateStore } from "@lib/store/useTemplateStore";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/ElementPanel.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 import { FormElementWithIndex } from "@lib/types/form-builder-types";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { PanelActions, PanelBodyRoot } from "./index";
-import { useIsWithin } from "@lib/hooks/form-builder";
+import { useIsWithin } from "@lib/hooks/form-builder/useIsWithin";
 import { useRefsContext } from "./RefsContext";
 import { FormElementTypes, FormElement } from "@lib/types";
 import { useTreeRef } from "@formBuilder/components/shared/right-panel/treeview/provider/TreeRefProvider";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SelectedElement.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/SelectedElement.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "@i18n/client";
 import { CheckBoxEmptyIcon, CheckIcon, RadioEmptyIcon } from "@serverComponents/icons";
 import { ShortAnswer, Options, SubOptions, RichText, SubElement } from "./elements";
 import { ElementOption, FormElementWithIndex } from "@lib/types/form-builder-types";
-import { useElementOptions } from "@lib/hooks/form-builder";
+import { useElementOptions } from "@lib/hooks/form-builder/useElementOptions";
 import { ConditionalIndicator } from "@formBuilder/components/shared/conditionals/ConditionalIndicator";
 import { DateElement } from "./elements/DateElement";
 import { DateFormat } from "@clientComponents/forms/FormattedDate/types";

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/sub-elements/PanelHightlight.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/sub-elements/PanelHightlight.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 
-import { useIsWithin } from "@lib/hooks/form-builder";
+import { useIsWithin } from "@lib/hooks/form-builder/useIsWithin";
 import { cn } from "@lib/utils";
 
 export const PanelHightLight = ({

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -8,7 +8,7 @@ import { Button } from "@clientComponents/globals";
 
 import { RightPanelOpen, RoundCloseIcon } from "@serverComponents/icons";
 import { cn } from "@lib/utils";
-import { useActivePathname } from "@lib/hooks/form-builder";
+import { useActivePathname } from "@lib/hooks/form-builder/useActivePathname";
 import { DownloadCSVWithGroups } from "@formBuilder/[id]/edit/translate/components/DownloadCSVWithGroups";
 import { useTreeRef } from "./treeview/provider/TreeRefProvider";
 import { TreeView } from "./treeview/TreeView";

--- a/components/clientComponents/globals/SubNavLink.tsx
+++ b/components/clientComponents/globals/SubNavLink.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import React, { ReactElement, useEffect, useState } from "react";
-import { useActivePathname } from "@lib/hooks/form-builder";
+import { useActivePathname } from "@lib/hooks/form-builder/useActivePathname";
 import { cn } from "@lib/utils";
 
 export const SubNavLink = ({

--- a/lib/hooks/form-builder/index.ts
+++ b/lib/hooks/form-builder/index.ts
@@ -1,6 +1,0 @@
-export { useAllowPublish } from "./useAllowPublish";
-export { useElementOptions } from "./useElementOptions";
-export { useActivePathname } from "./useActivePathname";
-export { useIsWithin } from "./useIsWithin";
-export { useIsAdminUser } from "./useIsAdminUser";
-export { RefStoreProvider } from "./useRefStore";


### PR DESCRIPTION
# Summary | Résumé

Removes the form-builder hooks directory barrel file and updates related imports
