### PR TITLE
chore: Content tweaks (save progress etc.) 

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1307,14 +1307,14 @@
   "saveAndResume": {
     "savedErrorMessage": "There was an error saving your changes.",
     "savedSuccessMessage": "Your changes have been saved.",
-    "title": "Resume filling out the form later",
+    "title": "Enable saving answers",
     "toggleOn": "On",
     "toggleOff": "Off",
     "toggleDescription": {
-      "text1": "Enable saving answers in progress",
-      "text2": "Allow people to pause and resume the form later. With the option to save a copy of their answers so far on their device. These can then be uploaded into the form later."
+      "text1": "Resuming filling out a form in progress",
+      "text2": "Gives users the option to pause and finish filling out the form later. People filling out the form can get a copy of their answers filled in so far, as well as a copy of their answers once the form has been submitted."
     },
-    "a11yDescription": "Save progress and resume form later",
+    "a11yDescription": "Save progress and resume the form later",
     "saveButton": "Save"
   }
 }

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -444,7 +444,7 @@
   "formDeleteDialogTitleFailed": "Error",
   "formDownload": {
     "btnText": "What can I do with a form file?",
-    "description": "Keep a version of your form on your computer",
+    "description": "Keep a version of your form on your computer.",
     "dialog": {
       "downloadButtonText": "Download a copy",
       "message1": "Download a form file to share a draft form with others. Collaborators can upload the form file and view the progress that has been made.",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1307,12 +1307,12 @@
   "saveAndResume": {
     "savedErrorMessage": "Une erreur s'est produite lors de l'enregistrement de vos modifications.",
     "savedSuccessMessage": "Vos modifications ont été enregistrées.",
-    "title": "Reprendre le remplissage du formulaire",
+    "title": "Permettre la sauvegarde des réponses",
     "toggleOn": "Activé",
     "toggleOff": "Désactivé",
     "toggleDescription": {
-      "text1": "Permettre l'enregistrement des réponses en cours",
-      "text2": "Permettre aux personnes de prendre une pause et de reprendre le formulaire plus tard. Avec la possibilité d'enregistré une copie des réponses remplies jusqu’à présent sur leur appareil. Celles-ci peuvent être téléversées dans le formulaire plus tard."
+      "text1": "Reprendre le remplissage d'un formulaire en cours",
+      "text2": "Donne la possiblité aux utilisateur·rice·s de prendre une pause et de compléter le formulaire plus tard. Les personnes qui remplissent le formulaire peuvent obtenir une copie des réponses remplies jusqu’à présent, ainsi qu'une copie de leur réponses une fois le formulaire soumis."
     },
     "a11yDescription": "Enregistrer la progression et reprendre le formulaire plus tard",
     "saveButton": "Enregistrer"

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -444,7 +444,7 @@
   "formDeleteDialogTitleFailed": "Erreur",
   "formDownload": {
     "btnText": "Que puis-je faire avec un fichier de formulaire?",
-    "description": "Conservez une version du formulaire sur votre ordinateur",
+    "description": "Conservez une version du formulaire sur votre ordinateur.",
     "dialog": {
       "downloadButtonText": "Télécharger une copie",
       "message1": "Téléchargez un fichier de formulaire pour partager l’ébauche avec d'autres personnes. Les collaborateur·rice·s peuvent ainsi ouvrir le fichier dans Formulaires GC et visualiser les progrès réalisés.",


### PR DESCRIPTION
# This includes

- General cleanup
- Clarifying in settings that turning the feature on also includes allowing users to get a copy of their answers once the form is submitted