### PR TITLE
fix: Ensure form submit button doesn't get stuck in loading state

### DIFF
--- a/components/clientComponents/forms/Form/SubmitButton.tsx
+++ b/components/clientComponents/forms/Form/SubmitButton.tsx
@@ -67,7 +67,7 @@ export const SubmitButton: React.FC<SubmitButtonProps> = ({
     if (submissionError) {
       setLoading(false);
     }
-  }, [submissionError]);
+  }, [submissionError, loading]);
 
   return (
     <>


### PR DESCRIPTION
# Summary | Résumé

Fixes #5879 

Previously, if the form is already displaying a validation message and the user clicks submit again and the form returns another validation message, the submit button would remain stuck in the loading state. This PR adds the loading variable to the dependency array that handles resetting the button state.

| Before                                          | After                                        |
| ----------------------------------------------- | -------------------------------------------- |
| ![Screen Recording 2025-07-17 at 1 19 17 PM](https://github.com/user-attachments/assets/5d1461a0-0870-48a9-b8a5-7edab9fa418b) | ![Screen Recording 2025-07-17 at 1 19 52 PM](https://github.com/user-attachments/assets/4f6f563a-fa31-4d29-9a3e-01b2bfc13cf2) |
