### PR TITLE
chore: hide date modified on confirmation page

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
@@ -79,6 +79,7 @@ export const FormWrapper = ({
   if (submissionId && submissionDate) {
     return (
       <div className="gc-form-wrapper">
+        <style dangerouslySetInnerHTML={{ __html: `.gc-date-modified { display: none; }` }} />
         <TextPage formId={formRecord.id} formRecord={formRecord} />
         {saveAndResume && (
           <ToastContainer limit={1} autoClose={5000} containerId="public-facing-form" />
@@ -130,6 +131,7 @@ export const FormWrapper = ({
       >
         {currentForm}
       </Form>
+
       {saveAndResume && (
         <ToastContainer limit={1} autoClose={false} containerId="public-facing-form" />
       )}

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/page.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/page.tsx
@@ -104,6 +104,7 @@ export default async function Page(props0: {
   // Note: We can look to remove this route in the future
   // With save and resume enabled we will re-render the form vs have a confirmation page route
   if (step === "confirmation") {
+    dateModified = false;
     pageContent = (
       <div className={classes}>
         <TextPage formId={formId} formRecord={formRecord} />

--- a/components/clientComponents/globals/DateModified.tsx
+++ b/components/clientComponents/globals/DateModified.tsx
@@ -12,7 +12,7 @@ export const DateModified = ({ updatedAt }: { updatedAt: string | undefined }) =
   formattedDate = date.toISOString().slice(0, 10);
 
   return (
-    <div className="mt-10">
+    <div className="gc-date-modified mt-10">
       {t("dateModified")}: {formattedDate}
     </div>
   );


### PR DESCRIPTION
# Summary | Résumé

Adds CSS to hide date modified on confirmation screen 