### PR TITLE
fix: Filter out richText elements from repeatingSet arrays when mapping responses/questions

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -183,7 +183,19 @@ export const getSubmissionsByFormat = AuthenticatedAction(
                   answer: answer.map((item) => {
                     return Object.values(item).map((value, index) => {
                       if (question?.properties.subElements) {
-                        const subQuestion = question?.properties.subElements[index];
+                        // Filter out richText elements from subElements since we access them by index
+                        const subQuestions = question?.properties.subElements.filter(
+                          (subElement) => {
+                            return subElement.type !== FormElementTypes.richText;
+                          }
+                        );
+
+                        if (!subQuestions.length || !subQuestions[index]) {
+                          throw new Error("No subQuestions found for dynamicRow");
+                        }
+
+                        const subQuestion = subQuestions[index];
+
                         return {
                           questionId: question?.id,
                           type: subQuestion.type,


### PR DESCRIPTION
# Summary | Résumé

When downloading responses, we map repeatingSet answers onto questions by using the index of the answer in the answer array to find the question. The problem arises when there is a richText element in the repeatingSet question array, there is no corresponding element in the answer array, so indexes are out of sync.

The fix is to filter out richText elements from the repeatingSet question array before using the answer index to find the question.

Also added a bit of checking/logging in case the indexes get out of sync for some other reason. 