### PR TITLE
chore: version # updates

### DIFF
--- a/components/clientComponents/globals/Footer.tsx
+++ b/components/clientComponents/globals/Footer.tsx
@@ -64,13 +64,19 @@ export const Footer = ({
         <div>
           {!isSplashPage && (
             <>
-              <nav aria-label={t("footer.ariaLabel")}>
+              <nav aria-label={t("footer.ariaLabel")} className="inline-block">
                 {displayFormBuilderFooter ? <FormBuilderLinks /> : <DefaultLinks />}
               </nav>
-              <Version label={t("version")} />
+
+              <Version
+                isFormBuilder={displayFormBuilderFooter ? true : false}
+                label={t("version")}
+              />
             </>
           )}
-          {isSplashPage && <Version label={t("version")} />}
+          {isSplashPage && (
+            <Version isFormBuilder={displayFormBuilderFooter ? true : false} label={t("version")} />
+          )}
         </div>
 
         {!disableGcBranding && (

--- a/components/serverComponents/globals/Footer.tsx
+++ b/components/serverComponents/globals/Footer.tsx
@@ -66,10 +66,15 @@ export const Footer = async ({
               <nav aria-label={t("footer.ariaLabel")}>
                 {displayFormBuilderFooter ? <FormBuilderLinks /> : <DefaultLinks />}
               </nav>
-              <Version label={t("version")} />
+              <Version
+                isFormBuilder={displayFormBuilderFooter ? true : false}
+                label={t("version")}
+              />
             </>
           )}
-          {isSplashPage && <Version label={t("version")} />}
+          {isSplashPage && (
+            <Version isFormBuilder={displayFormBuilderFooter ? true : false} label={t("version")} />
+          )}
         </div>
         {!disableGcBranding && (
           <div className="min-w-[168px]">

--- a/components/serverComponents/globals/Version.tsx
+++ b/components/serverComponents/globals/Version.tsx
@@ -1,12 +1,18 @@
 import packageJson from "../../../package.json";
+import { cn } from "@lib/utils";
 
 const deploymentId = process.env.NEXT_DEPLOYMENT_ID || "local";
 
-export const Version = ({ label }: { label: string }) => {
+export const Version = ({ label, isFormBuilder }: { label: string; isFormBuilder: boolean }) => {
   const { version } = packageJson;
 
   return (
-    <div className="mt-2 text-sm text-slate-800">
+    <div
+      className={cn(
+        isFormBuilder && "mt-2 text-sm text-slate-800",
+        !isFormBuilder && " text-sm text-slate-800 inline-block mr-10"
+      )}
+    >
       {label}: {version} <span className="hidden"> - {deploymentId}</span>
     </div>
   );

--- a/components/serverComponents/globals/Version.tsx
+++ b/components/serverComponents/globals/Version.tsx
@@ -2,7 +2,7 @@ import packageJson from "../../../package.json";
 
 const deploymentId = process.env.NEXT_DEPLOYMENT_ID || "local";
 
-export const Version = async ({ label }: { label: string }) => {
+export const Version = ({ label }: { label: string }) => {
   const { version } = packageJson;
 
   return (


### PR DESCRIPTION
# Summary | Résumé

- Removes `async` from version --- not needed.
- Updates style when version is on a front facing form

For front facing -- single line
<img width="480" alt="Screenshot 2025-04-14 at 11 23 54 AM" src="https://github.com/user-attachments/assets/64663ed9-2b86-4fe0-88ec-88200fffcff2" />

