### PR TITLE
fix: Save on preview to prevent error on uploaded form file

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/PreviewNavigation.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/PreviewNavigation.tsx
@@ -1,10 +1,18 @@
 "use client";
 import React from "react";
 import { LangSwitcher } from "@formBuilder/components/shared/LangSwitcher";
+import { SaveButton } from "@formBuilder/components/shared/SaveButton";
 
 export const PreviewNavigation = () => {
   return (
     <div className="relative">
+      <div className="absolute left-0 top-0 mt-2">
+        {/* 
+            SaveButton should mostly be invisible, but is here to handle 
+            autosave when opening a form file to prevent errors on Settings 
+        */}
+        <SaveButton />
+      </div>
       <div className="absolute right-0 top-0">
         <LangSwitcher descriptionLangKey="previewingIn" />
       </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/SaveButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/SaveButton.tsx
@@ -164,7 +164,8 @@ export const SaveButton = () => {
     return null;
   }
 
-  const showSave = pathname?.includes("edit") || pathname?.includes("translate");
+  const showSave =
+    pathname?.includes("edit") || pathname?.includes("translate") || pathname?.includes("preview");
 
   if (!showSave) {
     return null;


### PR DESCRIPTION
# Summary | Résumé

When uploading a form file, the user is directed to the Preview page.
This page does not autosave, so if the user then went straight to Settings and tried to make a change, it would throw an error.

This PR just adds the SaveButton to the Preview page so that an autosave is triggered when navigating away.
