### PR TITLE
fix: await for param for unprocessed api route

### DIFF
--- a/app/api/id/[form]/submission/unprocessed/route.ts
+++ b/app/api/id/[form]/submission/unprocessed/route.ts
@@ -8,7 +8,7 @@ export const dynamic = "force-dynamic";
 
 export const GET = middleware([sessionExists()], async (req, props) => {
   try {
-    const formId = props.params?.form;
+    const formId = await props.params?.form;
 
     if (!formId || typeof formId !== "string") {
       return NextResponse.json({ error: "Bad request" }, { status: 400 });


### PR DESCRIPTION
# Summary | Résumé

Given we're now using Next 15... found an issue where we didn't await the `props.params?.form` in the  unprocessed api route.


Was throwing 

```
Error: Route "/api/id/[form]/submission/unprocessed" used `params.form`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
```

<img width="1017" alt="Screenshot 2025-01-08 at 11 06 36 AM" src="https://github.com/user-attachments/assets/03fd6992-1fab-4ef2-b6c9-2d867c726452" />
