### PR TITLE
chore: use not found page for 0000

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { Publish } from "./Publish";
 import { authorization } from "@lib/privileges";
 import { authCheckAndThrow } from "@lib/actions";
+import { notFound } from "next/navigation";
 
 import Markdown from "markdown-to-jsx";
 
@@ -37,6 +38,10 @@ export default async function Page(props: { params: Promise<{ id: string; locale
 
   if (!session) {
     return <LoggedOutTab tabName={LoggedOutTabName.PUBLISH} />;
+  }
+
+  if (id === "0000") {
+    return notFound();
   }
 
   const userCanPublish = await authorization

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -2,6 +2,7 @@ import { serverTranslation } from "@i18n";
 import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/LoggedOutTab";
 import { authCheckAndThrow } from "@lib/actions";
 import { SettingsNavigation } from "./components/SettingsNavigation";
+import { notFound } from "next/navigation";
 
 export default async function Layout(props: {
   children: React.ReactNode;
@@ -19,6 +20,10 @@ export default async function Layout(props: {
 
   if (!session) {
     return <LoggedOutTab tabName={LoggedOutTabName.SETTINGS} />;
+  }
+
+  if (id === "0000") {
+    return notFound();
   }
 
   return (


### PR DESCRIPTION
# Summary | Résumé

Add `0000` checks for settings and publish when a user is logged in and has an unsaved form.

Folks shouldn't be able to visit these pages direct or in an unsaved state.