### PR TITLE
chore: break out save for purpose option

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -275,17 +275,6 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
       return;
     }
 
-    updateField("formPurpose", purposeOption);
-    result = (await updateTemplateFormPurpose({
-      id,
-      formPurpose: formPurpose,
-    })) as FormServerError;
-
-    if (result?.error) {
-      toast.error(<ErrorSaving errorCode={FormServerErrorCodes.FORM_PURPOSE} />, "wide");
-      return;
-    }
-
     toast.success(t("settingsResponseDelivery.savedSuccessMessage"));
 
     refreshData && refreshData();
@@ -298,10 +287,27 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
     classification,
     setToDatabaseDelivery,
     setToEmailDelivery,
-    updateField,
-    purposeOption,
-    formPurpose,
   ]);
+
+  /*--------------------------------------------*
+   * Save form purpose option
+   *--------------------------------------------*/
+
+  const saveFormPurpose = useCallback(async () => {
+    const result = await updateTemplateFormPurpose({
+      id,
+      formPurpose: purposeOption,
+    });
+
+    if (result?.error) {
+      toast.error(<ErrorSaving errorCode={FormServerErrorCodes.FORM_PURPOSE} />, "wide");
+      return;
+    }
+
+    toast.success(t("settingsResponseDelivery.savedSuccessMessage"));
+
+    refreshData && refreshData();
+  }, [t, refreshData, id, purposeOption]);
 
   // Update local state
   const updateDeliveryOption = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
@@ -483,6 +489,10 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
               )}
             </div>
 
+            {/*--------------------------------------------*
+             * Purpose option section
+             *--------------------------------------------*/}
+
             <div className="mb-10">
               <h2>{t("settingsPurposeAndUse.title")}</h2>
               <p className="mb-2">
@@ -535,11 +545,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
             </div>
           </div>
 
-          <Button
-            disabled={!isValid || isPublished}
-            theme="secondary"
-            onClick={saveDeliveryOptions}
-          >
+          <Button disabled={!isValid || isPublished} theme="secondary" onClick={saveFormPurpose}>
             {t("settingsResponseDelivery.saveButton")}
           </Button>
           <FormPurposeHelpButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -161,12 +161,10 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
       if (!completeEmailAddressRegex.test(inputEmailValue)) {
         return false;
       }
-      return (
-        isValidDeliveryOption && (emailDeliveryOptionsChanged || purposeOption !== formPurpose)
-      );
+      return isValidDeliveryOption && emailDeliveryOptionsChanged;
     }
 
-    if (deliveryOptionValue === initialDeliveryOption && purposeOption === formPurpose) {
+    if (deliveryOptionValue === initialDeliveryOption) {
       return false;
     }
 
@@ -183,8 +181,6 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
     initialSubjectFr,
     classification,
     securityAttribute,
-    purposeOption,
-    formPurpose,
   ]);
 
   /*--------------------------------------------*
@@ -545,7 +541,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
             </div>
           </div>
 
-          <Button disabled={!isValid || isPublished} theme="secondary" onClick={saveFormPurpose}>
+          <Button disabled={isPublished} theme="secondary" onClick={saveFormPurpose}>
             {t("settingsPurposeAndUse.saveButton")}
           </Button>
           <FormPurposeHelpButton />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -546,7 +546,7 @@ export const ResponseDelivery = ({ isFormsAdmin }: { isFormsAdmin: boolean }) =>
           </div>
 
           <Button disabled={!isValid || isPublished} theme="secondary" onClick={saveFormPurpose}>
-            {t("settingsResponseDelivery.saveButton")}
+            {t("settingsPurposeAndUse.saveButton")}
           </Button>
           <FormPurposeHelpButton />
         </div>

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -743,7 +743,8 @@
       "admin": "Administrative purposes",
       "nonAdmin": "Non-administrative purposes",
       "unset": "Unset"
-    }
+    },
+    "saveButton": "Save changes"
   },
   "settingsResponseDelivery": {
     "selectClassification": "Data classification",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -743,7 +743,8 @@
       "admin": "Fins administratives",
       "nonAdmin": "Fins non-administratives",
       "unset": "Pas défini"
-    }
+    },
+    "saveButton": "Enregistrer les modifications"
   },
   "settingsResponseDelivery": {
     "selectClassification": "Classification des données",


### PR DESCRIPTION
# Summary | Résumé

Fixes small issue currently on staging server where the Delivery option was trying to be updated when saving a form purpose.

This PR splits the saves 1 for the Delivery option and 1 for the form purpose. 