### PR TITLE
chore: Update card background colour

### DIFF
--- a/components/clientComponents/globals/card/Card.tsx
+++ b/components/clientComponents/globals/card/Card.tsx
@@ -44,7 +44,7 @@ export const Card = ({
   headingStyle?: string;
 }) => {
   return (
-    <div className="inline-flex justify-between rounded-lg border-2 border-solid border-[#ebf0f4] p-4">
+    <div className="inline-flex justify-between rounded-lg border-2 border-solid border-[#ebf0f4] bg-white p-4">
       {icon && <div>{icon}</div>}
       <div className="mx-8 mt-4 flex flex-col justify-start">
         {children && children}

--- a/components/serverComponents/globals/card/Card.tsx
+++ b/components/serverComponents/globals/card/Card.tsx
@@ -25,7 +25,7 @@ export const Card = ({
   headingStyle?: string;
 }) => {
   return (
-    <div className="inline-flex justify-between rounded-lg border-2 border-solid border-[#ebf0f4] p-4">
+    <div className="inline-flex justify-between rounded-lg border-2 border-solid border-[#ebf0f4] bg-white p-4">
       {icon && <div>{icon}</div>}
       <div className="mx-8 mt-4 flex flex-col justify-start">
         {children && children}


### PR DESCRIPTION
# Summary | Résumé

Adds a background colour <img width="22" alt="Screenshot 2024-12-04 at 2 10 01 PM" src="https://github.com/user-attachments/assets/aaff3148-d2ec-403f-a57c-b4c082697cd6"> for the Card components




<img width="1037" alt="Screenshot 2024-12-04 at 2 04 12 PM" src="https://github.com/user-attachments/assets/89514505-085b-4018-927e-ad828ebc0843">
