### PR TITLE
chore: Add ability for gc forms admin to switch to api mode for live form

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -23,10 +23,10 @@ type APIKeyCustomEventDetails = {
 
 /**
  * API Key Dialog
- * @param isPublished - boolean - Allows skipping the save request when a form is already published
+ * @param isVaultDelivery - boolean - Allows skipping the save request when a form is already published
  * @returns JSX.Element
  */
-export const ApiKeyDialog = ({ isPublished = false }: { isPublished?: boolean }) => {
+export const ApiKeyDialog = ({ isVaultDelivery = false }: { isVaultDelivery?: boolean }) => {
   const dialog = useDialogRef();
   const { Event } = useCustomEvent();
   const { t } = useTranslation("form-builder");
@@ -78,9 +78,12 @@ export const ApiKeyDialog = ({ isPublished = false }: { isPublished?: boolean })
     setHasError(false);
     setGenerating(true);
     try {
-      // Note - checking should be done outside of this dialog
-      // to ensure the form is already using the Vault
-      if (!isPublished) {
+      /*
+        Allows skipping the save request
+        if it's determined that the form being delivered
+        to the vault
+      */
+      if (!isVaultDelivery) {
         const result = await sendResponsesToVault({
           id: id,
         });

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -23,7 +23,7 @@ type APIKeyCustomEventDetails = {
 
 /**
  * API Key Dialog
- * @param isVaultDelivery - boolean - Allows skipping the save request when a form is already published
+ * @param isVaultDelivery - boolean - Allows skipping the save request when a form is already saving to the vault -- example a live form swapping to API mode
  * @returns JSX.Element
  */
 export const ApiKeyDialog = ({ isVaultDelivery = false }: { isVaultDelivery?: boolean }) => {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -23,10 +23,10 @@ type APIKeyCustomEventDetails = {
 
 /**
  * API Key Dialog
- * @param ensureSaveToVault - boolean - Allows skipping the vault save before generating the key use to generate keys for live forms
+ * @param isPublished - boolean - Allows skipping the save request when a form is already published
  * @returns JSX.Element
  */
-export const ApiKeyDialog = ({ ensureSaveToVault = true }: { ensureSaveToVault?: boolean }) => {
+export const ApiKeyDialog = ({ isPublished = false }: { isPublished?: boolean }) => {
   const dialog = useDialogRef();
   const { Event } = useCustomEvent();
   const { t } = useTranslation("form-builder");
@@ -78,7 +78,9 @@ export const ApiKeyDialog = ({ ensureSaveToVault = true }: { ensureSaveToVault?:
     setHasError(false);
     setGenerating(true);
     try {
-      if (ensureSaveToVault) {
+      // Note - checking should be done outside of this dialog
+      // to ensure the form is already using the Vault
+      if (!isPublished) {
         const result = await sendResponsesToVault({
           id: id,
         });

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -21,7 +21,12 @@ type APIKeyCustomEventDetails = {
   id: string;
 };
 
-export const ApiKeyDialog = () => {
+/**
+ * API Key Dialog
+ * @param ensureSaveToVault - boolean - Allows skipping the vault save before generating the key use to generate keys for live forms
+ * @returns JSX.Element
+ */
+export const ApiKeyDialog = ({ ensureSaveToVault = true }: { ensureSaveToVault?: boolean }) => {
   const dialog = useDialogRef();
   const { Event } = useCustomEvent();
   const { t } = useTranslation("form-builder");
@@ -73,15 +78,16 @@ export const ApiKeyDialog = () => {
     setHasError(false);
     setGenerating(true);
     try {
-      // First ensure all responses are sent to vault
-      const result = await sendResponsesToVault({
-        id: id,
-      });
+      if (ensureSaveToVault) {
+        const result = await sendResponsesToVault({
+          id: id,
+        });
 
-      if (result.error) {
-        // Throw the generic key creation error
-        // Handling as generic as we're in the process of creating a key
-        throw new Error(result.error);
+        if (result.error) {
+          // Throw the generic key creation error
+          // Handling as generic as we're in the process of creating a key
+          throw new Error(result.error);
+        }
       }
 
       const key = await _createKey(id);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -80,8 +80,8 @@ export const ApiKeyDialog = ({ isVaultDelivery = false }: { isVaultDelivery?: bo
     try {
       /*
         Allows skipping the save request
-        if it's determined that the form being delivered
-        to the vault
+        if it's determined that the form responses 
+        are already being delivered to the vault
       */
       if (!isVaultDelivery) {
         const result = await sendResponsesToVault({

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiKeyButton.tsx
@@ -41,7 +41,7 @@ export const ApiKeyButton = ({
       {showDelete && apiKeyId ? (
         <>
           <DeleteKeyButton id={id} keyId={apiKeyId} />
-          <ResponseDeliveryHelpButtonWithApi />
+          {showHelp && <ResponseDeliveryHelpButtonWithApi />}
         </>
       ) : (
         <>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiKeyButton.tsx
@@ -5,17 +5,22 @@ import { useTranslation } from "@i18n/client";
 import { EventKeys, useCustomEvent } from "@lib/hooks/useCustomEvent";
 import { DeleteKeyButton } from "./DeleteKeyButton";
 import { SubmitButton as GenerateApiKeyButton } from "@clientComponents/globals/Buttons/SubmitButton";
+import { Theme } from "@clientComponents/globals/Buttons/themes";
 import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
 import { ResponseDeliveryHelpButtonWithApi } from "./dialogs/ResponseDeliveryHelpDialogApiWithApi";
 
 type ApiKeyButtonProps = {
   showDelete?: boolean;
   i18nKey?: string;
+  theme?: Theme;
+  showHelp?: boolean;
 };
 
 export const ApiKeyButton = ({
   showDelete = false,
   i18nKey = "settings.api.generateKey",
+  theme = "primary",
+  showHelp = true,
 }: ApiKeyButtonProps) => {
   const { t } = useTranslation("form-builder");
   const { id } = useParams();
@@ -42,7 +47,7 @@ export const ApiKeyButton = ({
         <>
           <GenerateApiKeyButton
             loading={false}
-            theme="primary"
+            theme={theme}
             disabled={Boolean(apiKeyId)}
             onClick={() => {
               openDialog();
@@ -50,7 +55,7 @@ export const ApiKeyButton = ({
           >
             {t(i18nKey)}
           </GenerateApiKeyButton>
-          <ResponseDeliveryHelpButtonWithApi />
+          {showHelp && <ResponseDeliveryHelpButtonWithApi />}
         </>
       )}
     </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -2,8 +2,6 @@ import { serverTranslation } from "@i18n";
 import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/LoggedOutTab";
 import { authCheckAndThrow } from "@lib/actions";
 import { SettingsNavigation } from "./components/SettingsNavigation";
-import { ApiKeyDialog } from "../components/dialogs/ApiKeyDialog/ApiKeyDialog";
-import { DeleteApiKeyDialog } from "../components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog";
 
 export default async function Layout({
   children,
@@ -25,8 +23,6 @@ export default async function Layout({
       <h1>{t("gcFormsSettings")}</h1>
       <SettingsNavigation id={id} />
       {children}
-      <ApiKeyDialog />
-      <DeleteApiKeyDialog />
     </>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -2,6 +2,8 @@ import { serverTranslation } from "@i18n";
 import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/LoggedOutTab";
 import { authCheckAndThrow } from "@lib/actions";
 import { SettingsNavigation } from "./components/SettingsNavigation";
+import { ApiKeyDialog } from "../components/dialogs/ApiKeyDialog/ApiKeyDialog";
+import { DeleteApiKeyDialog } from "../components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog";
 
 export default async function Layout({
   children,
@@ -23,6 +25,8 @@ export default async function Layout({
       <h1>{t("gcFormsSettings")}</h1>
       <SettingsNavigation id={id} />
       {children}
+      <ApiKeyDialog />
+      <DeleteApiKeyDialog />
     </>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/FormOwnership.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/FormOwnership.tsx
@@ -74,7 +74,7 @@ export const FormOwnership = ({
 
   return (
     <>
-      <div className="mb-20" data-testid="form-ownership">
+      <div className="mb-10" data-testid="form-ownership">
         <h2>{t("Manage ownership")}</h2>
         {message && message}
         <p className="mb-4">{t("assignUsersToTemplate")}</p>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageApiKey.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageApiKey.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useTranslation } from "@i18n/client";
+import { ApiKeyButton } from "../components/ApiKeyButton";
+export const ManageApiKey = () => {
+  const { t } = useTranslation("form-builder");
+  return (
+    <div className="mb-10">
+      <h2>{t("switchToApiMode.title")}</h2>
+      <p className="mb-4">{t("switchToApiMode.description")}</p>
+      <ApiKeyButton
+        theme="secondary"
+        i18nKey="switchToApiMode.btnText"
+        showDelete={true}
+        showHelp={false}
+      />
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageApiKey.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageApiKey.tsx
@@ -1,11 +1,15 @@
 "use client";
 import { useTranslation } from "@i18n/client";
 import { ApiKeyButton } from "../components/ApiKeyButton";
+import { SettingsApplicationsIcon } from "@serverComponents/icons";
 export const ManageApiKey = () => {
   const { t } = useTranslation("form-builder");
   return (
     <div className="mb-10">
-      <h2>{t("switchToApiMode.title")}</h2>
+      <h2>
+        <SettingsApplicationsIcon className="-mt-10px mr-1 inline-block" />{" "}
+        {t("switchToApiMode.title")}{" "}
+      </h2>
       <p className="mb-4">{t("switchToApiMode.description")}</p>
       <ApiKeyButton
         theme="secondary"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
@@ -6,6 +6,7 @@ import { SetClosingDate } from "./close/SetClosingDate";
 import { FormOwnership } from "./FormOwnership";
 import { ErrorPanel } from "@clientComponents/globals/ErrorPanel";
 import { updateTemplateUsers } from "@formBuilder/actions";
+import { ManageApiKey } from "./ManageApiKey";
 import { ThrottlingRate } from "./ThrottlingRate";
 
 interface User {
@@ -61,6 +62,7 @@ export const ManageForm = (props: ManageFormProps) => {
         updateTemplateUsers={updateTemplateUsers}
       />
       {canManageOwnership && <ThrottlingRate formId={id} />}
+      {canManageOwnership && <ManageApiKey />}
       <DownloadForm />
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
@@ -17,7 +17,7 @@ interface User {
 
 interface ManageFormProps {
   nonce: string | null;
-  canManageOwnership: boolean;
+  canManageAllForms: boolean;
   canSetClosingDate: boolean;
   formRecord?: FormRecord;
   usersAssignedToFormRecord?: User[];
@@ -32,13 +32,13 @@ export const ManageForm = (props: ManageFormProps) => {
     formRecord,
     usersAssignedToFormRecord,
     allUsers,
-    canManageOwnership,
+    canManageAllForms,
     canSetClosingDate,
     id,
     closedDetails,
   } = props;
 
-  if (!canManageOwnership) {
+  if (!canManageAllForms) {
     return (
       <>
         {canSetClosingDate && <SetClosingDate formId={id} closedDetails={closedDetails} />}
@@ -61,8 +61,8 @@ export const ManageForm = (props: ManageFormProps) => {
         allUsers={allUsers}
         updateTemplateUsers={updateTemplateUsers}
       />
-      {canManageOwnership && <ThrottlingRate formId={id} />}
-      {canManageOwnership && <ManageApiKey />}
+      {canManageAllForms && <ThrottlingRate formId={id} />}
+      {canManageAllForms && <ManageApiKey />}
       <DownloadForm />
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
@@ -62,7 +62,7 @@ export const ManageForm = (props: ManageFormProps) => {
         updateTemplateUsers={updateTemplateUsers}
       />
       {canManageAllForms && <ThrottlingRate formId={id} />}
-      {canManageAllForms && <ManageApiKey />}
+      {canManageAllForms && formRecord.isPublished && <ManageApiKey />}
       <DownloadForm />
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ThrottlingRate.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ThrottlingRate.tsx
@@ -122,7 +122,7 @@ export const ThrottlingRate = ({ formId }: { formId: string }) => {
   }, [formId, throttlingErrorString]);
 
   return (
-    <div className="mb-20">
+    <div className="mb-10">
       <form onSubmit={handleSubmit}>
         <h2>{t("throttling.title")}</h2>
         <div role="alert">

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -101,6 +101,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
   const allUsers = await getAllUsers(ability);
 
   const isPublished = templateWithAssociatedUsers.formRecord.isPublished;
+  const isVaultDelivery = !templateWithAssociatedUsers.formRecord.deliveryMethod;
 
   return (
     <>
@@ -115,12 +116,15 @@ export default async function Page({ params: { id } }: { params: { id: string } 
         closedDetails={closedDetails}
       />
       {/* 
-        Only show for live forms --- draft forms
-        should use Response Delivery page
+        - Only show for users with manage all forms privileges
+            - we do an additional check here in case the code above to reach this point changes later
+        - Only show for forms with vault delivery already set
+        - Only show for live forms 
+            - draft forms should use Response Delivery page
       */}
-      {isPublished && manageAllForms && (
+      {isPublished && manageAllForms && isVaultDelivery && (
         <>
-          <ApiKeyDialog isPublished={true} />
+          <ApiKeyDialog isVaultDelivery={true} />
           <DeleteApiKeyDialog />
         </>
       )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -99,15 +99,17 @@ export default async function Page({ params: { id } }: { params: { id: string } 
   const allUsers = await getAllUsers(ability);
 
   return (
-    <ManageForm
-      nonce={nonce}
-      id={id}
-      canManageOwnership={canManageOwnership}
-      canSetClosingDate={canSetClosingDate}
-      formRecord={templateWithAssociatedUsers.formRecord}
-      usersAssignedToFormRecord={templateWithAssociatedUsers.users}
-      allUsers={allUsers}
-      closedDetails={closedDetails}
-    />
+    <>
+      <ManageForm
+        nonce={nonce}
+        id={id}
+        canManageOwnership={canManageOwnership}
+        canSetClosingDate={canSetClosingDate}
+        formRecord={templateWithAssociatedUsers.formRecord}
+        usersAssignedToFormRecord={templateWithAssociatedUsers.users}
+        allUsers={allUsers}
+        closedDetails={closedDetails}
+      />
+    </>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({
   };
 }
 
-const getCanManageOwnership = (formId: string, ability: UserAbility | null) => {
+const canManageAllForms = (formId: string, ability: UserAbility | null) => {
   if (!ability || formId === "0000") {
     return false;
   }
@@ -70,7 +70,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
 
   let closedDetails;
 
-  const canManageOwnership = getCanManageOwnership(id, ability);
+  const hasCanManageAllForms = canManageAllForms(id, ability);
   const canSetClosingDate = getCanSetClosingDate(id, ability, session);
   const nonce = await getNonce();
 
@@ -79,12 +79,12 @@ export default async function Page({ params: { id } }: { params: { id: string } 
     closedDetails = closedData?.closedDetails;
   }
 
-  if (!canManageOwnership || id === "0000") {
+  if (!hasCanManageAllForms || id === "0000") {
     return (
       <ManageForm
         nonce={nonce}
         id={id}
-        canManageOwnership={canManageOwnership}
+        canManageAllForms={false}
         canSetClosingDate={canSetClosingDate}
         closedDetails={closedDetails}
       />
@@ -107,7 +107,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
       <ManageForm
         nonce={nonce}
         id={id}
-        canManageOwnership={canManageOwnership}
+        canManageAllForms={hasCanManageAllForms}
         canSetClosingDate={canSetClosingDate}
         formRecord={templateWithAssociatedUsers.formRecord}
         usersAssignedToFormRecord={templateWithAssociatedUsers.users}
@@ -118,7 +118,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
         Allow users with manage all forms to 
         switch to API delivery option for live forms
       */}
-      {isPublished && canManageOwnership && (
+      {isPublished && hasCanManageAllForms && (
         <>
           <ApiKeyDialog
             ensureSaveToVault={false} // Skip re-saving given this is a live form

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -70,7 +70,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
 
   let closedDetails;
 
-  const hasCanManageAllForms = canManageAllForms(id, ability);
+  const manageAllForms = canManageAllForms(id, ability);
   const canSetClosingDate = getCanSetClosingDate(id, ability, session);
   const nonce = await getNonce();
 
@@ -79,7 +79,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
     closedDetails = closedData?.closedDetails;
   }
 
-  if (!hasCanManageAllForms || id === "0000") {
+  if (!manageAllForms || id === "0000") {
     return (
       <ManageForm
         nonce={nonce}
@@ -107,7 +107,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
       <ManageForm
         nonce={nonce}
         id={id}
-        canManageAllForms={hasCanManageAllForms}
+        canManageAllForms={manageAllForms}
         canSetClosingDate={canSetClosingDate}
         formRecord={templateWithAssociatedUsers.formRecord}
         usersAssignedToFormRecord={templateWithAssociatedUsers.users}
@@ -118,7 +118,7 @@ export default async function Page({ params: { id } }: { params: { id: string } 
         Allow users with manage all forms to 
         switch to API delivery option for live forms
       */}
-      {isPublished && hasCanManageAllForms && (
+      {isPublished && manageAllForms && (
         <>
           <ApiKeyDialog
             ensureSaveToVault={false} // Skip re-saving given this is a live form

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -9,6 +9,8 @@ import { UserAbility } from "@lib/types";
 import { Session } from "next-auth";
 import { getNonce } from "./actions";
 import { checkIfClosed } from "@lib/actions/checkIfClosed";
+import { ApiKeyDialog } from "../../components/dialogs/ApiKeyDialog/ApiKeyDialog";
+import { DeleteApiKeyDialog } from "../../components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog";
 
 export async function generateMetadata({
   params: { locale },
@@ -98,6 +100,8 @@ export default async function Page({ params: { id } }: { params: { id: string } 
 
   const allUsers = await getAllUsers(ability);
 
+  const isPublished = templateWithAssociatedUsers.formRecord.isPublished;
+
   return (
     <>
       <ManageForm
@@ -110,6 +114,18 @@ export default async function Page({ params: { id } }: { params: { id: string } 
         allUsers={allUsers}
         closedDetails={closedDetails}
       />
+      {/* 
+        Allow users with manage all forms to 
+        switch to API delivery option for live forms
+      */}
+      {isPublished && canManageOwnership && (
+        <>
+          <ApiKeyDialog
+            ensureSaveToVault={false} // Skip re-saving given this is a live form
+          />
+          <DeleteApiKeyDialog />
+        </>
+      )}
     </>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/page.tsx
@@ -115,14 +115,12 @@ export default async function Page({ params: { id } }: { params: { id: string } 
         closedDetails={closedDetails}
       />
       {/* 
-        Allow users with manage all forms to 
-        switch to API delivery option for live forms
+        Only show for live forms --- draft forms
+        should use Response Delivery page
       */}
       {isPublished && manageAllForms && (
         <>
-          <ApiKeyDialog
-            ensureSaveToVault={false} // Skip re-saving given this is a live form
-          />
+          <ApiKeyDialog isPublished={true} />
           <DeleteApiKeyDialog />
         </>
       )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/page.tsx
@@ -1,8 +1,6 @@
 import { serverTranslation } from "@i18n";
 import { Metadata } from "next";
 import { ResponseDelivery } from "./components/ResponseDelivery";
-import { ApiKeyDialog } from "../components/dialogs/ApiKeyDialog/ApiKeyDialog";
-import { DeleteApiKeyDialog } from "../components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog";
 import { authCheckAndRedirect } from "@lib/actions";
 import { checkPrivilegesAsBoolean } from "@lib/privileges";
 
@@ -18,7 +16,6 @@ export async function generateMetadata({
 }
 
 export default async function Page() {
-
   const { ability } = await authCheckAndRedirect();
 
   const isFormsAdmin = checkPrivilegesAsBoolean(ability, [
@@ -27,12 +24,6 @@ export default async function Page() {
       subject: "FormRecord",
     },
   ]);
-  
-  return (
-    <>
-      <ResponseDelivery isFormsAdmin={isFormsAdmin} />
-      <ApiKeyDialog />
-      <DeleteApiKeyDialog />
-    </>
-  );
+
+  return <ResponseDelivery isFormsAdmin={isFormsAdmin} />;
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/page.tsx
@@ -3,6 +3,8 @@ import { Metadata } from "next";
 import { ResponseDelivery } from "./components/ResponseDelivery";
 import { authCheckAndRedirect } from "@lib/actions";
 import { checkPrivilegesAsBoolean } from "@lib/privileges";
+import { ApiKeyDialog } from "../components/dialogs/ApiKeyDialog/ApiKeyDialog";
+import { DeleteApiKeyDialog } from "../components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog";
 
 export async function generateMetadata({
   params: { locale },
@@ -25,5 +27,11 @@ export default async function Page() {
     },
   ]);
 
-  return <ResponseDelivery isFormsAdmin={isFormsAdmin} />;
+  return (
+    <>
+      <ResponseDelivery isFormsAdmin={isFormsAdmin} />
+      <ApiKeyDialog />
+      <DeleteApiKeyDialog />
+    </>
+  );
 }

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -455,6 +455,11 @@
     "downloadBtnText": "Download form file",
     "title": "Download form file"
   },
+  "switchToApiMode": {
+    "title": "Switch to API delivery",
+    "description": "New responses will be available through the API endpoint",
+    "btnText": "Switch to API delivery"
+  },
   "formIntroduction": "Form introduction",
   "formInvalidProperty": "Invalid: {{property}}",
   "formMissingProperty": "Missing: {{property}}",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -455,6 +455,11 @@
     "downloadBtnText": "Télécharger le fichier du formulaire",
     "title": "Télécharger le fichier du formulaire"
   },
+  "switchToApiMode": {
+    "title": "Switch to API delivery [FR]",
+    "description": "New responses will be available through the API endpoint [FR]",
+    "btnText": "Switch to API delivery [FR]"
+  },
   "formIntroduction": "Introduction du formulaire ",
   "formInvalidProperty": "Invalide : {{property}}",
   "formMissingProperty": "Il manque : {{property}}",


### PR DESCRIPTION
# Summary | Résumé

Adds admin screen to allow generating an Api key for a live form.

Noting this will show for user with Manage all forms + a published form.

<img width="620" alt="Screenshot 2024-11-27 at 10 20 22 AM" src="https://github.com/user-attachments/assets/871d61cc-d13f-45b4-8334-453e064d3c32">


