### PR TITLE
chore: adds invcanada as a valid gov email

### DIFF
--- a/lib/tests/validation/validation.test.js
+++ b/lib/tests/validation/validation.test.js
@@ -469,6 +469,7 @@ describe("Gov Email domain validator", () => {
     ["test+example@cds-snc.ca", true],
     ["test.hi+example-1@cds-snc.ca", true],
     ["test.with'apostrophe@cds-snc.ca", true],
+    ["test@invcanada.ca", true],
   ])(`Should return true if email is valid (testing "%s")`, async (email, isValid) => {
     expect(isValidGovEmail(email)).toBe(isValid);
   });

--- a/lib/validation/validation.tsx
+++ b/lib/validation/validation.tsx
@@ -470,7 +470,7 @@ export const setFocusOnErrorMessage = (props: FormikProps<Responses>, errorId: s
  */
 export const isValidGovEmail = (email: string): boolean => {
   const regex =
-    /^([a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+(\+[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]*)?)@((?:[a-zA-Z0-9-.]+\.gc\.ca|cds-snc\.freshdesk\.com)|(canada|cds-snc|elections|rcafinnovation|canadacouncil|nfb|debates-debats)\.ca)$/;
+    /^([a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+(\+[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]*)?)@((?:[a-zA-Z0-9-.]+\.gc\.ca|cds-snc\.freshdesk\.com)|(canada|cds-snc|elections|rcafinnovation|canadacouncil|nfb|debates-debats|invcanada)\.ca)$/;
   return regex.test(email);
 };
 


### PR DESCRIPTION
# Summary | Résumé

Adds invcanada.ca as a valid gov email to the signup flow. [Support Slack Thread](https://gcdigital.slack.com/archives/C03T4FAE9FV/p1747412034849619)

# Test

Adding a test account with invcanada.ca should pass the signup validation.

![Screenshot 2025-05-16 at 1 42 39 PM](https://github.com/user-attachments/assets/edf2adfc-be06-4e85-a00d-ec97e20c1b69)

