### PR TITLE
fix: Date component- set lower threshold for year validation

### DIFF
--- a/components/clientComponents/forms/FormattedDate/FormattedDate.tsx
+++ b/components/clientComponents/forms/FormattedDate/FormattedDate.tsx
@@ -170,7 +170,7 @@ export const FormattedDate = (props: FormattedDateProps): React.ReactElement => 
                 name={`${name}-${part}`}
                 id={`${name}-${part}`}
                 type="number"
-                min={1900}
+                min={1000}
                 autoComplete={autocomplete ? "bday-year" : undefined}
                 className={cn("!w-28", meta.error && "gc-error-input")}
                 value={dateObject?.YYYY || ""}

--- a/components/clientComponents/forms/FormattedDate/utils.ts
+++ b/components/clientComponents/forms/FormattedDate/utils.ts
@@ -45,7 +45,7 @@ export const isValidDate = (dateObject: DateObject): boolean => {
     return false;
   }
 
-  if (dateObject.YYYY < 1900) {
+  if (dateObject.YYYY < 1000) {
     return false;
   }
 


### PR DESCRIPTION
# Summary | Résumé

Fixes #4958 
1900 was chosen as the minimum year for date validation purposes, fairly arbitrarily. This lowers it to 1000.