### PR TITLE
fix: Fixes default country for an address

### DIFF
--- a/components/clientComponents/forms/AddressComplete/AddressComplete.tsx
+++ b/components/clientComponents/forms/AddressComplete/AddressComplete.tsx
@@ -79,7 +79,10 @@ export const AddressComplete = (props: AddressCompleteProps): React.ReactElement
           city: "",
           province: "",
           postalCode: "",
-          country: "",
+          // Make sure the initial default is CAN to avoid null cases when:
+          // - the address is "Canada only"
+          // - the address is not "Canada only" and the country drop down was not interacted with
+          country: "CAN",
         }
   );
 
@@ -205,7 +208,7 @@ export const AddressComplete = (props: AddressCompleteProps): React.ReactElement
         city: "",
         province: "",
         postalCode: "",
-        country: "",
+        country: "CAN",
       };
     } else {
       baseAddressObject = addressObject;


### PR DESCRIPTION
# Summary | Résumé

Previously the default country (Canada) was not being set for both "Canada only" and not "Canada only" addresses. For "Canada only" addresses, the country was never set. For not "Canada only" countries, the country would be null until the user interacted with the country drop down.

The fix sets the default to Canada for both cases.

## Test

Create a form with pages and on a page add an address that is "Canada only" and another address that is not "Canada only" (default).
Try filling in the form by not setting any values and go to the Review page. The country should be set to Canada for both cases.
Try filling the form again and for the not "Canada only" country dropdown, select a country other than Canada. This country should show on the Review page.


