### PR TITLE
chore: Push the z-Index for tooltips up to the top, so they aren't cut off.

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/ToolTip.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/ToolTip.tsx
@@ -17,7 +17,7 @@ export const ToolTip = ({ children, text }: { children: React.ReactElement; text
       })}
       <span
         id={id}
-        className={`invisible z-[1000] absolute -left-14 -top-10 w-36 whitespace-nowrap rounded bg-gray-800 p-1 text-center text-sm text-white after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700 after:content-[''] peer-hover:visible peer-focus:visible`}
+        className={`invisible absolute -left-14 -top-10 z-[1000] w-36 whitespace-nowrap rounded bg-gray-800 p-1 text-center text-sm text-white after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700 after:content-[''] peer-hover:visible peer-focus:visible`}
       >
         {text}
       </span>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/ToolTip.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/ToolTip.tsx
@@ -17,7 +17,7 @@ export const ToolTip = ({ children, text }: { children: React.ReactElement; text
       })}
       <span
         id={id}
-        className={`invisible absolute -left-14 -top-10 w-36 whitespace-nowrap rounded bg-gray-800 p-1 text-center text-sm text-white after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700 after:content-[''] peer-hover:visible peer-focus:visible`}
+        className={`invisible ontop absolute -left-14 -top-10 w-36 whitespace-nowrap rounded bg-gray-800 p-1 text-center text-sm text-white after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700 after:content-[''] peer-hover:visible peer-focus:visible`}
       >
         {text}
       </span>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/ToolTip.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/lexical-editor/ToolTip.tsx
@@ -17,7 +17,7 @@ export const ToolTip = ({ children, text }: { children: React.ReactElement; text
       })}
       <span
         id={id}
-        className={`invisible ontop absolute -left-14 -top-10 w-36 whitespace-nowrap rounded bg-gray-800 p-1 text-center text-sm text-white after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700 after:content-[''] peer-hover:visible peer-focus:visible`}
+        className={`invisible z-[1000] absolute -left-14 -top-10 w-36 whitespace-nowrap rounded bg-gray-800 p-1 text-center text-sm text-white after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray-700 after:content-[''] peer-hover:visible peer-focus:visible`}
       >
         {text}
       </span>

--- a/styles/_form-builder.scss
+++ b/styles/_form-builder.scss
@@ -378,3 +378,7 @@
 .flow-container {
   height: calc(100vh - 300px);
 }
+
+.ontop {
+  z-index: 1000;
+}

--- a/styles/_form-builder.scss
+++ b/styles/_form-builder.scss
@@ -378,7 +378,3 @@
 .flow-container {
   height: calc(100vh - 300px);
 }
-
-.ontop {
-  z-index: 1000;
-}


### PR DESCRIPTION
Closes #5197