### PR TITLE
chore: fix initial form id for element dialog upload link

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/FileInput.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/FileInput.tsx
@@ -19,7 +19,9 @@ export const FileInput = ({ title }: { title: string }) => {
     translationLanguagePriority: s.translationLanguagePriority,
   }));
 
-  const link = `/${translationLanguagePriority}/form-builder/${id}/settings`;
+  const formId = id || "0000";
+
+  const link = `/${translationLanguagePriority}/form-builder/${formId}/settings`;
 
   return hasApiKeyId ? (
     <WithApiDescription title={title} />


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where id can be empty and in turn breaks the settings link.