### PR TITLE
chore: Add search to accounts page

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/client/FilterButton.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/client/FilterButton.tsx
@@ -16,7 +16,7 @@ export const FilterButton = ({
   return (
     <RoundedButton
       theme={active ? "primary" : "secondary"}
-      className=""
+      className="flex min-w-[100px] justify-center"
       onClick={() => {
         router.push(url);
       }}

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/client/UserSearch.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/client/UserSearch.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export const UserSearch = () => {
+  const { t } = useTranslation("admin-users");
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Get the current query from the URL
+  const currentQuery = searchParams.get("query") || "";
+  const [searchTerm, setSearchTerm] = useState(currentQuery);
+
+  // Debounce the search to avoid too many URL updates
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchTerm === currentQuery) return;
+
+      // Create new URLSearchParams
+      const params = new URLSearchParams(searchParams);
+
+      // Update or delete the query parameter
+      if (searchTerm) {
+        params.set("query", searchTerm);
+      } else {
+        params.delete("query");
+      }
+
+      // Keep the active/deactivated filter if it exists
+      const filter = searchParams.get("filter");
+      if (filter) {
+        params.set("filter", filter);
+      }
+
+      // Update the URL with the new search params
+      router.replace(`${pathname}?${params.toString()}`);
+    }, 300); // 300ms debounce
+
+    return () => clearTimeout(timer);
+  }, [searchTerm, currentQuery, router, pathname, searchParams]);
+
+  return (
+    <div className="mb-4 w-2/3 max-w-2xl">
+      <label htmlFor="user-search" className="mb-2 block font-bold">
+        {t("search.label")}
+      </label>
+      <input
+        id="user-search"
+        type="text"
+        className="w-full rounded-md border-2 border-slate-700 p-2"
+        placeholder={t("search.placeholder")}
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        aria-label={t("search.ariaLabel")}
+      />
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/NavigationFrame.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/NavigationFrame.tsx
@@ -20,7 +20,7 @@ export const NavigtationFrame = async ({
 
   return (
     <>
-      <div className="mb-5">
+      <div className="my-5">
         <ul
           id="accountsFilterList"
           className="flex list-none px-0 text-base"

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UsersList.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UsersList.tsx
@@ -1,12 +1,13 @@
 import { UserCard } from "./UserCard";
 import { authCheckAndThrow } from "@lib/actions";
 import { serverTranslation } from "@i18n";
-import { Card } from "@serverComponents/globals/card/Card";
 import { ScrollHelper } from "../client/ScrollHelper";
+import { UserSearch } from "../client/UserSearch";
 import { authorization, getPrivilege } from "@lib/privileges";
 import { getUsers } from "@lib/users";
+import Fuse from "fuse.js";
 
-export const UsersList = async ({ filter }: { filter?: string }) => {
+export const UsersList = async ({ filter, query }: { filter?: string; query?: string }) => {
   const { ability } = await authCheckAndThrow();
 
   const canManageUser = await authorization
@@ -24,16 +25,38 @@ export const UsersList = async ({ filter }: { filter?: string }) => {
 
   if (!publishFormsId) throw new Error("No publish forms privilege found in global privileges.");
 
+  // Fetch users with filter
   const users = await getUsers(filter ? { active: filter === "active" } : undefined);
+
+  // Apply fuzzy search if query exists - we can fine tune these as needed
+  let filteredUsers = users;
+  if (query && query.trim() !== "") {
+    const fuse = new Fuse(users, {
+      keys: [
+        { name: "name", weight: 2 },
+        { name: "email", weight: 1.5 },
+      ],
+      threshold: 0.3, // Lower threshold for more accurate matches
+      distance: 100, // Allow matching terms that are further apart
+      ignoreLocation: true, // Match anywhere in the string
+      minMatchCharLength: 3,
+      shouldSort: true, // Sort results by score
+      useExtendedSearch: true, // see: https://www.fusejs.io/examples.html#extended-search
+    });
+
+    filteredUsers = fuse.search(query).map((result) => result.item);
+  }
 
   const { t } = await serverTranslation("admin-users");
 
   return (
     <div aria-live="polite">
       <ScrollHelper />
-      {users?.length > 0 ? (
+      <UserSearch />
+
+      {filteredUsers?.length > 0 ? (
         <ul data-testid="accountsList" className="m-0 list-none p-0">
-          {users?.map((user) => {
+          {filteredUsers?.map((user) => {
             return (
               <li
                 className="mb-4 flex max-w-2xl flex-row rounded-md border-2 border-black p-2"
@@ -53,13 +76,13 @@ export const UsersList = async ({ filter }: { filter?: string }) => {
           })}
         </ul>
       ) : (
-        <Card>
-          <p className="text-[#748094]">
-            {filter === "active"
-              ? t("accountsFilter.noActiveAccounts")
-              : t("accountsFilter.noDeactivatedAccounts")}
-          </p>
-        </Card>
+        <p className="text-lg font-semibold">
+          {query
+            ? t("search.noResults")
+            : filter === "active"
+            ? t("accountsFilter.noActiveAccounts")
+            : t("accountsFilter.noDeactivatedAccounts")}
+        </p>
       )}
     </div>
   );

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UsersList.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/components/server/UsersList.tsx
@@ -39,7 +39,7 @@ export const UsersList = async ({ filter, query }: { filter?: string; query?: st
       threshold: 0.3, // Lower threshold for more accurate matches
       distance: 100, // Allow matching terms that are further apart
       ignoreLocation: true, // Match anywhere in the string
-      minMatchCharLength: 3,
+      minMatchCharLength: 2,
       shouldSort: true, // Sort results by score
       useExtendedSearch: true, // see: https://www.fusejs.io/examples.html#extended-search
     });

--- a/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(with nav)/accounts/page.tsx
@@ -24,7 +24,8 @@ export async function generateMetadata(props: {
 export default AuthenticatedPage(
   [authorization.canViewAllUsers, authorization.canAccessPrivileges],
   async ({ params, searchParams }) => {
-    const { userState } = await searchParams;
+    const resolvedSearchParams = await searchParams;
+    const { userState } = resolvedSearchParams;
 
     if (Array.isArray(userState)) {
       throw new Error("Invalid user state, expected a string and received an array");
@@ -34,12 +35,14 @@ export default AuthenticatedPage(
 
     const { t } = await serverTranslation("admin-users", { lang: locale });
 
+    const query = resolvedSearchParams.query?.toString() || "";
+
     return (
       <>
         <h1 className="mb-0 border-0">{t("accounts")}</h1>
         <NavigtationFrame userState={userState}>
           <Suspense key={userState} fallback={<Loader />}>
-            <UsersList filter={userState} />
+            <UsersList filter={userState} query={query.trim()} />
           </Suspense>
         </NavigtationFrame>
       </>

--- a/i18n/translations/en/admin-users.json
+++ b/i18n/translations/en/admin-users.json
@@ -58,5 +58,11 @@
   "userAdministration": "User administration",
   "error": {
     "permissions": "Failed to update permissions."
+  },
+  "search": {
+    "label": "Search",
+    "placeholder": "Search by name or email address",
+    "noResults": "No results found",
+    "ariaLabel": "Search accounts by name or email address"
   }
 }

--- a/i18n/translations/fr/admin-users.json
+++ b/i18n/translations/fr/admin-users.json
@@ -58,5 +58,11 @@
   "userAdministration": "Administration des l’utilisateurs",
   "error": {
     "permissions": "Les autorisations n'ont pas pu être mises à jour."
+  },
+  "search": {
+    "label": "Search [FR]",
+    "placeholder": "Search by name or email address [FR]",
+    "noResults": "No results found [FR]",
+    "ariaLabel": "Search accounts by name or email address [FR]"
   }
 }

--- a/i18n/translations/fr/admin-users.json
+++ b/i18n/translations/fr/admin-users.json
@@ -60,9 +60,9 @@
     "permissions": "Les autorisations n'ont pas pu être mises à jour."
   },
   "search": {
-    "label": "Search [FR]",
-    "placeholder": "Search by name or email address [FR]",
-    "noResults": "No results found [FR]",
-    "ariaLabel": "Search accounts by name or email address [FR]"
+    "label": "Recherche",
+    "placeholder": "Rechercher par nom ou adresse courriel",
+    "noResults": "Aucun résultat trouvé",
+    "ariaLabel": "Recherche de comptes par nom ou par adresse courriel"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "downshift": "^8.3.1",
     "file-type": "^21.0.0",
     "formik": "2.4.6",
+    "fuse.js": "^7.1.0",
     "got": "11",
     "htmlparser2": "8.0.2",
     "i18next": "^23.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12409,6 +12409,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "fuse.js@npm:7.1.0"
+  checksum: 10c0/c0d1b1d192a4bdf3eade897453ddd28aff96b70bf3e49161a45880f9845ebaee97265595db633776700a5bcf8942223c752754a848d70c508c3c9fd997faad1e
+  languageName: node
+  linkType: hard
+
 "gcforms@workspace:.":
   version: 0.0.0-use.local
   resolution: "gcforms@workspace:."
@@ -12494,6 +12501,7 @@ __metadata:
     eslint-plugin-tailwindcss: "npm:^3.17.5"
     file-type: "npm:^21.0.0"
     formik: "npm:2.4.6"
+    fuse.js: "npm:^7.1.0"
     got: "npm:11"
     htmlparser2: "npm:8.0.2"
     husky: "npm:^9.0.10"


### PR DESCRIPTION
# Summary | Résumé

Adds search to accounts page

Note: This also handles extended search i.e. or queries see https://www.fusejs.io/examples.html#extended-search

<img width="765" alt="Screenshot 2025-06-13 at 7 34 52 AM" src="https://github.com/user-attachments/assets/d85458b6-9bd3-4147-8954-5dcaadcaa2e0" />

Also fixed up the filter nav styling

**Before:**
<img width="358" alt="Screenshot 2025-06-13 at 7 35 32 AM" src="https://github.com/user-attachments/assets/d3dd8b26-e4e6-4a85-83a1-cc7c42959c51" />


