### PR TITLE
chore: handle file mis-match issues for save progress 

### DIFF
--- a/components/clientComponents/forms/ResumeForm/ErrorLoading.tsx
+++ b/components/clientComponents/forms/ResumeForm/ErrorLoading.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "@i18n/client";
+import { WarningIcon } from "@serverComponents/icons";
+
+export const ErrorLoading = ({ errorCode }: { errorCode?: string }) => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation(["form-builder", "common"]);
+
+  const title = t("saveAndResume.problemLoadingAnswers.title", {
+    lng: language,
+    ns: "common",
+  });
+
+  const message = t("saveAndResume.problemLoadingAnswers.description", {
+    lng: language,
+    ns: "common",
+  });
+
+  return (
+    <div className="w-full">
+      <h3 className="!mb-0 pb-2 text-xl font-semibold">
+        <WarningIcon className="mr-1 mt-[-4] inline-block size-8 fill-red-800" /> {title}
+      </h3>
+      <p className="mb-2 text-black">{message} </p>
+      <p className="mb-5 text-sm text-black">
+        {errorCode && t("saveAndResume.problemLoadingAnswers.errorCode", { code: errorCode })}
+      </p>
+    </div>
+  );
+};

--- a/components/clientComponents/forms/ResumeForm/Upload.tsx
+++ b/components/clientComponents/forms/ResumeForm/Upload.tsx
@@ -8,6 +8,7 @@ import { toast } from "@formBuilder/components/shared/Toast";
 import { FormServerErrorCodes } from "@lib/types/form-builder-types";
 import { safeJSONParse } from "@lib/utils";
 import { ErrorResuming } from "./ErrorResuming";
+import { ErrorLoading } from "./ErrorLoading";
 import { useLogClient } from "@lib/hooks/LogClient/useLogClient";
 import { ResumeUploadIcon } from "@serverComponents/icons/ResumeUploadIcon";
 
@@ -121,6 +122,20 @@ export const Upload = ({ formId }: { formId: string }) => {
         router.push(`/${language}/id/${id}`);
       } catch (e) {
         const timestamp = Date.now();
+
+        if (
+          errorCode === FormServerErrorCodes.FORM_RESUME_INVALID_MISMATCHED_FORM_ID ||
+          errorCode === FormServerErrorCodes.FORM_RESUME_NO_TARGET ||
+          errorCode === FormServerErrorCodes.FORM_RESUME_NO_DATA ||
+          errorCode === FormServerErrorCodes.FORM_RESUME_NO_ELEMENT ||
+          errorCode === FormServerErrorCodes.FORM_RESUME_NO_FORM_ELEMENT_DATA
+        ) {
+          // Do not log these errors as they are expected in some cases
+          // (e.g. user uploads a file with a different form ID or wrong file).
+          toast.error(<ErrorLoading errorCode={`${errorCode}-${timestamp}`} />, "resume");
+          return;
+        }
+
         logClientError({ code: errorCode as FormServerErrorCodes, formId, timestamp });
         toast.error(<ErrorResuming errorCode={`${errorCode}-${timestamp}`} />, "resume");
       }

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -238,6 +238,11 @@
       "description": "Try uploading the file again or restart a new form and copy-paste your answers from the file.",
       "errorCode": "Error code: {{code}}"
     },
+    "problemLoadingAnswers": {
+      "title": "Problem loading answers from file",
+      "description": "Make sure you're selecting the right file. Try uploading again, or restart a new form and copy-paste your answers from your file.",
+      "errorCode": "Error code: {{code}}"
+    },
     "resumePage": {
       "upload": {
         "title": "Load your answers",

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -238,6 +238,11 @@
       "description": "Essayez de téléverser à nouveau le fichier ou recommencez un nouveau formulaire et copiez-collez vos réponses du fichier.",
       "errorCode": "Code d'erreur : {{code}}"
     },
+    "problemLoadingAnswers": {
+      "title": "Problème de téléversement du fichier",
+      "description": "Vérifiez que vous avez sélectionné le bon fichier. Essayez de téléverser à nouveau, ou recommencez un nouveau formulaire et copiez-collez vos réponses à partir de votre fichier.",
+      "errorCode": "Error code: {{code}}"
+    },
     "resumePage": {
       "upload": {
         "title": "Téléversez vos réponses",


### PR DESCRIPTION
# Summary | Résumé

Adds a more specific error message for mis-matched files.

Fixes: https://github.com/cds-snc/platform-forms-client/issues/5479

<img width="500" alt="Screenshot 2025-06-03 at 8 43 27 AM" src="https://github.com/user-attachments/assets/af9c4d90-0f1d-458b-9fe8-5735c76c203f" />


Covers 

```
FR-01
FR-02
FR-03
FR-04
```
```
FR-07
```
