### PR TITLE
fix: Rainbow deployment add new lb rule for non actions

### DIFF
--- a/.github/workflows/rainbow-deployment/action.yml
+++ b/.github/workflows/rainbow-deployment/action.yml
@@ -104,3 +104,10 @@ runs:
           --priority 1 \
           --actions Type=forward,TargetGroupArn=$target_group_arn \
           --tags Key=Name,Value=rainbow-${{ inputs.deployment-identifier }} > /dev/null 2>&1
+
+        aws elbv2 create-rule \
+          --listener-arn ${{ inputs.load-balancer-listener-arn }} \
+          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"query-string\",\"QueryStringConfig\":{\"Values\":[{\"Key\":\"dpl\",\"Value\":\"${{ steps.latest-release-identifier.outputs.value }}\"}]}}]" \
+          --priority 2 \
+          --actions Type=forward,TargetGroupArn=$target_group_arn \
+          --tags Key=Name,Value=rainbow-${{ inputs.deployment-identifier }} > /dev/null 2>&1

--- a/scripts/bump-load-balancer-listener-rainbow-rules-priority.sh
+++ b/scripts/bump-load-balancer-listener-rainbow-rules-priority.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 LISTENER_ARN=$1
 
 rules_priority_to_bump=""
-priority_number=2
+priority_number=3
 
 rules=$(aws elbv2 describe-rules \
   --listener-arn $LISTENER_ARN \

--- a/scripts/clean-up-rainbow-deployment.sh
+++ b/scripts/clean-up-rainbow-deployment.sh
@@ -13,13 +13,14 @@ existing_load_balancer_listener_rules=$(
   aws elbv2 describe-rules \
     --listener-arn $LISTENER_ARN \
     --no-paginate \
-    --query "Rules[?contains(Actions[0].ForwardConfig.TargetGroups[0].TargetGroupArn, '/rainbow-$shorter_deployment_identifier/')].RuleArn" \
-    | jq -r ".[0]"
+    --query "Rules[?contains(Actions[0].ForwardConfig.TargetGroups[0].TargetGroupArn, '/rainbows-$shorter_deployment_identifier/')].RuleArn" \
+    | jq -r ".[]"
 )
 
-if [ "$existing_load_balancer_listener_rules" != "null" ]; then
-  aws elbv2 delete-rule --rule-arn $existing_load_balancer_listener_rules > /dev/null 2>&1
-fi
+
+for rule_arn in $existing_load_balancer_listener_rules; do
+ aws elbv2 delete-rule --rule-arn $rule_arn > /dev/null 2>&1
+done
 
 last_command_output=$(
   aws elbv2 describe-target-groups --names rainbow-$shorter_deployment_identifier 2>/dev/null || echo "null"
@@ -35,3 +36,4 @@ aws lambda delete-function --function-name rainbow-$DEPLOYMENT_IDENTIFIER > /dev
 aws ecr batch-delete-image \
   --repository-name forms_app_legacy \
   --image-ids imageTag=$DEPLOYMENT_IDENTIFIER > /dev/null 2>&1
+


### PR DESCRIPTION
# Summary | Résumé
![Screenshot 2025-05-23 at 10 35 32 AM](https://github.com/user-attachments/assets/06a23cdc-65b7-4060-aaff-9ac0155056b6)

Ensures that all application assets that do not have a `x-deployment-id` header also get routed to the same legacy instance that the resources can be found on.  This was not done originally as the assumption was that the local client copy of JS package would detect the drift and cause a full refresh on next navigation.  Unfortunately this was found not to be the case.  As we continue to explore ways to provide a more meaningful user experience after version launches this PR should ensure a user never gets a broken app.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Need to find a way to let the user know that a new version is available and replace the JS bundle.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [ ] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
