### PR TITLE
chore: fix styling when lots of items

### DIFF
--- a/components/clientComponents/forms/CurrentGroupSelector/Menu.tsx
+++ b/components/clientComponents/forms/CurrentGroupSelector/Menu.tsx
@@ -33,7 +33,7 @@ export const Menu = () => {
     <div
       id="group-menu"
       popover="auto"
-      className="rounded-lg border-1 border-slate-500 bg-white shadow-md"
+      className="max-h-60 overflow-y-scroll rounded-lg border-1 border-slate-500 bg-white shadow-md"
       style={{
         // @ts-expect-error - CSS anchor positioning is not in the types yet
         positionAnchor: "--group-menu-trigger",


### PR DESCRIPTION
# Summary | Résumé

Update to handle overflow scrolling --- when there's lots of groups