### PR TITLE
chore: add published check for file input within a repeating set

### DIFF
--- a/lib/hooks/form-builder/useAllowPublish.tsx
+++ b/lib/hooks/form-builder/useAllowPublish.tsx
@@ -97,9 +97,22 @@ export const useAllowPublish = () => {
   const userCanPublish = ability?.can("update", "FormRecord", "isPublished");
   const { hasApiKeyId } = useFormBuilderConfig();
 
-  const hasFileInputElement = form?.elements?.some(
-    (element) => element.type === FormElementTypes.fileInput
-  );
+  const hasFileInputElement = useMemo(() => {
+    // Helper function to recursively check for file input elements
+    const checkForFileInput = (elements?: FormElement[]): boolean => {
+      if (!elements) return false;
+
+      return elements.some(
+        (element) =>
+          // Check if the current element is a file input
+          element.type === FormElementTypes.fileInput ||
+          // Check sub-elements if they exist
+          (element.properties?.subElements && checkForFileInput(element.properties.subElements))
+      );
+    };
+
+    return checkForFileInput(form?.elements);
+  }, [form?.elements]);
 
   // Note the key names here can be anthing but
   // the values must be booleans


### PR DESCRIPTION
# Summary | Résumé

Adds check for sub-elements + file inputs 

Fixes: #5771