### PR TITLE
chore: reword misleading error message in notifyConnector.ts

### DIFF
--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -67,6 +67,6 @@ export const sendEmail = async (
       })
     );
 
-    throw new Error(`Failed to send submission through GC Notify.`);
+    throw new Error(`Failed to send email through GC Notify.`);
   }
 };


### PR DESCRIPTION
# Summary | Résumé

- Rewords misleading error message in `notifyConnector.ts`.