### PR TITLE
chore: add path helper to template store

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/MoreDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/MoreDialog.tsx
@@ -2,7 +2,6 @@
 import React, { useCallback, useEffect } from "react";
 import { useTranslation } from "@i18n/client";
 import { Button } from "@clientComponents/globals";
-import { getPathString } from "@lib/utils/form-builder/getPath";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { Dialog, useDialogRef } from "@formBuilder/components/shared/Dialog";
 import { useCustomEvent } from "@lib/hooks/useCustomEvent";
@@ -18,14 +17,16 @@ import { useRefsContext } from "@formBuilder/[id]/edit/components/RefsContext";
 import { FormElement } from "@lib/types";
 
 export const MoreDialog = () => {
-  const { elements, updateField, setChangeKey, getFormElementById } = useTemplateStore((s) => ({
-    lang: s.lang,
-    updateField: s.updateField,
-    elements: s.form.elements,
-    getFocusInput: s.getFocusInput,
-    setChangeKey: s.setChangeKey,
-    getFormElementById: s.getFormElementById,
-  }));
+  const { getPathString, updateField, setChangeKey, getFormElementById } = useTemplateStore(
+    (s) => ({
+      lang: s.lang,
+      updateField: s.updateField,
+      getFocusInput: s.getFocusInput,
+      setChangeKey: s.setChangeKey,
+      getFormElementById: s.getFormElementById,
+      getPathString: s.getPathString,
+    })
+  );
 
   const [item, setItem] = React.useState<FormElement | undefined>(undefined);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -81,7 +82,7 @@ export const MoreDialog = () => {
         className="ml-5"
         theme="primary"
         onClick={() => {
-          updateField(getPathString(item.id, elements), item.properties);
+          updateField(getPathString(item.id), item.properties);
           setChangeKey(String(new Date().getTime()));
           handleClose();
         }}

--- a/lib/store/types.ts
+++ b/lib/store/types.ts
@@ -26,6 +26,7 @@ export interface TemplateStoreState extends TemplateStoreProps {
   };
   getId: () => string;
   setId: (id: string) => void;
+  getPathString: (id: number) => string;
   setLang: (lang: Language) => void;
   toggleLang: () => void;
   toggleTranslationLanguagePriority: () => void;

--- a/lib/store/useTemplateStore.tsx
+++ b/lib/store/useTemplateStore.tsx
@@ -105,6 +105,9 @@ const createTemplateStore = (initProps?: Partial<InitialTemplateStoreProps>) => 
               set((state) => {
                 state.id = id;
               }),
+            getPathString(id) {
+              return getPathString(id, get().form.elements);
+            },
             setLang: (lang) =>
               set((state) => {
                 state.lang = lang;


### PR DESCRIPTION
# Summary | Résumé

Updates template store to include path helper.

The template store already has access to the `elements` -- with this update we can let the template store do the work and avoid pulling the elements into place where we just use them for a lookup.


