### PR TITLE
chore: Add api option to support form

### DIFF
--- a/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
@@ -17,6 +17,8 @@ import { SubmitButton } from "../../../components/client/SubmitButton";
 import { useState } from "react";
 import { email, minLength, object, safeParse, string, toLowerCase, toTrimmed } from "valibot";
 import { Success } from "../../../components/client/Success";
+import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
+import { FeatureFlags } from "@lib/cache/types";
 
 export const SupportForm = () => {
   const {
@@ -26,6 +28,9 @@ export const SupportForm = () => {
 
   const [errors, setErrors] = useState<ErrorStates>({ validationErrors: [] });
   const [submitted, setSubmitted] = useState(false);
+
+  const { getFlag } = useFeatureFlags();
+  const apiFlag = getFlag(FeatureFlags.apiAccess);
 
   const getError = (fieldKey: string) => {
     return errors.validationErrors.find((e) => e.fieldKey === fieldKey)?.fieldValue || "";
@@ -174,6 +179,16 @@ export const SupportForm = () => {
                     name: "technical",
                     label: t("support.request.option2"),
                   },
+                  ...(apiFlag
+                    ? [
+                        {
+                          id: "request-technical-api",
+                          name: "technical-api",
+                          label: t("support.request.apiOption"),
+                        },
+                      ]
+                    : []),
+
                   {
                     id: "request-form",
                     name: "form",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -911,7 +911,8 @@
     "lookingForADemo": "Looking to learn more about GC Forms?",
     "request": {
       "option1": "Ask a question",
-      "option2": "Get technical support",
+      "option2": "Get help using GC Forms",
+      "apiOption": "Request technical support with the API",
       "option3": "Report a problem with a published form",
       "option4": "Other",
       "title": "Reason for reaching out"

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -911,7 +911,8 @@
     "lookingForADemo": "Vous cherchez à en savoir plus sur Formulaires GC?",
     "request": {
       "option1": "Poser une question",
-      "option2": "Obtenir du soutien technique",
+      "option2": "Obtenir de l'aide pour utiliser Formulaires GC",
+      "apiOption": "Demander de l'assistance technique avec l'API",
       "option3": "Signaler un problème avec un formulaire publié",
       "option4": "Autre",
       "title": "Raison pour laquelle vous nous contactez"


### PR DESCRIPTION
# Summary | Résumé

Adds API option to support form behind a feature flag.

Version 1 update of the support form #4375 

<img width="717" alt="Screenshot 2024-12-05 at 9 45 38 AM" src="https://github.com/user-attachments/assets/9cd7f9b7-366e-4568-a7cf-55c087be889e">

It works 

<img width="644" alt="Screenshot 2024-12-05 at 9 42 58 AM" src="https://github.com/user-attachments/assets/b389eb37-0e8b-4571-bed2-6a0f935161ab">


## Testing 

Ensure you test with the flag on /off
