### PR TITLE
chore: Clarify what the API rate limit increase means in admin

### DIFF
--- a/i18n/translations/en/admin-settings.json
+++ b/i18n/translations/en/admin-settings.json
@@ -34,18 +34,18 @@
   },
   "throttling": {
     "title": "API rate limit",
-    "description": "Increase API rate limit for up to 12 weeks",
+    "description": "Increase API rate limit to 1000 requests per minute",
     "weeks": "weeks",
     "permanent": "Increase API rate limit indefinitely",
     "updateRate": "Modify API rate",
-    "resetRate": "Reset API rate",
-    "tooltip": "Checking this will not schedule the API rate for a specific period of time. To schedule an end to the API rate, uncheck this and the 'weeks' input will be enabled.",
+    "resetRate": "Reset API rate to 500 requests per minute",
+    "tooltip": "Checking this will not schedule the API rate for a specific period of time. To schedule an end to the API rate, uncheck this and the 'weeks' input will be enabled, for up to 12 weeks.",
     "succcessUpdate": {
-      "title": "API rate increased",
-      "description": "The API rate will stay in effect until: {{success}}"
+      "title": "API rate increased to 1000 requests per minute",
+      "description": "New rate will stay in effect until: {{success}}"
     },
     "succcessReset": {
-      "title": "API rate was reset."
+      "title": "API rate was reset to 500 requests per minute."
     },
     "error": "API rate could not be modified. Try again later."
   }

--- a/i18n/translations/fr/admin-settings.json
+++ b/i18n/translations/fr/admin-settings.json
@@ -34,18 +34,18 @@
   },
   "throttling": {
     "title": "Limite du débit de l'API",
-    "description": "Augmenter la limite du débit de l'API pour un maximum de 12 semaines",
+    "description": "Augmenter la limite du débit de l'API à 1000 demandes par minute",
     "weeks": "semaines",
     "permanent": "Augmenter la limite du débit de l'API indéfiniment",
     "updateRate": "Modifier le débit de l'API",
-    "resetRate": "Réinitialiser le débit de l'API",
-    "tooltip": "Le fait de cocher cette case ne programmera pas le débit de l'API pour une période de temps spécifique. Pour programmer une fin, décochez cette case et l'entrée 'semaines' sera activée.",
+    "resetRate": "Réinitialiser le débit de l'API à 500 demandes par minute",
+    "tooltip": "Le fait de cocher cette case ne programmera pas le débit de l'API pour une période de temps spécifique. Pour programmer une fin, décochez cette case et l'entrée 'semaines' sera activée (pour un maximum de 12 semaines).",
     "succcessUpdate": {
-      "title": "Le débit de l'API a été augmenté",
-      "description": "Le débit restera en vigueur jusqu'à : {{success}}"
+      "title": "Le débit de l'API a été augmenté à 1000 demandes par minute",
+      "description": "Le nouveau débit restera en vigueur jusqu'à : {{success}}"
     },
     "succcessReset": {
-      "title": "Le débit de l'API a été réinitialisé."
+      "title": "Le débit de l'API a été réinitialisé à 500 demandes par minute."
     },
     "error": "Le débit de l'API n'a pas pu être modifié. Veuillez réessayer plus tard."
   }


### PR DESCRIPTION
## Summary

Based on feedback:
https://gcdigital.slack.com/archives/C074DJX9ETX/p1734542232241549
https://github.com/cds-snc/forms-api/blob/ca13d7545d64bfc471ce9d3f079b4efdd32912e4/src/config.ts#L45

### What is the API limit?
- Low rate limit = 500 requests / minute (default)
- High rate limit = 1000 requests / minute (increased by admin)

### How long does a change apply?
- Specified end = could be up to 12 weeks
- Indefinitely

### Corresponding changes to documentation
- EN: https://cds-snc.github.io/forms-api/monitoring/
- FR: https://cds-snc.github.io/forms-api/surveiller/