### PR TITLE
chore: update GCDS package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/lib-dynamodb": "^3.826.0",
     "@bufbuild/protobuf": "^2.2.3",
     "@casl/ability": "6.7.3",
-    "@cdssnc/gcds-tokens": "2.10.0",
+    "@cdssnc/gcds-tokens": "2.12.0",
     "@gcforms/connectors": "workspace:*",
     "@gcforms/editor": "workspace:*",
     "@gcforms/tag-input": "workspace:*",

--- a/styles/_dropdown.scss
+++ b/styles/_dropdown.scss
@@ -1,11 +1,14 @@
-
-@import '../node_modules/@cdssnc/gcds-tokens/build/web/css/components/select.css';
+@import "../node_modules/@cdssnc/gcds-tokens/build/web/css/components/select.css";
 
 .gcds-select-wrapper {
   display: block;
   margin: 0;
   padding: 0;
   border: 0;
+
+  @media only screen and (width < 48em) {
+    font: var(--gcds-select-font-mobile);
+  }
 
   select {
     box-sizing: border-box;
@@ -14,7 +17,7 @@
 
 .gcds-select-wrapper {
   max-width: 75ch;
-  font: var(--gcds-select-font);
+  font: var(--gcds-select-font-desktop);
   color: var(--gcds-select-default-text);
   transition: color ease-in-out 0.15s;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,10 +1610,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cdssnc/gcds-tokens@npm:2.10.0":
-  version: 2.10.0
-  resolution: "@cdssnc/gcds-tokens@npm:2.10.0"
-  checksum: 10c0/0d75c3ac6d9e2039eebb755a3f941e70c9cbba261a4b7bae1005abf8430ff7f93a90e72fbd10443c3431a1c139b09a8f15e424b5b119e4fbdf5ebacd2a3426a8
+"@cdssnc/gcds-tokens@npm:2.12.0":
+  version: 2.12.0
+  resolution: "@cdssnc/gcds-tokens@npm:2.12.0"
+  checksum: 10c0/d5e2396d636a16e7d1607611ee8de7cec4e20b544781d7e862a69a499bc67ac0d4db5af6cff030cd95f3b4451c1f33c7b9d59ca6ea1ec6d8d797f20f3254242a
   languageName: node
   linkType: hard
 
@@ -12381,7 +12381,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.24.7"
     "@bufbuild/protobuf": "npm:^2.2.3"
     "@casl/ability": "npm:6.7.3"
-    "@cdssnc/gcds-tokens": "npm:2.10.0"
+    "@cdssnc/gcds-tokens": "npm:2.12.0"
     "@eslint/eslintrc": "npm:^3"
     "@gcforms/connectors": "workspace:*"
     "@gcforms/editor": "workspace:*"


### PR DESCRIPTION
# Summary | Résumé

Updates select css to remove deprecated token for select font

https://github.com/cds-snc/gcds-tokens/pull/449


Ref for CSS:

https://github.com/cds-snc/gcds-components/blob/main/packages/web/src/components/gcds-select/gcds-select.css