### PR TITLE
chore: update Notify timeout setting

### DIFF
--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 
 const NotifyClient = axios.create({
   baseURL: "https://api.notification.canada.ca",
-  timeout: 2000,
+  timeout: 5000,
   headers: {
     "Content-Type": "application/json",
     Authorization: `ApiKey-v1 ${process.env.NOTIFY_API_KEY}`,


### PR DESCRIPTION
# Summary | Résumé

Adjusts Axios timeout to 5 secs for Notify call this now matches the current Reliability queue setting.