### PR TITLE
fix: form-builder skip to main content

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -101,6 +101,7 @@ export default async function Layout(props: {
                       <main
                         id="content"
                         className="form-builder my-7 min-h-[calc(100vh-300px)] w-full"
+                        tabIndex={-1}
                       >
                         {children}
                       </main>


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where in the form-builder, the browser focus was not moving to the main content element. A tabindex=-1 was used on the main content area to fix this. The fix is more of a work around than a fix because a tabindex should not be required to move focus to a section.

Test by opening the form builder, tabbing to the skip link, activating it and then keying tab again. The focus should in the main section and not in the header section. 