### PR TITLE
fix: Prevent access to Edit on Published forms

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -3,7 +3,7 @@ import React, { useState, useCallback, useEffect, useRef, useMemo } from "react"
 import { cn } from "@lib/utils";
 import debounce from "lodash.debounce";
 import { useTranslation } from "@i18n/client";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Language, LocalizedFormProperties } from "@lib/types/form-builder-types";
 import { ElementPanel } from ".";
 import { ConfirmationDescriptionWithGroups } from "./ConfirmationDescriptionWithGroups";
@@ -33,6 +33,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
     updateField,
     translationLanguagePriority,
     getLocalizationAttribute,
+    isPublished,
   } = useTemplateStore((s) => ({
     title:
       s.form[s.localizeField(LocalizedFormProperties.TITLE, s.translationLanguagePriority)] ?? "",
@@ -40,10 +41,12 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
     updateField: s.updateField,
     translationLanguagePriority: s.translationLanguagePriority,
     getLocalizationAttribute: s.getLocalizationAttribute,
+    isPublished: s.isPublished,
   }));
 
   const [value, setValue] = useState<string>(title);
   const searchParams = useSearchParams();
+  const router = useRouter();
   const focusTitle = searchParams?.get("focusTitle") ? true : false;
   const titleInput = useRef<HTMLTextAreaElement>(null);
   const groupId = useGroupStore((state) => state.id);
@@ -64,6 +67,13 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
   useEffect(() => {
     setValue(title);
   }, [title]);
+
+  useEffect(() => {
+    if (isPublished) {
+      router.replace(`/${locale}/form-builder/${id}/settings/`);
+      return;
+    }
+  }, [router, isPublished, id, locale]);
 
   const _debounced = debounce(
     useCallback(


### PR DESCRIPTION
# Summary | Résumé

Somewhere between Edit -> EditWithGroups transition, a bit of code that handles preventing access to Edit on published forms was lost.