### PR TITLE
chore: add max row count for repeating sets

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/DynamicRowOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/DynamicRowOptions.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { Input } from "@formBuilder/components/shared/Input";
 import { useTranslation } from "@i18n/client";
 import { FormElement, FormElementTypes } from "@lib/types";
 import { Label } from "./Label";
 import { Hint } from "./Hint";
+import { MAX_DYNAMIC_ROW_AMOUNT } from "@root/constants";
+import { WarningIcon } from "@serverComponents/icons";
 
 export const DynamicRowOptions = ({
   item,
@@ -12,6 +15,7 @@ export const DynamicRowOptions = ({
   setItem: (item: FormElement) => void;
 }) => {
   const { t } = useTranslation("form-builder");
+  const [error, setError] = useState<boolean>(false);
 
   if (item.type !== FormElementTypes.dynamicRow) {
     return null;
@@ -25,6 +29,8 @@ export const DynamicRowOptions = ({
         id={`maxNumberOfRows--modal--${item.id}`}
         type="number"
         min="1"
+        placeholder={MAX_DYNAMIC_ROW_AMOUNT.toString()}
+        max={String(MAX_DYNAMIC_ROW_AMOUNT)}
         className="w-1/4"
         value={item.properties.maxNumberOfRows || ""}
         onKeyDown={(e) => {
@@ -33,6 +39,8 @@ export const DynamicRowOptions = ({
           }
         }}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setError(false);
+
           // if value is "", unset the field
           if (e.target.value === "") {
             setItem({
@@ -47,6 +55,12 @@ export const DynamicRowOptions = ({
 
           const value = parseInt(e.target.value);
           if (!isNaN(value) && value >= 1) {
+            // Ensure the value does not exceed the maximum allowed rows
+            if (value > MAX_DYNAMIC_ROW_AMOUNT) {
+              setError(true);
+              return;
+            }
+
             setItem({
               ...item,
               properties: {
@@ -57,6 +71,13 @@ export const DynamicRowOptions = ({
           }
         }}
       />
+
+      {error && (
+        <div className="my-4 font-bold text-red-700">
+          <WarningIcon className="inline-block fill-red-700" />{" "}
+          {t("moreDialog.dynamicRow.errorMaxRows", { maxRows: MAX_DYNAMIC_ROW_AMOUNT })}
+        </div>
+      )}
     </section>
   );
 };

--- a/constants.ts
+++ b/constants.ts
@@ -6,3 +6,7 @@ export const BODY_SIZE_LIMIT_WITH_FILES = Number(
   process.env.NEXT_PUBLIC_BODY_SIZE_LIMIT_WITH_FILES || mbToBytes(6)
 );
 export const MAX_RESPONSE_SIZE = kbToBytes(380);
+
+export const MAX_FILE_SIZE = mbToBytes(10);
+
+export const MAX_DYNAMIC_ROW_AMOUNT = 25;

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -580,6 +580,9 @@
       "title": "Additional tags",
       "description": "Add flexible labels to include metadata for form elements so that related questions can be categorized or so that data can be transformed.",
       "errorTagTooLong": "Tag cannot exceed 50 characters"
+    },
+    "dynamicRow": {
+      "errorMaxRows": "Maximum row limit cannot exceed {{maxRows}}."
     }
   },
   "moreOptions": "More options",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -582,7 +582,7 @@
       "errorTagTooLong": "Tag cannot exceed 50 characters"
     },
     "dynamicRow": {
-      "errorMaxRows": "Maximum row limit cannot exceed {{maxRows}}."
+      "errorMaxRows": "The maximum number of answers cannot exceed {{maxRows}}."
     }
   },
   "moreOptions": "More options",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -580,6 +580,9 @@
       "title": "Balises supplémentaires",
       "description": "Vous pouvez ajouter des étiquettes flexibles  pour inclure des métadonnées aux éléments du formulaire afin de catégoriser les questions connexes ou de transformer les données.",
       "errorTagTooLong": "La balise ne peut pas dépasser 50 caractères"
+    },
+    "dynamicRow": {
+      "errorMaxRows": "Maximum row limit cannot exceed {{maxRows}}. [FR]"
     }
   },
   "moreOptions": "Plus d'options  ",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -582,7 +582,7 @@
       "errorTagTooLong": "La balise ne peut pas dépasser 50 caractères"
     },
     "dynamicRow": {
-      "errorMaxRows": "Maximum row limit cannot exceed {{maxRows}}. [FR]"
+      "errorMaxRows": "Le nombre maximal de réponses ne peut pas dépasser {{maxRows}}."
     }
   },
   "moreOptions": "Plus d'options  ",

--- a/lib/hooks/form-builder/useHandleAdd.tsx
+++ b/lib/hooks/form-builder/useHandleAdd.tsx
@@ -6,6 +6,7 @@ import { blockLoader } from "../../utils/form-builder/blockLoader";
 import { elementLoader } from "@lib/utils/form-builder/elementLoader";
 import { logMessage } from "@lib/logger";
 import { getDefaultFileGroupTypes } from "@lib/fileInput/fileGroupsToFileTypes";
+import { MAX_DYNAMIC_ROW_AMOUNT } from "@root/constants";
 
 import { allowedTemplates, TemplateTypes } from "@lib/utils/form-builder";
 import {
@@ -67,7 +68,7 @@ export const useHandleAdd = () => {
 
   const loadError = t("failedToReadFormFile");
 
-  /* Note this callback is also in ElementPanel */
+  // Note: For Sub elements see handleAddSubElement (below)
   const handleAddElement = useCallback(
     async (index: number, type?: FormElementTypes) => {
       let id;
@@ -97,12 +98,18 @@ export const useHandleAdd = () => {
       }
 
       const item = await create(type as FormElementTypes);
-      if (item.type === "dynamicRow") {
-        item.properties.dynamicRow = await getTranslatedDynamicRowProperties();
-      }
 
-      if (item.type === FormElementTypes.fileInput) {
-        item.properties.fileType = getDefaultFileGroupTypes();
+      // Set default properties based on element type
+      switch (item.type) {
+        case FormElementTypes.fileInput:
+          item.properties.fileType = getDefaultFileGroupTypes();
+          break;
+        case FormElementTypes.dynamicRow:
+          item.properties.dynamicRow = await getTranslatedDynamicRowProperties();
+          item.properties.maxNumberOfRows = MAX_DYNAMIC_ROW_AMOUNT;
+          break;
+        default:
+          break;
       }
 
       id = await add(index, item.type, item, groupId);
@@ -121,6 +128,7 @@ export const useHandleAdd = () => {
     [add, create, groupId, treeView, loadError]
   );
 
+  // Handle adding a sub-element
   const handleAddSubElement = useCallback(
     async (elId: number, subIndex: number, type?: FormElementTypes) => {
       let id;
@@ -156,8 +164,13 @@ export const useHandleAdd = () => {
 
       const item = await create(type as FormElementTypes);
 
-      if (item.type === FormElementTypes.fileInput) {
-        item.properties.fileType = getDefaultFileGroupTypes();
+      // Set default properties based on element type
+      switch (item.type) {
+        case FormElementTypes.fileInput:
+          item.properties.fileType = getDefaultFileGroupTypes();
+          break;
+        default:
+          break;
       }
 
       id = await addSubItem(elId, subIndex, item.type, item);


### PR DESCRIPTION
# Summary | Résumé

Closes: https://github.com/cds-snc/platform-forms-client/issues/5964

- Updates the form builder to ensure a max row count is set when adding a repeating set.
- Defaults max row count for repeating sets to 25


Notes: 

In a future PR we might want to update front facing form to ensure a max rows property is set regardless of the template value.  This would handle cases where the property isn't set and also legacy templates.

This PR doesn't alter existing templates i.e. if a form already has created a repeating set.



https://github.com/user-attachments/assets/12ab84df-8af1-4697-a68d-984b452ea75f

