### PR TITLE
chore: Add the migration to produce a perm template to user view object.

### DIFF
--- a/prisma/migrations/20250130165334_create_template_user_view/migration.sql
+++ b/prisma/migrations/20250130165334_create_template_user_view/migration.sql
@@ -1,0 +1,3 @@
+CREATE VIEW "TemplateUserView" AS
+SELECT "A" as templateId, "B" as userId
+FROM public."_TemplateToUser";

--- a/prisma/migrations/20250130165334_create_template_user_view/migration.sql
+++ b/prisma/migrations/20250130165334_create_template_user_view/migration.sql
@@ -1,3 +1,3 @@
 CREATE VIEW "TemplateUserView" AS
 SELECT "A" as templateId, "B" as userId
-FROM public."_TemplateToUser";
+FROM "_TemplateToUser";


### PR DESCRIPTION
A required addition to handle an issue caused by AWS Services not allowing uppercase column names, and Prisma using uppercase column names for Many-To-Many relation tables.