### PR TITLE
feat: rainbow lambda to write logs in existing Forms CloudWatch log group

### DIFF
--- a/.github/workflows/rainbow-deployment/action.yml
+++ b/.github/workflows/rainbow-deployment/action.yml
@@ -54,7 +54,8 @@ runs:
           --timeout 15 \
           --memory-size 2048 \
           --code ImageUri=${{ inputs.ecr-registry-uri }}/forms_app_legacy:${{ inputs.deployment-process-identifier }} \
-          --vpc-config SubnetIds=${{ inputs.forms-lambda-client-subnet-ids }},SecurityGroupIds=${{ inputs.forms-lambda-client-security-group-ids }} | jq -r ".FunctionArn")
+          --vpc-config SubnetIds=${{ inputs.forms-lambda-client-subnet-ids }},SecurityGroupIds=${{ inputs.forms-lambda-client-security-group-ids }} | jq -r ".FunctionArn") \
+          --logging-config LogFormat=Text,LogGroup=Forms
 
         aws lambda wait function-active --function-name rainbow-${{ inputs.deployment-process-identifier }}
 


### PR DESCRIPTION
# Summary | Résumé

- Redirects logs from Rainbow lambda functions to existing CloudWatch Forms log group