### PR TITLE
chore: Turn on lint rule for tailwind enforces-shorthand

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/page.tsx
@@ -43,7 +43,7 @@ export default async function Page(props: { params: Promise<{ locale: string }> 
       <div className="flex flex-row justify-center">
         <div className="rounded-lg border bg-white p-10">
           <h2>
-            <ManageAccountsIcon className="inline-block h-14 w-14" /> {t("accountAdministration")}
+            <ManageAccountsIcon className="inline-block size-14" /> {t("accountAdministration")}
           </h2>
           <p>{t("manageUsersAndTheirForms")}</p>
           <p>
@@ -55,7 +55,7 @@ export default async function Page(props: { params: Promise<{ locale: string }> 
 
         <div className="ml-20 rounded-lg border bg-white p-10">
           <h2>
-            <SettingsApplicationsIcon className="inline-block h-14 w-14" />
+            <SettingsApplicationsIcon className="inline-block size-14" />
             {t("systemAdministration")}
           </h2>
           <p>{t("configureHowTheApplicationWorks")}</p>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
@@ -174,7 +174,7 @@ export const PanelBody = ({
                       t("addElementDialog.addressComplete.components.postalCodeOrZip")}
                   </div>
                 </div>
-                <div className="mb-4 ml-4 mt-4 w-1/2 self-end">
+                <div className="my-4 ml-4 w-1/2 self-end">
                   <ElementRequired
                     onRequiredChange={onRequiredChange}
                     item={item}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/AddressComplete.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/AddressComplete.tsx
@@ -10,7 +10,7 @@ export const AddressComplete = () => {
 
   return (
     <div>
-      <div className="mb-4 mt-4">
+      <div className="my-4">
         <Image
           src="/img/address-complete.png"
           width="179"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -258,7 +258,7 @@ function FloatingLinkEditor({
               }}
             >
               {linkUrl}
-              <EditIcon title={t("editLink")} className="absolute right-0 inline-block h-5 w-5" />
+              <EditIcon title={t("editLink")} className="absolute right-0 inline-block size-5" />
             </button>
           </div>
           {/* <LinkPreview url={linkUrl} /> */}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/Description.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/Description.tsx
@@ -44,7 +44,7 @@ export const Description = ({
               <>{primaryLanguage}</>
             </LanguageLabel>
             <textarea
-              className="h-full w-full p-4 focus:outline-blue-focus"
+              className="size-full p-4 focus:outline-blue-focus"
               id={`element-${element.id}-description-${primaryLanguage}`}
               aria-describedby={`element-${element.id}-description-${primaryLanguage}-language`}
               value={element.properties[localizeField(field, primaryLanguage)]}
@@ -67,7 +67,7 @@ export const Description = ({
               <>{secondaryLanguage}</>
             </LanguageLabel>
             <textarea
-              className="h-full w-full p-4 focus:outline-blue-focus"
+              className="size-full p-4 focus:outline-blue-focus"
               id={`element-${element.id}-description-${secondaryLanguage}`}
               aria-describedby={`element-${element.id}-description-${secondaryLanguage}-language`}
               value={element.properties[localizeField(field, secondaryLanguage)]}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/Title.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/Title.tsx
@@ -41,7 +41,7 @@ export const Title = ({
               <>{primaryLanguage}</>
             </LanguageLabel>
             <textarea
-              className="h-full w-full p-4 focus:outline-blue-focus"
+              className="size-full p-4 focus:outline-blue-focus"
               id={`element-${element.id}-title-${primaryLanguage}`}
               aria-describedby={`element-${element.id}-title-${primaryLanguage}-language`}
               value={element.properties[localizeField(field, primaryLanguage)]}
@@ -61,7 +61,7 @@ export const Title = ({
               <>{secondaryLanguage}</>
             </LanguageLabel>
             <textarea
-              className="h-full w-full p-4 focus:outline-blue-focus"
+              className="size-full p-4 focus:outline-blue-focus"
               id={`element-${element.id}-title-${secondaryLanguage}`}
               aria-describedby={`element-${element.id}-title-${secondaryLanguage}-language`}
               value={element.properties[localizeField(field, secondaryLanguage)]}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/Translate.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/Translate.tsx
@@ -148,7 +148,7 @@ export const Translate = () => {
                   <>{primaryLanguage}</>
                 </LanguageLabel>
                 <textarea
-                  className="h-full w-full p-4 focus:outline-blue-focus"
+                  className="size-full p-4 focus:outline-blue-focus"
                   id="form-title-en"
                   aria-describedby="form-title-en-language"
                   value={form[localizeField(LocalizedFormProperties.TITLE, primaryLanguage)]}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -54,7 +54,7 @@ const GroupSection = ({
                 <>{primaryLanguage}</>
               </LanguageLabel>
               <textarea
-                className="h-full w-full p-4 focus:outline-blue-focus"
+                className="size-full p-4 focus:outline-blue-focus"
                 id={`group-${groupId}-title-${primaryLanguage}`}
                 aria-describedby={`group-${groupId}-title-${primaryLanguage}-language`}
                 value={group[localizeField(LocalizedGroupProperties.TITLE, primaryLanguage)]}
@@ -74,7 +74,7 @@ const GroupSection = ({
                 <>{secondaryLanguage}</>
               </LanguageLabel>
               <textarea
-                className="h-full w-full p-4 focus:outline-blue-focus"
+                className="size-full p-4 focus:outline-blue-focus"
                 id={`group-${groupId}-title-${secondaryLanguage}`}
                 aria-describedby={`group-${groupId}-title-${secondaryLanguage}-language`}
                 value={group[localizeField(LocalizedGroupProperties.TITLE, secondaryLanguage)]}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/loading.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
     <div className="flex w-1/2 items-center justify-center">
-      <div className="mt-6 h-20 w-20 animate-spin rounded-full border-y-4 border-indigo-700"></div>
+      <div className="mt-6 size-20 animate-spin rounded-full border-y-4 border-indigo-700"></div>
     </div>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/CheckAll.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/CheckAll.tsx
@@ -93,13 +93,13 @@ export const CheckAll = ({
         }}
       >
         {checkAllStatus === allCheckedState.ALL && (
-          <CheckAllIcon title={tooltip} className="h-6 w-6" />
+          <CheckAllIcon title={tooltip} className="size-6" />
         )}
         {checkAllStatus === allCheckedState.SOME && (
-          <CheckIndeterminateIcon title={tooltip} className="h-6 w-6" />
+          <CheckIndeterminateIcon title={tooltip} className="size-6" />
         )}
         {checkAllStatus === allCheckedState.NONE && (
-          <CheckBoxEmptyIcon title={tooltip} className="h-6 w-6" />
+          <CheckBoxEmptyIcon title={tooltip} className="size-6" />
         )}
       </span>
     </Tooltip.Simple>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/DownloadDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/DownloadDialog.tsx
@@ -335,7 +335,7 @@ export const DownloadDialog = ({
               </Button>
               {isDownloading && (
                 <div role="status" className="mt-2">
-                  <SpinnerIcon className="h-8 w-8 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600" />
+                  <SpinnerIcon className="size-8 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600" />
                   <span className="sr-only">{t("loading")}</span>
                 </div>
               )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Pagination.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Pagination.tsx
@@ -106,7 +106,7 @@ export const Pagination = ({
           }`}
           aria-disabled={isFirstPage}
         >
-          <StartIcon className="inline-block h-6 w-6 group-focus:fill-white" />
+          <StartIcon className="inline-block size-6 group-focus:fill-white" />
           {t("downloadResponsesTable.header.pagination.start")}
         </a>
       </Link>
@@ -127,7 +127,7 @@ export const Pagination = ({
             }`}
             aria-disabled={isFirstPage}
           >
-            <BackArrowIcon className="inline-block h-6 w-6 group-focus:fill-white" />
+            <BackArrowIcon className="inline-block size-6 group-focus:fill-white" />
             {t("downloadResponsesTable.header.pagination.previous")}
           </a>
         </Link>
@@ -148,7 +148,7 @@ export const Pagination = ({
             aria-disabled={isLastPage}
           >
             {t("downloadResponsesTable.header.pagination.next")}
-            <ForwardArrowIcon className="inline-block h-6 w-6 group-focus:fill-white" />
+            <ForwardArrowIcon className="inline-block size-6 group-focus:fill-white" />
           </a>
         </Link>
       </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/loading.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
     <div className="flex w-1/2 items-center justify-center">
-      <div className="mt-6 h-20 w-20 animate-spin rounded-full border-y-4 border-indigo-700"></div>
+      <div className="mt-6 size-20 animate-spin rounded-full border-y-4 border-indigo-700"></div>
     </div>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/loading.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
     <div className="flex w-1/2 items-center justify-center">
-      <div className="mt-6 h-20 w-20 animate-spin rounded-full border-y-4 border-indigo-700"></div>
+      <div className="mt-6 size-20 animate-spin rounded-full border-y-4 border-indigo-700"></div>
     </div>
   );
 }

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/tag-input/Tags.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/tag-input/Tags.tsx
@@ -15,7 +15,7 @@ export const Tag = ({ tag, onRemove }: TagProps) => {
   return (
     <div
       data-testid="tag"
-      className="m-1 inline-block rounded-l-xl rounded-r-xl border-2 border-gray-default px-2"
+      className="m-1 inline-block rounded-xl border-2 border-gray-default px-2"
     >
       <span className="inline-block">
         {tag}

--- a/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
@@ -121,7 +121,7 @@ export const ContactForm = () => {
           </Alert.Warning>
           <form id="contactus" action={submitForm} noValidate>
             {errors.error && (
-              <Alert.Danger focussable={true} title={t("error")} className="mb-2 mt-2">
+              <Alert.Danger focussable={true} title={t("error")} className="my-2">
                 <p>{t(errors.error)}</p>
               </Alert.Danger>
             )}

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
@@ -123,7 +123,7 @@ export const UnlockPublishingForm = ({ userEmail }: { userEmail: string }) => {
           <p className="mb-14">{t("unlockPublishing.paragraph1")}</p>
           <form id="unlock-publishing" action={submitForm} noValidate>
             {errors.error && (
-              <Alert.Danger focussable={true} title={t("error")} className="mb-2 mt-2">
+              <Alert.Danger focussable={true} title={t("error")} className="my-2">
                 <p>{t(errors.error)}</p>
               </Alert.Danger>
             )}

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/components/client/MFAForm.tsx
@@ -145,7 +145,7 @@ export const MFAForm = () => {
             </ol>
           </Alert>
         )}
-      <h1 data-testid="verify-title" ref={headingRef} className="mb-6 mt-6 border-0">
+      <h1 data-testid="verify-title" ref={headingRef} className="my-6 border-0">
         {t("verify.title")}
       </h1>
       <p className="mb-12 mt-10">{t("verify.emailHasBeenSent")}</p>

--- a/app/(gcforms)/[locale]/(user authentication)/auth/mfa/resend/components/client/ReVerify.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/mfa/resend/components/client/ReVerify.tsx
@@ -87,7 +87,7 @@ export const ReVerify = (): ReactElement => {
           ) : undefined}
         </Alert>
       )}
-      <h1 ref={headingRef} className="mb-6 mt-6 border-0">
+      <h1 ref={headingRef} className="my-6 border-0">
         {t("reVerify.title")}
       </h1>
       <p className="mt-10">{t("reVerify.description")}</p>

--- a/app/(gcforms)/[locale]/(user authentication)/profile/components/server/Icon.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/profile/components/server/Icon.tsx
@@ -4,6 +4,6 @@ export const Icon = ({ checked }: { checked: boolean }) => {
   return checked ? (
     <CircleCheckIcon className="mr-2 inline-block w-9 fill-green-700" />
   ) : (
-    <CancelIcon className="mr-2 inline-block h-9 w-9 fill-red-700" />
+    <CancelIcon className="mr-2 inline-block size-9 fill-red-700" />
   );
 };

--- a/components/clientComponents/admin/LeftNav/NavLink.tsx
+++ b/components/clientComponents/admin/LeftNav/NavLink.tsx
@@ -39,7 +39,7 @@ export const LeftNav = ({ href, children, title = "", onClick, testid }: LinkBut
   };
 
   return (
-    <div className="relative z-10 flex h-[60px] w-[60px]">
+    <div className="relative z-10 flex size-[60px]">
       <Tooltip.Simple text={title} side="right">
         <Link
           {...(isActive && { "aria-current": "page" })}

--- a/components/clientComponents/forms/AddressComplete/AddressComplete.tsx
+++ b/components/clientComponents/forms/AddressComplete/AddressComplete.tsx
@@ -312,7 +312,7 @@ export const AddressComplete = (props: AddressCompleteProps): React.ReactElement
           {!isReady && (
             <>
               <div role="status" className="mt-2">
-                <SpinnerIcon className="h-8 w-8 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600" />
+                <SpinnerIcon className="size-8 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600" />
                 <span className="sr-only">{t("loading")}</span>
               </div>
             </>

--- a/components/clientComponents/globals/Alert/Alert.cy.tsx
+++ b/components/clientComponents/globals/Alert/Alert.cy.tsx
@@ -46,7 +46,7 @@ describe("<Alert />", () => {
         <Alert.Success
           title="This is a title"
           body="This is a body"
-          icon={<CircleCheckIcon className="mr-1 h-12 w-12" />}
+          icon={<CircleCheckIcon className="mr-1 size-12" />}
         />
       );
 

--- a/components/clientComponents/globals/Alert/Alert.tsx
+++ b/components/clientComponents/globals/Alert/Alert.tsx
@@ -208,7 +208,7 @@ const AlertContainer = ({
           data-testid="alert-dismiss"
           id="dismissButton"
           aria-label={t("alert.dismissAlert")}
-          className="absolute right-0 mr-4 h-10 w-10 rounded-full border border-slate-950 bg-white text-2xl text-slate-950"
+          className="absolute right-0 mr-4 size-10 rounded-full border border-slate-950 bg-white text-2xl text-slate-950"
           onClick={onDismiss}
         >
           x

--- a/components/clientComponents/globals/Buttons/LeftNav.tsx
+++ b/components/clientComponents/globals/Buttons/LeftNav.tsx
@@ -35,7 +35,7 @@ export const LeftNav = ({
   };
 
   return (
-    <div className="relative z-10 flex h-[60px] w-[60px]">
+    <div className="relative z-10 flex size-[60px]">
       <Tooltip.Simple text={title} side="right">
         <Link
           {...(isActive && { "aria-current": "page" })}

--- a/components/clientComponents/globals/Buttons/SubmitButton.tsx
+++ b/components/clientComponents/globals/Buttons/SubmitButton.tsx
@@ -96,7 +96,7 @@ export const SubmitButton = ({
       {icon && <div className={cn(theme !== "icon" && "-ml-2 mr-2 w-8")}>{icon}</div>}
       {children}
       {loading && (
-        <SpinnerIcon className="ml-2 h-7 w-7 animate-spin fill-blue-600 text-white dark:text-white" />
+        <SpinnerIcon className="ml-2 size-7 animate-spin fill-blue-600 text-white dark:text-white" />
       )}
       <div aria-live="polite" className="sr-only">
         {loading && `${describeLoading ? describeLoading : t("loadingResult")}`}

--- a/components/clientComponents/globals/Header/Header.tsx
+++ b/components/clientComponents/globals/Header/Header.tsx
@@ -51,7 +51,7 @@ export const Header = ({ context = "default", className }: HeaderParams) => {
         )}
       >
         {isBannerEnabled && (
-          <div className="bg-slate-800 px-4 py-4 text-white">
+          <div className="bg-slate-800 p-4 text-white">
             <div className="mr-4 inline-block border-2 border-white-default px-2 py-1">
               {bannerType}
             </div>
@@ -60,7 +60,7 @@ export const Header = ({ context = "default", className }: HeaderParams) => {
             </div>
           </div>
         )}
-        <div className="grid w-full grid-flow-col px-2 py-2">
+        <div className="grid w-full grid-flow-col p-2">
           <div className="flex">
             <Link
               href={`/${language}/form-builder`}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,8 +34,7 @@ const eslintConfig = [
           argsIgnorePattern: "^_",
           caughtErrors: "none", // This allows unused catch parameters
         },
-      ],
-      "tailwindcss/enforces-shorthand": "off",
+      ]
     },
     ignorePatterns: [
       "/utils",


### PR DESCRIPTION
# Summary | Résumé

Turns `tailwindcss/enforces-shorthand` "on"

Updates existing files to use shorthand.

i.e. 

use

```
size-14 ✅ 
```

not
```
h-14 w-14 ❌ 
```




