### PR TITLE
chore: Adds a comment with a link to the client error codes doc

### DIFF
--- a/lib/types/form-builder-types.ts
+++ b/lib/types/form-builder-types.ts
@@ -116,6 +116,8 @@ export interface CDSHTMLDialogElement extends HTMLElement {
   ): void;
 }
 
+// Add new error codes to this doc for visibility:
+// https://docs.google.com/document/d/1Za03rcuC9YUDtNXuNyHAwUi7wtp-vgVFxBx0Oy2JZz8
 export const FormServerErrorCodes = {
   BRANDING: "550",
   CLASSIFICATION: "551",


### PR DESCRIPTION
# Summary | Résumé

Adds a comment with a link to the client error codes doc. More info is in the [google doc](https://docs.google.com/document/d/1Za03rcuC9YUDtNXuNyHAwUi7wtp-vgVFxBx0Oy2JZz8/edit?tab=t.0).

If this approach becomes difficult to maintain in the future, instead of a google doc a script could also generate a README or similar. But since the main end user of the error code info will be support, a Google doc may be more accessible than a github link to a README.

