### PR TITLE
fix: adds check for validation errors to submit button loader

### DIFF
--- a/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
+++ b/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
@@ -29,7 +29,8 @@ export const PrimaryFormButtons = ({
   getFormDelay: () => number;
   saveAndResumeEnabled?: boolean;
 }) => {
-  const validationError = Object.entries(props.errors).length > 0;
+  const submissionError =
+    Object.entries(props.errors).length > 0 || props.status === FormStatus.ERROR;
   return (
     <div className="flex">
       {isGroupsCheck && isShowReviewPage && (
@@ -57,7 +58,7 @@ export const PrimaryFormButtons = ({
                   getFormDelay={getFormDelay}
                   formID={formId}
                   formTitle={formTitle}
-                  validationError={validationError}
+                  submissionError={submissionError}
                 />
               </div>
             );
@@ -69,7 +70,7 @@ export const PrimaryFormButtons = ({
           getFormDelay={getFormDelay}
           formID={formId}
           formTitle={formTitle}
-          validationError={validationError}
+          submissionError={submissionError}
         />
       )}
     </div>

--- a/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
+++ b/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
@@ -29,6 +29,7 @@ export const PrimaryFormButtons = ({
   getFormDelay: () => number;
   saveAndResumeEnabled?: boolean;
 }) => {
+  const validationError = Object.entries(props.errors).length > 0;
   return (
     <div className="flex">
       {isGroupsCheck && isShowReviewPage && (
@@ -56,7 +57,7 @@ export const PrimaryFormButtons = ({
                   getFormDelay={getFormDelay}
                   formID={formId}
                   formTitle={formTitle}
-                  props={props}
+                  validationError={validationError}
                 />
               </div>
             );
@@ -68,7 +69,7 @@ export const PrimaryFormButtons = ({
           getFormDelay={getFormDelay}
           formID={formId}
           formTitle={formTitle}
-          props={props}
+          validationError={validationError}
         />
       )}
     </div>

--- a/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
+++ b/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
@@ -56,7 +56,7 @@ export const PrimaryFormButtons = ({
                   getFormDelay={getFormDelay}
                   formID={formId}
                   formTitle={formTitle}
-                  status={props.status}
+                  props={props}
                 />
               </div>
             );
@@ -68,7 +68,7 @@ export const PrimaryFormButtons = ({
           getFormDelay={getFormDelay}
           formID={formId}
           formTitle={formTitle}
-          status={props.status}
+          props={props}
         />
       )}
     </div>

--- a/components/clientComponents/forms/Form/SubmitButton.tsx
+++ b/components/clientComponents/forms/Form/SubmitButton.tsx
@@ -5,21 +5,20 @@ import { cn } from "@lib/utils";
 import { useTranslation } from "@i18n/client";
 import { logMessage } from "@lib/logger";
 import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
-import { InnerFormProps } from "./types";
 
 interface SubmitButtonProps {
   getFormDelay: () => number;
   formID: string;
   formTitle: string;
   disabled: boolean;
-  props: InnerFormProps;
+  validationError?: boolean;
 }
 export const SubmitButton: React.FC<SubmitButtonProps> = ({
   getFormDelay,
   formID,
   formTitle,
   disabled,
-  props,
+  validationError,
 }) => {
   const { t } = useTranslation();
   const [formTimerState, { startTimer, checkTimer, disableTimer }] = useFormTimer();
@@ -63,12 +62,11 @@ export const SubmitButton: React.FC<SubmitButtonProps> = ({
     }
   }, [checkTimer, formTimerState.remainingTime, formTimerEnabled]);
 
-  // Keeps loading in sync with the form validation state
   useEffect(() => {
-    if (props.errors) {
+    if (validationError) {
       setLoading(false);
     }
-  }, [props.errors]);
+  }, [validationError]);
 
   return (
     <>

--- a/components/clientComponents/forms/Form/SubmitButton.tsx
+++ b/components/clientComponents/forms/Form/SubmitButton.tsx
@@ -11,14 +11,14 @@ interface SubmitButtonProps {
   formID: string;
   formTitle: string;
   disabled: boolean;
-  validationError?: boolean;
+  submissionError?: boolean;
 }
 export const SubmitButton: React.FC<SubmitButtonProps> = ({
   getFormDelay,
   formID,
   formTitle,
   disabled,
-  validationError,
+  submissionError,
 }) => {
   const { t } = useTranslation();
   const [formTimerState, { startTimer, checkTimer, disableTimer }] = useFormTimer();
@@ -63,10 +63,10 @@ export const SubmitButton: React.FC<SubmitButtonProps> = ({
   }, [checkTimer, formTimerState.remainingTime, formTimerEnabled]);
 
   useEffect(() => {
-    if (validationError) {
+    if (submissionError) {
       setLoading(false);
     }
-  }, [validationError]);
+  }, [submissionError]);
 
   return (
     <>

--- a/components/clientComponents/forms/Form/SubmitButton.tsx
+++ b/components/clientComponents/forms/Form/SubmitButton.tsx
@@ -5,29 +5,29 @@ import { cn } from "@lib/utils";
 import { useTranslation } from "@i18n/client";
 import { logMessage } from "@lib/logger";
 import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
+import { InnerFormProps } from "./types";
 
 interface SubmitButtonProps {
   getFormDelay: () => number;
   formID: string;
   formTitle: string;
   disabled: boolean;
-  status?: string;
+  props: InnerFormProps;
 }
 export const SubmitButton: React.FC<SubmitButtonProps> = ({
   getFormDelay,
   formID,
   formTitle,
   disabled,
-  status,
+  props,
 }) => {
   const { t } = useTranslation();
   const [formTimerState, { startTimer, checkTimer, disableTimer }] = useFormTimer();
   const [submitTooEarly, setSubmitTooEarly] = useState(false);
   const screenReaderRemainingTime = useRef(formTimerState.remainingTime);
   const formDelay = useRef(getFormDelay());
-
-  // Used to show a spinner for the initial hCAPTCHA verification step
-  const [submitting, setSubmitting] = useState(false);
+  // Used to show a spinner for the initial validation and hCAPTCHA loading steps
+  const [loading, setLoading] = useState(false);
 
   const { getFlag } = useFeatureFlags();
   const timerEnabled = getFlag("formTimer");
@@ -62,6 +62,13 @@ export const SubmitButton: React.FC<SubmitButtonProps> = ({
       };
     }
   }, [checkTimer, formTimerState.remainingTime, formTimerEnabled]);
+
+  // Keeps loading in sync with the form validation state
+  useEffect(() => {
+    if (props.errors) {
+      setLoading(false);
+    }
+  }, [props.errors]);
 
   return (
     <>
@@ -120,10 +127,9 @@ export const SubmitButton: React.FC<SubmitButtonProps> = ({
           }
           // Only change state if submitTooEarly is already set to true
           submitTooEarly && setSubmitTooEarly(false);
-
-          setSubmitting(true);
+          setLoading(true);
         }}
-        loading={submitting && status !== "Error"}
+        loading={loading}
       >
         {t("submitButton")}
       </Button>


### PR DESCRIPTION
# Summary | Résumé

Currently when on a single page form with a required question, the loader would spin indefinitely. The form could still be submitted and this only impacted single page forms.
The fix adds check for validation errors to submit button spinner.

## Test

1. Open a single page form with at least one required field. 
2. Fill in no fields and submit the form. The submit button should be in the original state (not spinning).
3. Fill in the required fields and submit the form. The submit button should show a spinner while loading. (using dev tools network throttling helps with this step)

Example single page form:
https://5qrq7fxzeuwjq55z2co2lfu4bq0qedxt.lambda-url.ca-central-1.on.aws/en/id/cm9cvyajz0000l40c9138xgn8

https://github.com/user-attachments/assets/77feccc4-c37a-4ad7-82be-5c4846442fcd


Example multi page form:
https://5qrq7fxzeuwjq55z2co2lfu4bq0qedxt.lambda-url.ca-central-1.on.aws/en/id/cm9cvzvbl0000l70bs8siu4cx


https://github.com/user-attachments/assets/e9f806f5-ae9e-4efd-855b-64f0b179ec69


