### PR TITLE
fix: Cancelling a file upload shows a dev tools a11y warning

### DIFF
--- a/components/clientComponents/forms/FileInput/FileInput.tsx
+++ b/components/clientComponents/forms/FileInput/FileInput.tsx
@@ -155,13 +155,13 @@ export const FileInput = (props: FileInputProps): React.ReactElement => {
               )}: ${fileName}`}</span>
               <span aria-hidden={true}>
                 {fileName} ({(fileSize / 1024 / 1024).toFixed(2)} {t("input-validation.MB")}){" "}
-                <Button theme="link" className="ml-3 [&_svg]:focus:fill-white" onClick={resetInput}>
-                  <div className="group ml-1 p-2 pr-3">
-                    <CancelIcon className="inline-block" />
-                    <span className="ml-1 inline-block group-hover:underline">{t("cancel")}</span>
-                  </div>
-                </Button>
               </span>
+              <Button theme="link" className="ml-3 [&_svg]:focus:fill-white" onClick={resetInput}>
+                <div className="group ml-1 p-2 pr-3">
+                  <CancelIcon className="inline-block" />
+                  <span className="ml-1 inline-block group-hover:underline">{t("cancel")}</span>
+                </div>
+              </Button>
             </>
           ) : (
             t("file-upload-no-file-selected")


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/5649

<img width="1478" alt="451376517-912241d2-80d2-4b0e-8338-6028ce9e06aa" src="https://github.com/user-attachments/assets/c0059ea1-10ee-4c04-8a70-e2263ca88346" />


Moves cancel button out of hidden span tag.