### PR TITLE
chore: app settings provider

### DIFF
--- a/__utils__/setupTests.ts
+++ b/__utils__/setupTests.ts
@@ -127,6 +127,11 @@ jest.mock("@lib/logger", () => {
   };
 });
 
+jest.mock("@lib/hooks/useAppSettings", () => ({
+  __esModule: true,
+  getAppSetting: jest.fn((setting: string) => (setting)),
+}));
+
 // Common secrets needed for functionality
 // Overwrite incase accidently injected
 process.env = {

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
@@ -20,13 +20,11 @@ export const FormWrapper = ({
   header,
   currentForm,
   allowGrouping,
-  hCaptchaSiteKey,
 }: {
   formRecord: TypeOmit<FormRecord, "name" | "deliveryOption">;
   header: React.ReactNode;
   currentForm: JSX.Element[];
   allowGrouping?: boolean | undefined;
-  hCaptchaSiteKey?: string | undefined;
 }) => {
   // TODO cast language as "en" | "fr" in TS below
   const {
@@ -113,7 +111,6 @@ export const FormWrapper = ({
           );
         }}
         allowGrouping={allowGrouping}
-        hCaptchaSiteKey={hCaptchaSiteKey}
       >
         {currentForm}
       </Form>

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/page.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/page.tsx
@@ -16,7 +16,6 @@ import { FormDelayProvider } from "@lib/hooks/useFormDelayContext";
 import { ResumeForm } from "@clientComponents/forms/ResumeForm/ResumeForm";
 import { getSomeFlags } from "@lib/cache/flags";
 import { FeatureFlags } from "@lib/cache/types";
-import { getAppSetting } from "@lib/appSettings";
 
 export async function generateMetadata(props0: {
   params: Promise<{ locale: string; props: string[] }>;
@@ -48,8 +47,6 @@ export default async function Page(props0: {
   const params = await props0.params;
 
   const { locale, props } = params;
-
-  const hCaptchaSiteKey = (await getAppSetting("hCaptchaSiteKey")) || "";
 
   const formId = props[0];
   const step = props[1] ?? "";
@@ -125,7 +122,6 @@ export default async function Page(props0: {
             formRecord={formRecord}
             currentForm={currentForm}
             allowGrouping={isAllowGrouping}
-            hCaptchaSiteKey={hCaptchaSiteKey}
           />
         </FormDelayProvider>
       </div>

--- a/app/(gcforms)/[locale]/layout.tsx
+++ b/app/(gcforms)/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { ClientContexts } from "@clientComponents/globals/ClientContexts";
 import { ReactHydrationCheck } from "@clientComponents/globals";
 import { getSomeFlags } from "@lib/cache/flags";
 import { FeatureFlags } from "@lib/cache/types";
+import { getAllAppSettings } from "@lib/appSettings";
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
   const session = await auth();
@@ -16,10 +17,12 @@ export default async function Layout({ children }: { children: React.ReactNode }
     FeatureFlags.hCaptcha,
   ]);
 
+  const appSettings = await getAllAppSettings();
+
   return (
     <>
       <ReactHydrationCheck />
-      <ClientContexts session={session} featureFlags={featureFlags}>
+      <ClientContexts session={session} featureFlags={featureFlags} appSettings={appSettings}>
         {children}
       </ClientContexts>
     </>

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -37,6 +37,7 @@ import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
 import { hCaptchaEnabled } from "@clientComponents/globals/Captcha/helpers";
 import { Captcha } from "@clientComponents/globals/Captcha/Captcha";
 import HCaptcha from "@hcaptcha/react-hcaptcha";
+import { useAppSettings } from "@lib/hooks/useAppSettings";
 
 /**
  * This is the "inner" form component that isn't connected to Formik and just renders a simple form
@@ -66,6 +67,9 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const { getFlag } = useFeatureFlags();
   const captchaEnabled = hCaptchaEnabled(getFlag("hCaptcha"), props.isPreview);
   const hCaptchaRef = useRef<HCaptcha>(null);
+
+  const { getAppSetting } = useAppSettings();
+  const hCaptchaSiteKey = getAppSetting("hCaptchaSiteKey") || "";
 
   // Used to set any values we'd like added for use in the below withFormik handleSubmit().
   useFormValuesChanged();
@@ -213,7 +217,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               <Captcha
                 hCaptchaRef={hCaptchaRef}
                 lang={language}
-                hCaptchaSiteKey={props.hCaptchaSiteKey}
+                hCaptchaSiteKey={hCaptchaSiteKey}
                 successCb={handleSubmit}
                 blockableMode={false}
               />

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -37,7 +37,6 @@ import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
 import { hCaptchaEnabled } from "@clientComponents/globals/Captcha/helpers";
 import { Captcha } from "@clientComponents/globals/Captcha/Captcha";
 import HCaptcha from "@hcaptcha/react-hcaptcha";
-import { useAppSettings } from "@lib/hooks/useAppSettings";
 
 /**
  * This is the "inner" form component that isn't connected to Formik and just renders a simple form
@@ -67,9 +66,6 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   const { getFlag } = useFeatureFlags();
   const captchaEnabled = hCaptchaEnabled(getFlag("hCaptcha"), props.isPreview);
   const hCaptchaRef = useRef<HCaptcha>(null);
-
-  const { getAppSetting } = useAppSettings();
-  const hCaptchaSiteKey = getAppSetting("hCaptchaSiteKey") || "";
 
   // Used to set any values we'd like added for use in the below withFormik handleSubmit().
   useFormValuesChanged();
@@ -217,7 +213,6 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               <Captcha
                 hCaptchaRef={hCaptchaRef}
                 lang={language}
-                hCaptchaSiteKey={hCaptchaSiteKey}
                 successCb={handleSubmit}
                 blockableMode={false}
               />

--- a/components/clientComponents/forms/Form/types.ts
+++ b/components/clientComponents/forms/Form/types.ts
@@ -25,7 +25,6 @@ export interface FormProps {
   matchedIds?: string[];
   saveSessionProgress: (language?: Language) => void;
   saveAndResumeEnabled?: boolean;
-  hCaptchaSiteKey?: string | undefined;
 }
 
 export type InnerFormProps = FormProps & FormikProps<Responses>;

--- a/components/clientComponents/globals/Captcha/Captcha.tsx
+++ b/components/clientComponents/globals/Captcha/Captcha.tsx
@@ -2,6 +2,7 @@ import HCaptcha from "@hcaptcha/react-hcaptcha";
 import { logMessage } from "@lib/logger";
 import { verifyHCaptchaToken } from "./actions";
 import { useRouter } from "next/navigation";
+import { useAppSettings } from "@lib/hooks/useAppSettings";
 
 // Running in "100% Passive" mode that will never challenge users. The mode is set at account level.
 // In the future we hope to use "99.9% Passive hybrid" that will show an A11Y prompt for the .1%
@@ -10,17 +11,17 @@ export const Captcha = ({
   successCb,
   hCaptchaRef,
   lang,
-  hCaptchaSiteKey,
   blockableMode = true,
 }: {
   successCb: () => void;
   hCaptchaRef: React.RefObject<HCaptcha | null>;
   lang: string;
-  hCaptchaSiteKey: string | undefined;
   // Determines whether or not to block a user marked as a bot by siteverify from submitting a form
   blockableMode?: boolean;
 }) => {
   const router = useRouter();
+  const { getAppSetting } = useAppSettings();
+  const hCaptchaSiteKey = getAppSetting("hCaptchaSiteKey") || "";
 
   if (!hCaptchaSiteKey) {
     logMessage.error("hCaptcha: hCaptchaSiteKey is missing");

--- a/components/clientComponents/globals/ClientContexts.tsx
+++ b/components/clientComponents/globals/ClientContexts.tsx
@@ -5,13 +5,15 @@ import { Session } from "next-auth";
 import { AccessControlProvider } from "@lib/hooks/useAccessControl";
 import { RefsProvider } from "@formBuilder/[id]/edit/components/RefsContext";
 import { FeatureFlagsProvider } from "@lib/hooks/useFeatureFlags";
-import { Flags } from "@lib/cache/types";
+import { AllAppSettings, Flags } from "@lib/cache/types";
+import { AppSettingsProvider } from "@lib/hooks/useAppSettings";
 
 export const ClientContexts: React.FC<{
   session: Session | null;
   children: React.ReactNode;
   featureFlags: Flags;
-}> = ({ session, children, featureFlags }) => {
+  appSettings: AllAppSettings;
+}> = ({ session, children, featureFlags, appSettings }) => {
   return (
     <SessionProvider
       // initial session
@@ -23,7 +25,9 @@ export const ClientContexts: React.FC<{
     >
       <AccessControlProvider>
         <RefsProvider>
-          <FeatureFlagsProvider featureFlags={featureFlags}>{children}</FeatureFlagsProvider>
+          <FeatureFlagsProvider featureFlags={featureFlags}>
+            <AppSettingsProvider appSettings={appSettings}>{children}</AppSettingsProvider>
+          </FeatureFlagsProvider>
         </RefsProvider>
       </AccessControlProvider>
     </SessionProvider>

--- a/lib/cache/types.ts
+++ b/lib/cache/types.ts
@@ -19,3 +19,14 @@ export type Flags = {
 export type PickFlags<T extends FeatureFlagKeys[]> = {
   [K in T[number]]: boolean;
 };
+
+export type AllAppSettings =
+  | {
+      internalId: string;
+      descriptionEn: string | null;
+      descriptionFr: string | null;
+      nameEn: string;
+      nameFr: string;
+      value: string | null;
+    }[]
+  | never[];

--- a/lib/hooks/useAppSettings.tsx
+++ b/lib/hooks/useAppSettings.tsx
@@ -27,7 +27,7 @@ export const useAppSettings = () => {
   const { settings } = useContext(AppSettingsContext);
   return {
     getAppSetting: (internalId: string) => {
-      if (!Array.isArray(settings)) {
+      if (!Array.isArray(settings) || settings.length === 0) {
         logMessage.warn("Client tried to access an app setting but there were no settings loaded.");
         return;
       }

--- a/lib/hooks/useAppSettings.tsx
+++ b/lib/hooks/useAppSettings.tsx
@@ -4,7 +4,7 @@ import { logMessage } from "@lib/logger";
 import { createContext, useContext, useState } from "react";
 
 const AppSettingsContext = createContext({
-  settings: {} as AllAppSettings,
+  settings: [] as AllAppSettings,
   getAppSetting: () => {},
 });
 

--- a/lib/hooks/useAppSettings.tsx
+++ b/lib/hooks/useAppSettings.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { AllAppSettings } from "@lib/cache/types";
+import { logMessage } from "@lib/logger";
+import { createContext, useContext, useState } from "react";
+
+const AppSettingsContext = createContext({
+  settings: {} as AllAppSettings,
+  getAppSetting: () => {},
+});
+
+export const AppSettingsProvider = ({
+  children,
+  appSettings,
+}: {
+  children: React.ReactNode;
+  appSettings: AllAppSettings;
+}) => {
+  const [settings] = useState(appSettings);
+  return (
+    <AppSettingsContext.Provider value={{ settings, getAppSetting: () => {} }}>
+      {children}
+    </AppSettingsContext.Provider>
+  );
+};
+
+export const useAppSettings = () => {
+  const { settings } = useContext(AppSettingsContext);
+  return {
+    getAppSetting: (internalId: string) => {
+      if (!Array.isArray(settings)) {
+        logMessage.warn("Client tried to access an app setting but there were no settings loaded.");
+        return;
+      }
+      const setting = settings.filter((setting) => setting.internalId === internalId).pop();
+      return setting?.value;
+    },
+  };
+};


### PR DESCRIPTION
# Summary | Résumé

Adds an app settings provider and utility hook. Also updates hCaptcha to use the app setting provider to show it works.

A followup PR could be to replace other instances where prop drilling was used to get an app setting.
