### PR TITLE
fix: a11y updates for file input

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/Description.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/Description.tsx
@@ -22,7 +22,7 @@ export const Description = ({
 
   return (
     <div className="mb-2">
-      <Label>{t("inputDescription")}</Label>
+      <Label htmlFor={`description--modal--${item.id}`}>{t("inputDescription")}</Label>
       <Hint>{t("descriptionDescription")}</Hint>
       <TextArea
         id={`description--modal--${item.id}`}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/Question.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/Question.tsx
@@ -23,7 +23,7 @@ export const Question = ({
 
   return (
     <div className="mb-2">
-      <Label htmlFor={`titleEn--modal--${item.id}`}>{label}</Label>
+      <Label htmlFor={`title--modal--${item.id}`}>{label}</Label>
       <Input
         id={`title--modal--${item.id}`}
         name={`item${item.id}`}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/utils.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/utils.ts
@@ -37,7 +37,7 @@ export const downloadKey = async (key: string, templateId: string) => {
 
   // Generate zip
   zip.generateAsync({ type: "nodebuffer", streamFiles: true }).then((buffer) => {
-    const fileName = `${templateId}_api.zip`;
+    const fileName = `api-key-${templateId}.zip`;
     downloadFileFromBlob(new Blob([buffer]), fileName);
   });
 };

--- a/components/clientComponents/forms/FileInput/FileInput.tsx
+++ b/components/clientComponents/forms/FileInput/FileInput.tsx
@@ -193,7 +193,7 @@ export const FileInput = (props: FileInputProps): React.ReactElement => {
               <span aria-hidden={true}>
                 {fileName} ({fileSize.size} {t(`input-validation.${fileSize.unit}`)}){" "}
               </span>
-              <ResetButton resetInput={resetInput} lang={lang} />
+              <ResetButton fileName={fileName} resetInput={resetInput} lang={lang} />
             </div>
           ) : (
             <span className="my-4 inline-block max-w-fit">{t("file-upload-no-file-selected")}</span>

--- a/components/clientComponents/forms/FileInput/FileInput.tsx
+++ b/components/clientComponents/forms/FileInput/FileInput.tsx
@@ -132,6 +132,14 @@ export const FileInput = (props: FileInputProps): React.ReactElement => {
     allowedFileTypes = htmlInputAccept;
   }
 
+  const describedBy = [
+    `${name}_file_selected`,
+    ariaDescribedBy,
+    meta.error ? `${name}_error` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <>
       {meta.error && <ErrorMessage id={`${name}_error`}>{meta.error}</ErrorMessage>}
@@ -156,9 +164,7 @@ export const FileInput = (props: FileInputProps): React.ReactElement => {
           className={cn(themes.base, themes.secondary, "mr-4")}
           aria-disabled={disabled}
           aria-labelledby="file-input-button-text"
-          aria-describedby={`${name}_file_selected ${ariaDescribedBy} ${
-            meta.error ? `${name}_error` : null
-          }`}
+          aria-describedby={describedBy}
         >
           <span id="file-input-button-text" aria-hidden={true}>
             {t("file-upload-button-text")}

--- a/components/clientComponents/forms/FileInput/ResetButton.tsx
+++ b/components/clientComponents/forms/FileInput/ResetButton.tsx
@@ -5,9 +5,11 @@ import { Button } from "@clientComponents/globals/Buttons/Button";
 
 export const ResetButton = ({
   resetInput,
+  fileName,
   lang,
 }: {
   resetInput: () => void;
+  fileName: string;
   lang: string | undefined;
 }) => {
   const { t } = useTranslation("common", { lng: lang });
@@ -16,6 +18,7 @@ export const ResetButton = ({
       theme="link"
       className="ml-3 text-red-destructive focus:text-white [&_svg]:fill-red [&_svg]:focus:fill-white"
       onClick={resetInput}
+      aria-label={`${t("remove", { lng: lang })} ${fileName}`}
     >
       <div className="group ml-1 p-2 pr-3">
         <span className="mr-1 inline-block  underline focus:text-white group-hover:no-underline">

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -233,7 +233,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
               {labelText}
             </Label>
           )}
-          {description && <Description id={`${id}`}>{description}</Description>}
+          {description && <Description id={`desc-${id}`}>{description}</Description>}
           <FileInput
             id={`${id}`}
             name={`${id}`}


### PR DESCRIPTION
# Summary | Résumé

Partial fixes for https://github.com/cds-snc/platform-forms-client/issues/5760

- 1 Forms > Settings > Response Delivery > Add API Key
Once the key is created the page updates with the key Id. Is it announced? The attached video shows what I hear. The previous attempt though I thought I heard the key number announced? Either way once the key number is announced, it may help to prefix it with “key” or something similar so it’s clear what it is.

- 2 Forms > Edit Page > Add form Element > File Upload
In the preview window, the Chose File button has a few undefined labels. See image.

- 4  Forms > Edit Page > Add form Element > More
File input and label id does not match. See image.

- 5 Forms > Edit Page > Add form Element > More
Hint text input and label missing relationship. See image.

- 6 Form filler > Choose file > (added a file)
Remove button is missing a label. See image.
I wonder if some kind of relationship could be created between the Remove button and the file name?

- 7 Form filler > Choose file
Choose file has a null reference in aria-describedby