### PR TITLE
fix: missing translation in admin settings

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/FormOwnership.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/FormOwnership.tsx
@@ -75,7 +75,7 @@ export const FormOwnership = ({
   return (
     <>
       <div className="mb-10" data-testid="form-ownership">
-        <h2>{t("Manage ownership")}</h2>
+        <h2>{t("title")}</h2>
         {message && message}
         <p className="mb-4">{t("assignUsersToTemplate")}</p>
         <p className="mb-2 font-bold">{t("enterOwnersEmail")} </p>

--- a/i18n/translations/en/admin-forms.json
+++ b/i18n/translations/en/admin-forms.json
@@ -3,7 +3,7 @@
   "gotoResponses": "Go to responses",
   "draft": "Draft",
   "published": "Published",
-  "manageOwnerships": "Manage ownerships",
+  "manageOwnerships": "Manage ownership",
   "overdueResponses": "Overdue responses",
   "noForms": "No forms found",
   "deleteForm": "Delete form"

--- a/i18n/translations/fr/manage-form-access.json
+++ b/i18n/translations/fr/manage-form-access.json
@@ -23,7 +23,7 @@
   "inviteToForm": "Inviter à gérer les réponses",
   "loading": "Téléchargement...",
   "manageFormAccess": "Gérer l'accès",
-  "manageOwnership": "Gérer le propriétaire",
+  "manageOwnership": "Gérer les propriétaires",
   "mustBeAGovernmentAddress": "Ajoutez des collègues en utilisant leur adresse courriel individuelle, et non une boîte de réception partagée conformément à nos <a href='/fr/terms-of-use' target='_blank'>conditions d'utilisation</a>.",
   "next": "Continuer",
   "optionalMessage": "Message (optionnel)",


### PR DESCRIPTION
Fixes #5363 

EN: "Manage ownership"
FR: "Gérer les propriétaires"

https://gcdigital.slack.com/archives/C01GFD150MC/p1744030538019659