### PR TITLE
fix: update validation error list to be removed from the tab order

### DIFF
--- a/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/contact/components/client/ContactForm.tsx
@@ -94,7 +94,7 @@ export const ContactForm = () => {
             <ValidationMessage
               type={ErrorStatus.ERROR}
               validation={true}
-              tabIndex={0}
+              focussable={true}
               id="validationErrors"
               heading={t("input-validation.heading", { ns: "common" })}
             >

--- a/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/support/components/client/SupportForm.tsx
@@ -91,7 +91,7 @@ export const SupportForm = () => {
             <ValidationMessage
               type={ErrorStatus.ERROR}
               validation={true}
-              tabIndex={0}
+              focussable={true}
               id="validationErrors"
               heading={t("input-validation.heading", { ns: "common" })}
             >

--- a/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
+++ b/app/(gcforms)/[locale]/(support)/unlock-publishing/components/client/UnlockPublishingForm.tsx
@@ -104,7 +104,7 @@ export const UnlockPublishingForm = ({ userEmail }: { userEmail: string }) => {
             <ValidationMessage
               type={ErrorStatus.ERROR}
               validation={true}
-              tabIndex={0}
+              focussable={true}
               id="unlockPublishingValidationErrors"
               heading={t("input-validation.heading", { ns: "common" })}
             >

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -130,7 +130,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   ) : (
     <>
       {formStatusError && (
-        <Alert type={ErrorStatus.ERROR} heading={formStatusError} tabIndex={0} id={serverErrorId} />
+        <Alert type={ErrorStatus.ERROR} heading={formStatusError} id={serverErrorId} />
       )}
 
       {/* ServerId error */}
@@ -146,7 +146,6 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
           })}
           validation={true}
           id={errorId}
-          tabIndex={0}
           focussable={true}
         >
           {errorList}

--- a/components/clientComponents/forms/StatusError/StatusError.tsx
+++ b/components/clientComponents/forms/StatusError/StatusError.tsx
@@ -29,13 +29,7 @@ export const StatusError = ({ formId, language }: { formId: string; language: La
   const { t } = useTranslation("error");
   const link = `/${language}/id/${formId}`;
   return (
-    <Alert
-      type={ErrorStatus.ERROR}
-      tabIndex={0}
-      id="gc-form-errors-server"
-      autoFocus
-      focussable={true}
-    >
+    <Alert type={ErrorStatus.ERROR} id="gc-form-errors-server" autoFocus focussable={true}>
       <h2>{t("sever-error.title")}</h2>
       <div className="mt-4">
         <Text i18nKey="sever-error.body" values={{ formLink: link }} />


### PR DESCRIPTION
# Summary | Résumé

For forms-form error validation and similar pages like contact and support, this PR updates the validation error list to be removed from the tab order. The error list was previously in the tab order and could be confusing as a user tabs and lands on the error container (that is not a form control, link etc.).

The update changes the` tabindex=0` to `tabindex=-1` so the list can still be focussed and announced on an error but not be in the tab order.
