### PR TITLE
Fix: Pin to Node Alpine 3.20

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22-alpine3.20
 
 ARG USERNAME=node
 ARG USER_UID=1000
@@ -10,7 +10,7 @@ COPY .yarnrc.yml /src
 WORKDIR /src
 RUN yarn install
 
-FROM node:22-alpine
+FROM node:22-alpine3.20
 
 ARG USERNAME=node
 ARG USER_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine as build
+FROM node:22-alpine3.20 as build
 ENV NODE_ENV=production
 ENV NEXT_PUBLIC_ADDRESSCOMPLETE_API_KEY=UR78-BU29-RU35-EP49 
 
@@ -16,7 +16,7 @@ RUN yarn workspaces focus gcforms flag_initialization
 RUN yarn build
 RUN yarn workspaces focus gcforms flag_initialization --production
 
-FROM node:22-alpine as final
+FROM node:22-alpine3.20 as final
 LABEL maintainer="-"
 
 ENV NODE_ENV=production

--- a/Dockerfile.pr
+++ b/Dockerfile.pr
@@ -1,6 +1,6 @@
 # Form viewier that runs as a Lambda function.  It is used to create 
 # Lambda function review environments for each PR.
-FROM node:22-alpine as build
+FROM node:22-alpine3.20 as build
 
 ENV NODE_ENV=production
 ENV NEXT_OUTPUT_STANDALONE=true
@@ -19,7 +19,7 @@ RUN corepack enable && yarn set version berry
 RUN yarn workspaces focus gcforms flag_initialization
 RUN yarn build
 
-FROM node:22-alpine as final
+FROM node:22-alpine3.20 as final
 LABEL maintainer="-"
 
 ARG COGNITO_APP_CLIENT_ID


### PR DESCRIPTION
# Summary | Résumé
Pinning to Node Alpine 3.20 until Prisma 6.1.0 is released and implemented.

Fixes SSL location issue between Prisma and  Node Alpine > 3.20