### PR TITLE
fix: Prevent invitations to draft forms

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/ManageFormAccessDialog/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/ManageFormAccessDialog/actions.ts
@@ -10,7 +10,11 @@ import {
   TemplateNotFoundError,
   UserAlreadyHasAccessError,
 } from "@lib/invitations/exceptions";
-import { getTemplateWithAssociatedUsers, removeAssignedUserFromTemplate } from "@lib/templates";
+import {
+  getPublicTemplateByID,
+  getTemplateWithAssociatedUsers,
+  removeAssignedUserFromTemplate,
+} from "@lib/templates";
 import { serverTranslation } from "@i18n";
 import { logMessage } from "@lib/logger";
 import { inviteUserByEmail } from "@lib/invitations/inviteUserByEmail";
@@ -23,6 +27,17 @@ export const sendInvitation = async (emails: string[], templateId: string, messa
   const { t } = await serverTranslation("manage-form-access");
 
   const errors: string[] = [];
+
+  const template = await getPublicTemplateByID(templateId);
+  if (!template?.isPublished) {
+    logMessage.error(`Invitation failed - draft form ${templateId}`);
+    errors.push(t("draftFormError"));
+
+    return {
+      success: false,
+      errors,
+    };
+  }
 
   const invites = emails.map(async (email) => {
     try {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/NavigationTabs.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/NavigationTabs.tsx
@@ -5,6 +5,7 @@ import { TabNavLink } from "@clientComponents/globals/TabNavLink";
 import { usePathname } from "next/navigation";
 import { useTranslation } from "@i18n/client";
 import { ManageFormAccessButton } from "./ManageFormAccessDialog/ManageFormAccessButton";
+import { useTemplateStore } from "@lib/store/useTemplateStore";
 
 export const NavigationTabs = ({ formId }: { formId: string }) => {
   const {
@@ -12,6 +13,11 @@ export const NavigationTabs = ({ formId }: { formId: string }) => {
     i18n: { language: locale },
   } = useTranslation("form-builder-responses");
   const pathname = usePathname();
+  const { isPublished } = useTemplateStore((s) => {
+    return {
+      isPublished: s.isPublished,
+    };
+  });
 
   return (
     <nav className="relative mb-10 flex border-b border-black" aria-label={t("responses.navLabel")}>
@@ -46,9 +52,11 @@ export const NavigationTabs = ({ formId }: { formId: string }) => {
         </span>
       </TabNavLink>
 
-      <div className="absolute right-0">
-        <ManageFormAccessButton />
-      </div>
+      {isPublished && (
+        <div className="absolute right-0">
+          <ManageFormAccessButton />
+        </div>
+      )}
     </nav>
   );
 };

--- a/i18n/translations/en/manage-form-access.json
+++ b/i18n/translations/en/manage-form-access.json
@@ -32,5 +32,6 @@
   "resend": "Re-send invitation to {{email}}",
   "templateNotFound": "Template not found {{templateId}}",
   "userAlreadyHasAccess": "{{email}} already has access",
-  "userNotFound": "User not found"
+  "userNotFound": "User not found",
+  "draftFormError": "Can't send invitations to draft forms"
 }

--- a/i18n/translations/fr/manage-form-access.json
+++ b/i18n/translations/fr/manage-form-access.json
@@ -32,5 +32,6 @@
   "resend": "Renvoyer l'invitation pour {{email}}",
   "templateNotFound": "Gabarit non trouvé {{templateId}}",
   "userAlreadyHasAccess": "{{email}} a déjà accès",
-  "userNotFound": "User not found"
+  "userNotFound": "User not found",
+  "draftFormError": "Impossible d'envoyer des invitations à rédiger des formulaires"
 }


### PR DESCRIPTION
# Summary | Résumé

Removes the Manage access button on Draft forms
Also catches at the Server Action layer and prevents submission.