### PR TITLE
fix: Updates how a description is added to a checkbox or radio

### DIFF
--- a/components/clientComponents/forms/MultipleChoiceGroup/MultipleChoiceGroup.tsx
+++ b/components/clientComponents/forms/MultipleChoiceGroup/MultipleChoiceGroup.tsx
@@ -10,28 +10,16 @@ interface MultipleChoiceGroupProps extends InputFieldProps {
 }
 
 export const MultipleChoiceGroup = (props: MultipleChoiceGroupProps): React.ReactElement => {
-  const { className, choicesProps, type, ariaDescribedBy } = props;
+  const { className, choicesProps, type } = props;
 
   // field contains name, value, onChange, and other required Form attributes.
   const [field, meta] = useField(props);
 
   const choices = choicesProps.map((choice, index) => {
     return type == "checkbox" ? (
-      <Checkbox
-        {...choice}
-        key={index}
-        name={field.name}
-        className={className}
-        {...(ariaDescribedBy && { ariaDescribedBy: ariaDescribedBy })}
-      />
+      <Checkbox {...choice} key={index} name={field.name} className={className} />
     ) : (
-      <Radio
-        {...choice}
-        key={index}
-        name={field.name}
-        className={className}
-        {...(ariaDescribedBy && { ariaDescribedBy: ariaDescribedBy })}
-      />
+      <Radio {...choice} key={index} name={field.name} className={className} />
     );
   });
 

--- a/components/clientComponents/forms/MultipleChoiceGroup/MultipleChoiceGroup.tsx
+++ b/components/clientComponents/forms/MultipleChoiceGroup/MultipleChoiceGroup.tsx
@@ -22,7 +22,7 @@ export const MultipleChoiceGroup = (props: MultipleChoiceGroupProps): React.Reac
         key={index}
         name={field.name}
         className={className}
-        ariaDescribedBy={ariaDescribedBy}
+        {...(ariaDescribedBy && { ariaDescribedBy: ariaDescribedBy })}
       />
     ) : (
       <Radio
@@ -30,7 +30,7 @@ export const MultipleChoiceGroup = (props: MultipleChoiceGroupProps): React.Reac
         key={index}
         name={field.name}
         className={className}
-        ariaDescribedBy={ariaDescribedBy}
+        {...(ariaDescribedBy && { ariaDescribedBy: ariaDescribedBy })}
       />
     );
   });

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -150,7 +150,6 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
             type={FormElementTypes.checkbox}
             name={`${id}`}
             choicesProps={checkboxItems}
-            ariaDescribedBy={labelText ? labelText : undefined}
           />
         </FormGroup>
       );
@@ -174,7 +173,6 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
             type={FormElementTypes.radio}
             name={`${id}`}
             choicesProps={radioItems}
-            ariaDescribedBy={labelText ? labelText : undefined}
           />
         </FormGroup>
       );


### PR DESCRIPTION
# Summary | Résumé

Originally for any checkbox or radio, a description was repeated for each one. This fix removes the repeated description. This works because the description is linked from the container fieldset to the description using an aria-describedby. The original code did not break WCAG but was bad UX for screen reader users.

Note:
**This doesn't solve the other problem of very verbose page/group loads**. We need to think of a strategy how to announce adding dynamic groups of stuff to a form. I suspect we could update the page title and use the live region announce component or similar. But then we'd want to remove the main live=polite on the main form element and that would require a lot of testing and thinking about edge cases e.g. show-hide rules.

## Test

Look at the source code for a checkbox or radio with and without a description added using the form-builder. If there is a description, it should only appear once (not in each input=radio/checkbox)
