### PR TITLE
fix: Fix invitation email links

### DIFF
--- a/lib/invitations/inviteUserByEmail.ts
+++ b/lib/invitations/inviteUserByEmail.ts
@@ -67,12 +67,12 @@ export const inviteUserByEmail = async (
     // if invitation is expired, delete and recreate
     if (previousInvitation.expires < new Date()) {
       // check js dates vs prisma dates (see 2fa)
-      _deleteInvitation(previousInvitation.id);
+      await _deleteInvitation(previousInvitation.id);
       invitation = await _createInvitation(email, formId);
     }
 
     // send or resend invitation email
-    _sendInvitationEmail(sender, invitation, message, template.formRecord);
+    await _sendInvitationEmail(sender, invitation, message, template.formRecord);
 
     logEvent(
       ability.user.id,
@@ -86,7 +86,7 @@ export const inviteUserByEmail = async (
 
   // No previous invitation, create one
   invitation = await _createInvitation(email, formId);
-  _sendInvitationEmail(sender, invitation, message, template.formRecord);
+  await _sendInvitationEmail(sender, invitation, message, template.formRecord);
 
   return;
 };

--- a/lib/invitations/inviteUserByEmail.ts
+++ b/lib/invitations/inviteUserByEmail.ts
@@ -149,7 +149,7 @@ const _sendInvitationEmail = async (
     `Sending invitation email to ${email} for form ${templateId} with message ${message}`
   );
 
-  const HOST = getOrigin();
+  const HOST = await getOrigin();
 
   // Determine whether to send an invitation to register or an invitation to the form
   const user = await prisma.user.findFirst({

--- a/lib/invitations/tests/invitations.test.ts
+++ b/lib/invitations/tests/invitations.test.ts
@@ -33,10 +33,13 @@ jest.mock("@lib/logger");
 jest.mock("@lib/auditLogs");
 jest.mock("@lib/users");
 jest.mock("@lib/templates");
-jest.mock("@lib/origin");
 jest.mock("@lib/invitations/emailTemplates/inviteToFormsEmailTemplate");
 jest.mock("@lib/invitations/emailTemplates/inviteToCollaborateEmailTemplate");
 jest.mock("@lib/invitations/emailTemplates/ownerAddedEmailTemplate");
+
+jest.mock("@lib/origin", () => ({
+  getOrigin: jest.fn().mockReturnValue("http://localhost:3000"),
+}));
 
 describe("Invitations", () => {
   beforeEach(() => {


### PR DESCRIPTION
# Summary | Résumé

inviteUserByEmail was using getOrigin() to retrieve the base path for links. This function is (recently became?) async and needs to be awaited.
