### PR TITLE
chore: remove locale prop for Language toggle

### DIFF
--- a/components/clientComponents/globals/Header/LanguageToggle.tsx
+++ b/components/clientComponents/globals/Header/LanguageToggle.tsx
@@ -25,7 +25,6 @@ const LanguageToggle = () => {
     <Link
       href={href}
       className="text-right text-base"
-      locale={currentLang === "en" ? "fr" : "en"}
       aria-label={`${t("lang-toggle")}: ${currentLang == "en" ? "Français" : "English"}`}
       lang={currentLang === "en" ? "fr" : "en"}
       prefetch={false}

--- a/components/serverComponents/globals/LanguageToggle.tsx
+++ b/components/serverComponents/globals/LanguageToggle.tsx
@@ -13,7 +13,6 @@ const LanguageToggle = async () => {
     <Link
       href={pathname.replace(`/${currentLang}`, `/${currentLang === "en" ? "fr" : "en"}`)}
       className="text-right text-base"
-      locale={currentLang === "en" ? "fr" : "en"}
       aria-label={`${t("lang-toggle")}: ${currentLang == "en" ? "Français" : "English"}`}
       lang={currentLang === "en" ? "fr" : "en"}
       prefetch={false}


### PR DESCRIPTION
# Summary | Résumé

The locale prop is not supported for the app router - this PR removes it.

```
The `locale` prop is not supported in `next/link` while using the `app` router. Read more about app router internalization: https://nextjs.org/docs/app/building-your-application/routing/internationalization
```

Console warning:

<img width="1421" alt="Screenshot 2025-01-21 at 11 42 43 AM" src="https://github.com/user-attachments/assets/cf0a6893-022b-4522-b15e-db9dca4edde1" />

