### PR TITLE
fix: Addding textField sometimes adds Number field

### DIFF
--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -37,7 +37,11 @@ export const useHandleAdd = () => {
   const groupId = useGroupStore((state) => state.id);
 
   const create = useCallback(async (type: FormElementTypes) => {
-    const defaults = { ...defaultField, uuid: uuid() };
+    const defaults = {
+      ...defaultField,
+      uuid: uuid(),
+      properties: { ...defaultField.properties, validation: { required: false } },
+    };
 
     const labels = await getTranslatedElementProperties(type);
     const descriptionEn = labels.description.en;


### PR DESCRIPTION
# Summary | Résumé

Weird bug. Try this on the main branch:
- Start a new form
- Add a Number input
- Add a Short Answer

The Short Answer inherits the validation rule of the Number input, and now every time you add a Short Answer you end up with a Number input instead.

- Reload your browser
- Add a Short Answer

The Short Answer gets added fine now.

This PR fixes that weird bug.