### PR TITLE
chore: Set contentLength/maxLength indicator threshold for display

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Only show contentLength/maxLength indicator when contentLength reaches 80% of maxLength
 
-## [1.0.0] - 2025-04-77
+## [1.0.0] - 2025-04-17
 
 ### Changed
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2025-04-07
+## [1.0.1] - 2025-04-17
+
+### Changed
+
+- Only show contentLength/maxLength indicator when contentLength reaches 80% of maxLength
+
+## [1.0.0] - 2025-04-77
 
 ### Changed
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -128,13 +128,9 @@ export const Editor = ({
                 />
               </>
             )}
-            {maxLength && (
+            {maxLength && contentLength >= 0.8 * maxLength && (
               <div className="gc-editor-max-length">
-                {maxLength && (
-                  <>
-                    {contentLength}/{maxLength}
-                  </>
-                )}
+                {contentLength}/{maxLength}
               </div>
             )}
           </div>

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -59,7 +59,6 @@ export const Editor = ({
 
   const [floatingAnchorElem, setFloatingAnchorElem] = useState<HTMLDivElement | null>(null);
   const [isLinkEditMode, setIsLinkEditMode] = useState<boolean>(false);
-  const [contentLength, setContentLength] = useState<number>(0);
 
   const randomId = useId();
   const editorId = id || `editor-${randomId}`;
@@ -116,9 +115,7 @@ export const Editor = ({
             <LinkPlugin />
             <TabControlPlugin />
             <ListMaxIndentLevelPlugin maxDepth={5} />
-            {maxLength && (
-              <MaxLengthPlugin maxLength={maxLength} setContentLength={setContentLength} />
-            )}
+
             {floatingAnchorElem && (
               <>
                 <FloatingLinkEditorPlugin
@@ -128,10 +125,10 @@ export const Editor = ({
                 />
               </>
             )}
-            {maxLength && contentLength >= 0.8 * maxLength && (
-              <div className="gc-editor-max-length">
-                {contentLength}/{maxLength}
-              </div>
+            {maxLength && (
+              <>
+                <MaxLengthPlugin maxLength={maxLength} />
+              </>
             )}
           </div>
         </LexicalComposer>

--- a/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
+++ b/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
@@ -25,6 +25,7 @@ const MaxLengthIndicator = ({
   }
 
   return (
+    // Only show if contentLength reaches 80% of maxLength
     contentLength >= 0.8 * maxLength && (
       <div className="gc-editor-max-length">
         {contentLength}/{maxLength}

--- a/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
+++ b/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
@@ -10,16 +10,32 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { $trimTextContentFromAnchor } from "@lexical/selection";
 import { $restoreEditorState } from "@lexical/utils";
 import { $getSelection, $isRangeSelection, EditorState, RootNode } from "lexical";
-import { useEffect } from "react";
+import { JSX, useEffect, useState } from "react";
+import "./styles.css";
 
-export function MaxLengthPlugin({
+const MaxLengthIndicator = ({
   maxLength,
-  setContentLength,
+  contentLength,
 }: {
-  maxLength: number;
-  setContentLength: (length: number) => void;
-}): null {
+  maxLength?: number;
+  contentLength: number;
+}) => {
+  if (!maxLength) {
+    return null;
+  }
+  return (
+    maxLength &&
+    contentLength >= 0.8 * maxLength && (
+      <div className="gc-editor-max-length">
+        {contentLength}/{maxLength}
+      </div>
+    )
+  );
+};
+
+export function MaxLengthPlugin({ maxLength }: { maxLength: number }): JSX.Element {
   const [editor] = useLexicalComposerContext();
+  const [contentLength, setContentLength] = useState(0);
 
   useEffect(() => {
     let lastRestoredEditorState: EditorState | null = null;
@@ -52,5 +68,5 @@ export function MaxLengthPlugin({
     });
   }, [editor, maxLength, setContentLength]);
 
-  return null;
+  return <MaxLengthIndicator contentLength={contentLength} maxLength={maxLength} />;
 }

--- a/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
+++ b/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
@@ -23,8 +23,8 @@ const MaxLengthIndicator = ({
   if (!maxLength) {
     return null;
   }
+
   return (
-    maxLength &&
     contentLength >= 0.8 * maxLength && (
       <div className="gc-editor-max-length">
         {contentLength}/{maxLength}

--- a/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
+++ b/packages/editor/src/plugins/MaxLengthPlugin/index.tsx
@@ -28,7 +28,7 @@ const MaxLengthIndicator = ({
     // Only show if contentLength reaches 80% of maxLength
     contentLength >= 0.8 * maxLength && (
       <div className="gc-editor-max-length">
-        {contentLength}/{maxLength}
+        {contentLength >= maxLength ? maxLength : contentLength}/{maxLength}
       </div>
     )
   );

--- a/packages/editor/src/plugins/MaxLengthPlugin/styles.css
+++ b/packages/editor/src/plugins/MaxLengthPlugin/styles.css
@@ -1,0 +1,7 @@
+.gc-editor-max-length {
+  position: absolute;
+  bottom: 0;
+  right: 8px;
+  font-size: 0.8rem;
+  color: #999;
+}

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -1,11 +1,3 @@
 .gc-editor-container {
   position: relative;
 }
-
-.gc-editor-max-length {
-  position: absolute;
-  bottom: 0;
-  right: 8px;
-  font-size: 0.8rem;
-  color: #999;
-}


### PR DESCRIPTION
# Summary | Résumé

Only show the contentLength/maxLength indicator when contentLength reaches 80% of maxLength
