### PR TITLE
fix: Trim trailing/leading whitespace from passwords

### DIFF
--- a/app/(gcforms)/[locale]/(user authentication)/auth/login/actions.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/login/actions.ts
@@ -144,6 +144,7 @@ const validate = async (
       v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
     ]),
     password: v.string([
+      v.toTrimmed(),
       v.minLength(1, t("input-validation.required", { ns: "common" })),
       v.maxLength(50, t("fields.password.errors.maxLength")),
     ]),

--- a/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/register/action.ts
@@ -135,6 +135,7 @@ const validate = async (
         v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
       ]),
       password: v.string([
+        v.toTrimmed(),
         v.minLength(1, t("input-validation.required", { ns: "common" })),
         v.minLength(8, t("account.fields.password.error.minLength", { ns: "common" })),
         v.maxLength(50, t("account.fields.password.error.maxLength", { ns: "common" })),
@@ -156,6 +157,7 @@ const validate = async (
         ),
       ]),
       passwordConfirmation: v.string([
+        v.toTrimmed(),
         v.minLength(1, t("input-validation.required", { ns: "common" })),
       ]),
     },

--- a/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
+++ b/app/(gcforms)/[locale]/(user authentication)/auth/reset-password/[[...token]]/action.ts
@@ -266,6 +266,7 @@ const validatePasswordResetForm = async (
         v.custom((input) => isValidGovEmail(input), t("input-validation.validGovEmail")),
       ]),
       password: v.string([
+        v.toTrimmed(),
         v.minLength(8, t("account.fields.password.error.minLength", { ns: "common" })),
         v.maxLength(50, t("account.fields.password.error.maxLength", { ns: "common" })),
         v.custom(
@@ -286,6 +287,7 @@ const validatePasswordResetForm = async (
         ),
       ]),
       passwordConfirmation: v.string([
+        v.toTrimmed(),
         v.minLength(1, t("input-validation.required", { ns: "common" })),
       ]),
     },


### PR DESCRIPTION
# Summary | Résumé

Fixes #5635 

Cognito does not allow trailing or leading spaces in passwords. If a user accidentally includes a space (for example while copying a password from a text document), Cognito will error and we don't handle it. Details in the issue linked above.

Since trailing/leading spaces are not allowed, we should just trim them when sending passwords to Cognito on Sign in, Register, Password reset.
