### PR TITLE
fix: Switch SubOption to retrieve element by id

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOptions.tsx
@@ -59,17 +59,15 @@ export const SubOptions = ({
   elIndex: number;
   renderIcon?: RenderIcon;
 }) => {
-  const { elements, translationLanguagePriority } = useTemplateStore((s) => ({
-    elements: s.form.elements,
+  const { translationLanguagePriority, getFormElementById } = useTemplateStore((s) => ({
     translationLanguagePriority: s.translationLanguagePriority,
+    getFormElementById: s.getFormElementById,
   }));
 
   const subIndex = item.index;
-  // get choices from the parent element
-  const subElements = elements[elIndex].properties.subElements ?? [];
-  const choices = subElements[subIndex]?.properties.choices?.length
-    ? subElements[subIndex]?.properties.choices
-    : [{ en: "", fr: "" }];
+
+  const element = getFormElementById(item.id);
+  const choices = element?.properties.choices || [{ en: "", fr: "" }];
 
   if (!choices) {
     return <AddOptions elIndex={elIndex} subIndex={subIndex} />;


### PR DESCRIPTION
# Summary | Résumé

In certain circumstances (ie when form elements have been re-ordered), the elIndex can get out of sync and becomes a bad way of finding specific elements. This is part of an ongoing Tech Debt exercise to replace indexes by ID lookups.
