### PR TITLE
feat!: Deserialize dates when normalizing data

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -436,6 +436,20 @@ const sortByGroups = ({ form, elements }: { form: FormProperties; elements: Answ
   return sortByLayout({ layout, elements });
 };
 
+const getDateAsString = (answer: DateObject | string | object, dateFormat: DateFormat): string => {
+  try {
+    if (typeof answer === "object" && "YYYY" in answer && "MM" in answer && "DD" in answer) {
+      const dateObject = answer as unknown as DateObject;
+      return getFormattedDateFromObject(dateFormat, dateObject);
+    }
+
+    const dateObject = JSON.parse(answer as string) as DateObject;
+    return getFormattedDateFromObject(dateFormat, dateObject);
+  } catch (e) {
+    return answer as string;
+  }
+};
+
 const getAnswerAsString = (question: FormElement | undefined, answer: unknown): string => {
   if (question && question.type === "checkbox") {
     return Array(answer).join(", ");
@@ -453,15 +467,10 @@ const getAnswerAsString = (question: FormElement | undefined, answer: unknown): 
     if (!answer) {
       return "";
     }
+
     const dateFormat = (question.properties.dateFormat || "YYYY-MM-DD") as DateFormat;
 
-    try {
-      const dateObject = JSON.parse(answer as string) as DateObject;
-      return getFormattedDateFromObject(dateFormat, dateObject);
-    } catch (e) {
-      // If the answer is somehow not parseable as JSON, return it as is
-      return answer as string;
-    }
+    return getDateAsString(answer, dateFormat);
   }
 
   if (question && question.type === "addressComplete") {

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/date.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/date.ts
@@ -15,5 +15,5 @@ export const submission = {
 };
 
 export const result = {
-  "1": '{"YYYY":2024,"MM":11,"DD":28}',
+  "1": { YYYY: 2024, MM: 11, DD: 28 },
 };

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/kitchenSink.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/kitchenSink.ts
@@ -161,7 +161,7 @@ export const result = {
   "5": "two",
   "6": "four",
   "7": ["Condition 2", "Condition 3", "Condition 1"],
-  "8": '{"YYYY":1900,"MM":1,"DD":1}',
+  "8": { YYYY: 1900, MM: 1, DD: 1 },
   "9": "Canada Border Services Agency",
   "10": "12345",
   "11": {
@@ -170,7 +170,7 @@ export const result = {
     id: null,
   },
   "12": [
-    { "0": "short answer", "1": "two", "2": ["one", "two"], "3": '{"YYYY":1900,"MM":1,"DD":1}' },
-    { "0": "another", "1": "three", "2": ["two"], "3": '{"YYYY":1900,"MM":1,"DD":1}' },
+    { "0": "short answer", "1": "two", "2": ["one", "two"], "3": { YYYY: 1900, MM: 1, DD: 1 } },
+    { "0": "another", "1": "three", "2": ["two"], "3": { YYYY: 1900, MM: 1, DD: 1 } },
   ],
 };

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/missingInputs.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/missingInputs.ts
@@ -61,13 +61,13 @@ export const result = {
     {
       "0": "test2",
       "1": ["one", "two"],
-      "2": '{"YYYY":2024,"MM":11,"DD":28}',
+      "2": { YYYY: 2024, MM: 11, DD: 28 },
       "3": { name: null, size: null, id: null },
     },
     {
       "0": "test3",
       "1": ["two", "three"],
-      "2": '{"YYYY":2025,"MM":11,"DD":28}',
+      "2": { YYYY: 2025, MM: 11, DD: 28 },
       "3": { name: null, size: null, id: null },
     },
   ],

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/repeatingSet.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/repeatingSet.ts
@@ -45,8 +45,8 @@ export const submission = {
 
 export const result = {
   "1": [
-    { "0": "Test", "1": ["one", "two", "three"], "2": '{"YYYY":1900,"MM":1,"DD":1}' },
-    { "0": "test2", "1": ["one", "two"], "2": '{"YYYY":2024,"MM":11,"DD":28}' },
-    { "0": "test3", "1": ["two", "three"], "2": '{"YYYY":2025,"MM":11,"DD":28}' },
+    { "0": "Test", "1": ["one", "two", "three"], "2": { YYYY: 1900, MM: 1, DD: 1 } },
+    { "0": "test2", "1": ["one", "two"], "2": { YYYY: 2024, MM: 11, DD: 28 } },
+    { "0": "test3", "1": ["two", "three"], "2": { YYYY: 2025, MM: 11, DD: 28 } },
   ],
 };

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.16] - 2025-08-13
+
+- Add DateObject to Response definition
+
 ## [1.0.15] - 2025-08-13
 
 ### Changed

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/types",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/types/src/form-response-types.ts
+++ b/packages/types/src/form-response-types.ts
@@ -1,3 +1,5 @@
+import { DateObject } from "./form-types";
+
 export type Responses = {
   [key: string]: Response;
 };
@@ -9,6 +11,7 @@ export type Response =
   | Record<string, unknown>[]
   | FileInputResponse
   | FileInputResponse[]
+  | DateObject
   | Record<string, unknown>;
 
 export type FileInputResponse = {


### PR DESCRIPTION
# Summary | Résumé

**Breaking change!**
Deserialize formattedDate objects on the way into the Vault.

Previously, a formattedDate would be submitted to the Vault as a serialized object. For example:

```
{
  "1": "{\"DD\":13,\"MM\":8,\"YYYY\":2025}",
  "2": "Test",
  "4": "{\"YYYY\":2025,\"MM\":8,\"DD\":13}"
}
```

This would require a consumer pulling data from the vault (API, Response Downloads) to parse the string back into an object to access its properties.

This PR deserializes that object on the way into the Vault in the new `normalizeFormResponses` function. So now, a response with dates will look like this:

```
{
  "1": {
    "DD": 13,
    "MM": 8,
    "YYYY": 2025
  },
  "2": "Test",
  "4": {
    "YYYY": 2025,
    "MM": 8,
    "DD": 13
  }
}
```

Since this changes the format or shape of the data being stored in the Vault, it is considered a breaking change. API users will no longer need to deserialize data objects when extracting the data. The Download Responses section has already been updated to support.