### PR TITLE
chore: remove unused functions for global file size

### DIFF
--- a/lib/utils/fileSize.ts
+++ b/lib/utils/fileSize.ts
@@ -53,13 +53,3 @@ export const bytesToKbOrMbString = (
     unit: "MB",
   };
 };
-
-/**
- * When we base64 encode a file, there is a ~35% overhead in file size.
- * This function calculates the size of the file after base64 encoding.
- * @param fileSize - Size of the file in bytes
- * @returns
- */
-export const fileSizeWithBase64Overhead = (fileSize: number): number => {
-  return Math.round(fileSize * 1.35);
-};

--- a/lib/utils/fileSize.vitest.ts
+++ b/lib/utils/fileSize.vitest.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { bytesToKbOrMbString, bytesToMb, fileSizeWithBase64Overhead, kbToBytes, mbToBytes } from "./fileSize";
+import { bytesToKbOrMbString, bytesToMb, kbToBytes, mbToBytes } from "./fileSize";
 
 describe("bytesToMb", () => {
   it("converts 0 bytes to 0 MB", () => {
@@ -135,7 +135,6 @@ describe("kbToBytes", () => {
   });
 });
 
-
 describe("bytesToKbOrMbString", () => {
   it("returns bytes for values less than 500", () => {
     expect(bytesToKbOrMbString(0)).toEqual({ size: 0, unit: "bytes" });
@@ -144,14 +143,23 @@ describe("bytesToKbOrMbString", () => {
   });
 
   it("returns KB for values between 500 and 1040000", () => {
-    expect(bytesToKbOrMbString(500)).toEqual({ size: Math.round((500 / 1024) * 2) / 2, unit: "KB" });
+    expect(bytesToKbOrMbString(500)).toEqual({
+      size: Math.round((500 / 1024) * 2) / 2,
+      unit: "KB",
+    });
     expect(bytesToKbOrMbString(1024)).toEqual({ size: 1, unit: "KB" });
     expect(bytesToKbOrMbString(1536)).toEqual({ size: 1.5, unit: "KB" });
-    expect(bytesToKbOrMbString(1040000 - 1)).toEqual({ size: Math.round(((1040000 - 1) / 1024) * 2) / 2, unit: "KB" });
+    expect(bytesToKbOrMbString(1040000 - 1)).toEqual({
+      size: Math.round(((1040000 - 1) / 1024) * 2) / 2,
+      unit: "KB",
+    });
   });
 
   it("returns MB for values >= 1040000", () => {
-    expect(bytesToKbOrMbString(1040000)).toEqual({ size: Math.round((1040000 / 1048576) * 2) / 2, unit: "MB" });
+    expect(bytesToKbOrMbString(1040000)).toEqual({
+      size: Math.round((1040000 / 1048576) * 2) / 2,
+      unit: "MB",
+    });
     expect(bytesToKbOrMbString(1048576)).toEqual({ size: 1, unit: "MB" });
     expect(bytesToKbOrMbString(1572864)).toEqual({ size: 1.5, unit: "MB" });
     expect(bytesToKbOrMbString(2097152)).toEqual({ size: 2, unit: "MB" });
@@ -163,32 +171,13 @@ describe("bytesToKbOrMbString", () => {
   });
 
   it("handles edge cases", () => {
-    expect(bytesToKbOrMbString(500)).toEqual({ size: Math.round((500 / 1024) * 2) / 2, unit: "KB" });
-    expect(bytesToKbOrMbString(1040000)).toEqual({ size: Math.round((1040000 / 1048576) * 2) / 2, unit: "MB" });
-  });
-});
-
-describe("fileSizeWithBase64Overhead", () => {
-  it("returns 0 for 0 bytes", () => {
-    expect(fileSizeWithBase64Overhead(0)).toBe(0);
-  });
-
-  it("calculates base64 overhead for small files", () => {
-    expect(fileSizeWithBase64Overhead(1000)).toBe(Math.round(1000 * 1.35));
-    expect(fileSizeWithBase64Overhead(500)).toBe(Math.round(500 * 1.35));
-  });
-
-  it("calculates base64 overhead for large files", () => {
-    expect(fileSizeWithBase64Overhead(1048576)).toBe(Math.round(1048576 * 1.35));
-    expect(fileSizeWithBase64Overhead(10000000)).toBe(Math.round(10000000 * 1.35));
-  });
-
-  it("handles negative values", () => {
-    expect(fileSizeWithBase64Overhead(-1000)).toBe(Math.round(-1000 * 1.35));
-  });
-
-  it("returns integer values (rounded)", () => {
-    const result = fileSizeWithBase64Overhead(1234);
-    expect(Number.isInteger(result)).toBe(true);
+    expect(bytesToKbOrMbString(500)).toEqual({
+      size: Math.round((500 / 1024) * 2) / 2,
+      unit: "KB",
+    });
+    expect(bytesToKbOrMbString(1040000)).toEqual({
+      size: Math.round((1040000 / 1048576) * 2) / 2,
+      unit: "MB",
+    });
   });
 });

--- a/lib/validation/fileValidationClientSide.tsx
+++ b/lib/validation/fileValidationClientSide.tsx
@@ -1,8 +1,4 @@
-import { FileInputResponse, Responses } from "@lib/types";
-
 import { BODY_SIZE_LIMIT_WITH_FILES } from "@root/constants";
-import { ga } from "../client/clientHelpers";
-import { fileSizeWithBase64Overhead } from "../utils/fileSize";
 
 export const ALLOWED_FILE_TYPES = [
   { mime: "application/pdf", extensions: ["pdf"] },
@@ -44,60 +40,4 @@ export function isFileExtensionValid(fileName: string): boolean {
 
 export function isIndividualFileSizeValid(sizeInBytes: number): boolean {
   return sizeInBytes <= BODY_SIZE_LIMIT_WITH_FILES;
-}
-
-/**
- * There is a bodySizeLimit that applies to the entire POST payload, including
- * all uploaded files, configured in next.config.mjs
- *
- * We also have a const for BODY_SIZE_LIMIT_WITH_FILES for payloads with files
- *
- * Since uploaded files are serialized to base64, there is a ~35% overhead in file size.
- *
- * @param values
- * @param item
- * @param files
- * @param errors
- */
-export function isAllFilesSizeValid(values: Responses): boolean {
-  const files: FileInputResponse[] = [];
-  for (const item in values) {
-    const element = values[item];
-    // We're in a repeating set
-    if (Array.isArray(element)) {
-      element.forEach((el: string | FileInputResponse | Record<string, unknown>) => {
-        // Loop over answers in the repeating set
-        const answersIndexes = Object.keys(el);
-        answersIndexes.forEach((answerIndex) => {
-          // @ts-expect-error - Help typescript out a bit
-          if (el[answerIndex] && el[answerIndex].size) {
-            // @ts-expect-error - Help typescript out a bit
-            files.push(el[answerIndex]);
-          }
-        });
-      });
-    } else {
-      // Not repeating set
-      if (typeof element === "object" && element.size) {
-        files.push(element as FileInputResponse);
-      }
-    }
-    if (files) {
-      const totalSize = files.reduce(
-        (sum, file) => Number(sum) + fileSizeWithBase64Overhead(Number(file.size)),
-        0
-      );
-      if (totalSize > BODY_SIZE_LIMIT_WITH_FILES) {
-        // @TODO: Setup on GA
-        ga("file_upload_size_exceeded", {
-          size: totalSize,
-          limit: BODY_SIZE_LIMIT_WITH_FILES,
-          filesCount: files.length,
-        });
-        return false;
-      }
-    }
-  }
-
-  return true;
 }


### PR DESCRIPTION
# Summary | Résumé

Removes unused code for global file size checks.