### PR TITLE
fix: fixes issue with permissions and notifications toggling

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/FormOwnerSettings.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/FormOwnerSettings.tsx
@@ -15,7 +15,6 @@ interface FormOwnerSettingsProps {
 
 export const FormOwnerSettings = ({
   id,
-  formRecord,
   canSetClosingDate,
   closedDetails,
 }: FormOwnerSettingsProps) => {
@@ -23,12 +22,7 @@ export const FormOwnerSettings = ({
     <>
       {canSetClosingDate && <SetClosingDate formId={id} closedDetails={closedDetails} />}
       <SetSaveAndResume formId={id} />
-      <Notifications
-        formId={id}
-        notificationsInterval={formRecord?.notificationsInterval}
-        disabled={formRecord?.deliveryOption !== undefined}
-        off={formRecord?.deliveryOption !== undefined}
-      />
+      <Notifications formId={id} />
       <DownloadForm />
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/notifications/Notifications.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/notifications/Notifications.tsx
@@ -6,19 +6,16 @@ import { NotificationsToggle } from "./NotificationsToggle";
 import { Button } from "@clientComponents/globals";
 import { toast } from "@formBuilder/components/shared/Toast";
 import { ga } from "@lib/client/clientHelpers";
+import { useTemplateStore } from "@lib/store/useTemplateStore";
+import { isVaultDelivery } from "@lib/utils/form-builder";
 
-export const Notifications = ({
-  formId,
-  notificationsInterval,
-  disabled = false,
-  off = false,
-}: {
-  formId: string;
-  notificationsInterval: NotificationsInterval | undefined;
-  disabled?: boolean;
-  off?: boolean;
-}) => {
+export const Notifications = ({ formId }: { formId: string }) => {
   const { t } = useTranslation("form-builder");
+  const { notificationsInterval, getDeliveryOption } = useTemplateStore((s) => ({
+    notificationsInterval: s.notificationsInterval,
+    getDeliveryOption: s.getDeliveryOption,
+  }));
+  const isVault = isVaultDelivery(getDeliveryOption());
   const [notificationValue, setNotificationValue] = useState<string>(
     notificationsInterval ? String(notificationsInterval) : String(NotificationsInterval.OFF)
   );
@@ -73,19 +70,21 @@ export const Notifications = ({
       <p className="mb-8">{t("settings.notifications.description2")}</p>
       <div className="mb-4">
         <NotificationsToggle
-          isChecked={!off && notificationValue === String(NotificationsInterval.DAY) ? true : false}
+          isChecked={
+            isVault && notificationValue === String(NotificationsInterval.DAY) ? true : false
+          }
           toggleChecked={toggleChecked}
           onLabel={t("settings.notifications.options.off")}
           offLabel={t("settings.notifications.options.on")}
           description={t("settings.notifications.optionsDescription")}
-          disabled={disabled}
+          disabled={!isVault}
         />
       </div>
       <Button
         dataTestId="form-notifications-save"
         theme="secondary"
         onClick={saveNotificationsValue}
-        disabled={disabled}
+        disabled={!isVault}
       >
         {t("settings.notifications.save")}
       </Button>


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue with permissions and notifications toggling. Previously a user with less permissions would not see the notifications UI. Now they should.
Also when going from email to vault delivery and back again will reflect the correct notifications toggle state. Previously when going email to vault delivery the toggle notifications toggle would not update to on.