### PR TITLE
chore: Add prop to RichTextEditor to enable maxLength

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -143,6 +143,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
       {/* Form Intro + Title Panel */}
       {groupId === "start" && (
         <RichTextLocked
+          maxLength={20000}
           hydrated={hasHydrated}
           className="rounded-t-lg"
           summaryText={t("startFormIntro")}
@@ -181,6 +182,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
       {/* Privacy Panel */}
       {groupId === "start" && (
         <RichTextLocked
+          maxLength={50000}
           beforeContent={<PrivacyDescriptionBefore />}
           summaryText={t("groups.privacy.summary")}
           detailsText={
@@ -209,6 +211,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
       {/* Confirmation*/}
       {groupId === "end" && (
         <RichTextLocked
+          maxLength={20000}
           summaryText={t("groups.confirmation.summary")}
           beforeContent={
             <div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/RichTextEditor.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/RichTextEditor.tsx
@@ -16,12 +16,14 @@ export const RichTextEditor = ({
   lang,
   ariaLabel,
   ariaDescribedBy,
+  maxLength,
 }: {
   path: string;
   content: string;
   lang: Language;
   ariaLabel?: string;
   ariaDescribedBy?: string;
+  maxLength?: number;
 }) => {
   const { updateField, getLocalizationAttribute } = useTemplateStore((s) => ({
     updateField: s.updateField,
@@ -52,6 +54,7 @@ export const RichTextEditor = ({
         ariaLabel={ariaLabel || t("richTextEditor")}
         ariaDescribedBy={ariaDescribedBy}
         className="gc-formview gc-richText"
+        maxLength={maxLength}
         {...getLocalizationAttribute()}
       />
     </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/RichTextLocked.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/RichTextLocked.tsx
@@ -20,6 +20,7 @@ export const RichTextLocked = ({
   ariaLabel,
   className,
   hydrated,
+  maxLength,
 }: {
   beforeContent?: React.ReactElement | null;
   summaryText: string;
@@ -30,6 +31,7 @@ export const RichTextLocked = ({
   ariaLabel?: string;
   className?: string;
   hydrated?: boolean;
+  maxLength?: number;
 }) => {
   const { localizeField, form, translationLanguagePriority } = useTemplateStore((s) => ({
     localizeField: s.localizeField,
@@ -68,6 +70,7 @@ export const RichTextLocked = ({
                 content={content}
                 lang={translationLanguagePriority}
                 ariaLabel={ariaLabel}
+                maxLength={maxLength}
               />
             </div>
           )}


### PR DESCRIPTION
# Summary | Résumé

The new Editor component has a prop called maxLength. This just adds it to the RichTextEditor wrapping component so it can be set and passed through.
