### PR TITLE
chore: Don't try to retrieve the API key on new forms

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -62,7 +62,8 @@ export default async function Layout(props: {
   try {
     // No need to fetch in test, it will always not exist
     if (formID) {
-      apiKeyId = process.env.APP_ENV === "test" ? false : await checkKeyExists(formID);
+      apiKeyId =
+        process.env.APP_ENV === "test" || formID === "0000" ? false : await checkKeyExists(formID);
     }
   } catch (e) {
     // no-op


### PR DESCRIPTION
# Summary | Résumé

If a user creates a new form then navigates to Settings before saving, this `checkKeyExists` call will throw an exception at the privilege check.

No need to retrieve, as the form is new.
