### PR TITLE
chore: re enable Rainbow deployment

### DIFF
--- a/.github/workflows/rainbow-deployment/action.yml
+++ b/.github/workflows/rainbow-deployment/action.yml
@@ -3,8 +3,6 @@ name: Rainbow deployment
 inputs:
   deployment-process-identifier:
     required: true
-  legacy-version-git-ref:
-    required: true
   ecr-registry-uri:
     required: true
   ecr-registry-form-viewer-repository-name:
@@ -27,12 +25,21 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Find latest release identifier
+      id: latest-release-identifier
+      shell: bash
+      run: |
+        latestReleaseIdentifier=$(aws ecr describe-images \
+          --repository-name ${{ inputs.ecr-registry-form-viewer-repository-name }} \
+          --query 'sort_by(imageDetails, &imagePushedAt)[-1]' | jq -r ".imageTags[0]")
+        echo "value=$latestReleaseIdentifier" >> $GITHUB_OUTPUT
+
     - name: Build Rainbow Lambda image
       shell: bash
       run: |
         docker build -t rainbow \
           -f Dockerfile.rainbow \
-          --build-arg BASE_IMAGE=${{ inputs.ecr-registry-uri }}/${{ inputs.ecr-registry-form-viewer-repository-name }}:${{ inputs.legacy-version-git-ref }} \
+          --build-arg BASE_IMAGE=${{ inputs.ecr-registry-uri }}/${{ inputs.ecr-registry-form-viewer-repository-name }}:${{ steps.latest-release-identifier.outputs.value }} \
           --build-arg COGNITO_APP_CLIENT_ID=${{ inputs.cognito-app-client-id }} \
           --build-arg COGNITO_USER_POOL_ID=${{ inputs.cognito-user-pool-id }} .
 
@@ -49,13 +56,13 @@ runs:
 
         lambdaArn=$(aws lambda create-function \
           --function-name rainbow-${{ inputs.deployment-process-identifier }} \
+          --logging-config LogFormat=Text,LogGroup=Forms \
           --package-type Image \
           --role ${{ inputs.forms-lambda-client-role-arn }} \
           --timeout 15 \
           --memory-size 2048 \
           --code ImageUri=${{ inputs.ecr-registry-uri }}/forms_app_legacy:${{ inputs.deployment-process-identifier }} \
-          --vpc-config SubnetIds=${{ inputs.forms-lambda-client-subnet-ids }},SecurityGroupIds=${{ inputs.forms-lambda-client-security-group-ids }} | jq -r ".FunctionArn") \
-          --logging-config LogFormat=Text,LogGroup=Forms
+          --vpc-config SubnetIds=${{ inputs.forms-lambda-client-subnet-ids }},SecurityGroupIds=${{ inputs.forms-lambda-client-security-group-ids }} | jq -r ".FunctionArn")
 
         aws lambda wait function-active --function-name rainbow-${{ inputs.deployment-process-identifier }}
 
@@ -79,7 +86,7 @@ runs:
 
         aws elbv2 create-rule \
           --listener-arn ${{ inputs.load-balancer-listener-arn }} \
-          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"http-header\",\"HttpHeaderConfig\":{\"HttpHeaderName\":\"x-deployment-id\",\"Values\":[\"${{ inputs.legacy-version-git-ref }}\"]}}]" \
+          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"http-header\",\"HttpHeaderConfig\":{\"HttpHeaderName\":\"x-deployment-id\",\"Values\":[\"${{ steps.latest-release-identifier.outputs.value }}\"]}}]" \
           --priority 1 \
           --actions Type=forward,TargetGroupArn=$targetGroupArn \
           --tags Key=Name,Value=rainbow-${{ inputs.deployment-process-identifier }} > /dev/null 2>&1

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -37,10 +37,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get second to last release commit identifier
-        id: get-second-to-last-release
-        run: echo "ref=$(git rev-parse @~)" >> $GITHUB_OUTPUT
-
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
@@ -52,20 +48,19 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
-      # - name: Rainbow deployment
-      #   uses: ./.github/workflows/rainbow-deployment
-      #   with:
-      #     deployment-process-identifier: ${{ github.sha }}
-      #     legacy-version-git-ref: ${{ steps.get-second-to-last-release.outputs.ref }}
-      #     ecr-registry-uri: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com
-      #     ecr-registry-form-viewer-repository-name: form_viewer_staging
-      #     cognito-app-client-id: ${{ secrets.STAGING_COGNITO_APP_CLIENT_ID }}
-      #     cognito-user-pool-id: ${{ secrets.STAGING_COGNITO_USER_POOL_ID }}
-      #     load-balancer-listener-arn: ${{ vars.STAGING_LOAD_BALANCER_LISTENER_ARN }}
-      #     forms-lambda-client-role-arn: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-lambda-client
-      #     forms-lambda-client-subnet-ids: ${{ secrets.FORMS_LAMBDA_CLIENT_SUBNET_IDS }}
-      #     forms-lambda-client-security-group-ids: ${{ secrets.FORMS_LAMBDA_CLIENT_SECURITY_GROUP_IDS }}
-      #     hostname: forms-staging.cdssandbox.xyz
+      - name: Rainbow deployment
+        uses: ./.github/workflows/rainbow-deployment
+        with:
+          deployment-process-identifier: ${{ github.sha }}
+          ecr-registry-uri: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com
+          ecr-registry-form-viewer-repository-name: form_viewer_staging
+          cognito-app-client-id: ${{ secrets.STAGING_COGNITO_APP_CLIENT_ID }}
+          cognito-user-pool-id: ${{ secrets.STAGING_COGNITO_USER_POOL_ID }}
+          load-balancer-listener-arn: ${{ vars.STAGING_LOAD_BALANCER_LISTENER_ARN }}
+          forms-lambda-client-role-arn: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/forms-lambda-client
+          forms-lambda-client-subnet-ids: ${{ secrets.FORMS_LAMBDA_CLIENT_SUBNET_IDS }}
+          forms-lambda-client-security-group-ids: ${{ secrets.FORMS_LAMBDA_CLIENT_SECURITY_GROUP_IDS }}
+          hostname: forms-staging.cdssandbox.xyz
 
       - name: Download Form Viewer task definition
         id: download-taskdef-form-viewer


### PR DESCRIPTION
# Summary | Résumé

- Re-enables Rainbow deployment
- Fixes issue with `--logging-config` command option that was misplaced
- Modifies the way we build we detect the latest release for which we need a Rainbow lambda