### PR TITLE
chore: update markdown to jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.set": "4.3.2",
     "lodash.unset": "4.5.2",
-    "markdown-to-jsx": "7.5.0",
+    "markdown-to-jsx": "7.7.4",
     "next": "15.3.0",
     "next-auth": "5.0.0-beta.25",
     "node-fetch": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12710,7 +12710,7 @@ __metadata:
     lodash.merge: "npm:^4.6.2"
     lodash.set: "npm:4.3.2"
     lodash.unset: "npm:4.5.2"
-    markdown-to-jsx: "npm:7.5.0"
+    markdown-to-jsx: "npm:7.7.4"
     next: "npm:15.3.0"
     next-auth: "npm:5.0.0-beta.25"
     node-fetch: "npm:^3.3.2"
@@ -15163,12 +15163,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx@npm:7.5.0":
-  version: 7.5.0
-  resolution: "markdown-to-jsx@npm:7.5.0"
+"markdown-to-jsx@npm:7.7.4":
+  version: 7.7.4
+  resolution: "markdown-to-jsx@npm:7.7.4"
   peerDependencies:
     react: ">= 0.14.0"
-  checksum: 10c0/88213e64afd41d6934fbb70bcea0e2ef1f9553db1ba4c6f423b17d6e9c2b99c82b0fcbed29036dd5b91704b170803d1fae730ab40ae27af5c7994e2717686ebc
+  checksum: 10c0/692323e3cb5573ecce5f1f40c3b1a8d67bca40f2b4907ec266c23e7dffa2dcab466f738ea6569f8a5e6234ddcdccacbfeeb97b5e2f647b94bf29fa441f0083be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary | Résumé

Package update for markdown to jsx

https://github.com/quantizor/markdown-to-jsx/releases