### PR TITLE
fix: Restore user-set viewport on init

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/FlowWithProvider.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/logic/components/flow/FlowWithProvider.tsx
@@ -152,7 +152,7 @@ const Flow: ForwardRefRenderFunction<unknown, FlowProps> = ({ children, lang }, 
           }
         }}
       >
-        <Controls showInteractive={false} showZoom={true} showFitView={false} />
+        <Controls showInteractive={false} showZoom={true} showFitView={true} />
         <Background />
         {children}
       </ReactFlow>


### PR DESCRIPTION
# Summary | Résumé

Fixes #4530 

Improvements to the branching flowchart:
- Stops re-drawing every time a node is selected
- Saves viewport changes a user makes while using (zoom, pan)
- Restores viewport after a branching change is made

This should help keep users oriented while using the flow view. Note that there are a few situations that can cause either a blank screen or user disorientation:
- If zoomed all the way in on a node towards the top or bottom of a complex tree, clicking on "Reset to linear flow", the user could end up on a blank screen as the nodes are regrouped off screen
- Similarly if zoomed in on a specific node and making a change that moves that node offscreen

To help in these situations, the "fit view" button has been enabled (below the zoom +/- buttons)