### PR TITLE
fix: Allow free text in searchable list input

### DIFF
--- a/components/clientComponents/forms/Combobox/Combobox.tsx
+++ b/components/clientComponents/forms/Combobox/Combobox.tsx
@@ -26,6 +26,7 @@ export const Combobox = (props: ComboboxProps): React.ReactElement => {
             return inputValue ? choice.toLowerCase().includes(inputValue.toLowerCase()) : true;
           })
         );
+        setValue(inputValue);
       },
       items,
       onSelectedItemChange({ selectedItem }) {


### PR DESCRIPTION
# Summary | Résumé

The searchable list (Combobox) component has a bit of strange behaviour. We do not validate the input value against values in the list. The only validation that is run is if it is set as a Required input. But when that is the case, this odd bit of behaviour can be observed:

- Create a form with searchable drop-down (add some values the list)
- Set the input as required
- Go to Preview and test:
  - if you type something not in the list and just hit submit -> validation (required) error
  - if you start typing and click a matching item then hit submit -> success
  - if you start typing and click a matching item then modify or add more and hit submit -> success
  - if you start typing, click a matching item, then delete the text and enter something different -> success

This PR makes a change so that the input can be submitted with any arbitrary text that has been entered.

A future iteration of this component may be to add a "Validate input against provided list" option, but since we don't do that I think we should allow free text.