### PR TITLE
fix: detection of rainbow deployments with a priority greater than 2

### DIFF
--- a/.github/workflows/staging-rainbow-cleanup.yml
+++ b/.github/workflows/staging-rainbow-cleanup.yml
@@ -70,8 +70,8 @@ jobs:
             aws elbv2 describe-rules \
               --listener-arn ${{ env.LOAD_BALANCER_LISTENER_ARN }} \
               --no-paginate \
-              --query "Rules[?Priority > '${{ env.MAXIMUM_NUMBER_OF_RAINBOW_DEPLOYMENTS_TO_KEEP_ALIVE }}' && contains(Actions[0].ForwardConfig.TargetGroups[0].TargetGroupArn, 'rainbow')].RuleArn" \
-              | jq -r '.[]'
+              --query "Rules[?contains(Actions[0].ForwardConfig.TargetGroups[0].TargetGroupArn, 'rainbow')]" \
+              | jq -r '.[] | select(.Priority | tonumber > ${{ env.MAXIMUM_NUMBER_OF_RAINBOW_DEPLOYMENTS_TO_KEEP_ALIVE }}) | .RuleArn'
           ))
 
           if [ ${#arn_list[*]} -gt 0 ]; then


### PR DESCRIPTION
# Summary | Résumé

- Fixes detection of Rainbow deployments on scheduled cleanup