### PR TITLE
feat: adds feature flags for hCaptcha

### DIFF
--- a/app/(gcforms)/[locale]/layout.tsx
+++ b/app/(gcforms)/[locale]/layout.tsx
@@ -12,6 +12,8 @@ export default async function Layout({ children }: { children: React.ReactNode }
     FeatureFlags.scheduleClosingDate,
     FeatureFlags.apiAccess,
     FeatureFlags.saveAndResume,
+    FeatureFlags.formTimer,
+    FeatureFlags.hCaptcha,
   ]);
 
   return (

--- a/flag_initialization/default_flag_settings.json
+++ b/flag_initialization/default_flag_settings.json
@@ -3,5 +3,7 @@
   "addressComplete": false,
   "scheduleClosingDate": false,
   "apiAccess": false,
-  "saveAndResume": false
+  "saveAndResume": false,
+  "formTimer": false,
+  "hCaptcha": false
 }

--- a/i18n/translations/en/admin-flags.json
+++ b/i18n/translations/en/admin-flags.json
@@ -33,6 +33,14 @@
     "saveAndResume": {
       "title": "Save and resume later",
       "description": "Enable save and resume functionality"
+    },
+    "formTimer": {
+      "title": "formTimer",
+      "description": "Enable formTimer to delay a form submission and help prevent spam"
+    },
+    "hCaptcha": {
+      "title": "hCaptcha",
+      "description": "Enable hCaptcha spam prevention"
     }
   }
 }

--- a/i18n/translations/fr/admin-flags.json
+++ b/i18n/translations/fr/admin-flags.json
@@ -33,6 +33,14 @@
     "saveAndResume": {
       "title": "Enregistrer et reprendre plus tard",
       "description": "Activer la fonctionnalité d'enregistrement et de reprise"
+    },
+    "formTimer": {
+      "title": "formTimer",
+      "description": "Activez formTimer pour retarder l'envoi d'un formulaire et contribuer à prévenir le spam"
+    },
+    "hCaptcha": {
+      "title": "hCaptcha",
+      "description": "Activer la prévention anti-spam hCaptcha"
     }
   }
 }

--- a/lib/cache/types.ts
+++ b/lib/cache/types.ts
@@ -5,6 +5,8 @@ export const FeatureFlags = {
   scheduleClosingDate: "scheduleClosingDate",
   apiAccess: "apiAccess",
   saveAndResume: "saveAndResume",
+  formTimer: "formTimer",
+  hCaptcha: "hCaptcha",
 } as const;
 
 export type FeatureFlagKeys = keyof typeof FeatureFlags;


### PR DESCRIPTION
# Summary | Résumé

Adds a feature flag for hCaptcha. Also adds a feature flag for the form timer so we can disable/enable it depending on whether hCaptcha is on.

