### PR TITLE
chore: update setting page styling for API 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog.tsx
@@ -70,6 +70,7 @@ export const DeleteApiKeyDialog = () => {
       toast.success(<DeleteKeySuccess id={id} />, "wide");
       updateApiKeyId(false);
       setDeleting(false);
+      Event.fire(EventKeys.deleteApiKey, { id });
       dialog.current?.close();
       setIsOpen(false);
     } catch (error) {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/settings/SettingsDialog.tsx
@@ -456,7 +456,7 @@ const SettingsDialog = ({
                       label={t("settingsResponseDelivery.vaultOption")}
                       onChange={updateDeliveryOption}
                     >
-                      <span className="mb-1 ml-3 block text-sm">
+                      <span className="ml-3 block text-sm">
                         {t("settingsResponseDelivery.vaultOptionHint.text1")}{" "}
                         <a href={responsesLink}>
                           {t("settingsResponseDelivery.vaultOptionHint.text2")}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useState, useMemo } from "react";
+import React, { useCallback, useState, useMemo, useEffect } from "react";
 import {
   LocalizedFormProperties,
   FormServerError,
@@ -39,6 +39,8 @@ import { ApiDocNotes } from "./ApiDocNotes";
 import { DeleteKeyToChangeOptionsNote } from "./DeleteKeyToChangeOptionsNote";
 import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
 
+import { EventKeys, useCustomEvent } from "@lib/hooks/useCustomEvent";
+
 enum DeliveryOption {
   vault = "vault",
   email = "email",
@@ -63,6 +65,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
   const { refreshData } = useRefresh();
   const lang = i18n.language === "en" ? "en" : "fr";
   const { apiKeyId } = useFormBuilderConfig();
+  const { Event } = useCustomEvent();
 
   const {
     email,
@@ -321,6 +324,22 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
     }
     setClassification(value);
   }, []);
+
+  const handleDeleteApiKey = useCallback(() => {
+    if (deliveryOptionValue === DeliveryOption.vault) {
+      return;
+    }
+
+    // Set to vault when an API key is deleted
+    setDeliveryOptionValue(DeliveryOption.vault);
+  }, [deliveryOptionValue]);
+
+  useEffect(() => {
+    Event.on(EventKeys.deleteApiKey, handleDeleteApiKey);
+    return () => {
+      Event.off(EventKeys.deleteApiKey, handleDeleteApiKey);
+    };
+  }, [Event, handleDeleteApiKey]);
 
   return (
     <>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -113,13 +113,6 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
     t("formSettingsModal.emailOption.label")
   );
 
-  const apiLabel = (
-    <>
-      <span className="block">{t("formSettingsModal.apiOption.label")}</span>
-      <span className="block">{t("formSettingsModal.apiOption.note")}</span>
-    </>
-  );
-
   const userEmail = session.data?.user.email ?? "";
   let initialDeliveryOption = !email ? DeliveryOption.vault : DeliveryOption.email;
 
@@ -331,7 +324,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
 
   return (
     <>
-      <p className="mb-10 inline-block bg-purple-200 p-3 text-sm font-bold">
+      <p className="mb-4 w-3/5 rounded-md bg-indigo-50 p-3 font-bold">
         {t("settingsResponseDelivery.beforePublishMessage")}
       </p>
       {status === "authenticated" && (
@@ -357,25 +350,9 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                 </p>
               ) : null}
 
+              {/* Email Option */}
               {!hasApiKey && (
-                <>
-                  <Radio
-                    disabled={isPublished || hasApiKey}
-                    id={`delivery-option-${DeliveryOption.vault}`}
-                    checked={deliveryOptionValue === DeliveryOption.vault}
-                    name="response-delivery"
-                    value={DeliveryOption.vault}
-                    label={t("settingsResponseDelivery.vaultOption")}
-                    onChange={updateDeliveryOption}
-                  >
-                    <span className="mb-1 ml-3 block text-sm">
-                      {t("settingsResponseDelivery.vaultOptionHint.text1")}{" "}
-                      <a href={responsesLink}>
-                        {t("settingsResponseDelivery.vaultOptionHint.text2")}
-                      </a>
-                      .{t("settingsResponseDelivery.vaultOptionHint.text3")}
-                    </span>
-                  </Radio>
+                <div className="mb-10">
                   <Radio
                     disabled={isPublished || protectedBSelected || hasApiKey}
                     id={`delivery-option-${DeliveryOption.email}`}
@@ -384,8 +361,8 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                     value={DeliveryOption.email}
                     label={emailLabel}
                     onChange={updateDeliveryOption}
+                    className="mb-0"
                   />
-
                   {deliveryOptionValue === DeliveryOption.email && (
                     <ResponseEmail
                       inputEmail={inputEmailValue}
@@ -398,19 +375,57 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                       setIsInvalidEmailError={setIsInvalidEmailError}
                     />
                   )}
-                  {deliveryOptionValue !== DeliveryOption.email && <div className="mb-8"></div>}
+                </div>
+              )}
+              {/* End Email Option */}
 
+              {/* Vault Option */}
+              {!hasApiKey && (
+                <>
+                  <div className="mb-10">
+                    <Radio
+                      disabled={isPublished || hasApiKey}
+                      id={`delivery-option-${DeliveryOption.vault}`}
+                      checked={deliveryOptionValue === DeliveryOption.vault}
+                      name="response-delivery"
+                      value={DeliveryOption.vault}
+                      label={t("settingsResponseDelivery.vaultOption")}
+                      onChange={updateDeliveryOption}
+                      className="mb-0"
+                    >
+                      <span className="ml-3 block text-sm">
+                        {t("settingsResponseDelivery.vaultOptionHint.text1")}{" "}
+                        <a href={responsesLink}>
+                          {t("settingsResponseDelivery.vaultOptionHint.text2")}
+                        </a>
+                        .{t("settingsResponseDelivery.vaultOptionHint.text3")}
+                      </span>
+                    </Radio>
+                  </div>
+                  {/* End Vault Option */}
+
+                  {/* API Option */}
                   {apiAccess && (
-                    <>
-                      <Radio
-                        disabled={isPublished || protectedBSelected || hasApiKey}
-                        id={`delivery-option-${DeliveryOption.api}`}
-                        checked={deliveryOptionValue === DeliveryOption.api}
-                        name="response-delivery"
-                        value={DeliveryOption.api}
-                        label={apiLabel}
-                        onChange={updateDeliveryOption}
-                      />
+                    <div className="mb-10">
+                      <div>
+                        <Radio
+                          disabled={isPublished || protectedBSelected || hasApiKey}
+                          id={`delivery-option-${DeliveryOption.api}`}
+                          checked={deliveryOptionValue === DeliveryOption.api}
+                          name="response-delivery"
+                          value={DeliveryOption.api}
+                          label={t("formSettingsModal.apiOption.label")}
+                          onChange={updateDeliveryOption}
+                          className="mb-0"
+                        >
+                          <span className="ml-3 block text-sm">
+                            {t("formSettingsModal.apiOption.note")}
+                          </span>
+                        </Radio>
+                      </div>
+                      {/* End API Option */}
+
+                      {/*  API note */}
                       {deliveryOptionValue === DeliveryOption.api && (
                         <div className="mb-10 ml-4 border-l-4 pl-8">
                           <span className="block py-6 font-bold">
@@ -418,14 +433,16 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                           </span>
                         </div>
                       )}
-                    </>
+                      {/*  End API note */}
+                    </div>
                   )}
                 </>
               )}
+
               {apiAccess && deliveryOptionValue === DeliveryOption.api && (
                 <div>
-                  <ApiKeyButton showDelete />
                   <DeleteKeyToChangeOptionsNote hasApiKey={hasApiKey} />
+                  <ApiKeyButton showDelete />
                   <ApiDocNotes />
                 </div>
               )}
@@ -461,6 +478,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
                 checked={purposeOption === PurposeOption.admin}
                 value={PurposeOption.admin}
                 onChange={updatePurposeOption}
+                className="mb-20"
               />
               <div className="mb-4 ml-12 text-sm">
                 <div>

--- a/lib/hooks/useCustomEvent.tsx
+++ b/lib/hooks/useCustomEvent.tsx
@@ -20,6 +20,7 @@ export const EventKeys = {
   openMoreDialog: "open-more-dialog",
   openDeleteApiKeyDialog: "open-delete-api-key-dialog",
   openRulesDialog: "open-rules-dialog",
+  deleteApiKey: "delete-api-key",
 } as const;
 
 export const useCustomEvent = () => {


### PR DESCRIPTION
# Summary | Résumé
- [x] Change the order of radios to email, download, API 
Fixes #4731

<img width="500" alt="Screenshot 2024-12-02 at 9 37 02 AM" src="https://github.com/user-attachments/assets/e7b0ef0f-83a2-473f-8eaf-4c16e2e8c5f6">


- [x] Have the download radio selected after deletion to make it clear that this is now the default

Fixes #4724

https://github.com/user-attachments/assets/a5aaec7e-4e16-4a5f-a36b-0951aa9cd82c

- [x] Make the info banner at the top of the page match the style of the delete API key one.
<img width="600" alt="Screenshot 2024-12-02 at 9 50 26 AM" src="https://github.com/user-attachments/assets/e2975971-862c-41a1-98c6-0b5b34f3f900">

- [x] Add a mb-20 between each section to visually separate them a bit more.

👉  Note -- 20 was too much using 10
<img width="487" alt="Screenshot 2024-12-02 at 9 53 50 AM" src="https://github.com/user-attachments/assets/3b6419e6-2c2a-4631-8a51-a9ec05b70a75">

- [x] The sub text on the API radio is a different size - It should probably have the same classes as the highlighted span

Fixes [#4737](https://github.com/cds-snc/platform-forms-client/issues/4737)

<img width="700" alt="Screenshot 2024-12-02 at 9 55 47 AM" src="https://github.com/user-attachments/assets/ddc5305b-fa3c-4d1d-967e-de9d89505898">

- [x] Place the API key ID tool tip after "API key ID" rather than the number itself.

<img width="472" alt="Screenshot 2024-12-02 at 9 57 45 AM" src="https://github.com/user-attachments/assets/cd5c626e-bbad-49a2-84e8-91d4bec7060b">



