### PR TITLE
fix: Start section title on Review page sometimes appears in English on French interface

### DIFF
--- a/components/clientComponents/forms/Review/ReviewList.tsx
+++ b/components/clientComponents/forms/Review/ReviewList.tsx
@@ -31,7 +31,7 @@ export const ReviewList = ({
           reviewItems.map((reviewItem) => {
             const title = reviewItem.id === "start" ? startSectionTitle : reviewItem.title;
             const editLink = renderEditButton
-              ? renderEditButton({ id: reviewItem.id, title: reviewItem.title, theme: "link" })
+              ? renderEditButton({ id: reviewItem.id, title: title, theme: "link" })
               : null;
 
             const editButton = renderEditButton


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where in some circumstances, the Start page title on the Review page would appear in English on the French interface.
