### PR TITLE
chore: fix dialog heading + remove responses skip link for API screens

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/DeleteApiKeyDialog/DeleteApiKeyDialog.tsx
@@ -106,9 +106,9 @@ export const DeleteApiKeyDialog = () => {
           title={t("settings.api.deleteApiKeyDialog.title")}
         >
           <div className="p-5">
-            <h4 className="mb-2 text-2xl font-bold">
+            <h3 className="mb-2 text-2xl font-bold">
               {t("settings.api.deleteApiKeyDialog.cautionTitle")}
-            </h4>
+            </h3>
             <p className="mb-4">{t("settings.api.deleteApiKeyDialog.cautionText")}</p>
             <Trans
               ns="form-builder"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/DownloadTable.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/DownloadTable.tsx
@@ -26,6 +26,8 @@ import { NextStep } from "./NextStep";
 import { Tooltip } from "@formBuilder/components/shared/Tooltip";
 import { StatusFilter } from "../types";
 
+import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
+
 interface DownloadTableProps {
   vaultSubmissions: VaultSubmissionList[];
   formName: string;
@@ -59,6 +61,8 @@ export const DownloadTable = ({
   const [showDownloadSuccess, setShowDownloadSuccess] = useState<false | string>(false);
   const [removedRows, setRemovedRows] = useState<string[]>([]);
   const accountEscalated = nagwareResult && nagwareResult.level > 2;
+
+  const { hasApiKeyId } = useFormBuilderConfig();
 
   const [tableItems, tableItemsDispatch] = useReducer(
     reducerTableItems,
@@ -109,9 +113,12 @@ export const DownloadTable = ({
         </Alert.Success>
       )}
       <section>
-        <SkipLinkReusable anchor="#reportProblemButton">
-          {t("downloadResponsesTable.skipLink")}
-        </SkipLinkReusable>
+        {!hasApiKeyId && (
+          <SkipLinkReusable anchor="#reportProblemButton">
+            {t("downloadResponsesTable.skipLink")}
+          </SkipLinkReusable>
+        )}
+
         <div id="notificationsTop">
           {downloadError && (
             <Alert.Danger>


### PR DESCRIPTION
# Summary | Résumé

Fixes a11y issues for API screens.
