### PR TITLE
fix: Unescape question in validation message

### DIFF
--- a/components/clientComponents/forms/ErrorListItem/ErrorListMessage.tsx
+++ b/components/clientComponents/forms/ErrorListItem/ErrorListMessage.tsx
@@ -44,14 +44,44 @@ export const ErrorListMessage = ({
 
   switch (elementType) {
     case FormElementTypes.attestation:
-      return t("input-validation.error-list.check-all", { question, lng: language });
+      return t("input-validation.error-list.check-all", {
+        question,
+        lng: language,
+        interpolation: {
+          escapeValue: false,
+        },
+      });
     case FormElementTypes.checkbox:
-      return t("input-validation.error-list.checkbox", { question, lng: language });
+      return t("input-validation.error-list.checkbox", {
+        question,
+        lng: language,
+        interpolation: {
+          escapeValue: false,
+        },
+      });
     case FormElementTypes.dropdown:
-      return t("input-validation.error-list.select", { question, lng: language });
+      return t("input-validation.error-list.select", {
+        question,
+        lng: language,
+        interpolation: {
+          escapeValue: false,
+        },
+      });
     case FormElementTypes.fileInput:
-      return t("input-validation.error-list.file-input", { question, lng: language });
+      return t("input-validation.error-list.file-input", {
+        question,
+        lng: language,
+        interpolation: {
+          escapeValue: false,
+        },
+      });
     default:
-      return t("input-validation.error-list.default", { question, lng: language });
+      return t("input-validation.error-list.default", {
+        question,
+        lng: language,
+        interpolation: {
+          escapeValue: false,
+        },
+      });
   }
 };


### PR DESCRIPTION
# Summary | Résumé

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| <img width="653" alt="image" src="https://github.com/user-attachments/assets/fc981e63-4523-42f7-8fb8-fc58e486b702" /> | <img width="657" alt="image" src="https://github.com/user-attachments/assets/b07edda1-0a93-4822-9467-1506539e1ed4" /> |


