### PR TITLE
fix: save progress minimize renders for non-visible-components

### DIFF
--- a/components/clientComponents/forms/SaveAndResume/MobileDrawer.tsx
+++ b/components/clientComponents/forms/SaveAndResume/MobileDrawer.tsx
@@ -7,6 +7,7 @@ import { downloadDataAsBlob } from "@lib/downloadDataAsBlob";
 import { useTranslation } from "@i18n/client";
 import { useFormSubmissionData } from "@lib/hooks/useFormSubmissionData";
 import { LinkButton } from "@serverComponents/globals/Buttons/LinkButton";
+import { useCallback } from "react";
 
 export const MobileDrawer = ({
   drawerOpen,
@@ -25,11 +26,13 @@ export const MobileDrawer = ({
 
   const { fileName, getOptions } = useFormSubmissionData({ language, type });
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
+    if (!drawerOpen) return;
+
     const html = await generateDownloadHtml(getOptions());
     await downloadDataAsBlob(html.data, fileName, { "text/html": [".html"] });
     setDrawerOpen(false);
-  };
+  }, [getOptions, fileName, setDrawerOpen, drawerOpen]);
 
   return (
     <Drawer isVisible={drawerOpen} onClose={() => setDrawerOpen(false)}>

--- a/components/clientComponents/forms/SaveAndResume/SaveAndResume.tsx
+++ b/components/clientComponents/forms/SaveAndResume/SaveAndResume.tsx
@@ -52,19 +52,25 @@ export const SaveAndResume = ({ formId, language }: { formId: string; language: 
           <>{t("saveAndResume.more")}...</>
         </Button>
       </span>
-      <ConfirmDownloadDialog
-        type="progress"
-        language={language}
-        open={confirm}
-        handleClose={() => setConfirm(false)}
-      />
-      <MobileDrawer
-        drawerOpen={drawerOpen}
-        setDrawerOpen={setDrawerOpen}
-        formId={formId}
-        language={language}
-        type="progress"
-      />
+
+      {confirm && (
+        <ConfirmDownloadDialog
+          type="progress"
+          language={language}
+          open={confirm}
+          handleClose={() => setConfirm(false)}
+        />
+      )}
+
+      {drawerOpen && (
+        <MobileDrawer
+          drawerOpen={drawerOpen}
+          setDrawerOpen={setDrawerOpen}
+          formId={formId}
+          language={language}
+          type="progress"
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where confirm dialog / mobile drawer were unnecessarily performing renders and data look ups (i.e. when in an invisible state)

Updates Save and resume dialog + mobile navigation to prevent unnecessary renders 

Fixes ticket: 23654


