### PR TITLE
fix: Updates Combobox (Searchable list) to pre-populate if a value exists

### DIFF
--- a/components/clientComponents/forms/Combobox/Combobox.tsx
+++ b/components/clientComponents/forms/Combobox/Combobox.tsx
@@ -14,7 +14,6 @@ export const Combobox = (props: ComboboxProps): React.ReactElement => {
   const { id, name, className, choices = [], required, ariaDescribedBy } = props;
   const classes = cn("gc-combobox gcds-input-wrapper", className);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [field, meta, helpers] = useField(props);
   const { setValue } = helpers;
 
@@ -46,6 +45,7 @@ export const Combobox = (props: ComboboxProps): React.ReactElement => {
           required={required}
           {...(name && { name })}
           data-testid="combobox-input"
+          {...(field?.value && { value: field.value })}
         />
 
         {items.length >= 1 && (


### PR DESCRIPTION
# Summary | Résumé

Previously if a value was set in a Combobox (Searchable list) it was saved in Fomik but when returning to that Combobox the value would not be used to pre-populate. This fix pre-populates a Combobox value if one exists.

## Test

Create a form with at least one additional page and on that page add a Searchable list with at least two items. Open that form and continue to that page. Fill in the Searchable list and go to the Review page. The value should be there. Now go back to the previous page.  The Searchable list should be pre-populated with that value.
