### PR TITLE
chore: Move settings help dialogs into settings components folder

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/FormPurposeHelpButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/FormPurposeHelpButton.tsx
@@ -6,7 +6,7 @@ import { Button } from "@clientComponents/globals";
 import { InfoIcon } from "@serverComponents/icons";
 
 import Markdown from "markdown-to-jsx";
-import { Dialog, useDialogRef } from "./Dialog";
+import { Dialog, useDialogRef } from "../../../components/shared/Dialog";
 
 const FormPurposeHelpDialog = ({ handleClose }: { handleClose: () => void }) => {
   const { t } = useTranslation("form-builder");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -13,9 +13,9 @@ import { Radio } from "@formBuilder/components/shared/MultipleChoice";
 import { Button } from "@clientComponents/globals";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { completeEmailAddressRegex } from "@lib/utils/form-builder";
-import { ResponseDeliveryHelpButton } from "@formBuilder/components/shared/ResponseDeliveryHelpDialog";
-import { FormPurposeHelpButton } from "@formBuilder/components/shared/FormPurposeHelpButton";
-import { ResponseDeliveryHelpButtonWithApi } from "@formBuilder/components/shared/ResponseDeliveryHelpDialogApiWithApi";
+import { ResponseDeliveryHelpButton } from "@formBuilder/[id]/settings/components/ResponseDeliveryHelpDialog";
+import { FormPurposeHelpButton } from "@formBuilder/[id]/settings/components/FormPurposeHelpButton";
+import { ResponseDeliveryHelpButtonWithApi } from "@formBuilder/[id]/settings/components/ResponseDeliveryHelpDialogApiWithApi";
 import {
   ClassificationType,
   ClassificationSelect,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -13,9 +13,9 @@ import { Radio } from "@formBuilder/components/shared/MultipleChoice";
 import { Button } from "@clientComponents/globals";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { completeEmailAddressRegex } from "@lib/utils/form-builder";
-import { ResponseDeliveryHelpButton } from "@formBuilder/[id]/settings/components/ResponseDeliveryHelpDialog";
-import { FormPurposeHelpButton } from "@formBuilder/[id]/settings/components/FormPurposeHelpButton";
-import { ResponseDeliveryHelpButtonWithApi } from "@formBuilder/[id]/settings/components/ResponseDeliveryHelpDialogApiWithApi";
+import { ResponseDeliveryHelpButton } from "./ResponseDeliveryHelpDialog";
+import { FormPurposeHelpButton } from "./FormPurposeHelpButton";
+import { ResponseDeliveryHelpButtonWithApi } from "./ResponseDeliveryHelpDialogApiWithApi";
 import {
   ClassificationType,
   ClassificationSelect,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDeliveryHelpDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDeliveryHelpDialog.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "@i18n/client";
 
 import { Button } from "@clientComponents/globals";
 import { InfoIcon } from "@serverComponents/icons";
-import { Dialog, useDialogRef } from "./Dialog";
+import { Dialog, useDialogRef } from "../../../components/shared/Dialog";
 
 const ResponseDeliveryHelpDialog = ({ handleClose }: { handleClose: () => void }) => {
   const { t } = useTranslation("form-builder");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDeliveryHelpDialogApiWithApi.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDeliveryHelpDialogApiWithApi.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "@i18n/client";
 
 import { Button } from "@clientComponents/globals";
 import { InfoIcon } from "@serverComponents/icons";
-import { Dialog, useDialogRef } from "./Dialog";
+import { Dialog, useDialogRef } from "../../../components/shared/Dialog";
 
 const ResponseDeliveryHelpWithApiDialogWithApi = ({ handleClose }: { handleClose: () => void }) => {
   const { t } = useTranslation("form-builder");


### PR DESCRIPTION
# Summary | Résumé

Just a bit of reorg- colocating dialogs for the Settings page in the settings/components folder.
