### PR TITLE
chore: differentiate between timeouts and other type of errors when no Axios response is available in our GC Notify connector

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/connectors",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/connectors/src/gc-notify-connector.ts
+++ b/packages/connectors/src/gc-notify-connector.ts
@@ -1,5 +1,5 @@
 import { getAwsSecret } from "./getAwsSecret";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 const API_URL: string = "https://api.notification.canada.ca";
 
@@ -57,6 +57,7 @@ export class GCNotifyConnector {
       });
     } catch (error) {
       let errorMessage = "";
+
       if (axios.isAxiosError(error)) {
         if (error.response) {
           /*
@@ -73,7 +74,14 @@ export class GCNotifyConnector {
            * is an instance of XMLHttpRequest in the browser and an instance
            * of http.ClientRequest in Node.js
            */
-          errorMessage = `Request timed out`;
+
+          if (error.code === AxiosError.ECONNABORTED) {
+            errorMessage = `Request timed out`;
+          } else {
+            errorMessage = `Error code: ${error.code ?? "n/a"} / Error stack: ${
+              error.stack ?? "n/a"
+            }`;
+          }
         }
       } else if (error instanceof Error) {
         errorMessage = `${(error as Error).message}`;


### PR DESCRIPTION
# Summary | Résumé

- Adds a way to differentiate between timeouts and other type of errors when no Axios response is available once we have sent a request to GC Notify. This is a change included in the GC Notify connector package.

Note: even though we followed some documentation from Axios (https://axios-http.com/docs/handling_errors). There is only one true way of making sure we have a proper timeout (in the sense of the API not responding within the expected interval).