### PR TITLE
chore: Silence handled Prisma errors

### DIFF
--- a/lib/integration/prismaConnector.ts
+++ b/lib/integration/prismaConnector.ts
@@ -44,7 +44,7 @@ export const prismaErrors = <Error, T>(e: Error, returnValue: T): T => {
 
   // Return the backup value if a Prisma Error occurs
   if (e instanceof Prisma.PrismaClientKnownRequestError) {
-    logMessage.warn(e);
+    logMessage.info(e);
     return returnValue;
   }
 


### PR DESCRIPTION
# Summary | Résumé

Changes the logMessage level of handled Prisma errors so that they do not appear in Slack. The Prisma error is still captured in CloudWatch logs to be referred against for troubleshooting if required.

Current:
![Screenshot 2025-01-27 at 8 23 54 AM](https://github.com/user-attachments/assets/667bee33-4a55-489d-91f2-93737d002a0b)

Proposed:
![Screenshot 2025-01-27 at 8 24 02 AM](https://github.com/user-attachments/assets/bd32f24a-d060-4023-a900-65ddd396508b)


