### PR TITLE
fix: enable using Tab key to indent/outdent lists in RichText editor

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/Editor.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/Editor.tsx
@@ -17,6 +17,7 @@ import {
   $convertToMarkdownString,
   TRANSFORMERS,
 } from "@lexical/markdown";
+import TabControlPlugin from "./plugins/TabControlPlugin";
 
 const FloatingLinkEditorPlugin = dynamic(() => import("./plugins/FloatingLinkEditorPlugin"), {
   ssr: false,
@@ -104,6 +105,7 @@ export const Editor = ({ content, onChange, ariaLabel, ariaDescribedBy, lang }: 
         <LinkPlugin />
         <FloatingLinkEditorPlugin anchorElem={floatingAnchorElem} />
         <ListPlugin />
+        <TabControlPlugin />
         <ListMaxIndentPlugin maxDepth={5} />
       </LexicalComposer>
     </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/plugins/TabControlPlugin.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/plugins/TabControlPlugin.tsx
@@ -1,0 +1,28 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  COMMAND_PRIORITY_EDITOR,
+  INDENT_CONTENT_COMMAND,
+  KEY_TAB_COMMAND,
+  OUTDENT_CONTENT_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+export default function TabControlPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_TAB_COMMAND,
+      (payload) => {
+        const event: KeyboardEvent = payload;
+        event.preventDefault();
+        return editor.dispatchCommand(
+          event.shiftKey ? OUTDENT_CONTENT_COMMAND : INDENT_CONTENT_COMMAND,
+          undefined
+        );
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  }, [editor]);
+  return null;
+}


### PR DESCRIPTION
# Summary | Résumé

Enables using Tab/Shift-Tab to Indent/Outdent lists in the RichText editor.

Seems this was [fixed once before](https://github.com/cds-snc/platform-forms-client/pull/1235) but broke somewhere along the way.

Had to add a custom plugin to capture the Tab key and use it to fire an indent/outdent command