### PR TITLE
chore: adds debug info for the element id

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/conditionals/ConditionalIndicator.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/conditionals/ConditionalIndicator.tsx
@@ -28,8 +28,10 @@ const RuleIndicator = ({ choiceId }: { choiceId: string }) => {
   if (!indexes || !indexes[0]) return null;
   const itemId = indexes[0];
   const questionNumber = getQuestionNumber(elements[itemId], sortedElements);
+  // For debugging
+  const elementId = elements[itemId]?.id;
   return (
-    <div>
+    <div data-element-id={elementId}>
       <ConditionalIcon className="mr-2 mt-[-5px] inline-block" />
       <div className="inline-block p-2">
         {t("question")} {questionNumber}


### PR DESCRIPTION
# Summary | Résumé

Currently for a conditional element, the question id displayed in the form-builder ui is a little confusing. It stems back to when forms had questions listed by order, and that order index could be used to reference it. To help find the related element id (to reference the related element shown/hidden), a hidden debug data var was added.

Here is the related ticket:
https://cds-snc.freshdesk.com/a/tickets/22017

For example:

![Screenshot 2025-04-07 at 3 08 00 PM](https://github.com/user-attachments/assets/0dbaa2c0-e77c-4466-9ab6-0a2a90636dc2)



