### PR TITLE
[example] Adding hCaptcha to the Support form

### DIFF
--- a/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
@@ -135,7 +135,6 @@ export const SupportForm = ({ hCaptchaSiteKey }: { hCaptchaSiteKey: string }) =>
               <Link href={`/${language}/contact`}>{t("support.contactUs")}</Link>.
             </p>
           </Alert.Warning>
-          {/* <form id="support" action={submitForm} noValidate> */}
           <form
             ref={supportFormRef}
             method="POST"
@@ -248,7 +247,6 @@ export const SupportForm = ({ hCaptchaSiteKey }: { hCaptchaSiteKey: string }) =>
                 lang={language}
                 hCaptchaSiteKey={hCaptchaSiteKey}
                 successCb={() => {
-                  // const formData = new FormData(document.getElementById("support") as HTMLFormElement);
                   const formData = new FormData(supportFormRef.current as HTMLFormElement);
                   submitForm(formData);
                 }}

--- a/app/(gcforms)/[locale]/(support)/support/page.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/page.tsx
@@ -1,6 +1,7 @@
 import { serverTranslation } from "@i18n";
 import { Metadata } from "next";
 import { SupportForm } from "./components/client/SupportForm";
+import { getAppSetting } from "@lib/appSettings";
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
@@ -16,5 +17,7 @@ export async function generateMetadata(props: {
 }
 
 export default async function Page() {
-  return <SupportForm />;
+  const hCaptchaSiteKey = (await getAppSetting("hCaptchaSiteKey")) || "";
+
+  return <SupportForm hCaptchaSiteKey={hCaptchaSiteKey} />;
 }


### PR DESCRIPTION
# Summary | Résumé

The Support form is used as an example of how to add hCAPTCHA to a form.