### PR TITLE
chore: update add / remove sub choices for repeating sets

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOption.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOption.tsx
@@ -36,6 +36,7 @@ export const SubOption = ({
     setFocusInput,
     translationLanguagePriority,
     getLocalizationAttribute,
+    setChangeKey,
   } = useTemplateStore((s) => ({
     addSubChoice: s.addSubChoice,
     removeSubChoice: s.removeSubChoice,
@@ -44,6 +45,7 @@ export const SubOption = ({
     getFocusInput: s.getFocusInput,
     translationLanguagePriority: s.translationLanguagePriority,
     getLocalizationAttribute: s.getLocalizationAttribute,
+    setChangeKey: s.setChangeKey,
   }));
 
   const icon = renderIcon && renderIcon(index);
@@ -65,7 +67,8 @@ export const SubOption = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === "Enter") {
       setFocusInput(true);
-      addSubChoice(elIndex, subIndex);
+      addSubChoice(id, subIndex);
+      setChangeKey(String(new Date().getTime()));
     }
   };
 
@@ -94,8 +97,8 @@ export const SubOption = ({
   );
 
   return (
-    <div className="flex mt-3">
-      <div className="flex mt-2 w-5 justify-end">{icon}</div>
+    <div className="mt-3 flex">
+      <div className="mt-2 flex w-5 justify-end">{icon}</div>
       <Input
         id={`option--${id}--${index + 1}`}
         ref={input}
@@ -106,7 +109,7 @@ export const SubOption = ({
           updateValue(elIndex, subIndex, index, e.target.value)
         }
         onKeyDown={handleKeyDown}
-        className="ml-5 w-full max-h-9 !my-0"
+        className="!my-0 ml-5 max-h-9 w-full"
         {...getLocalizationAttribute()}
       />
       <Button
@@ -114,11 +117,12 @@ export const SubOption = ({
         className="group"
         id={`remove--${id}--${index + 1}`}
         icon={
-          <Close className="group-focus:fill-white-default bg-gray-selected hover:bg-gray-600" />
+          <Close className="bg-gray-selected hover:bg-gray-600 group-focus:fill-white-default" />
         }
         aria-label={`${t("removeOption")} ${value}`}
         onClick={() => {
-          removeSubChoice(elIndex, subIndex, index);
+          removeSubChoice(id, subIndex, index);
+          setChangeKey(String(new Date().getTime()));
         }}
       ></Button>
     </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOptions.tsx
@@ -7,23 +7,8 @@ import { SubOption } from "./SubOption";
 import { Button } from "@clientComponents/globals";
 import { FormElementWithIndex } from "@lib/types/form-builder-types";
 
-const AddButton = ({ elId, onClick }: { elId: number; onClick: (elId: number) => void }) => {
+const AddOption = ({ elId, subIndex }: { elId: number; subIndex: number }) => {
   const { t } = useTranslation("form-builder");
-  return (
-    <Button
-      className="!m-0 !mt-4"
-      theme="link"
-      id={`sub-add-option-${elId}`}
-      onClick={() => {
-        onClick(elId);
-      }}
-    >
-      {t("addOption")}
-    </Button>
-  );
-};
-
-const AddOptions = ({ elId, subIndex }: { elId: number; subIndex: number }) => {
   const { addSubChoice, setFocusInput, setChangeKey } = useTemplateStore((s) => ({
     addSubChoice: s.addSubChoice,
     setFocusInput: s.setFocusInput,
@@ -32,14 +17,18 @@ const AddOptions = ({ elId, subIndex }: { elId: number; subIndex: number }) => {
 
   return (
     <>
-      <AddButton
-        elId={elId}
+      <Button
+        className="!m-0 !mt-4"
+        theme="link"
+        id={`sub-add-option-${elId}`}
         onClick={() => {
           setFocusInput(true);
           addSubChoice(elId, subIndex);
           setChangeKey(String(new Date().getTime()));
         }}
-      />
+      >
+        {t("addOption")}
+      </Button>
     </>
   );
 };
@@ -66,7 +55,7 @@ export const SubOptions = ({
   const choices = element?.properties.choices || [{ en: "", fr: "" }];
 
   if (!choices) {
-    return <AddOptions elId={item.id} subIndex={subIndex} />;
+    return <AddOption elId={item.id} subIndex={subIndex} />;
   }
 
   const options = choices.map((child, choiceIndex) => {
@@ -91,7 +80,7 @@ export const SubOptions = ({
   return (
     <div className="mt-5">
       {options}
-      <AddOptions elId={item.id} subIndex={subIndex} />
+      <AddOption elId={item.id} subIndex={subIndex} />
     </div>
   );
 };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/SubOptions.tsx
@@ -7,21 +7,15 @@ import { SubOption } from "./SubOption";
 import { Button } from "@clientComponents/globals";
 import { FormElementWithIndex } from "@lib/types/form-builder-types";
 
-const AddButton = ({
-  elIndex,
-  onClick,
-}: {
-  elIndex: number;
-  onClick: (elIndex: number) => void;
-}) => {
+const AddButton = ({ elId, onClick }: { elId: number; onClick: (elId: number) => void }) => {
   const { t } = useTranslation("form-builder");
   return (
     <Button
       className="!m-0 !mt-4"
       theme="link"
-      id={`sub-add-option-${elIndex}`}
+      id={`sub-add-option-${elId}`}
       onClick={() => {
-        onClick(elIndex);
+        onClick(elId);
       }}
     >
       {t("addOption")}
@@ -29,19 +23,21 @@ const AddButton = ({
   );
 };
 
-const AddOptions = ({ elIndex, subIndex }: { elIndex: number; subIndex: number }) => {
-  const { addSubChoice, setFocusInput } = useTemplateStore((s) => ({
+const AddOptions = ({ elId, subIndex }: { elId: number; subIndex: number }) => {
+  const { addSubChoice, setFocusInput, setChangeKey } = useTemplateStore((s) => ({
     addSubChoice: s.addSubChoice,
     setFocusInput: s.setFocusInput,
+    setChangeKey: s.setChangeKey,
   }));
 
   return (
     <>
       <AddButton
-        elIndex={elIndex}
+        elId={elId}
         onClick={() => {
           setFocusInput(true);
-          addSubChoice(elIndex, subIndex);
+          addSubChoice(elId, subIndex);
+          setChangeKey(String(new Date().getTime()));
         }}
       />
     </>
@@ -70,7 +66,7 @@ export const SubOptions = ({
   const choices = element?.properties.choices || [{ en: "", fr: "" }];
 
   if (!choices) {
-    return <AddOptions elIndex={elIndex} subIndex={subIndex} />;
+    return <AddOptions elId={item.id} subIndex={subIndex} />;
   }
 
   const options = choices.map((child, choiceIndex) => {
@@ -95,7 +91,7 @@ export const SubOptions = ({
   return (
     <div className="mt-5">
       {options}
-      <AddOptions elIndex={elIndex} subIndex={subIndex} />
+      <AddOptions elId={item.id} subIndex={subIndex} />
     </div>
   );
 };

--- a/lib/store/types.ts
+++ b/lib/store/types.ts
@@ -48,7 +48,7 @@ export interface TemplateStoreState extends TemplateStoreProps {
   removeSubItem: (elIndex: number, id: number) => void;
   addChoice: (elIndex: number) => void;
   addLabeledChoice: (elIndex: number, label: { en: string; fr: string }) => Promise<number>;
-  addSubChoice: (elIndex: number, subIndex: number) => void;
+  addSubChoice: (elId: number, subIndex: number) => void;
   removeChoice: (elIndex: number, choiceIndex: number) => void;
   removeSubChoice: (elId: number, subIndex: number, choiceIndex: number) => void;
   getChoice: (elIndex: number, choiceIndex: number) => { en: string; fr: string } | undefined;

--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -343,19 +343,24 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
                 });
               });
             },
-            addSubChoice: (elIndex, subIndex) =>
+            addSubChoice: (elId, subIndex) => {
               set((state) => {
-                state.form.elements[elIndex].properties.subElements?.[
+                const parentIndex = getParentIndex(elId, state.form.elements);
+                if (parentIndex === undefined) return;
+                state.form.elements[parentIndex].properties.subElements?.[
                   subIndex
                 ].properties.choices?.push({ en: "", fr: "" });
-              }),
+              });
+            },
             removeChoice: (elIndex, choiceIndex) =>
               set((state) => {
                 state.form.elements[elIndex].properties.choices?.splice(choiceIndex, 1);
               }),
-            removeSubChoice: (elIndex, subIndex, choiceIndex) =>
+            removeSubChoice: (elId, subIndex, choiceIndex) =>
               set((state) => {
-                state.form.elements[elIndex].properties.subElements?.[
+                const parentIndex = getParentIndex(elId, state.form.elements);
+                if (parentIndex === undefined) return;
+                state.form.elements[parentIndex].properties.subElements?.[
                   subIndex
                 ].properties.choices?.splice(choiceIndex, 1);
               }),


### PR DESCRIPTION
# Summary | Résumé

Updates Sub options to use id vs index for adding / removing sub elements

Seeing an issue on staging ---doesn't seem to happen on local dev but was really slow.
<img width="968" alt="Screenshot 2024-12-03 at 1 55 40 PM" src="https://github.com/user-attachments/assets/554b1e6f-a051-4d22-a2d1-cf15dc433606">

