### PR TITLE
chore: Hide other delivery options when API key generated

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiDocNotes.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiDocNotes.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "@i18n/client";
 export const ApiDocNotes = () => {
   const { t } = useTranslation("form-builder");
   return (
-    <div className="mb-12 w-4/6">
+    <div className="mb-12 w-3/5">
       <p className="font-bold">{t("formSettingsModal.apiDocNotes.title")}</p>
       <Trans
         ns="form-builder"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/DeleteKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/DeleteKeyButton.tsx
@@ -15,8 +15,10 @@ export const DeleteKeyButton = ({ id, keyId }: { id: string; keyId: string }) =>
   return (
     <>
       <div className="mb-4">
-        <div className="font-bold">{t("settings.api.keyId")}</div>
-        {keyId} <ApiTooltip />
+        <div className="font-bold">
+          {t("settings.api.keyId")} <ApiTooltip />
+        </div>
+        {keyId}
       </div>
       <Button theme="destructive" className="mr-4" onClick={openDeleteApiDialog}>
         {t("settings.api.deleteKey")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/DeleteKeyToChangeOptionsNote.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/DeleteKeyToChangeOptionsNote.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from "@i18n/client";
+
+export const DeleteKeyToChangeOptionsNote = ({ hasApiKey }: { hasApiKey: boolean }) => {
+  const { t } = useTranslation("form-builder");
+  if (!hasApiKey) return null;
+  return (
+    <div className="mb-4 w-3/5 rounded-md bg-indigo-50 p-3">
+      <h5 className="font-bold">{t("settings.api.deleteApiKeyToChangeOptions.title")}</h5>
+      <p className="text-sm">{t("settings.api.deleteApiKeyToChangeOptions.message")}</p>
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -360,64 +360,75 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                   {t("settingsResponseDelivery.protectedBMessage")}
                 </p>
               ) : null}
-              <Radio
-                disabled={isPublished || hasApiKey}
-                id={`delivery-option-${DeliveryOption.vault}`}
-                checked={deliveryOptionValue === DeliveryOption.vault}
-                name="response-delivery"
-                value={DeliveryOption.vault}
-                label={t("settingsResponseDelivery.vaultOption")}
-                onChange={updateDeliveryOption}
-              >
-                <span className="mb-1 ml-3 block text-sm">
-                  {t("settingsResponseDelivery.vaultOptionHint.text1")}{" "}
-                  <a href={responsesLink}>{t("settingsResponseDelivery.vaultOptionHint.text2")}</a>.
-                  {t("settingsResponseDelivery.vaultOptionHint.text3")}
-                </span>
-              </Radio>
-              <Radio
-                disabled={isPublished || protectedBSelected || hasApiKey}
-                id={`delivery-option-${DeliveryOption.email}`}
-                checked={deliveryOptionValue === DeliveryOption.email}
-                name="response-delivery"
-                value={DeliveryOption.email}
-                label={emailLabel}
-                onChange={updateDeliveryOption}
-              />
 
-              {deliveryOptionValue === DeliveryOption.email && (
-                <ResponseEmail
-                  inputEmail={inputEmailValue}
-                  setInputEmail={setInputEmailValue}
-                  subjectEn={subjectEnValue}
-                  setSubjectEn={setSubjectEnValue}
-                  subjectFr={subjectFrValue}
-                  setSubjectFr={setSubjectFrValue}
-                  isInvalidEmailError={isInvalidEmailError}
-                  setIsInvalidEmailError={setIsInvalidEmailError}
-                />
-              )}
-              {deliveryOptionValue !== DeliveryOption.email && <div className="mb-8"></div>}
+              {!hasApiKey && (
+                <>
+                  <Radio
+                    disabled={isPublished}
+                    id={`delivery-option-${DeliveryOption.vault}`}
+                    checked={deliveryOptionValue === DeliveryOption.vault}
+                    name="response-delivery"
+                    value={DeliveryOption.vault}
+                    label={t("settingsResponseDelivery.vaultOption")}
+                    onChange={updateDeliveryOption}
+                  >
+                    <span className="mb-1 ml-3 block text-sm">
+                      {t("settingsResponseDelivery.vaultOptionHint.text1")}{" "}
+                      <a href={responsesLink}>
+                        {t("settingsResponseDelivery.vaultOptionHint.text2")}
+                      </a>
+                      .{t("settingsResponseDelivery.vaultOptionHint.text3")}
+                    </span>
+                  </Radio>
+                  <Radio
+                    disabled={isPublished || protectedBSelected}
+                    id={`delivery-option-${DeliveryOption.email}`}
+                    checked={deliveryOptionValue === DeliveryOption.email}
+                    name="response-delivery"
+                    value={DeliveryOption.email}
+                    label={emailLabel}
+                    onChange={updateDeliveryOption}
+                  />
 
-              {apiAccess && (
-                <Radio
-                  disabled={isPublished || hasApiKey || protectedBSelected}
-                  id={`delivery-option-${DeliveryOption.api}`}
-                  checked={deliveryOptionValue === DeliveryOption.api}
-                  name="response-delivery"
-                  value={DeliveryOption.api}
-                  label={apiLabel}
-                  onChange={updateDeliveryOption}
-                />
+                  {deliveryOptionValue === DeliveryOption.email && (
+                    <ResponseEmail
+                      inputEmail={inputEmailValue}
+                      setInputEmail={setInputEmailValue}
+                      subjectEn={subjectEnValue}
+                      setSubjectEn={setSubjectEnValue}
+                      subjectFr={subjectFrValue}
+                      setSubjectFr={setSubjectFrValue}
+                      isInvalidEmailError={isInvalidEmailError}
+                      setIsInvalidEmailError={setIsInvalidEmailError}
+                    />
+                  )}
+                  {deliveryOptionValue !== DeliveryOption.email && <div className="mb-8"></div>}
+
+                  {apiAccess && (
+                    <>
+                      <Radio
+                        disabled={isPublished || protectedBSelected}
+                        id={`delivery-option-${DeliveryOption.api}`}
+                        checked={deliveryOptionValue === DeliveryOption.api}
+                        name="response-delivery"
+                        value={DeliveryOption.api}
+                        label={apiLabel}
+                        onChange={updateDeliveryOption}
+                      />
+                      {deliveryOptionValue === DeliveryOption.api && (
+                        <div className="mb-10 ml-4 border-l-4 pl-8">
+                          <span className="block py-6 font-bold">
+                            {t("formSettingsModal.apiOption.startNote")}
+                          </span>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </>
               )}
 
               {apiAccess && deliveryOptionValue === DeliveryOption.api && (
                 <div>
-                  <div className="mb-10 ml-4 border-l-4 pl-8">
-                    <span className="block py-6 font-bold">
-                      {t("formSettingsModal.apiOption.startNote")}
-                    </span>
-                  </div>
                   <ApiKeyButton showDelete />
                   <ApiDocNotes />
                 </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -36,6 +36,7 @@ import { toast } from "@formBuilder/components/shared/Toast";
 import { ErrorSaving } from "@formBuilder/components/shared/ErrorSaving";
 import { ApiKeyButton } from "./ApiKeyButton";
 import { ApiDocNotes } from "./ApiDocNotes";
+import { DeleteKeyToChangeOptionsNote } from "./DeleteKeyToChangeOptionsNote";
 import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
 
 enum DeliveryOption {
@@ -421,26 +422,13 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                   )}
                 </>
               )}
-
               {apiAccess && deliveryOptionValue === DeliveryOption.api && (
                 <div>
                   <ApiKeyButton showDelete />
-
-                  {hasApiKey && (
-                    <div className="mb-4 w-4/6 rounded-md bg-indigo-50 p-3">
-                      <h5 className="font-bold">
-                        {t("settings.api.deleteApiKeyToChangeOptions.title")}
-                      </h5>
-                      <p className="text-sm">
-                        {t("settings.api.deleteApiKeyToChangeOptions.message")}
-                      </p>
-                    </div>
-                  )}
-
+                  <DeleteKeyToChangeOptionsNote hasApiKey={hasApiKey} />
                   <ApiDocNotes />
                 </div>
               )}
-
               {deliveryOptionValue !== DeliveryOption.api && !hasApiKey && (
                 <>
                   <Button

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -350,11 +350,6 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
 
             <div className="mb-10">
               <h2 className="mb-6">{t("settingsResponseDelivery.title")}</h2>
-              {hasApiKey && (
-                <p className="mb-10 inline-block bg-purple-200 p-3 text-sm font-bold">
-                  {t("settingsResponseDelivery.deleteApiKeyMessage")}
-                </p>
-              )}
               {protectedBSelected ? (
                 <p className="mb-5 inline-block bg-purple-200 p-3 text-sm font-bold">
                   {t("settingsResponseDelivery.protectedBMessage")}
@@ -430,9 +425,22 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
               {apiAccess && deliveryOptionValue === DeliveryOption.api && (
                 <div>
                   <ApiKeyButton showDelete />
+
+                  {hasApiKey && (
+                    <div className="mb-4 w-4/6 rounded-md bg-indigo-50 p-3">
+                      <h5 className="font-bold">
+                        {t("settings.api.deleteApiKeyToChangeOptions.title")}
+                      </h5>
+                      <p className="text-sm">
+                        {t("settings.api.deleteApiKeyToChangeOptions.message")}
+                      </p>
+                    </div>
+                  )}
+
                   <ApiDocNotes />
                 </div>
               )}
+
               {deliveryOptionValue !== DeliveryOption.api && !hasApiKey && (
                 <>
                   <Button

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -364,7 +364,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
               {!hasApiKey && (
                 <>
                   <Radio
-                    disabled={isPublished}
+                    disabled={isPublished || hasApiKey}
                     id={`delivery-option-${DeliveryOption.vault}`}
                     checked={deliveryOptionValue === DeliveryOption.vault}
                     name="response-delivery"
@@ -381,7 +381,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                     </span>
                   </Radio>
                   <Radio
-                    disabled={isPublished || protectedBSelected}
+                    disabled={isPublished || protectedBSelected || hasApiKey}
                     id={`delivery-option-${DeliveryOption.email}`}
                     checked={deliveryOptionValue === DeliveryOption.email}
                     name="response-delivery"
@@ -407,7 +407,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                   {apiAccess && (
                     <>
                       <Radio
-                        disabled={isPublished || protectedBSelected}
+                        disabled={isPublished || protectedBSelected || hasApiKey}
                         id={`delivery-option-${DeliveryOption.api}`}
                         checked={deliveryOptionValue === DeliveryOption.api}
                         name="response-delivery"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/dialogs/ResponseDeliveryHelpDialogApiWithApi.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/dialogs/ResponseDeliveryHelpDialogApiWithApi.tsx
@@ -135,7 +135,7 @@ export const ResponseDeliveryHelpButtonWithApi = () => {
 
   return (
     <>
-      <InfoIcon className="ml-4 inline-block" />
+      <InfoIcon className="ml-4 inline-block size-5" />
       <div className="ml-2 inline-block">
         <Button onClick={handleOpenDialog} theme="link">
           {t("settingsResponseDelivery.responseDeliveryHelpWithApi.cta")}


### PR DESCRIPTION
# Summary | Résumé

Updates Response delivery view to show note about deleting key before changing an option.

<img width="800" alt="Screenshot 2024-11-28 at 8 33 56 AM" src="https://github.com/user-attachments/assets/95696d5a-2384-4c81-b962-d1652bcb86ed">



