### PR TITLE
chore: update cypress workflow to cache next

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,7 +57,10 @@ jobs:
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path:  |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            ${{ github.workspace }}/.next/cache
+
           key: linux-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             linux-yarn-


### PR DESCRIPTION
# Summary | Résumé

Updates workflow file to cache `.next/cache` dir

<img width="1040" alt="Screenshot 2025-01-02 at 9 03 23 AM" src="https://github.com/user-attachments/assets/fc52bd00-4ec1-42a7-9375-be64f977aa55" />


https://nextjs.org/docs/pages/building-your-application/deploying/ci-build-caching#github-actions