### PR TITLE
fix:  alert heading margin

### DIFF
--- a/app/(gcforms)/[locale]/(user authentication)/components/client/forms/Alert.tsx
+++ b/app/(gcforms)/[locale]/(user authentication)/components/client/forms/Alert.tsx
@@ -80,7 +80,7 @@ export const Alert = ({
         </Button>
       ) : null}
       <div className="gc-alert__body">
-        {heading && <h2>{heading}</h2>}
+        {heading && <h2 className="!mt-0">{heading}</h2>}
         {children && (validation ? children : <div className="gc-alert__text">{children}</div>)}
       </div>
       {cta && <div>{cta}</div>}

--- a/components/clientComponents/forms/Alert/Alert.tsx
+++ b/components/clientComponents/forms/Alert/Alert.tsx
@@ -80,7 +80,7 @@ export const Alert = ({
         </Button>
       ) : null}
       <div className="gc-alert__body">
-        {heading && <h2>{heading}</h2>}
+        {heading && <h2 className="!mt-0">{heading}</h2>}
         {children && (validation ? children : <div className="gc-alert__text">{children}</div>)}
       </div>
       {cta && <div>{cta}</div>}


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/5662

Remove top margin for alerts

<img width="932" alt="Screenshot 2025-06-16 at 8 50 12 AM" src="https://github.com/user-attachments/assets/9bbd03c5-fff9-41f3-862e-f7c6b08b0241" />
