### PR TITLE
chore: AddressComplete use form values and customTranslate

### DIFF
--- a/components/clientComponents/forms/Review/FormElements/AddressComplete/AddressComplete.tsx
+++ b/components/clientComponents/forms/Review/FormElements/AddressComplete/AddressComplete.tsx
@@ -1,18 +1,15 @@
-import { useTranslation } from "@i18n/client";
-import { FormItem } from "../../helpers";
 import {
-  AddressCompleteLabels,
-  AddressElements,
+  type AddressCompleteLabels,
+  type AddressElements,
 } from "@clientComponents/forms/AddressComplete/types";
-import { Language } from "@lib/types/form-builder-types";
-import { AddressComponents } from "@lib/types";
-import { useGCFormsContext } from "@lib/hooks/useGCFormContext";
+import { type Language } from "@lib/types/form-builder-types";
+import { type AddressComponents } from "@lib/types";
+import { FormItem } from "../../helpers";
 import { getLocalizedProperty, safeJSONParse } from "@lib/utils";
 import { BaseElementArray } from "../BaseElementArray";
 import { BaseElement } from "../BaseElement";
 import { getCombinedAddressAsFormItem, getSplitAddressAsFormItem } from "./helpers";
-
-// TODO: Fix Canada not showing up in the output (other countries do) - on staging as well
+import { customTranslate } from "@lib/i18nHelpers";
 
 export const AddressComplete = ({
   formItem,
@@ -23,15 +20,11 @@ export const AddressComplete = ({
   language: Language;
   splitValues?: boolean;
 }): React.ReactElement => {
-  const { t } = useTranslation(["review", "common"]);
-  const { getValues } = useGCFormsContext();
-
-  const formValues = getValues();
+  const { t } = customTranslate("review");
   const element = formItem.element;
   const addressComponents = element?.properties?.addressComponents as AddressComponents;
-  const elementId = element?.id; // For TS next line...
-  const addressFormValue = formValues[elementId as keyof typeof elementId];
-  const addressValues = safeJSONParse(addressFormValue) as AddressElements;
+  const addressFormValue = formItem.values;
+  const addressValues = safeJSONParse(addressFormValue as string) as AddressElements;
 
   if (addressComponents?.splitAddress || splitValues) {
     const addressCompleteStrings = {

--- a/lib/i18nHelpers.ts
+++ b/lib/i18nHelpers.ts
@@ -3,28 +3,32 @@ import myFormsEn from "@i18n/translations/en/my-forms.json";
 import myFormsFr from "@i18n/translations/fr/my-forms.json";
 import commonEn from "@i18n/translations/en/common.json";
 import commonFr from "@i18n/translations/fr/common.json";
+import reviewEn from "@i18n/translations/en/review.json";
+import reviewFr from "@i18n/translations/fr/review.json";
 
 /**
  * This custom translation function works like useTranslation() from react-i18next which was not working in this context.
  * The language resources are hard coded to avoid having to async load them from the file system.
  * @param translationFile
  */
-export const customTranslate = (translationFile: "my-forms" | "common") => {
+export const customTranslate = (translationFile: "my-forms" | "common" | "review") => {
   if (!i18next.isInitialized) {
     i18next.init({
       fallbackLng: "en",
       supportedLngs: ["en", "fr"],
       preload: ["en", "fr"],
       debug: true,
-      ns: ["my-forms", "common", "form-builder"],
+      ns: ["my-forms", "common", "review"],
       resources: {
         en: {
           "my-forms": myFormsEn,
           common: commonEn,
+          review: reviewEn,
         },
         fr: {
           "my-forms": myFormsFr,
           common: commonFr,
+          review: reviewFr,
         },
       },
     });


### PR DESCRIPTION
# Summary | Résumé

Modify AddressComplete review component to use formItem.values like other component types.
Modify AddressComplete to use customTranslate
Modify customTranslate to support review translations.
