### PR TITLE
fix: Prevent submissions to closed forms

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
@@ -7,6 +7,9 @@ import { processFormData } from "./lib/processFormData";
 import { MissingFormDataError } from "./lib/exceptions";
 import { logMessage } from "@lib/logger";
 import { getPublicTemplateByID } from "@lib/templates";
+import { dateHasPast } from "@lib/utils";
+import { revalidatePath } from "next/cache";
+
 // import { validateResponses } from "@lib/validation/validation";
 
 // Public facing functions - they can be used by anyone who finds the associated server action identifer
@@ -23,6 +26,11 @@ export async function submitForm(
 
     if (!template) {
       throw new Error(`Could not find any form associated to identifier ${formId}`);
+    }
+
+    if (template.closingDate && dateHasPast(Date.parse(template.closingDate))) {
+      revalidatePath(`${language}/id/${formId}`);
+      return { id: formId, error: { name: "FormClosedError", message: "Form is closed" } };
     }
 
     // const validateResponsesResult = await validateResponses(values, template);


### PR DESCRIPTION
# Summary | Résumé

Forces a client side refresh using revalidatePath when submitForm is called on a form that has been closed.
This reloads the page which then correctly renders the form closed message.

Locally, there is a momentary flash of the form with the generic error before the page refreshes and displays the error. Will see how that appears live.