### PR TITLE
fix: testing possible fix for Rainbow cleanup Github action failing while still succeeding

### DIFF
--- a/.github/workflows/prod-rainbow-cleanup.yml
+++ b/.github/workflows/prod-rainbow-cleanup.yml
@@ -89,6 +89,7 @@ jobs:
     needs: cleanup-schedule-1
     if: ${{ needs.cleanup-schedule-1.outputs.ids != '' }}
     strategy:
+      max-parallel: 1
       matrix:
         deployment-identifier: ${{ fromJSON(needs.cleanup-schedule-1.outputs.ids) }}
     steps:

--- a/.github/workflows/staging-rainbow-cleanup.yml
+++ b/.github/workflows/staging-rainbow-cleanup.yml
@@ -89,6 +89,7 @@ jobs:
     needs: cleanup-schedule-1
     if: ${{ needs.cleanup-schedule-1.outputs.ids != '' }}
     strategy:
+      max-parallel: 1
       matrix:
         deployment-identifier: ${{ fromJSON(needs.cleanup-schedule-1.outputs.ids) }}
     steps:


### PR DESCRIPTION
# Summary | Résumé

- Limits the number of parallel jobs executed when cleaning up Rainbow resources to 1 to try to resolve the issue we started to see since introducing two new load balancer rules per new deployment.

Note: even though the Github action fails the Rainbow resources have disappeared from AWS so it is like it still succeeded. See https://github.com/cds-snc/platform-forms-client/actions/runs/15433312567