### PR TITLE
chore: update alignment for text in Status Boxes

### DIFF
--- a/components/clientComponents/globals/HealthCheckBox/HealthCheckBox.tsx
+++ b/components/clientComponents/globals/HealthCheckBox/HealthCheckBox.tsx
@@ -67,7 +67,7 @@ export const BoxContainer = ({
         className
       )}
     >
-      <div className="grid justify-items-center gap-1">{children}</div>
+      <div className="grid justify-items-center gap-1 text-center">{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
# Summary | Résumé

Centers "paragraph" text for status boxes.

<img width="907" alt="Screenshot 2024-12-04 at 2 52 22 PM" src="https://github.com/user-attachments/assets/e4cd4fba-d2fa-4dd3-8b95-d9d10dcd37aa">
