### PR TITLE
chore: Reset delivery option when creating API key

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -99,7 +99,7 @@ export const ApiKeyDialog = ({ isVaultDelivery = false }: { isVaultDelivery?: bo
           throw new Error(result.error);
         }
 
-        // Update the template store to reset the delivery option
+        // Sync the template store with the new delivery option
         resetDeliveryOption();
       }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ApiKeyDialog/ApiKeyDialog.tsx
@@ -16,6 +16,7 @@ import { logMessage } from "@lib/logger";
 import { sendResponsesToVault } from "@formBuilder/actions";
 import { useFormBuilderConfig } from "@lib/hooks/useFormBuilderConfig";
 import { GenerateKeySuccess } from "./GenerateKeySuccess";
+import { useTemplateStore } from "@lib/store/useTemplateStore";
 
 type APIKeyCustomEventDetails = {
   id: string;
@@ -30,6 +31,10 @@ export const ApiKeyDialog = ({ isVaultDelivery = false }: { isVaultDelivery?: bo
   const dialog = useDialogRef();
   const { Event } = useCustomEvent();
   const { t } = useTranslation("form-builder");
+
+  const { resetDeliveryOption } = useTemplateStore((s) => ({
+    resetDeliveryOption: s.resetDeliveryOption,
+  }));
 
   // Setup + Open dialog
   const [id, setId] = useState<string>("");
@@ -93,6 +98,9 @@ export const ApiKeyDialog = ({ isVaultDelivery = false }: { isVaultDelivery?: bo
           // Handling as generic as we're in the process of creating a key
           throw new Error(result.error);
         }
+
+        // Update the template store to reset the delivery option
+        resetDeliveryOption();
       }
 
       const key = await _createKey(id);


### PR DESCRIPTION
# Summary | Résumé

Update to ensure the template store is sync'd properly when creating an API key (save to vault).

Fixes https://github.com/cds-snc/platform-forms-client/issues/4793

## Testing

- Start with email delivery
- Change to API - generate a key
- Delete the API key (should be vault at this point)
- View responses page 
- Responses should show as "the vault"


https://github.com/user-attachments/assets/3a4a1cca-c817-4df5-b521-fb6da042fb85

