### PR TITLE
fix: Match first checkbox for branching purposes

### DIFF
--- a/lib/formContext.ts
+++ b/lib/formContext.ts
@@ -175,14 +175,28 @@ export const getValuesWithMatchedIds = (formElements: FormElement[], values: For
     }
 
     if (isChoiceInputType(el.type) && choices && Array.isArray(choices)) {
-      const choiceIndex = choices.findIndex(
-        (choice) =>
-          (choice.en !== "" && choice.en === value) || (choice.fr !== "" && choice.fr === value)
-      );
-      if (choiceIndex > -1) {
-        newValues[key] = `${el.id}.${choiceIndex}`;
+      if (Array.isArray(value)) {
+        // For checkboxes, map the values to their choiceIds
+        for (const selected of value) {
+          const choiceIndex = choices.findIndex((choice) => {
+            return (
+              (choice.en !== "" && choice.en === selected) ||
+              (choice.fr !== "" && choice.fr === selected)
+            );
+          });
+          newValues[key] = `${el.id}.${choiceIndex}`;
+          return;
+        }
       } else {
-        newValues[key] = value; // preserve original value if no match found
+        const choiceIndex = choices.findIndex(
+          (choice) =>
+            (choice.en !== "" && choice.en === value) || (choice.fr !== "" && choice.fr === value)
+        );
+        if (choiceIndex > -1) {
+          newValues[key] = `${el.id}.${choiceIndex}`;
+        } else {
+          newValues[key] = value; // preserve original value if no match found
+        }
       }
     }
   });


### PR DESCRIPTION
# Summary | Résumé

Our new matching algorithm for branching did not consider checkboxes.
Checkboxes are a weird thing to use for branching because they always return an array of options, and for branching purposes we need to match one item to determine where to go.
But since we allow them to use checkboxes, we need to just decide which item to match. This PR selects the first matching checkbox.
