### PR TITLE
chore: Add exit page url to translate page

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/ExitUrl.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/ExitUrl.tsx
@@ -5,6 +5,8 @@ import { Language } from "@lib/types/form-builder-types";
 import { LanguageLabel } from "@formBuilder/components/shared/LanguageLabel";
 import { useGroupStore } from "@formBuilder/components/shared/right-panel/treeview/store/useGroupStore";
 import { LocalizedElementProperties } from "@lib/types/form-builder-types";
+import { FieldsetLegend } from "./FieldsetLegend";
+import { useTranslation } from "@i18n/client";
 
 import { type Group } from "@lib/formContext";
 
@@ -22,6 +24,7 @@ const FieldInput = ({ groupId, val, lang }: { groupId: string; val: string; lang
         aria-describedby={`element-${groupId}-choice-en-language`}
         type="text"
         value={val}
+        placeholder={"https://"}
         onChange={(e) => {
           setExitButtonUrl({ id: groupId, locale: lang, url: e.target.value });
         }}
@@ -45,18 +48,22 @@ export const ExitUrl = ({
   const localizeField = useTemplateStore((s) => s.localizeField);
   const fieldPrimary = localizeField(field, primaryLanguage);
   const fieldSecondary = localizeField(field, secondaryLanguage);
+  const { t } = useTranslation("form-builder");
 
   return (
     <>
       <div>
-        <div className="mb-10 flex gap-px divide-x-2 border-y border-r border-gray-300">
-          <FieldInput groupId={groupId} val={group[fieldPrimary] || ""} lang={primaryLanguage} />
-          <FieldInput
-            groupId={groupId}
-            val={group[fieldSecondary] || ""}
-            lang={secondaryLanguage}
-          />
-        </div>
+        <fieldset>
+          <FieldsetLegend>{t("logic.exitUrl.label")}</FieldsetLegend>
+          <div className="mb-10 flex gap-px divide-x-2 border-y border-r border-gray-300">
+            <FieldInput groupId={groupId} val={group[fieldPrimary] || ""} lang={primaryLanguage} />
+            <FieldInput
+              groupId={groupId}
+              val={group[fieldSecondary] || ""}
+              lang={secondaryLanguage}
+            />
+          </div>
+        </fieldset>
       </div>
     </>
   );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/ExitUrl.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/ExitUrl.tsx
@@ -13,15 +13,18 @@ import { type Group } from "@lib/formContext";
 const FieldInput = ({ groupId, val, lang }: { groupId: string; val: string; lang: Language }) => {
   const setExitButtonUrl = useGroupStore((state) => state.setExitButtonUrl);
 
+  const elementId = `element-${groupId}-text-${lang}`;
+
   return (
-    <>
-      <LanguageLabel id={`element-${groupId}-en-language`} lang={lang}>
+    <div className="relative w-1/2 flex-1">
+      <LanguageLabel id={`${elementId}-description`} lang={lang}>
         <>{lang}</>
       </LanguageLabel>
+
       <input
         className="w-full p-4"
-        id={`element-${groupId}-text-${lang}`}
-        aria-describedby={`element-${groupId}-choice-en-language`}
+        id={elementId}
+        aria-describedby={`${elementId}-description`}
         type="text"
         value={val}
         placeholder={"https://"}
@@ -29,7 +32,7 @@ const FieldInput = ({ groupId, val, lang }: { groupId: string; val: string; lang
           setExitButtonUrl({ id: groupId, locale: lang, url: e.target.value });
         }}
       />
-    </>
+    </div>
   );
 };
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/ExitUrl.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/ExitUrl.tsx
@@ -1,0 +1,63 @@
+"use client";
+import React from "react";
+import { useTemplateStore } from "@lib/store/useTemplateStore";
+import { Language } from "@lib/types/form-builder-types";
+import { LanguageLabel } from "@formBuilder/components/shared/LanguageLabel";
+import { useGroupStore } from "@formBuilder/components/shared/right-panel/treeview/store/useGroupStore";
+import { LocalizedElementProperties } from "@lib/types/form-builder-types";
+
+import { type Group } from "@lib/formContext";
+
+const FieldInput = ({ groupId, val, lang }: { groupId: string; val: string; lang: Language }) => {
+  const setExitButtonUrl = useGroupStore((state) => state.setExitButtonUrl);
+
+  return (
+    <>
+      <LanguageLabel id={`element-${groupId}-en-language`} lang={lang}>
+        <>{lang}</>
+      </LanguageLabel>
+      <input
+        className="w-full p-4"
+        id={`element-${groupId}-text-${lang}`}
+        aria-describedby={`element-${groupId}-choice-en-language`}
+        type="text"
+        value={val}
+        onChange={(e) => {
+          setExitButtonUrl({ id: groupId, locale: lang, url: e.target.value });
+        }}
+      />
+    </>
+  );
+};
+
+export const ExitUrl = ({
+  groupId,
+  group,
+  primaryLanguage,
+}: {
+  groupId: string;
+  group: Group;
+  primaryLanguage: Language;
+}) => {
+  const secondaryLanguage = primaryLanguage === "en" ? "fr" : "en";
+
+  const field = LocalizedElementProperties.EXIT_URL;
+  const localizeField = useTemplateStore((s) => s.localizeField);
+  const fieldPrimary = localizeField(field, primaryLanguage);
+  const fieldSecondary = localizeField(field, secondaryLanguage);
+
+  return (
+    <>
+      <div>
+        <div className="mb-10 flex gap-px divide-x-2 border-y border-r border-gray-300">
+          <FieldInput groupId={groupId} val={group[fieldPrimary] || ""} lang={primaryLanguage} />
+          <FieldInput
+            groupId={groupId}
+            val={group[fieldSecondary] || ""}
+            lang={secondaryLanguage}
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -431,6 +431,10 @@ export const TranslateWithGroups = () => {
             Object.keys(groups).map((groupKey) => {
               const thisGroup = groups[groupKey];
               const groupName = thisGroup.name;
+
+              const nextAction = groups[groupKey]?.nextAction;
+              const isExitPage = nextAction === "exit" ? true : false;
+
               if (groupKey == "review" || groupKey == "end" || groupKey == "start") return null;
               return (
                 <div key={groupKey}>
@@ -445,8 +449,7 @@ export const TranslateWithGroups = () => {
                     secondaryLanguage={secondaryLanguage}
                   />
 
-                  {/* EXIT URL */}
-                  {thisGroup.exitUrlEn || thisGroup.exitUrlFr ? (
+                  {isExitPage ? (
                     <ExitUrl
                       groupId={groupKey}
                       group={thisGroup}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -24,6 +24,8 @@ import { sortGroup } from "@lib/utils/form-builder/groupedFormHelpers";
 import { Group } from "@lib/formContext";
 import { TranslateCustomizeSet } from "./TranslateCustomizeSet";
 
+import { ExitUrl } from "./ExitUrl";
+
 const GroupSection = ({
   groupId,
   group,
@@ -435,6 +437,14 @@ export const TranslateWithGroups = () => {
                   <SectionTitle>
                     {t("logic.pageTitle")} <em>{groupName}</em>
                   </SectionTitle>
+                  {/* EXIT URL */}
+                  {thisGroup.exitUrlEn || thisGroup.exitUrlFr ? (
+                    <ExitUrl
+                      groupId={groupKey}
+                      group={thisGroup}
+                      primaryLanguage={primaryLanguage}
+                    />
+                  ) : null}
                   <GroupSection
                     group={thisGroup}
                     groupId={groupKey}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/translate/components/TranslateWithGroups.tsx
@@ -437,6 +437,14 @@ export const TranslateWithGroups = () => {
                   <SectionTitle>
                     {t("logic.pageTitle")} <em>{groupName}</em>
                   </SectionTitle>
+
+                  <GroupSection
+                    group={thisGroup}
+                    groupId={groupKey}
+                    primaryLanguage={primaryLanguage}
+                    secondaryLanguage={secondaryLanguage}
+                  />
+
                   {/* EXIT URL */}
                   {thisGroup.exitUrlEn || thisGroup.exitUrlFr ? (
                     <ExitUrl
@@ -445,12 +453,7 @@ export const TranslateWithGroups = () => {
                       primaryLanguage={primaryLanguage}
                     />
                   ) : null}
-                  <GroupSection
-                    group={thisGroup}
-                    groupId={groupKey}
-                    primaryLanguage={primaryLanguage}
-                    secondaryLanguage={secondaryLanguage}
-                  />
+
                   {sortGroup({ form, group: thisGroup }).map((element, index) => {
                     return (
                       <div className="section" id={`section-${index}`} key={element.id}>

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1245,7 +1245,7 @@
       "buttonLabel": "Customize the button destination by copy-pasting a more relevant link below:"
     },
     "exitUrl": {
-      "label": "Exit Url"
+      "label": "Exit button URL link"
     },
     "noPages": {
       "text1": "Add a <strong>New page</strong> from the",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1245,7 +1245,7 @@
       "buttonLabel": "Customize the button destination by copy-pasting a more relevant link below:"
     },
     "exitUrl": {
-      "label": "Exit URL"
+      "label": "Exit Url"
     },
     "noPages": {
       "text1": "Add a <strong>New page</strong> from the",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1244,6 +1244,9 @@
       "buttonDescription": "An exit button takes people to the organization website corresponding to the branding of the form.",
       "buttonLabel": "Customize the button destination by copy-pasting a more relevant link below:"
     },
+    "exitUrl": {
+      "label": "Exit URL"
+    },
     "noPages": {
       "text1": "Add a <strong>New page</strong> from the",
       "text2": "Pages tab",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1245,7 +1245,7 @@
       "buttonLabel": "Personnalisez la destination du bouton en copiant-collant un lien plus pertinent ci-dessous :"
     },
     "exitUrl": {
-      "label": "Exit Url [FR]"
+      "label": "Lien URL pour le bouton de sortie"
     },
     "noPages": {
       "text1": "Ajoutez une <strong>Nouvelle page</strong> dans",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1245,7 +1245,7 @@
       "buttonLabel": "Personnalisez la destination du bouton en copiant-collant un lien plus pertinent ci-dessous :"
     },
     "exitUrl": {
-      "label": "Exit URL [FR]"
+      "label": "Exit Url [FR]"
     },
     "noPages": {
       "text1": "Ajoutez une <strong>Nouvelle page</strong> dans",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1244,6 +1244,9 @@
       "buttonDescription": "Un bouton de sortie renvoie les personnes vers le site Web de l'organisation correspondant à l'image de marque du formulaire.",
       "buttonLabel": "Personnalisez la destination du bouton en copiant-collant un lien plus pertinent ci-dessous :"
     },
+    "exitUrl": {
+      "label": "Exit URL [FR]"
+    },
     "noPages": {
       "text1": "Ajoutez une <strong>Nouvelle page</strong> dans",
       "text2": "l'onglet Pages",

--- a/lib/types/form-builder-types.ts
+++ b/lib/types/form-builder-types.ts
@@ -38,6 +38,7 @@ export enum LocalizedElementProperties {
   TITLE = "title",
   DESCRIPTION = "description",
   PLACEHOLDER = "placeholder",
+  EXIT_URL = "exitUrl",
 }
 
 export interface LocalizedProperty {


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/5030

Adds missing exit page url to the translate page

<img width="800" alt="Screenshot 2025-06-18 at 8 39 01 AM" src="https://github.com/user-attachments/assets/00e058bb-2227-4a5d-bf9e-ba0327382b10" />
