### PR TITLE
fix: Updates duplicate element to use numbers

### DIFF
--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -371,9 +371,12 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
                 const element = JSON.parse(JSON.stringify(state.form.elements[elIndex]));
                 element.id = id;
                 if (element.type !== "richText") {
-                  element.properties[state.localizeField("title")] = `${
-                    element.properties[state.localizeField("title")]
-                  } copy`;
+                  const regExRemovePastCount = /\s\(\d{1,3}\)$/;
+                  const title = element.properties[state.localizeField("title")].replace(
+                    regExRemovePastCount,
+                    ""
+                  );
+                  element.properties[state.localizeField("title")] = `${title} (${elIndex + 1})`;
                 }
                 state.form.elements.splice(elIndex + 1, 0, element);
                 state.form.layout.splice(elIndex + 1, 0, id);


### PR DESCRIPTION
# Summary | Résumé

Instead of using the hard coded "copy" text, a numerical count was used to keep track of duplicated rich text elements in the form builder.

Another option would have been to pass to the related function the "copy" or "duplicate" text in both languages. Though "duplicate" is probably not ideal since that would require a gender in French.

![Screenshot 2024-11-19 at 3 42 07 PM](https://github.com/user-attachments/assets/cc60ef13-a2ea-4f41-bd3b-f3f251489c98)
