### PR TITLE
fix: Prevent access to Responses on unsaved form

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/page.tsx
@@ -101,6 +101,10 @@ export default async function Page(props: {
 
   const { locale, id, statusFilter: statusFilterParams } = params;
 
+  if (id === "0000") {
+    redirect(`/${locale}/form-builder/${id}/edit`);
+  }
+
   const { session } = await authCheckAndThrow().catch(() => ({
     session: null,
   }));


### PR DESCRIPTION
# Summary | Résumé

Prevent access to Responses page on unsaved forms
