### PR TITLE
chore: Adds a check that an api key exists before showing throttle ui

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
@@ -40,7 +40,7 @@ export const ManageForm = (props: ManageFormProps) => {
   } = props;
 
   const { apiKeyId } = useFormBuilderConfig();
-  
+
   if (!canManageAllForms) {
     return (
       <>
@@ -65,7 +65,7 @@ export const ManageForm = (props: ManageFormProps) => {
         updateTemplateUsers={updateTemplateUsers}
       />
       {canManageAllForms && apiKeyId && <ThrottlingRate formId={id} />}
-      {canManageAllForms && formRecord.isPublished && <ManageApiKey />}
+      {canManageAllForms && formRecord.isPublished && apiKeyId && <ManageApiKey />}
       <DownloadForm />
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/ManageForm.tsx
@@ -7,6 +7,7 @@ import { FormOwnership } from "./FormOwnership";
 import { ErrorPanel } from "@clientComponents/globals/ErrorPanel";
 import { updateTemplateUsers } from "@formBuilder/actions";
 import { ThrottlingRate } from "./ThrottlingRate";
+import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
 
 interface User {
   id: string;
@@ -37,6 +38,8 @@ export const ManageForm = (props: ManageFormProps) => {
     closedDetails,
   } = props;
 
+  const { apiKeyId } = useFormBuilderConfig();
+
   if (!canManageOwnership) {
     return (
       <>
@@ -60,7 +63,7 @@ export const ManageForm = (props: ManageFormProps) => {
         allUsers={allUsers}
         updateTemplateUsers={updateTemplateUsers}
       />
-      {canManageOwnership && <ThrottlingRate formId={id} />}
+      {canManageOwnership && apiKeyId && <ThrottlingRate formId={id} />}
       <DownloadForm />
     </>
   );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "singleQuote": false
   },
   "scripts": {
-    "upgrade": "yarn run upgrade --scope @testing-library",
     "dev": "yarn prisma:dev && yarn initialize && next dev",
     "dev:turbo": "yarn prisma:dev && yarn initialize && next dev --turbo",
     "dev:secure": "yarn prisma:dev && yarn initialize && next dev --experimental-https",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "singleQuote": false
   },
   "scripts": {
+    "upgrade": "yarn run upgrade --scope @testing-library",
     "dev": "yarn prisma:dev && yarn initialize && next dev",
     "dev:turbo": "yarn prisma:dev && yarn initialize && next dev --turbo",
     "dev:secure": "yarn prisma:dev && yarn initialize && next dev --experimental-https",


### PR DESCRIPTION
# Summary | Résumé

Previously the Throttle UI was showing up whether a form had an API key or not, only a check was done for ownership managing. This adds a check for an API key before showing the Throttle UI.

## Test

Create a new form and go to the settings screen and click on the "Form Management" screen. The Throttle UI should not be displayed.
Next click on the "Response Delivery" tab and click "Receive responses via API" and then click "Generate API Key". Now go to the "Form Management" screen. The Throttle UI should be shown.