### PR TITLE
chore: Replace update with simple delete for removeDeliveryOption

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -348,20 +348,19 @@ export const sendResponsesToVault = async ({
 }: {
   id: string;
 }): Promise<{
-  formRecord: FormRecord | null;
+  success?: boolean;
   error?: string;
 }> => {
   try {
     const { ability } = await authCheckAndThrow();
 
-    const response = await removeDeliveryOption(ability, formID);
-    if (!response) {
-      throw new Error(`Template API response was null. Request information: { ${formID} }`);
-    }
+    await removeDeliveryOption(ability, formID);
 
-    return { formRecord: response };
+    return {
+      success: true,
+    };
   } catch (error) {
-    return { formRecord: null, error: (error as Error).message };
+    return { success: false, error: (error as Error).message };
   }
 };
 

--- a/app/api/templates/[formID]/route.ts
+++ b/app/api/templates/[formID]/route.ts
@@ -201,12 +201,6 @@ export const PUT = middleware(
         return NextResponse.json(response);
       } else if (sendResponsesToVault) {
         const response = await removeDeliveryOption(ability, formID);
-        if (!response)
-          throw new Error(
-            `Template API response was null. Request information: method = ${
-              req.method
-            } ; query = ${JSON.stringify(props.params)} ; body = ${JSON.stringify(props.body)}`
-          );
         return NextResponse.json(response);
       }
       throw new MalformedAPIRequest(

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -522,37 +522,20 @@ describe("Template CRUD functions", () => {
     });
 
     it("Remove DeliveryOption from template", async () => {
-      (prismaMock.template.update as jest.MockedFunction<any>).mockResolvedValue(
-        buildPrismaResponse("formtestID", formConfiguration)
-      );
+      (prismaMock.template.findFirstOrThrow as jest.MockedFunction<any>).mockResolvedValue({
+        isPublished: false,
+      });
 
-      const updatedTemplate = await removeDeliveryOption(user1Ability, "formtestID");
+      await removeDeliveryOption(user1Ability, "formtestID");
 
-      expect(prismaMock.template.update).toHaveBeenCalledWith(
+      expect(prismaMock.deliveryOption.deleteMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
-            id: "formtestID",
-            isPublished: false,
-            deliveryOption: {
-              isNot: null,
-            },
-          },
-          data: {
-            deliveryOption: {
-              delete: true,
-            },
+            templateId: "formtestID",
           },
         })
       );
 
-      expect(updatedTemplate).toEqual(
-        expect.objectContaining({
-          id: "formtestID",
-          form: formConfiguration,
-          isPublished: false,
-          securityAttribute: "Unclassified",
-        })
-      );
       expect(mockedLogEvent).toHaveBeenCalledWith(
         user1Ability.userID,
         { id: "formtestID", type: "Form" },


### PR DESCRIPTION
# Summary | Résumé

removeDeliveryOption was attempting to use a prisma.update to remove the deliveryOption record when changing to API mode. This was not working as expected, and was throwing an incorrect TemplateAlreadyPublishedError.

Modified to:
- Initial `isPublished` check and throw exception as published templates cannot be changed
- Delete any DeliveryOptions for template
