### PR TITLE
chore: Add view for API submissions available

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/NoResponses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/NoResponses.tsx
@@ -1,13 +1,31 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, HeadingLevel } from "@clientComponents/globals/card/Card";
 import Image from "next/image";
 import { VaultStatus } from "@lib/types";
 import { useTranslation } from "react-i18next";
 import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
+import { newResponsesExist } from "../actions";
 
-export const NoResponses = ({ statusFilter }: { statusFilter: string }) => {
+export const NoResponses = ({ statusFilter, formId }: { statusFilter: string; formId: string }) => {
   const { t } = useTranslation("form-builder-responses");
   const { hasApiKeyId } = useFormBuilderConfig();
+
+  const [checkingApiSubmissions, setCheckingApiSubmissions] = useState(true);
+  const [hasApiSubmissions, setHasApiSubmissions] = useState(false);
+
+  useEffect(() => {
+    const getApiSubmissions = async () => {
+      const result = await newResponsesExist(formId);
+      if (result === true) {
+        setHasApiSubmissions(true);
+        setCheckingApiSubmissions(false);
+      }
+    };
+    if (hasApiKeyId) {
+      getApiSubmissions();
+    }
+  }, [hasApiKeyId, formId]);
+
   return (
     <>
       {statusFilter === VaultStatus.NEW && (
@@ -37,15 +55,7 @@ export const NoResponses = ({ statusFilter }: { statusFilter: string }) => {
           headingStyle="gc-h2 text-[#748094]"
         />
       )}
-      {hasApiKeyId && statusFilter === VaultStatus.CONFIRMED && (
-        <Card
-          icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
-          title={t("downloadResponsesTable.card.noNewResponsesApi")}
-          content={t("downloadResponsesTable.card.noNewResponsesApiMessage")}
-          headingTag={HeadingLevel.H1}
-          headingStyle="gc-h2 text-[#748094]"
-        />
-      )}
+
       {statusFilter === VaultStatus.PROBLEM && (
         <>
           <h1 className="visually-hidden">{t("tabs.problemResponses.title")}</h1>
@@ -55,6 +65,37 @@ export const NoResponses = ({ statusFilter }: { statusFilter: string }) => {
             content={t("downloadResponsesTable.card.noProblemResponsesMessage")}
           />
         </>
+      )}
+
+      {/* 
+          API user has no responses available
+        */}
+      {hasApiKeyId &&
+        !checkingApiSubmissions &&
+        !hasApiSubmissions &&
+        statusFilter === VaultStatus.CONFIRMED && (
+          <Card
+            icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+            title={t("downloadResponsesTable.card.noNewResponsesApi")}
+            content={t("downloadResponsesTable.card.noNewResponsesApiMessage")}
+            headingTag={HeadingLevel.H1}
+            headingStyle="gc-h2 text-[#748094]"
+          />
+        )}
+
+      {/* 
+          No responses are available for this view 
+          but there are submissions available for API retreival 
+        */}
+
+      {!checkingApiSubmissions && hasApiKeyId && hasApiSubmissions && (
+        <Card
+          icon={<Image src="/img/mailbox.svg" alt="" width="200" height="200" />}
+          title={t("downloadResponsesTable.card.apiResponsesAvailable")}
+          content={t("downloadResponsesTable.card.apiResponsesAvailableMessage")}
+          headingTag={HeadingLevel.H1}
+          headingStyle="gc-h2 text-[#748094]"
+        />
       )}
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/components/Responses.tsx
@@ -98,7 +98,7 @@ export const Responses = ({ responseDownloadLimit, overdueAfter }: ResponsesProp
               />
             </>
           ) : (
-            <NoResponses statusFilter={ucfirst(statusFilter)} />
+            <NoResponses formId={formId} statusFilter={ucfirst(statusFilter)} />
           )}
         </div>
       </>
@@ -132,7 +132,7 @@ export const Responses = ({ responseDownloadLimit, overdueAfter }: ResponsesProp
             />
           </>
         ) : (
-          <NoResponses statusFilter={ucfirst(statusFilter)} />
+          <NoResponses formId={formId} statusFilter={ucfirst(statusFilter)} />
         )}
       </div>
     </>

--- a/i18n/translations/en/form-builder-responses.json
+++ b/i18n/translations/en/form-builder-responses.json
@@ -150,7 +150,9 @@
       "noProblemResponses": "No responses reported with problems",
       "noProblemResponsesMessage": "Problem responses will appear here until signed off for removal from GC Forms.",
       "noNewResponsesApi": "No responses available for API retrieval",
-      "noNewResponsesApiMessage": "Submitted form responses will appear here and be available in GC Forms for 45 days."
+      "noNewResponsesApiMessage": "Submitted form responses will appear here and be available in GC Forms for 45 days.",
+      "apiResponsesAvailable": "Responses are available",
+      "apiResponsesAvailableMessage": "Please use the API to retrieve responses."
     },
     "notifications": {
       "downloadComplete": "Responses moved to the “Downloaded” tab",

--- a/i18n/translations/fr/form-builder-responses.json
+++ b/i18n/translations/fr/form-builder-responses.json
@@ -150,7 +150,9 @@
       "noProblemResponses": "Aucune réponse signalée avec problème",
       "noProblemResponsesMessage": "Les réponses signalées avec problèmes apparaîtront ici jusqu'à ce qu'elles soient approuvées pour leur suppression de Formulaires GC.",
       "noNewResponsesApi": "Aucune réponse n'est disponible pour être récupérée par l'intermédiaire de l'API",
-      "noNewResponsesApiMessage": "Les réponses soumises au formulaire apparaîtront ici et seront disponible dans Formulaires GC pendant 45 jours."
+      "noNewResponsesApiMessage": "Les réponses soumises au formulaire apparaîtront ici et seront disponible dans Formulaires GC pendant 45 jours.",
+      "apiResponsesAvailable": "Responses are available [FR]",
+      "apiResponsesAvailableMessage": "Please use the API to retrieve responses. [FR]"
     },
     "notifications": {
       "downloadComplete": "Réponses déplacées vers l'onglet « Téléchargements »",


### PR DESCRIPTION
# Summary | Résumé

Adds Card view for when API submissions are available but haven't been retrieved.

For example 

A new draft form is created.
A few submissions are submitted.

At this point nothing is confirmed.

Previously the no responses available screen would show --- which isn't accurate they just haven't been retrieved via the API to show.
