### PR TITLE
bug: ensure array is sent for checkbox elements when they are in a hidden state

### DIFF
--- a/lib/formContext.ts
+++ b/lib/formContext.ts
@@ -688,7 +688,7 @@ export const filterValuesByShownElements = (values: Responses, elementsShown: Fo
       // Note: want to keep original value type (e.g. Checkbox=Array) or Formik may get confused
       filteredValues[key] = values[key];
     } else {
-      filteredValues[key] = "";
+      filteredValues[key] = Array.isArray(values[key]) ? [] : "";
     }
   });
   return filteredValues;


### PR DESCRIPTION
# Summary | Résumé

Update to ensure when emptying out values the emptied value remains the same type i.e. array or string of the incoming value.


## Testing

- Create 2 checkbox lists 
- Make the second one a show hide based on one of the values in the first.
- Toggle the second list to show and set a value
- Toggle the second list to hide ... in this case the value should be "empty" when sending the payload as it's hidden,
- Ensure the value sent is an array for the checkbox type