### PR TITLE
fix: Fix case of an empty formatted date on a groups page

### DIFF
--- a/components/clientComponents/forms/Review/FormElements/FormattedDate.tsx
+++ b/components/clientComponents/forms/Review/FormElements/FormattedDate.tsx
@@ -14,6 +14,11 @@ export const FormattedDate = ({
   }
 
   const formattedDateKeyValues = safeJSONParse(formItem.values as string) as DateObject;
+
+  if (!formattedDateKeyValues) {
+    return <BaseElement formItem={formItem} />;
+  }
+
   const formattedDateFormat = Object.keys(formattedDateKeyValues).join("-") as DateFormat;
   const formattedDate = getFormattedDateFromObject(formattedDateFormat, formattedDateKeyValues);
   const formItemAsDate = {


### PR DESCRIPTION
# Summary | Résumé

Fix case of an empty formatted date on a groups page

## Test

Create a form. On the start page add a formatted date. Also add a formatted date to a page.

Navigate to the form and in both cases leave the date inputs empty and navigate to the Review page. The formatted date element should be listed with a "-".

Do the same but with date inputs filled in. The dates should show as expected on the Review page
