### PR TITLE
fix: translations CSV export where some commas were not escaped

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/DownloadCSVWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/DownloadCSVWithGroups.tsx
@@ -57,7 +57,11 @@ export const DownloadCSVWithGroups = () => {
     if (element.properties.choices) {
       element.properties.choices.map((choice, choiceIndex) => {
         if (choice.en || choice.fr) {
-          data.push([`${description} - Option ${choiceIndex + 1}`, choice.en, choice.fr]);
+          data.push([
+            `${description} - Option ${choiceIndex + 1}`,
+            formatText(choice.en),
+            formatText(choice.fr),
+          ]);
         }
       });
     }


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where some commas were not escaped in a CSV file generated from the translations export feature.

## Test

See original ticket. Try th importing the JSON form and then from the Translation tab, click the translation export feature. Then open the exported CSV file in Excel. Search for "River, Stream, or Creek" - these should be in the same column.
