### PR TITLE
chore: review server actions

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/view-templates/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/view-templates/actions.ts
@@ -1,7 +1,10 @@
 "use server";
+
 import { getAllTemplates } from "@lib/templates";
 import { AuthenticatedAction } from "@lib/actions";
 import { FormRecord } from "@lib/types";
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const getTemplates = AuthenticatedAction(async () => {
   const templates = await getAllTemplates();
@@ -16,6 +19,8 @@ export const getLatestPublishedTemplates = AuthenticatedAction(async () => {
 
   return filterTemplateProperties(templates);
 });
+
+// Internal and private functions - won't be converted into server actions
 
 const filterTemplateProperties = (templates: FormRecord[]) => {
   return templates.map((template) => {

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-forms/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-forms/actions.ts
@@ -1,20 +1,11 @@
 "use server";
 
-import { cache } from "react";
 import { deleteTemplate } from "@lib/templates";
 import { TemplateHasUnprocessedSubmissions } from "@lib/templates";
-import { getAppSetting } from "@lib/appSettings";
 import { revalidatePath } from "next/cache";
 import { AuthenticatedAction } from "@lib/actions";
 
 // Public facing functions - they can be used by anyone who finds the associated server action identifer
-
-export const overdueSettings = cache(async () => {
-  const promptPhaseDays = await getAppSetting("nagwarePhasePrompted");
-  const warnPhaseDays = await getAppSetting("nagwarePhaseWarned");
-  const responseDownloadLimit = await getAppSetting("responseDownloadLimit");
-  return { promptPhaseDays, warnPhaseDays, responseDownloadLimit };
-});
 
 export const deleteForm = AuthenticatedAction(async (id: string) => {
   try {

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-forms/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-forms/actions.ts
@@ -1,11 +1,13 @@
 "use server";
-import { cache } from "react";
 
+import { cache } from "react";
 import { deleteTemplate } from "@lib/templates";
 import { TemplateHasUnprocessedSubmissions } from "@lib/templates";
 import { getAppSetting } from "@lib/appSettings";
 import { revalidatePath } from "next/cache";
 import { AuthenticatedAction } from "@lib/actions";
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const overdueSettings = cache(async () => {
   const promptPhaseDays = await getAppSetting("nagwarePhasePrompted");

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-permissions/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-permissions/actions.ts
@@ -1,8 +1,11 @@
 "use server";
+
 import { updatePrivilegesForUser } from "@lib/privileges";
 import { checkPrivilegesAsBoolean } from "@lib/privileges";
 import { revalidatePath } from "next/cache";
 import { authCheckAndThrow } from "@lib/actions";
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const updatePrivileges = async (
   userID: string,

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-permissions/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-permissions/actions.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { updatePrivilegesForUser } from "@lib/privileges";
-import { checkPrivilegesAsBoolean } from "@lib/privileges";
 import { revalidatePath } from "next/cache";
 import { authCheckAndThrow } from "@lib/actions";
 
@@ -13,16 +12,15 @@ export const updatePrivileges = async (
   action: "add" | "remove"
 ) => {
   const { ability } = await authCheckAndThrow();
-  if (checkPrivilegesAsBoolean(ability, [{ action: "update", subject: "User" }])) {
-    try {
-      const result = await updatePrivilegesForUser(ability, userID, [{ id: privilegeID, action }]);
-      revalidatePath(
-        "(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-permissions",
-        "page"
-      );
-      return { data: result };
-    } catch (e) {
-      return { error: "Failed to update permissions." };
-    }
+
+  try {
+    const result = await updatePrivilegesForUser(ability, userID, [{ id: privilegeID, action }]);
+    revalidatePath(
+      "(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/[id]/manage-permissions",
+      "page"
+    );
+    return { data: result };
+  } catch (e) {
+    return { error: "Failed to update permissions." };
   }
 };

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/actions.ts
@@ -5,6 +5,8 @@ import { revalidatePath } from "next/cache";
 import { getUsers, updateActiveStatus } from "@lib/users";
 import { authCheckAndThrow } from "@lib/actions";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 export const updatePublishing = async (
   userID: string,
   publishFormsId: string,

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { checkPrivilegesAsBoolean, updatePrivilegesForUser, getPrivilege } from "@lib/privileges";
+import { updatePrivilegesForUser, getPrivilege } from "@lib/privileges";
 import { revalidatePath } from "next/cache";
 import { getUsers, updateActiveStatus } from "@lib/users";
 import { authCheckAndThrow } from "@lib/actions";
@@ -13,19 +13,14 @@ export const updatePublishing = async (
   action: "add" | "remove"
 ) => {
   const { ability } = await authCheckAndThrow();
-  if (checkPrivilegesAsBoolean(ability, [{ action: "update", subject: "User" }])) {
-    await updatePrivilegesForUser(ability, userID, [{ id: publishFormsId, action }]);
-    revalidatePath("(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts", "page");
-  }
+  await updatePrivilegesForUser(ability, userID, [{ id: publishFormsId, action }]);
+  revalidatePath("(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts", "page");
 };
 
 export const updateActive = async (userID: string, active: boolean) => {
   const { ability } = await authCheckAndThrow();
-
-  if (checkPrivilegesAsBoolean(ability, [{ action: "update", subject: "User" }])) {
-    await updateActiveStatus(ability, userID, active);
-    revalidatePath("(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts", "page");
-  }
+  await updateActiveStatus(ability, userID, active);
+  revalidatePath("(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts", "page");
 };
 
 export const getAllUsers = async (active?: boolean) => {

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/flags/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/flags/actions.ts
@@ -1,7 +1,10 @@
 "use server";
+
 import { enableFlag, disableFlag, checkAll, checkOne } from "@lib/cache/flags";
 import { revalidatePath } from "next/cache";
 import { authCheckAndThrow } from "@lib/actions";
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 // Note: any thrown errors will be caught in the Error boundary/component
 

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/flags/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/flags/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { enableFlag, disableFlag, checkAll, checkOne } from "@lib/cache/flags";
+import { enableFlag, disableFlag } from "@lib/cache/flags";
 import { revalidatePath } from "next/cache";
 import { authCheckAndThrow } from "@lib/actions";
 
@@ -17,16 +17,4 @@ export async function modifyFlag(id: string, value: boolean) {
     await disableFlag(ability, id);
   }
   revalidatePath("(gcforms)/[locale]/(app administration)/admin/(with nav)/flags", "page");
-}
-
-export async function getAllFlags() {
-  const { ability } = await authCheckAndThrow();
-
-  return checkAll(ability);
-}
-
-export async function checkFlag(id: string) {
-  await authCheckAndThrow();
-
-  return checkOne(id);
 }

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/settings/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/settings/actions.ts
@@ -11,11 +11,7 @@ import { logMessage } from "@lib/logger";
 import { authCheckAndThrow } from "@lib/actions";
 import { redirect } from "next/navigation";
 
-function nullCheck(formData: FormData, key: string) {
-  const result = formData.get(key);
-  if (!result) throw new Error(`No value found for ${key}`);
-  return result as string;
-}
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function getSetting(internalId: string) {
   const { ability } = await authCheckAndThrow();
@@ -73,4 +69,12 @@ export async function deleteSetting(internalId: string) {
     throw new Error("Error deleting setting");
   });
   revalidatePath("(gcforms)/[locale]/(app administration)/admin/(with nav)/settings", "page");
+}
+
+// Internal and private functions - won't be converted into server actions
+
+function nullCheck(formData: FormData, key: string) {
+  const result = formData.get(key);
+  if (!result) throw new Error(`No value found for ${key}`);
+  return result as string;
 }

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/settings/actions.ts
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/settings/actions.ts
@@ -7,7 +7,6 @@ import {
   updateAppSetting,
 } from "@lib/appSettings";
 import { revalidatePath } from "next/cache";
-import { logMessage } from "@lib/logger";
 import { authCheckAndThrow } from "@lib/actions";
 import { redirect } from "next/navigation";
 
@@ -15,7 +14,6 @@ import { redirect } from "next/navigation";
 
 export async function getSetting(internalId: string) {
   const { ability } = await authCheckAndThrow();
-  logMessage.error("Getting setting with internalId: " + internalId);
   return getFullAppSetting(ability, internalId);
 }
 

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/settings/components/server/ManageSettingForm.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/settings/components/server/ManageSettingForm.tsx
@@ -2,7 +2,6 @@ import { serverTranslation } from "@i18n";
 import { createSetting, getSetting, updateSetting } from "../../actions";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
 import { SaveButton } from "../client/SaveButton";
-
 import { Danger } from "@clientComponents/globals/Alert/Alert";
 import { Label } from "@clientComponents/forms";
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { Language, FormServerErrorCodes, ServerActionError } from "@lib/types/form-builder-types";
 import { getAppSetting } from "@lib/appSettings";
 import { logEvent } from "@lib/auditLogs";
@@ -53,6 +54,8 @@ import {
 } from "@clientComponents/forms/AddressComplete/utils";
 import { serverTranslation } from "@i18n";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 export const fetchSubmissions = AuthenticatedAction(
   async ({
     formId,
@@ -105,63 +108,6 @@ export const fetchSubmissions = AuthenticatedAction(
     }
   }
 );
-
-const sortByLayout = ({ layout, elements }: { layout: number[]; elements: Answer[] }) => {
-  return elements.sort((a, b) => layout.indexOf(a.questionId) - layout.indexOf(b.questionId));
-};
-
-const sortByGroups = ({ form, elements }: { form: FormProperties; elements: Answer[] }) => {
-  const groups = orderGroups(form.groups, form.groupsLayout) ?? {};
-  const layout = getLayoutFromGroups(form, groups);
-  return sortByLayout({ layout, elements });
-};
-
-const getAnswerAsString = (question: FormElement | undefined, answer: unknown): string => {
-  if (question && question.type === "checkbox") {
-    return Array(answer).join(", ");
-  }
-
-  if (question && question.type === "formattedDate") {
-    // Could be empty if the date was not required
-    if (!answer) {
-      return "";
-    }
-    const dateFormat = (question.properties.dateFormat || "YYYY-MM-DD") as DateFormat;
-    const dateObject = JSON.parse(answer as string) as DateObject;
-
-    return getFormattedDateFromObject(dateFormat, dateObject);
-  }
-
-  if (question && question.type === "addressComplete") {
-    if (!answer) {
-      return "";
-    }
-
-    if (question.properties.addressComponents?.splitAddress === true) {
-      return answer as string; //Address was split, return as is.
-    }
-
-    const addressObject = JSON.parse(answer as string) as AddressElements;
-    return getAddressAsString(addressObject);
-  }
-
-  return answer as string;
-};
-
-const logDownload = async (
-  responseIdStatusArray: { id: string; status: string }[],
-  format: DownloadFormat
-) => {
-  const ability = await getAbility();
-  responseIdStatusArray.forEach((item) => {
-    logEvent(
-      ability.user.id,
-      { type: "Response", id: item.id },
-      "DownloadResponse",
-      `Downloaded form response in ${format} for submission ID ${item.id}`
-    );
-  });
-};
 
 export const getSubmissionsByFormat = AuthenticatedAction(
   async ({
@@ -444,3 +390,62 @@ export const getSubmissionRemovalDate = AuthenticatedAction(
     }
   }
 );
+
+// Internal and private functions - won't be converted into server actions
+
+const sortByLayout = ({ layout, elements }: { layout: number[]; elements: Answer[] }) => {
+  return elements.sort((a, b) => layout.indexOf(a.questionId) - layout.indexOf(b.questionId));
+};
+
+const sortByGroups = ({ form, elements }: { form: FormProperties; elements: Answer[] }) => {
+  const groups = orderGroups(form.groups, form.groupsLayout) ?? {};
+  const layout = getLayoutFromGroups(form, groups);
+  return sortByLayout({ layout, elements });
+};
+
+const getAnswerAsString = (question: FormElement | undefined, answer: unknown): string => {
+  if (question && question.type === "checkbox") {
+    return Array(answer).join(", ");
+  }
+
+  if (question && question.type === "formattedDate") {
+    // Could be empty if the date was not required
+    if (!answer) {
+      return "";
+    }
+    const dateFormat = (question.properties.dateFormat || "YYYY-MM-DD") as DateFormat;
+    const dateObject = JSON.parse(answer as string) as DateObject;
+
+    return getFormattedDateFromObject(dateFormat, dateObject);
+  }
+
+  if (question && question.type === "addressComplete") {
+    if (!answer) {
+      return "";
+    }
+
+    if (question.properties.addressComponents?.splitAddress === true) {
+      return answer as string; //Address was split, return as is.
+    }
+
+    const addressObject = JSON.parse(answer as string) as AddressElements;
+    return getAddressAsString(addressObject);
+  }
+
+  return answer as string;
+};
+
+const logDownload = async (
+  responseIdStatusArray: { id: string; status: string }[],
+  format: DownloadFormat
+) => {
+  const ability = await getAbility();
+  responseIdStatusArray.forEach((item) => {
+    logEvent(
+      ability.user.id,
+      { type: "Response", id: item.id },
+      "DownloadResponse",
+      `Downloaded form response in ${format} for submission ID ${item.id}`
+    );
+  });
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/ManageFormAccessDialog/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/ManageFormAccessDialog/actions.ts
@@ -16,6 +16,8 @@ import { logMessage } from "@lib/logger";
 import { inviteUserByEmail } from "@lib/invitations/inviteUserByEmail";
 import { cancelInvitation as cancelInvitationAction } from "@lib/invitations/cancelInvitation";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 export const sendInvitation = async (emails: string[], templateId: string, message: string) => {
   const { ability } = await authCheckAndThrow();
   const { t } = await serverTranslation("manage-form-access");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/actions.ts
@@ -1,11 +1,11 @@
 "use server";
+
 import { createKey, deleteKey, refreshKey } from "@lib/serviceAccount";
 import { revalidatePath } from "next/cache";
-
 import { promises as fs } from "fs";
 import path from "path";
 
-// Privilege Checks are done at the lib/serviceAccount.ts level
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const getReadmeContent = async () => {
   try {
@@ -16,6 +16,8 @@ export const getReadmeContent = async () => {
     return { error: true };
   }
 };
+
+// Privilege Checks are done at the lib/serviceAccount.ts level for the next server actions
 
 export const createServiceAccountKey = async (templateId: string) => {
   revalidatePath(

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/actions.ts
@@ -2,6 +2,8 @@
 
 import { headers } from "next/headers";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 // Can throw because it is not called by Client Components
 // @todo Should these types of functions be moved to a different file?
 export const getNonce = async () => {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { promises as fs } from "fs";
-
 import { AuthenticatedAction } from "@lib/actions";
 import { getAbility } from "@lib/privileges";
 import {
@@ -25,7 +24,6 @@ import {
 } from "@lib/templates";
 import { serverTranslation } from "@i18n";
 import { revalidatePath } from "next/cache";
-import { checkOne } from "@lib/cache/flags";
 import { isValidDateString } from "@lib/utils/date/isValidDateString";
 import { allowedTemplates, TemplateTypes } from "@lib/utils/form-builder";
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -24,6 +24,7 @@ import {
 } from "@lib/templates";
 import { serverTranslation } from "@i18n";
 import { revalidatePath } from "next/cache";
+import { checkOne } from "@lib/cache/flags";
 import { isValidDateString } from "@lib/utils/date/isValidDateString";
 import { allowedTemplates, TemplateTypes } from "@lib/utils/form-builder";
 
@@ -67,7 +68,7 @@ export const createOrUpdateTemplate = AuthenticatedAction(
       const ability = await getAbility();
 
       const response = await createDbTemplate({
-        userID: ability.userID,
+        userID: ability.user.id,
         formConfig: formConfig,
         name: name,
         deliveryOption: deliveryOption,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -23,7 +23,6 @@ import {
   updateResponseDeliveryOption,
   updateFormPurpose,
 } from "@lib/templates";
-
 import { serverTranslation } from "@i18n";
 import { revalidatePath } from "next/cache";
 import { checkOne } from "@lib/cache/flags";
@@ -38,6 +37,8 @@ export type CreateOrUpdateTemplateType = {
   securityAttribute?: SecurityAttribute;
   formPurpose?: FormPurpose;
 };
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const createOrUpdateTemplate = AuthenticatedAction(
   async ({
@@ -64,58 +65,30 @@ export const createOrUpdateTemplate = AuthenticatedAction(
           formPurpose,
         });
       }
-      return await createTemplate({
-        formConfig,
-        name,
-        deliveryOption,
-        securityAttribute,
-        formPurpose,
+
+      const ability = await getAbility();
+
+      const response = await createDbTemplate({
+        userID: ability.userID,
+        formConfig: formConfig,
+        name: name,
+        deliveryOption: deliveryOption,
+        securityAttribute: securityAttribute,
+        formPurpose: formPurpose,
       });
+
+      if (!response) {
+        throw new Error(
+          `Template API response was null. Request information: { formConfig: ${formConfig}, name: ${name}, deliveryOption: ${deliveryOption}, securityAttribute: ${securityAttribute}`
+        );
+      }
+
+      return { formRecord: response };
     } catch (e) {
       return { formRecord: null, error: (e as Error).message };
     }
   }
 );
-
-const createTemplate = async ({
-  formConfig,
-  name,
-  deliveryOption,
-  securityAttribute,
-  formPurpose,
-}: {
-  formConfig: FormProperties;
-  name?: string;
-  deliveryOption?: DeliveryOption;
-  securityAttribute?: SecurityAttribute;
-  formPurpose?: FormPurpose;
-}): Promise<{
-  formRecord: FormRecord | null;
-  error?: string;
-}> => {
-  try {
-    const ability = await getAbility();
-
-    const response = await createDbTemplate({
-      userID: ability.user.id,
-      formConfig: formConfig,
-      name: name,
-      deliveryOption: deliveryOption,
-      securityAttribute: securityAttribute,
-      formPurpose: formPurpose,
-    });
-
-    if (!response) {
-      throw new Error(
-        `Template API response was null. Request information: { formConfig: ${formConfig}, name: ${name}, deliveryOption: ${deliveryOption}, securityAttribute: ${securityAttribute}`
-      );
-    }
-
-    return { formRecord: response };
-  } catch (error) {
-    return { formRecord: null, error: (error as Error).message };
-  }
-};
 
 export const updateTemplate = AuthenticatedAction(
   async ({

--- a/app/(gcforms)/[locale]/(form administration)/forms/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/actions.ts
@@ -9,6 +9,8 @@ import { revalidatePath } from "next/cache";
 import { FormRecord } from "@lib/types";
 import { AuthenticatedAction } from "@lib/actions";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 export const getForm = AuthenticatedAction(
   async (formId: string): Promise<{ formRecord: FormRecord | null; error?: string }> => {
     try {

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/Invitations/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/Invitations/actions.ts
@@ -11,6 +11,8 @@ import {
   UserNotFoundError,
 } from "@lib/invitations/exceptions";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 export const accept = async (id: string) => {
   const { ability } = await authCheckAndThrow();
   const { t } = await serverTranslation("manage-form-access");

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
@@ -1,10 +1,13 @@
 "use server";
+
 import { PublicFormRecord, Responses, SubmissionRequestBody } from "@lib/types";
 import { buildFormDataObject } from "./lib/buildFormDataObject";
 import { parseRequestData } from "./lib/parseRequestData";
 import { processFormData } from "./lib/processFormData";
 import { MissingFormDataError, MissingFormIdError } from "./lib/exceptions";
 import { logMessage } from "@lib/logger";
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function submitForm(
   values: Responses,

--- a/app/(gcforms)/[locale]/(support)/contact/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/contact/actions.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { serverTranslation } from "@i18n";
 import { createTicket } from "@lib/integration/freshdesk";
 import { logMessage } from "@lib/logger";
@@ -12,35 +13,7 @@ export interface ErrorStates {
   error?: string;
 }
 
-const validate = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["signup", "common"], { lang: language });
-
-  const SupportSchema = object({
-    // checkbox input can send a non-string value when empty
-    request: string(t("input-validation.required", { ns: "common" }), [
-      minLength(1, t("input-validation.required", { ns: "common" })),
-    ]),
-    description: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
-    name: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
-    email: string([
-      toLowerCase(),
-      toTrimmed(),
-      minLength(1, t("input-validation.required", { ns: "common" })),
-      email(t("input-validation.email", { ns: "common" })),
-    ]),
-    department: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
-    // Note: branch and jobTitle are not required/validated
-    branch: string(),
-    jobTitle: string(),
-  });
-
-  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function contact(
   language: string,
@@ -129,3 +102,35 @@ ${description}<br/>
   }
   return { error: "", validationErrors: [] };
 }
+
+// Internal and private functions - won't be converted into server actions
+
+const validate = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["signup", "common"], { lang: language });
+
+  const SupportSchema = object({
+    // checkbox input can send a non-string value when empty
+    request: string(t("input-validation.required", { ns: "common" }), [
+      minLength(1, t("input-validation.required", { ns: "common" })),
+    ]),
+    description: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
+    name: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
+    email: string([
+      toLowerCase(),
+      toTrimmed(),
+      minLength(1, t("input-validation.required", { ns: "common" })),
+      email(t("input-validation.email", { ns: "common" })),
+    ]),
+    department: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
+    // Note: branch and jobTitle are not required/validated
+    branch: string(),
+    jobTitle: string(),
+  });
+
+  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
+};

--- a/app/(gcforms)/[locale]/(support)/support/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/support/actions.ts
@@ -1,8 +1,8 @@
 "use server";
+
 import { serverTranslation } from "@i18n";
 import { createTicket } from "@lib/integration/freshdesk";
 import { logMessage } from "@lib/logger";
-
 import { email, minLength, object, safeParse, string, toLowerCase, toTrimmed } from "valibot";
 
 export interface ErrorStates {
@@ -13,29 +13,7 @@ export interface ErrorStates {
   error?: string;
 }
 
-const validate = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["common"], { lang: language });
-
-  const SupportSchema = object({
-    name: string([minLength(1, t("input-validation.required"))]),
-    email: string([
-      toLowerCase(),
-      toTrimmed(),
-      minLength(1, t("input-validation.required")),
-      email(t("input-validation.email")),
-    ]),
-    // radio input can send a non-string value when empty
-    request: string(t("input-validation.required"), [minLength(1, t("input-validation.required"))]),
-    description: string([minLength(1, t("input-validation.required"))]),
-  });
-
-  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function support(
   language: string,
@@ -106,3 +84,29 @@ ${description}<br/>
   }
   return { error: "", validationErrors: [] };
 }
+
+// Internal and private functions - won't be converted into server actions
+
+const validate = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["common"], { lang: language });
+
+  const SupportSchema = object({
+    name: string([minLength(1, t("input-validation.required"))]),
+    email: string([
+      toLowerCase(),
+      toTrimmed(),
+      minLength(1, t("input-validation.required")),
+      email(t("input-validation.email")),
+    ]),
+    // radio input can send a non-string value when empty
+    request: string(t("input-validation.required"), [minLength(1, t("input-validation.required"))]),
+    description: string([minLength(1, t("input-validation.required"))]),
+  });
+
+  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
+};

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/actions.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { authCheckAndRedirect } from "@lib/actions";
 import { serverTranslation } from "@i18n";
 import { createTicket } from "@lib/integration/freshdesk";
@@ -24,39 +25,7 @@ export interface ErrorStates {
   error?: string;
 }
 
-const validate = async (
-  language: string,
-  userEmail: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["unlock-publishing", "common"], { lang: language });
-
-  const SupportSchema = object({
-    managerEmail: string([
-      toLowerCase(),
-      toTrimmed(),
-      minLength(1, t("input-validation.required", { ns: "common" })),
-      email(t("input-validation.email", { ns: "common" })),
-      custom(
-        (email) => isValidGovEmail(email),
-        t("input-validation.validGovEmail", { ns: "common" })
-      ),
-      custom(
-        (email) => email?.toLowerCase() != userEmail?.toLowerCase(),
-        t("input-validation.notSameAsUserEmail", { ns: "common" })
-      ),
-    ]),
-    department: string([
-      minLength(1, t("input-validation.required", { ns: "common" })),
-      maxLength(50, t("signUpRegistration.fields.name.error.maxLength")),
-    ]),
-    goals: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
-  });
-
-  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function unlockPublishing(
   language: string,
@@ -115,3 +84,39 @@ export async function unlockPublishing(
 
   return { error: "", validationErrors: [] };
 }
+
+// Internal and private functions - won't be converted into server actions
+
+const validate = async (
+  language: string,
+  userEmail: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["unlock-publishing", "common"], { lang: language });
+
+  const SupportSchema = object({
+    managerEmail: string([
+      toLowerCase(),
+      toTrimmed(),
+      minLength(1, t("input-validation.required", { ns: "common" })),
+      email(t("input-validation.email", { ns: "common" })),
+      custom(
+        (email) => isValidGovEmail(email),
+        t("input-validation.validGovEmail", { ns: "common" })
+      ),
+      custom(
+        (email) => email?.toLowerCase() != userEmail?.toLowerCase(),
+        t("input-validation.notSameAsUserEmail", { ns: "common" })
+      ),
+    ]),
+    department: string([
+      minLength(1, t("input-validation.required", { ns: "common" })),
+      maxLength(50, t("signUpRegistration.fields.name.error.maxLength")),
+    ]),
+    goals: string([minLength(1, t("input-validation.required", { ns: "common" }))]),
+  });
+
+  return safeParse(SupportSchema, formEntries, { abortPipeEarly: true });
+};

--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/actions.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import * as v from "valibot";
 import { serverTranslation } from "@i18n";
 import { begin2FAAuthentication, initiateSignIn } from "@lib/auth";
@@ -25,28 +26,8 @@ export interface ErrorStates {
   };
 }
 
-const validate = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["login", "common"], { lang: language });
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
-  const formValidationSchema = v.object({
-    username: v.string([
-      v.toLowerCase(),
-      v.toTrimmed(),
-      v.minLength(1, t("input-validation.required", { ns: "common" })),
-      v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
-    ]),
-    password: v.string([
-      v.minLength(1, t("input-validation.required", { ns: "common" })),
-      v.maxLength(50, t("fields.password.errors.maxLength")),
-    ]),
-  });
-  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
-};
 export const login = async (
   language: string,
   _: ErrorStates,
@@ -143,4 +124,29 @@ export const login = async (
     validationErrors: [],
     authError: await handleErrorById("InternalServiceExceptionLogin", language),
   };
+};
+
+// Internal and private functions - won't be converted into server actions
+
+const validate = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["login", "common"], { lang: language });
+
+  const formValidationSchema = v.object({
+    username: v.string([
+      v.toLowerCase(),
+      v.toTrimmed(),
+      v.minLength(1, t("input-validation.required", { ns: "common" })),
+      v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
+    ]),
+    password: v.string([
+      v.minLength(1, t("input-validation.required", { ns: "common" })),
+      v.maxLength(50, t("fields.password.errors.maxLength")),
+    ]),
+  });
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
 };

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/actions.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import * as v from "valibot";
 import { serverTranslation } from "@i18n";
 import { redirect } from "next/navigation";
@@ -28,51 +29,7 @@ export interface ErrorStates {
   success?: boolean;
 }
 
-const validate = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["auth-verify"], { lang: language });
-
-  const formValidationSchema = v.object({
-    verificationCode: v.string([
-      v.minLength(1, t("verify.fields.confirmationCode.error.notEmpty")),
-      v.length(5, t("verify.fields.confirmationCode.error.length")),
-      v.regex(/^[a-z0-9]*$/i, t("verify.fields.confirmationCode.error.noSymbols")),
-    ]),
-    authenticationFlowToken: v.string([v.minLength(1)]),
-    email: v.string([v.toTrimmed(), v.toLowerCase(), v.minLength(1)]),
-  });
-  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
-};
-
-const isUserActive = async (email: string) => {
-  // Check if user is active and is allowed to sign in
-  const prismaUser = await prisma.user.findUnique({
-    where: {
-      email: email,
-    },
-    select: {
-      id: true,
-      active: true,
-    },
-  });
-
-  if (prismaUser === null) {
-    // The user is logging in for the first time and doesn't yet exist in the db
-    return true;
-  }
-  return prismaUser.active;
-};
-
-const isUserLockedOut = async (email: string) => {
-  const userInAuthFlow = await prisma.cognitoCustom2FA.exists({
-    email: email,
-  });
-  return !userInAuthFlow;
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const verify = async (
   language: string,
@@ -212,4 +169,52 @@ export const getRedirectPath = async (locale: string) => {
   }
 
   return { callback: `/${locale}/auth/policy` };
+};
+
+// Internal and private functions - won't be converted into server actions
+
+const validate = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["auth-verify"], { lang: language });
+
+  const formValidationSchema = v.object({
+    verificationCode: v.string([
+      v.minLength(1, t("verify.fields.confirmationCode.error.notEmpty")),
+      v.length(5, t("verify.fields.confirmationCode.error.length")),
+      v.regex(/^[a-z0-9]*$/i, t("verify.fields.confirmationCode.error.noSymbols")),
+    ]),
+    authenticationFlowToken: v.string([v.minLength(1)]),
+    email: v.string([v.toTrimmed(), v.toLowerCase(), v.minLength(1)]),
+  });
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
+};
+
+const isUserActive = async (email: string) => {
+  // Check if user is active and is allowed to sign in
+  const prismaUser = await prisma.user.findUnique({
+    where: {
+      email: email,
+    },
+    select: {
+      id: true,
+      active: true,
+    },
+  });
+
+  if (prismaUser === null) {
+    // The user is logging in for the first time and doesn't yet exist in the db
+    return true;
+  }
+  return prismaUser.active;
+};
+
+const isUserLockedOut = async (email: string) => {
+  const userInAuthFlow = await prisma.cognitoCustom2FA.exists({
+    email: email,
+  });
+  return !userInAuthFlow;
 };

--- a/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import * as v from "valibot";
 import {
   isValidGovEmail,
@@ -34,63 +35,7 @@ export interface ErrorStates {
   };
 }
 
-const validate = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["signup", "common"], { lang: language });
-
-  const formValidationSchema = v.object(
-    {
-      name: v.string([
-        v.minLength(1, t("input-validation.required", { ns: "common" })),
-        v.maxLength(50, t("signUpRegistration.fields.name.error.maxLength")),
-      ]),
-      username: v.string([
-        v.toLowerCase(),
-        v.toTrimmed(),
-        v.minLength(1, t("input-validation.required", { ns: "common" })),
-        v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
-      ]),
-      password: v.string([
-        v.minLength(1, t("input-validation.required", { ns: "common" })),
-        v.minLength(8, t("account.fields.password.error.minLength", { ns: "common" })),
-        v.maxLength(50, t("account.fields.password.error.maxLength", { ns: "common" })),
-        v.custom(
-          (password) => containsLowerCaseCharacter(password),
-          t("account.fields.password.error.oneLowerCase", { ns: "common" })
-        ),
-        v.custom(
-          (password) => containsUpperCaseCharacter(password),
-          t("account.fields.password.error.oneUpperCase", { ns: "common" })
-        ),
-        v.custom(
-          (password) => containsNumber(password),
-          t("account.fields.password.error.oneNumber", { ns: "common" })
-        ),
-        v.custom(
-          (password) => containsSymbol(password),
-          t("account.fields.password.error.oneSymbol", { ns: "common" })
-        ),
-      ]),
-      passwordConfirmation: v.string([
-        v.minLength(1, t("input-validation.required", { ns: "common" })),
-      ]),
-    },
-    [
-      v.forward(
-        v.custom(
-          (input) => input.password === input.passwordConfirmation,
-          t("account.fields.passwordConfirmation.error.mustMatch", { ns: "common" })
-        ),
-        ["passwordConfirmation"]
-      ),
-    ]
-  );
-  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const register = async (
   language: string,
@@ -154,4 +99,64 @@ export const register = async (
   }
 
   return { validationErrors: [], authError: { title: t("InternalServiceException") } };
+};
+
+// Internal and private functions - won't be converted into server actions
+
+const validate = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["signup", "common"], { lang: language });
+
+  const formValidationSchema = v.object(
+    {
+      name: v.string([
+        v.minLength(1, t("input-validation.required", { ns: "common" })),
+        v.maxLength(50, t("signUpRegistration.fields.name.error.maxLength")),
+      ]),
+      username: v.string([
+        v.toLowerCase(),
+        v.toTrimmed(),
+        v.minLength(1, t("input-validation.required", { ns: "common" })),
+        v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
+      ]),
+      password: v.string([
+        v.minLength(1, t("input-validation.required", { ns: "common" })),
+        v.minLength(8, t("account.fields.password.error.minLength", { ns: "common" })),
+        v.maxLength(50, t("account.fields.password.error.maxLength", { ns: "common" })),
+        v.custom(
+          (password) => containsLowerCaseCharacter(password),
+          t("account.fields.password.error.oneLowerCase", { ns: "common" })
+        ),
+        v.custom(
+          (password) => containsUpperCaseCharacter(password),
+          t("account.fields.password.error.oneUpperCase", { ns: "common" })
+        ),
+        v.custom(
+          (password) => containsNumber(password),
+          t("account.fields.password.error.oneNumber", { ns: "common" })
+        ),
+        v.custom(
+          (password) => containsSymbol(password),
+          t("account.fields.password.error.oneSymbol", { ns: "common" })
+        ),
+      ]),
+      passwordConfirmation: v.string([
+        v.minLength(1, t("input-validation.required", { ns: "common" })),
+      ]),
+    },
+    [
+      v.forward(
+        v.custom(
+          (input) => input.password === input.passwordConfirmation,
+          t("account.fields.passwordConfirmation.error.mustMatch", { ns: "common" })
+        ),
+        ["passwordConfirmation"]
+      ),
+    ]
+  );
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
 };

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import * as v from "valibot";
 import { serverTranslation } from "@i18n";
 import { sendPasswordResetLink, validateSecurityAnswers } from "@lib/auth";
@@ -37,118 +38,7 @@ export interface ErrorStates {
   }[];
 }
 
-const validateInitialResetForm = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["common"], { lang: language });
-  const schema = v.object({
-    username: v.string([
-      v.toLowerCase(),
-      v.toTrimmed(),
-      v.minLength(1, t("input-validation.required")),
-      v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
-    ]),
-  });
-
-  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
-};
-
-const validateQuestionChallengeForm = async (
-  language: string,
-  formEntries: {
-    [k: string]: FormDataEntryValue;
-  }
-) => {
-  const { t } = await serverTranslation(["common"], { lang: language });
-  const schema = v.object({
-    question1: v.string([
-      v.toLowerCase(),
-      v.toTrimmed(),
-      v.minLength(1, t("input-validation.required")),
-      v.minLength(4, t("input-validation.min-length-4-characters")),
-    ]),
-    question1Id: v.string([v.minLength(1, t("input-validation.required"))]),
-    question2: v.string([
-      v.toLowerCase(),
-      v.toTrimmed(),
-      v.minLength(1, t("input-validation.required")),
-      v.minLength(4, t("input-validation.min-length-4-characters")),
-    ]),
-    question2Id: v.string([v.minLength(1, t("input-validation.required"))]),
-    question3: v.string([
-      v.toLowerCase(),
-      v.toTrimmed(),
-      v.minLength(1, t("input-validation.required")),
-      v.minLength(4, t("input-validation.min-length-4-characters")),
-    ]),
-    question3Id: v.string([v.minLength(1, t("input-validation.required"))]),
-    email: v.string([
-      v.toLowerCase(),
-      v.toTrimmed(),
-      v.minLength(1, t("input-validation.required")),
-      v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
-    ]),
-  });
-
-  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
-};
-
-const validatePasswordResetForm = async (
-  language: string,
-  formEntries: { [k: string]: FormDataEntryValue }
-) => {
-  const { t } = await serverTranslation(["reset-password", "common"], { lang: language });
-  const schema = v.object(
-    {
-      confirmationCode: v.coerce(
-        v.number("resetPassword.fields.confirmationCode.error.number"),
-        Number
-      ),
-      username: v.string([
-        v.toLowerCase(),
-        v.toTrimmed(),
-        v.minLength(1, t("input-validation.required")),
-        v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
-      ]),
-      password: v.string([
-        v.minLength(8, t("account.fields.password.error.minLength", { ns: "common" })),
-        v.maxLength(50, t("account.fields.password.error.maxLength", { ns: "common" })),
-        v.custom(
-          (password) => containsLowerCaseCharacter(password),
-          t("account.fields.password.error.oneLowerCase", { ns: "common" })
-        ),
-        v.custom(
-          (password) => containsUpperCaseCharacter(password),
-          t("account.fields.password.error.oneUpperCase", { ns: "common" })
-        ),
-        v.custom(
-          (password) => containsNumber(password),
-          t("account.fields.password.error.oneNumber", { ns: "common" })
-        ),
-        v.custom(
-          (password) => containsSymbol(password),
-          t("account.fields.password.error.oneSymbol", { ns: "common" })
-        ),
-      ]),
-      passwordConfirmation: v.string([
-        v.minLength(1, t("input-validation.required", { ns: "common" })),
-      ]),
-    },
-    [
-      v.forward(
-        v.custom(
-          (input) => input.password === input.passwordConfirmation,
-          t("account.fields.passwordConfirmation.error.mustMatch", { ns: "common" })
-        ),
-        ["passwordConfirmation"]
-      ),
-    ]
-  );
-  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const sendResetLink = async (
   language: string,
@@ -295,6 +185,121 @@ export const resetPassword = async (
       authError: await handleErrorById("InternalServiceExceptionLogin", language),
     };
   }
+};
+
+// Internal and private functions - won't be converted into server actions
+
+const validateInitialResetForm = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["common"], { lang: language });
+  const schema = v.object({
+    username: v.string([
+      v.toLowerCase(),
+      v.toTrimmed(),
+      v.minLength(1, t("input-validation.required")),
+      v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
+    ]),
+  });
+
+  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
+};
+
+const validateQuestionChallengeForm = async (
+  language: string,
+  formEntries: {
+    [k: string]: FormDataEntryValue;
+  }
+) => {
+  const { t } = await serverTranslation(["common"], { lang: language });
+  const schema = v.object({
+    question1: v.string([
+      v.toLowerCase(),
+      v.toTrimmed(),
+      v.minLength(1, t("input-validation.required")),
+      v.minLength(4, t("input-validation.min-length-4-characters")),
+    ]),
+    question1Id: v.string([v.minLength(1, t("input-validation.required"))]),
+    question2: v.string([
+      v.toLowerCase(),
+      v.toTrimmed(),
+      v.minLength(1, t("input-validation.required")),
+      v.minLength(4, t("input-validation.min-length-4-characters")),
+    ]),
+    question2Id: v.string([v.minLength(1, t("input-validation.required"))]),
+    question3: v.string([
+      v.toLowerCase(),
+      v.toTrimmed(),
+      v.minLength(1, t("input-validation.required")),
+      v.minLength(4, t("input-validation.min-length-4-characters")),
+    ]),
+    question3Id: v.string([v.minLength(1, t("input-validation.required"))]),
+    email: v.string([
+      v.toLowerCase(),
+      v.toTrimmed(),
+      v.minLength(1, t("input-validation.required")),
+      v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
+    ]),
+  });
+
+  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
+};
+
+const validatePasswordResetForm = async (
+  language: string,
+  formEntries: { [k: string]: FormDataEntryValue }
+) => {
+  const { t } = await serverTranslation(["reset-password", "common"], { lang: language });
+  const schema = v.object(
+    {
+      confirmationCode: v.coerce(
+        v.number("resetPassword.fields.confirmationCode.error.number"),
+        Number
+      ),
+      username: v.string([
+        v.toLowerCase(),
+        v.toTrimmed(),
+        v.minLength(1, t("input-validation.required")),
+        v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
+      ]),
+      password: v.string([
+        v.minLength(8, t("account.fields.password.error.minLength", { ns: "common" })),
+        v.maxLength(50, t("account.fields.password.error.maxLength", { ns: "common" })),
+        v.custom(
+          (password) => containsLowerCaseCharacter(password),
+          t("account.fields.password.error.oneLowerCase", { ns: "common" })
+        ),
+        v.custom(
+          (password) => containsUpperCaseCharacter(password),
+          t("account.fields.password.error.oneUpperCase", { ns: "common" })
+        ),
+        v.custom(
+          (password) => containsNumber(password),
+          t("account.fields.password.error.oneNumber", { ns: "common" })
+        ),
+        v.custom(
+          (password) => containsSymbol(password),
+          t("account.fields.password.error.oneSymbol", { ns: "common" })
+        ),
+      ]),
+      passwordConfirmation: v.string([
+        v.minLength(1, t("input-validation.required", { ns: "common" })),
+      ]),
+    },
+    [
+      v.forward(
+        v.custom(
+          (input) => input.password === input.passwordConfirmation,
+          t("account.fields.passwordConfirmation.error.mustMatch", { ns: "common" })
+        ),
+        ["passwordConfirmation"]
+      ),
+    ]
+  );
+  return v.safeParse(schema, formEntries, { abortPipeEarly: true });
 };
 
 const logPasswordReset = async (email: string) => {

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
@@ -256,7 +256,7 @@ const validatePasswordResetForm = async (
   const schema = v.object(
     {
       confirmationCode: v.coerce(
-        v.number("resetPassword.fields.confirmationCode.error.number"),
+        v.number(t("resetPassword.fields.confirmationCode.error.number")),
         Number
       ),
       username: v.string([

--- a/app/(gcforms)/[locale]/(user authentication)/components/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/components/action.ts
@@ -1,5 +1,8 @@
 "use server";
+
 import { signOut } from "@lib/auth";
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const logout = async (locale: string) => {
   await signOut({ redirect: true, redirectTo: `/${locale}/auth/logout` });

--- a/app/(gcforms)/[locale]/(user authentication)/profile/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/profile/action.ts
@@ -1,17 +1,11 @@
 "use server";
+
 import { updateSecurityAnswer } from "@lib/auth";
 import { authCheckAndThrow } from "@lib/actions";
 import { revalidatePath } from "next/cache";
 import * as v from "valibot";
 
-const validateData = (formData: { [k: string]: unknown }) => {
-  const schema = v.object({
-    oldQuestionId: v.string("Field is required", [v.minLength(1)]),
-    newQuestionId: v.string("Field is required", [v.minLength(1)]),
-    newAnswer: v.string("Field is required", [v.toLowerCase(), v.toTrimmed(), v.minLength(4)]),
-  });
-  return v.safeParse(schema, formData, { abortPipeEarly: true });
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const updateSecurityQuestion = async (
   oldQuestionId: string,
@@ -35,4 +29,15 @@ export const updateSecurityQuestion = async (
   });
   revalidatePath("(gcforms)/[locale]/(user authentication)/profile");
   return response;
+};
+
+// Internal and private functions - won't be converted into server actions
+
+const validateData = (formData: { [k: string]: unknown }) => {
+  const schema = v.object({
+    oldQuestionId: v.string("Field is required", [v.minLength(1)]),
+    newQuestionId: v.string("Field is required", [v.minLength(1)]),
+    newAnswer: v.string("Field is required", [v.toLowerCase(), v.toTrimmed(), v.minLength(4)]),
+  });
+  return v.safeParse(schema, formData, { abortPipeEarly: true });
 };

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { createInstance } from "i18next";
 import resourcesToBackend from "i18next-resources-to-backend";
 import { initReactI18next } from "react-i18next/initReactI18next";
@@ -6,19 +7,7 @@ import { getOptions, languages } from "./settings";
 import { headers, cookies } from "next/headers";
 import { pathLanguageDetection } from "./utils";
 
-const initI18next = async (lang: string, ns: string | string[]) => {
-  const i18nInstance = createInstance();
-  await i18nInstance
-    .use(initReactI18next)
-    .use(
-      resourcesToBackend(
-        (language: string, namespace: string) =>
-          import(`./translations/${language}/${namespace}.json`)
-      )
-    )
-    .init(getOptions(lang, ns));
-  return i18nInstance;
-};
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function serverTranslation(
   ns?: string | string[],
@@ -43,3 +32,19 @@ export async function getCurrentLanguage() {
   const cookieLang = (await cookies()).get("i18next")?.value;
   return pathLang || cookieLang || languages[0];
 }
+
+// Internal and private functions - won't be converted into server actions
+
+const initI18next = async (lang: string, ns: string | string[]) => {
+  const i18nInstance = createInstance();
+  await i18nInstance
+    .use(initReactI18next)
+    .use(
+      resourcesToBackend(
+        (language: string, namespace: string) =>
+          import(`./translations/${language}/${namespace}.json`)
+      )
+    )
+    .init(getOptions(lang, ns));
+  return i18nInstance;
+};

--- a/lib/actions/checkIfClosed.ts
+++ b/lib/actions/checkIfClosed.ts
@@ -4,6 +4,8 @@ import { prisma, prismaErrors } from "@lib/integration/prismaConnector";
 import { ClosedDetails } from "@lib/types";
 import { dateHasPast } from "@lib/utils";
 
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
+
 export const checkIfClosed = async (formId: string) => {
   try {
     let isPastClosingDate = false;

--- a/lib/cache/throttlingCache.ts
+++ b/lib/cache/throttlingCache.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { logMessage } from "@lib/logger";
 import { getRedisInstance } from "../integration/redisConnector";
 import { getWeeksInSeconds } from "@lib/utils/date/dateConversions";
@@ -9,7 +10,10 @@ const REDIS_RATE_LIMIT_KEY_PREFIX: string = "rate-limit";
 const THROTTLE_SETTING = {
   high: "high",
 } as const;
+
 export type ThrottleSetting = keyof typeof THROTTLE_SETTING; // For completeness, even though not currently used
+
+// Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export const getThrottling = async (
   formId: string


### PR DESCRIPTION
# Summary | Résumé

Part of https://github.com/cds-snc/platform-forms-client/issues/4774

- Adds a delimitation in server actions files to have a clear boundary between public facing functions and internal ones
- Deletes unused server actions
- Removes duplication of privilege checks for some server actions
- Fixes issue with error message due to missing `serverTranslation` call