### PR TITLE
chore: add migration script to add StatusCreatedAt property to Vault NAME# items

### DIFF
--- a/utils/statusCreatedAtMigration/.env_example
+++ b/utils/statusCreatedAtMigration/.env_example
@@ -1,0 +1,8 @@
+# Copy to .env
+
+LOCAL_AWS_ENDPOINT=http://127.0.0.1:4566
+
+#AWS_ACCESS_KEY_ID=test
+#AWS_SECRET_ACCESS_KEY=test
+#AWS_SESSION_TOKEN=test
+#AWS_REGION=ca-central-1

--- a/utils/statusCreatedAtMigration/main.ts
+++ b/utils/statusCreatedAtMigration/main.ts
@@ -1,0 +1,82 @@
+/* eslint-disable no-console */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { ScanCommand, ScanCommandOutput, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { config } from "dotenv";
+
+const main = async () => {
+  try {
+    const dynamodbClient = new DynamoDBClient({
+      region: process.env.AWS_REGION ?? "ca-central-1",
+      ...(process.env.LOCAL_AWS_ENDPOINT && { endpoint: process.env.LOCAL_AWS_ENDPOINT }),
+    });
+
+    let lastEvaluatedKey = null;
+    let numberOfUpdatedVaultNameItems = 0;
+
+    while (lastEvaluatedKey !== undefined) {
+      const scanResults: ScanCommandOutput = await dynamodbClient.send(
+        new ScanCommand({
+          TableName: "Vault",
+          ExclusiveStartKey: lastEvaluatedKey ?? undefined,
+          Limit: 100, // The next `TransactWriteCommand` operation we gonna run can only update 100 items per request
+          FilterExpression: "begins_with(NAME_OR_CONF, :nameOrConfPrefix)",
+          ExpressionAttributeNames: {
+            "#name": "Name",
+            "#status": "Status",
+          },
+          ExpressionAttributeValues: {
+            ":nameOrConfPrefix": "NAME#",
+          },
+          ProjectionExpression: "FormID,#name,#status,CreatedAt",
+        })
+      );
+
+      if (scanResults.Items && scanResults.Items.length > 0) {
+        await dynamodbClient.send(
+          new TransactWriteCommand({
+            TransactItems: scanResults.Items.map((item) => {
+              return {
+                Update: {
+                  TableName: "Vault",
+                  Key: {
+                    FormID: item["FormID"],
+                    NAME_OR_CONF: `NAME#${item["Name"]}`,
+                  },
+                  UpdateExpression: "SET #statusCreatedAtKey = :statusCreatedAtValue",
+                  ExpressionAttributeNames: {
+                    "#statusCreatedAtKey": "Status#CreatedAt",
+                  },
+                  ExpressionAttributeValues: {
+                    ":statusCreatedAtValue": `${item["Status"]}#${item["CreatedAt"]}`,
+                  },
+                },
+              };
+            }),
+          })
+        );
+
+        numberOfUpdatedVaultNameItems += scanResults.Items.length;
+
+        process.stdout.write(
+          `Migration in progress ... ${numberOfUpdatedVaultNameItems} Vault NAME# items have been updated.\r`
+        );
+      }
+
+      lastEvaluatedKey = scanResults.LastEvaluatedKey;
+
+      // Rate limiting to avoid exceeding provisioned capacity
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    console.log(
+      `\nMigration completed successfully!\nA total of ${numberOfUpdatedVaultNameItems} Vault NAME# items have been updated and now include a StatusCreatedAt property that combines the existing Status and CreatedAt values.`
+    );
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// config() adds the .env variables to process.env
+config();
+
+main();

--- a/utils/statusCreatedAtMigration/package.json
+++ b/utils/statusCreatedAtMigration/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "status_created_at_vault_name_items_migration",
+  "version": "0.1.0",
+  "description": "Add or update `StatusCreatedAt` property (using the existing `Status` and `CreatedAt` properties from the same item) in `NAME#` items.",
+  "main": "main.ts",
+  "scripts": {
+    "migrate": "tsx main.ts"
+  },
+  "keywords": [],
+  "author": "Clément Janin",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.693.0",
+    "@aws-sdk/lib-dynamodb": "^3.693.0",
+    "dotenv": "^16.4.5",
+    "tsx": "^4.19.2"
+  },
+  "packageManager": "yarn@4.0.2"
+}

--- a/utils/statusCreatedAtMigration/tsconfig.json
+++ b/utils/statusCreatedAtMigration/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+
+    /* Interop Constraints */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+
+    /* Completeness */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -20265,6 +20265,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"status_created_at_vault_name_items_migration@workspace:utils/statusCreatedAtMigration":
+  version: 0.0.0-use.local
+  resolution: "status_created_at_vault_name_items_migration@workspace:utils/statusCreatedAtMigration"
+  dependencies:
+    "@aws-sdk/client-dynamodb": "npm:^3.693.0"
+    "@aws-sdk/lib-dynamodb": "npm:^3.693.0"
+    dotenv: "npm:^16.4.5"
+    tsx: "npm:^4.19.2"
+  languageName: unknown
+  linkType: soft
+
 "std-env@npm:^3.5.0":
   version: 3.7.0
   resolution: "std-env@npm:3.7.0"


### PR DESCRIPTION
# Summary | Résumé

Part 4 of https://github.com/cds-snc/platform-forms-client/issues/4287

- Adds or updates `Status#CreatedAt` property (using the existing Status and CreatedAt properties from the same item) in NAME# items.