### PR TITLE
chore: Add default file types to json for file inputs 

### DIFF
--- a/lib/fileInput/fileGroupsToFileTypes.ts
+++ b/lib/fileInput/fileGroupsToFileTypes.ts
@@ -40,3 +40,8 @@ export const fileGroupToFileTypes = (fileGroup: string) => {
 
   return [];
 };
+
+export const getDefaultFileGroupTypes = () => {
+  const types = ["documents", "images", "spreadsheets"];
+  return fileGroupsToFileTypes(types);
+};

--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -5,6 +5,7 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { blockLoader } from "../../utils/form-builder/blockLoader";
 import { elementLoader } from "@lib/utils/form-builder/elementLoader";
 import { logMessage } from "@lib/logger";
+import { getDefaultFileGroupTypes } from "@lib/fileInput/fileGroupsToFileTypes";
 
 import { allowedTemplates, TemplateTypes } from "@lib/utils/form-builder";
 import {
@@ -99,6 +100,11 @@ export const useHandleAdd = () => {
       if (item.type === "dynamicRow") {
         item.properties.dynamicRow = await getTranslatedDynamicRowProperties();
       }
+
+      if (item.type === FormElementTypes.fileInput) {
+        item.properties.fileType = getDefaultFileGroupTypes();
+      }
+
       id = await add(index, item.type, item, groupId);
       treeView?.current?.addItem(String(id));
 
@@ -123,8 +129,6 @@ export const useHandleAdd = () => {
       const closeAll = new CustomEvent("close-all-panel-menus");
       window && window.dispatchEvent(closeAll);
 
-      //
-
       if (type === "customJson") {
         try {
           await elementLoader(subIndex, async (data, position) => {
@@ -137,8 +141,6 @@ export const useHandleAdd = () => {
 
         return id;
       }
-
-      //
 
       if (allowedTemplates.includes(type as TemplateTypes)) {
         try {
@@ -153,6 +155,11 @@ export const useHandleAdd = () => {
       }
 
       const item = await create(type as FormElementTypes);
+
+      if (item.type === FormElementTypes.fileInput) {
+        item.properties.fileType = getDefaultFileGroupTypes();
+      }
+
       id = await addSubItem(elId, subIndex, item.type, item);
       setChangeKey(String(new Date().getTime())); //Force a re-render
 


### PR DESCRIPTION
# Summary | Résumé




Update to add default file types that will be accepted when a file input is inserted via the builder.

This update ensures the "more" modal has default file types to start which allows the UI to display all types as checked by default.

https://github.com/user-attachments/assets/e1157708-d914-40c1-a913-1b609cc898b8

In the previous code undefined or an empty array would default to  "all" but would not be reflected as "checked" in the builder.
