### PR TITLE
chore: add form id to log for form not found

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -395,7 +395,11 @@ export const getSubmissionsByFormat = async ({
         );
     }
   } catch (err) {
-    logMessage.error(`Could not create submissions in format ${format}: ${(err as Error).message}`);
+    logMessage.error(
+      `Could not create submissions in format ${format} formId: ${formID}: ${
+        (err as Error).message
+      }`
+    );
 
     if (err instanceof FormBuilderError) {
       return {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -206,7 +206,7 @@ export const getSubmissionsByFormat = async ({
     const fullFormTemplate = await getFullTemplateByID(ability, formID);
 
     if (fullFormTemplate === null) {
-      logMessage.error(`getSubmissionsByFormat form not found: ${formID}`);
+      logMessage.warn(`getSubmissionsByFormat form not found: ${formID}`);
       throw new FormBuilderError("Form not found", FormServerErrorCodes.FORM_NOT_FOUND);
     }
 
@@ -395,7 +395,7 @@ export const getSubmissionsByFormat = async ({
         );
     }
   } catch (err) {
-    logMessage.error(
+    logMessage.warn(
       `Could not create submissions in format ${format} formId: ${formID}: ${
         (err as Error).message
       }`

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[statusFilter]/actions.ts
@@ -206,6 +206,7 @@ export const getSubmissionsByFormat = async ({
     const fullFormTemplate = await getFullTemplateByID(ability, formID);
 
     if (fullFormTemplate === null) {
+      logMessage.error(`getSubmissionsByFormat form not found: ${formID}`);
       throw new FormBuilderError("Form not found", FormServerErrorCodes.FORM_NOT_FOUND);
     }
 


### PR DESCRIPTION
# Summary | Résumé

Adds a form ID to logs to help track errors downloading submissions.

<img width="665" alt="Screenshot 2024-11-20 at 11 09 51 AM" src="https://github.com/user-attachments/assets/485fb76a-964d-462f-ab8a-bbfdc8188a27">


