### PR TITLE
fix: slow check get review items

### DIFF
--- a/components/clientComponents/forms/Review/helpers.ts
+++ b/components/clientComponents/forms/Review/helpers.ts
@@ -85,13 +85,14 @@ export const getGroupsWithElementIds = (
     return [] as GroupsWithElementIds[];
   }
 
+  // Remove any hidden elements from Show-Hide (only include elements interacted with by the user)
+  const shownFormElements = filterShownElements(formRecord, formValues);
+
   return groupHistoryIds
     .filter((key) => key !== "review")
     .map((groupId) => {
       const group: Group = groups[groupId as keyof typeof groups] || {};
 
-      // Remove any hidden elements from Show-Hide (only include elements interacted with by the user)
-      const shownFormElements = filterShownElements(formRecord, formValues);
       const elementIds = getElementIdsAsNumber(
         filterValuesForShownElements(group.elements, shownFormElements)
       );


### PR DESCRIPTION
# Summary | Résumé

Fixes [Ticket #23654](https://cds-snc.freshdesk.com/a/tickets/23654) rendering bottleneck for the review page.

Moves `shownFormElements` out of a nested loop to prevent unnecessary re-evaluation.  

Prior to this fix the function was being called in the loop.  Given a case where we have many groups the execution time starts to balloon.


<table>
  <tr>
    <td><strong>Before (4 secs + )</strong></td>
    <td><strong>After (< 1 sec)</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/84718e4b-3bfa-41c8-a158-6af227a3c5c7" width="350"/></td>
    <td><img src="https://github.com/user-attachments/assets/96711179-5807-4614-949d-ddb92c02c859" width="350"/></td>
  </tr>
</table>



**Before**

Here we can see the before which was locking up the browser and causing rendering issues (for large forms - many pages + elements)

https://github.com/user-attachments/assets/45b7bc62-8d1b-4e05-9841-6c6122f3c343



**After** 

https://github.com/user-attachments/assets/e9068e69-1aec-466e-979f-e567e6ebbaa2




