### PR TITLE
fix: extra space in Dockerfile CMD instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ COPY --from=base /src/.next/static ./.next/static
 
 EXPOSE 3000
 
-CMD ["node ", "server.js"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
# Summary | Résumé

- Removes extra space in Dockerfile CMD instruction