### PR TITLE
fix: update focus heading logic for front facing forms

### DIFF
--- a/app/(gcforms)/[locale]/(support)/components/client/FocusH2.tsx
+++ b/app/(gcforms)/[locale]/(support)/components/client/FocusH2.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { ReactElement, useRef, useEffect } from "react";
+
+export const FocusH2 = ({
+  children,
+  group,
+}: {
+  children: ReactElement | string;
+  group?: string; // Optional group prop to identify the section
+}) => {
+  const headingSuccessRef = useRef(null);
+
+  useEffect(() => {
+    const el = headingSuccessRef.current as unknown as HTMLElement;
+
+    if (el) {
+      // Add a tabindex if one does not exist on the element. This needed to focus an element,
+      // unless it is a form control like an input or button
+
+      // Give the DOM a little time to update
+      setTimeout(() => {
+        el?.focus();
+      }, 40);
+    }
+  }, [group]);
+
+  return (
+    <h2 key={group} tabIndex={-1} data-group={group} data-testid="focus-h2" ref={headingSuccessRef}>
+      {children}
+    </h2>
+  );
+};

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -34,7 +34,7 @@ import { FormStatus } from "@gcforms/types";
 import { CaptchaFail } from "@clientComponents/globals/FormCaptcha/CaptchaFail";
 import { ga } from "@lib/client/clientHelpers";
 
-import { FocusHeader } from "app/(gcforms)/[locale]/(support)/components/client/FocusHeader";
+import { FocusH2 } from "app/(gcforms)/[locale]/(support)/components/client/FocusH2";
 
 import { SubmitProgress } from "@clientComponents/forms/SubmitProgress/SubmitProgress";
 
@@ -183,9 +183,9 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
               isShowReviewPage &&
               currentGroup !== LockedSections.REVIEW &&
               currentGroup !== LockedSections.START && (
-                <FocusHeader headingTag="h2">
+                <FocusH2 group={currentGroup || "default"}>
                   {getGroupTitle(currentGroup, language as Language)}
-                </FocusHeader>
+                </FocusH2>
               )}
 
             {children}


### PR DESCRIPTION
# Summary | Résumé

Updates front facing forms to ensure heading is focused when navigating to next page.