### PR TITLE
fix: rainbow deployment script should select ECR image identifier that comes just before the latest one

### DIFF
--- a/.github/workflows/rainbow-deployment/action.yml
+++ b/.github/workflows/rainbow-deployment/action.yml
@@ -31,7 +31,7 @@ runs:
       run: |
         latestReleaseIdentifier=$(aws ecr describe-images \
           --repository-name ${{ inputs.ecr-registry-form-viewer-repository-name }} \
-          --query 'sort_by(imageDetails, &imagePushedAt)[-1]' | jq -r ".imageTags[0]")
+          --query 'sort_by(imageDetails, &imagePushedAt)[-2]' | jq -r ".imageTags[0]")
         echo "value=$latestReleaseIdentifier" >> $GITHUB_OUTPUT
 
     - name: Build Rainbow Lambda image


### PR DESCRIPTION
# Summary | Résumé

- Fixes Rainbow deployment script to select ECR image identifier that comes just before the latest one