### PR TITLE
fix: remove Redis disconnect function call (tentative fix)

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,13 +2,17 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     if (!process.env.REDIS_URL) {
       // eslint-disable-next-line no-console
-      console.log("No REDIS_URL environment variable found, skipping flags initialization and privilege cache flush");
+      console.log(
+        "No REDIS_URL environment variable found, skipping flags initialization and privilege cache flush"
+      );
       return;
     }
+
     // Initialize the feature flags when the app server is started
     await import("@lib/flags/initialization").then(async (m) => {
       m.initiateFlags();
     });
+
     // Flush the privilege cache for users when the app server is started
     // This ensures that if privileges were changed they take immediate global effect.
     await import("@lib/cache/privilegeCache").then(async (m) => {

--- a/lib/cache/privilegeCache.ts
+++ b/lib/cache/privilegeCache.ts
@@ -35,7 +35,7 @@ export const privilegeDelete = async (userID: string): Promise<void> => {
     const redis = await getRedisInstance();
 
     await redis.del(deleteParameter);
-    logMessage.debug(`Deleting Cached Privileges  for ${deleteParameter}`);
+    logMessage.debug(`Deleting cached privileges for ${deleteParameter}`);
   } catch (e) {
     logMessage.error(e as Error);
     throw new Error("Could not connect to cache");
@@ -61,9 +61,11 @@ export const flushValues = async () => {
   if (!cacheAvailable) return;
   try {
     const redis = await getRedisInstance();
+
     const stream = redis.scanStream({
       match: "auth:privileges:*",
     });
+
     stream.on("data", function (keys: string[]) {
       // `keys` is an array of strings representing key names
       if (keys.length) {
@@ -74,9 +76,10 @@ export const flushValues = async () => {
         pipeline.exec();
       }
     });
+
     return new Promise<void>((resolve) =>
       stream.on("end", () => {
-        logMessage.debug("Cached Privileges have been cleared");
+        logMessage.debug("Cached privileges have been cleared");
         resolve();
       })
     );

--- a/lib/flags/initialization.ts
+++ b/lib/flags/initialization.ts
@@ -37,17 +37,19 @@ const createFlag = async (key: string, value: boolean) => {
     .exec();
 };
 export const initiateFlags = async () => {
-  logMessage.info("Running flag initiation");
+  logMessage.info("Running flag initialization");
+
   if (process.env.APP_ENV === "test") {
-    logMessage.info("Application is TEST mode, skipping flag initialization");
+    logMessage.info("Application is in TEST mode, skipping flag initialization");
     return;
   }
-  const redis = await getRedisInstance();
 
   try {
     let currentFlags = await checkAll();
     const defaultFlags: { [key: string]: boolean } = initialFlags;
-    logMessage.info("Checking for Depreceated Flags");
+
+    logMessage.info("Checking for deprecated flags");
+
     const removeFlags = [];
     for (const key in currentFlags) {
       if (typeof defaultFlags[key] === "undefined" || defaultFlags[key] === null) {
@@ -62,7 +64,9 @@ export const initiateFlags = async () => {
     await Promise.all(removeFlags);
 
     currentFlags = await checkAll();
-    logMessage.info("Checking for New Flags");
+
+    logMessage.info("Checking for new flags");
+
     const addFlags = [];
     for (const key in initialFlags) {
       if (typeof currentFlags[key] === "undefined" || currentFlags[key] === null) {
@@ -77,7 +81,5 @@ export const initiateFlags = async () => {
     await Promise.all(addFlags);
   } catch (err) {
     logMessage.error(err);
-  } finally {
-    redis.disconnect();
   }
 };


### PR DESCRIPTION
# Summary | Résumé

- (tentative) Fixes production `Connection is closed` errors
  - Removes the "disconnect from Redis" function call
  
# Note

Not yet sure why we have not seen it before in Staging (probably because the traffic was not high enough) but since it happens in both the ECS task and Rainbow lambdas it must have something to do with the NextJS server being built in standalone mode + what we changed to be able to achieve this (aka flag initialization).

I was able to confirm that the error we keep getting in Production is thrown by the `ioredis` library that we use to interact with Redis.

Here is the specific code that produces those errors:

```

export declare const CONNECTION_CLOSED_ERROR_MSG = "Connection is closed.";

===

function close() {
        self.setStatus("end");
        self.flushQueue(new Error(utils_1.CONNECTION_CLOSED_ERROR_MSG));
    }

===

if (self.manuallyClosing) {
            self.manuallyClosing = false;
            debug("skip reconnecting since the connection is manually closed.");
            return close();
        }
```