### PR TITLE
fix: Updates captcha fail page secondary title to H2

### DIFF
--- a/components/clientComponents/globals/FormCaptcha/CaptchaFail.tsx
+++ b/components/clientComponents/globals/FormCaptcha/CaptchaFail.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useTranslation } from "@i18n/client";
-import { GcdsH1 } from "@serverComponents/globals/GcdsH1";
 
 // Future TODO: add pause-resume logic and support flow.
 
@@ -9,7 +8,7 @@ export const CaptchaFail = () => {
   const { t } = useTranslation("captcha");
   return (
     <>
-      <GcdsH1 tabIndex={-1}>{t("title")}</GcdsH1>
+      <h2>{t("title")}</h2>
       <p>{t("helpOptions.title")}</p>
       <ul>
         <li>{t("helpOptions.item1")}</li>


### PR DESCRIPTION
# Summary | Résumé

Updates captcha fail page secondary title to H2

Previous
![Screenshot 2025-04-07 at 11 14 28 AM](https://github.com/user-attachments/assets/bf847002-97b4-4361-9d44-810088180515)

Updated
![Screenshot 2025-04-07 at 11 14 52 AM](https://github.com/user-attachments/assets/c2c54218-548e-4a47-85e8-ca5651e28ba8)

## Testing

Probably the easiest way would be to programmatically force the fail page to show in Forms.tsx