### PR TITLE
chore: Refactor BackButton to use new visible pages function

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/BackButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/preview/BackButton.tsx
@@ -17,12 +17,14 @@ export const BackButton = ({
   saveAndResumeEnabled?: boolean;
 }) => {
   const { t } = useTranslation("review");
-  const { setGroup, previousGroup, currentGroup } = useGCFormsContext();
+  const { setGroup, getPreviousGroup, currentGroup } = useGCFormsContext();
 
   // Do not show on the Review page
   if (!currentGroup || currentGroup !== LockedSections.REVIEW) {
     return <></>;
   }
+
+  const previousGroup = getPreviousGroup(currentGroup);
 
   return (
     <Button
@@ -41,7 +43,7 @@ export const BackButton = ({
         <>
           <BackArrowIcon24x24
             className="group-focus:fill-white group-active:fill-white"
-            title={t("goBack", { lng: language })}
+            title={t("goBack", { lng: language }) + " " + previousGroup}
           />
           <span className="hidden laptop:block">{t("goBack", { lng: language })}</span>
         </>

--- a/components/clientComponents/forms/BackButtonGroup/BackButtonGroup.tsx
+++ b/components/clientComponents/forms/BackButtonGroup/BackButtonGroup.tsx
@@ -15,7 +15,7 @@ export const BackButtonGroup = ({
   onClick?: () => void;
   saveAndResumeEnabled?: boolean;
 }) => {
-  const { currentGroup, getGroupHistory, handlePreviousAction } = useGCFormsContext();
+  const { currentGroup, getGroupHistory, getPreviousGroup, setGroup } = useGCFormsContext();
   const { t } = useTranslation("form-builder");
 
   // Only show on Group screens
@@ -37,7 +37,8 @@ export const BackButtonGroup = ({
       <Button
         onClick={async (e) => {
           e.preventDefault();
-          handlePreviousAction();
+          const previousGroup = getPreviousGroup(currentGroup);
+          setGroup(previousGroup);
           onClick && onClick();
           // Focus the H1 on the start page as the beginning of the page, and then for any other
           // sub page, focus the H2. This works since the start page will not have an H2.


### PR DESCRIPTION
# Summary | Résumé

Subsequent to #5779 
Refactors the BackButton and BackButtonGroup to use the new visibleGroups algorithm to find the last group vs groupHistory.