### PR TITLE
fix: followup to screen reader re-announcing the form label on every input change

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -251,9 +251,13 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               handleSubmit(e);
             }}
             noValidate
-            // Needed for the show-hide behavior. Not ideal because all child elements will inherit
-            // and could make AT announcing noisy/confusing. Override any noisy elements with a
-            // parent aria-live="off". There are caveats - See: TODO
+            // This is needed so dynamic changes e.g. show-hide elements are announced when shown
+            // on the form. Though the relationship between controlling and shown/hidden element is
+            // not very clear and can hopefully be improved.
+            // For more info and progress see: #4769
+            // Also, this this is not ideal because all child elements will inherit and any "noisy"
+            // child elements will need to be overridden with aria-live="off" for AT e.g. labels
+            // For more info and caveats see: #4766
             aria-live="polite"
           >
             {isGroupsCheck &&

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -251,8 +251,10 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               handleSubmit(e);
             }}
             noValidate
-            // TODO: probably needed for the show-hide feature
-            // aria-live="polite"
+            // Needed for the show-hide behavior. Not ideal because all child elements will inherit
+            // and could make AT announcing noisy/confusing. Override any noisy elements with a
+            // parent aria-live="off". There are caveats - See: TODO
+            aria-live="polite"
           >
             {isGroupsCheck &&
               isShowReviewPage &&

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -251,6 +251,8 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               handleSubmit(e);
             }}
             noValidate
+            // TODO: probably needed for the show-hide feature
+            // aria-live="polite"
           >
             {isGroupsCheck &&
               isShowReviewPage &&

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -252,12 +252,12 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
             }}
             noValidate
             // This is needed so dynamic changes e.g. show-hide elements are announced when shown
-            // on the form. Though the relationship between controlling and shown/hidden element is
-            // not very clear and can hopefully be improved.
+            // on the form. Though the relationship between the controlling and shown/hidden element
+            // is not very clear and can hopefully be improved.
             // For more info and progress see: #4769
-            // Also, this this is not ideal because all child elements will inherit and any "noisy"
-            // child elements will need to be overridden with aria-live="off" for AT e.g. labels
-            // For more info and caveats see: #4766
+            // Also, this this is not ideal because all child elements will inherit the live=polit
+            // and any "noisy" child elements should be overridden with aria-live="off" for AT
+            // e.g. labels. For more info and caveats see: #4766
             aria-live="polite"
           >
             {isGroupsCheck &&

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -99,10 +99,10 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
 
   switch (element.type) {
     case FormElementTypes.textField:
+      // live=off is a fix for #4766 (same for others below)
       return (
-        <div className="focus-group gcds-input-wrapper">
-          {/* live=off is a fix for #4766 */}
-          <div aria-live="off">{labelComponent}</div>
+        <div className="focus-group gcds-input-wrapper" aria-live="off">
+          {labelComponent}
           {description && <Description id={`${id}`}>{description}</Description>}
           <TextInput
             type={textType}
@@ -118,9 +118,8 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
       );
     case FormElementTypes.textArea:
       return (
-        <div className="focus-group gcds-textarea-wrapper">
-          {/* live=off is a fix for #4766 */}
-          <div aria-live="off">{labelComponent}</div>
+        <div className="focus-group gcds-textarea-wrapper" aria-live="off">
+          {labelComponent}
           {description && <Description id={`${id}`}>{description}</Description>}
           <TextArea
             id={`${id}`}
@@ -280,7 +279,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     case FormElementTypes.addressComplete: {
       const addressComponents = element.properties.addressComponents;
       return (
-        <div className="focus-group">
+        <div className="focus-group" aria-live="off">
           <AddressComplete
             label={labelText}
             id={`${id}`}
@@ -295,7 +294,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     }
     case FormElementTypes.formattedDate: {
       return (
-        <div className="focus-group">
+        <div className="focus-group" aria-live="off">
           <FormattedDate
             label={labelText}
             description={description}

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -100,8 +100,9 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
   switch (element.type) {
     case FormElementTypes.textField:
       return (
-        <div className="focus-group gcds-input-wrapper" aria-live="off">
-          {labelComponent}
+        <div className="focus-group gcds-input-wrapper">
+          {/* live=off is a fix for #4766 */}
+          <div aria-live="off">{labelComponent}</div>
           {description && <Description id={`${id}`}>{description}</Description>}
           <TextInput
             type={textType}
@@ -117,8 +118,9 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
       );
     case FormElementTypes.textArea:
       return (
-        <div className="focus-group gcds-textarea-wrapper" aria-live="off">
-          {labelComponent}
+        <div className="focus-group gcds-textarea-wrapper">
+          {/* live=off is a fix for #4766 */}
+          <div aria-live="off">{labelComponent}</div>
           {description && <Description id={`${id}`}>{description}</Description>}
           <TextArea
             id={`${id}`}
@@ -278,7 +280,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     case FormElementTypes.addressComplete: {
       const addressComponents = element.properties.addressComponents;
       return (
-        <div className="focus-group" aria-live="off">
+        <div className="focus-group">
           <AddressComplete
             label={labelText}
             id={`${id}`}
@@ -293,7 +295,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     }
     case FormElementTypes.formattedDate: {
       return (
-        <div className="focus-group" aria-live="off">
+        <div className="focus-group">
           <FormattedDate
             label={labelText}
             description={description}

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -100,7 +100,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
   switch (element.type) {
     case FormElementTypes.textField:
       return (
-        <div className="focus-group gcds-input-wrapper">
+        <div className="focus-group gcds-input-wrapper" aria-live="off">
           {labelComponent}
           {description && <Description id={`${id}`}>{description}</Description>}
           <TextInput
@@ -117,7 +117,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
       );
     case FormElementTypes.textArea:
       return (
-        <div className="focus-group gcds-textarea-wrapper">
+        <div className="focus-group gcds-textarea-wrapper" aria-live="off">
           {labelComponent}
           {description && <Description id={`${id}`}>{description}</Description>}
           <TextArea
@@ -278,7 +278,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     case FormElementTypes.addressComplete: {
       const addressComponents = element.properties.addressComponents;
       return (
-        <div className="focus-group">
+        <div className="focus-group" aria-live="off">
           <AddressComplete
             label={labelText}
             id={`${id}`}
@@ -293,7 +293,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     }
     case FormElementTypes.formattedDate: {
       return (
-        <div className="focus-group">
+        <div className="focus-group" aria-live="off">
           <FormattedDate
             label={labelText}
             description={description}


### PR DESCRIPTION
# Summary | Résumé

This is a followup PR to the previous fix #4704. The form live-region is added back and to stop the "noisy" form labels, a live=off is added around them.

TL/DR: Should work fine.
This appears to work well with screen readers. It is generally a best practice to have any attributes like live-regions rendered as close as possible to the original rendered HTML. This is because if the DOM becomes complex, there is a good chance an AT will ignore any dynamic changes in the DOM unless told about them. But in this case, a live-region is added on the form element that is in the original-ish HTML. So the AT is paying attention to this element. A few children below are the dynamically added show-hide elements with labels that have an overriding live=off.  AT should pick these up and AT are getting better and better at noticing dynamic DOM changes.
Also the form validation elements are outside the label and won't be impacted.

A follow up question/investigation could be looking into why a form label is re-rendered when the related input is updated. The label and input are siblings (not nested in each other) so it is not related to a parent component re-rendering. Or at least not in an obvious way. I suspect this has something to do with Formik. I left this as a TODO after spending a few hours looking into it.

