### PR TITLE
chore: update static pages to use generateStaticParams.

### DIFF
--- a/app/(gcforms)/[locale]/(static pages)/sla/page.tsx
+++ b/app/(gcforms)/[locale]/(static pages)/sla/page.tsx
@@ -5,6 +5,10 @@ import { Metadata } from "next";
 import frContent from "@content/fr/sla.md";
 import enContent from "@content/en/sla.md";
 
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "fr" }];
+}
+
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {

--- a/app/(gcforms)/[locale]/(static pages)/terms-and-conditions/page.tsx
+++ b/app/(gcforms)/[locale]/(static pages)/terms-and-conditions/page.tsx
@@ -5,6 +5,10 @@ import { serverTranslation } from "@i18n";
 import frContent from "@content/fr/terms-and-conditions.md";
 import enContent from "@content/en/terms-and-conditions.md";
 
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "fr" }];
+}
+
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {

--- a/app/(gcforms)/[locale]/(static pages)/terms-of-use/page.tsx
+++ b/app/(gcforms)/[locale]/(static pages)/terms-of-use/page.tsx
@@ -23,6 +23,10 @@ export async function generateMetadata(props: {
   };
 }
 
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "fr" }];
+}
+
 const TermsOfUse = async (props: TermsOfUseProps) => {
   const params = await props.params;
 


### PR DESCRIPTION
# Summary | Résumé

Adds `generateStaticParams` to our static pages. 

We can now see the build is now pre-rendering en / fr and marking as SSG


| Before                                                                                                                                         | After                                                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="469" alt="Screenshot 2025-06-20 at 8 42 39 AM" src="https://github.com/user-attachments/assets/7eb7ee16-138b-488a-bf53-040085c5fcf2" /> | <img width="667" alt="Screenshot 2025-06-20 at 8 47 01 AM" src="https://github.com/user-attachments/assets/6890bea0-6349-4cd4-aedf-968659b48bc6" /> |

