### PR TITLE
fix: for Radio button / group unexpected behaviour

### DIFF
--- a/components/clientComponents/forms/FormGroup/FormGroup.tsx
+++ b/components/clientComponents/forms/FormGroup/FormGroup.tsx
@@ -22,8 +22,6 @@ export const FormGroup = (props: FormGroupProps): React.ReactElement => {
       data-testid="formGroup"
       className={classes}
       aria-describedby={ariaDescribedBy}
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={0}
     >
       {children}
     </fieldset>

--- a/components/clientComponents/forms/FormGroup/FormGroup.tsx
+++ b/components/clientComponents/forms/FormGroup/FormGroup.tsx
@@ -22,6 +22,9 @@ export const FormGroup = (props: FormGroupProps): React.ReactElement => {
       data-testid="formGroup"
       className={classes}
       aria-describedby={ariaDescribedBy}
+      // Used to programmatically focus a form group by e.g. a form validation skip ahead link
+      // -1 is used over 0, so the group is not in the natural tab order which is confusing for AT
+      tabIndex={-1}
     >
       {children}
     </fieldset>


### PR DESCRIPTION
# Summary | Résumé

A radio/checkbox group does not need a tabindex on a container, this can cause unpredictable behavior in assistive technologies.
