### PR TITLE
fix: On form publish delete draft responses before switching to Published status

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -566,6 +566,10 @@ export async function updateIsPublishedForTemplate(
   try {
     await authorization.canPublishForm(ability, formID);
 
+    // Delete all form responses created during draft mode
+    if (isPublished && process.env.APP_ENV !== "test")
+      await deleteDraftFormResponses(ability, formID);
+
     // We use a where unique input to ensure we are only updating the form if it is not published
     const updatedTemplate = await prisma.template
       .update({
@@ -588,10 +592,6 @@ export async function updateIsPublishedForTemplate(
       .catch((e) => prismaErrors(e, null));
 
     if (updatedTemplate === null) return updatedTemplate;
-
-    // Delete all form responses created during draft mode
-    if (isPublished && process.env.APP_ENV !== "test")
-      await deleteDraftFormResponses(ability, formID);
 
     if (formCache.cacheAvailable) formCache.invalidate(formID);
 


### PR DESCRIPTION
# Summary | Résumé
![Screenshot 2024-12-11 at 11 04 08 AM](https://github.com/user-attachments/assets/9b220766-8740-43b4-9354-04f8be691468)

Fixes a  🐔 before 🥚 bug.
Was previously trying to delete draft responses after the published status had been changed on the template.
Now deletes draft responses before updating the status on the template.
