### PR TITLE
chore: add GA event for when a form reaches a dead end

### DIFF
--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -12,7 +12,7 @@ import { Language } from "@lib/types/form-builder-types";
 
 import { getLocalizedProperty } from "@lib/utils";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { tryFocusOnPageLoad } from "@lib/client/clientHelpers";
+import { ga, tryFocusOnPageLoad } from "@lib/client/clientHelpers";
 import { useFormDelay } from "@lib/hooks/useFormDelayContext";
 import { ForwardArrowIcon24x24 } from "@serverComponents/icons";
 import { isFormClosed } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/actions";
@@ -59,6 +59,9 @@ export const NextButton = ({
     !hasNextAction(currentGroup) &&
     hasReviewPage(formRecord.form)
   ) {
+    ga("form_has_dead_end", {
+      formId: formRecord.id,
+    });
     return <div data-testid="dead-end"></div>;
   }
 


### PR DESCRIPTION
# Summary | Résumé

Adds GA event for when a form is "broken" and reaches a "dead end". This even will help us know how often forms are reaching this state to give us another indicator of high level app health.
