### PR TITLE
chore: add strict value to form types

### DIFF
--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.0.13] - 2025-07-08
+
+### Changed
+
+- Add strictValue to ElementProperties for use with ComboBox / Searchable list
+
 ## [1.0.12] - 2025-06-25
 
 ### Changed

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/types",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/types/src/form-types.ts
+++ b/packages/types/src/form-types.ts
@@ -128,6 +128,7 @@ export interface ElementProperties {
   addressComponents?: AddressComponents | undefined;
   dynamicRow?: dynamicRowType;
   sortOrder?: SortValue;
+  strictValue?: boolean;
   [key: string]:
     | string
     | string[]


### PR DESCRIPTION
# Summary | Résumé

Updates form types to add strict value  in support of extracted from https://github.com/cds-snc/platform-forms-client/pull/5572