### PR TITLE
fix: fix wrapping for share menu when no name

### DIFF
--- a/components/clientComponents/globals/Header/ShareDropdown.tsx
+++ b/components/clientComponents/globals/Header/ShareDropdown.tsx
@@ -62,10 +62,13 @@ export const ShareDropdown = () => {
                   "flex cursor-pointer items-center rounded-md p-2 text-sm outline-none hover:bg-gray-600 hover:text-white-default focus:bg-gray-600 focus:text-white-default [&_svg]:hover:fill-white [&_svg]:focus:fill-white"
                 }
               >
-                {t("share.missingName.message1")}
-                <span className="mx-1 underline">{t("share.missingName.message2")}</span>
-                {t("share.missingName.message3")}
-                <span className="sr-only">{t("share.missingName.message4")}</span>
+                <span>
+                  {t("share.missingName.message1")}
+                  <span className="mx-1 underline">{t("share.missingName.message2")}</span>
+
+                  {t("share.missingName.message3")}
+                  <span className="sr-only">{t("share.missingName.message4")}</span>
+                </span>
               </DropdownMenuPrimitive.Item>
             )}
 


### PR DESCRIPTION
# Summary | Résumé

Fixes https://github.com/cds-snc/platform-forms-client/issues/2783

Fixes share menu issue for `fr` when a form doesn't have a name.

<img width="636" alt="Screenshot 2025-03-11 at 2 59 07 PM" src="https://github.com/user-attachments/assets/20243a53-473b-4738-ab99-b0050ae2719b" />
