### PR TITLE
chore: add specific mime type error

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/exceptions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/exceptions.ts
@@ -28,12 +28,19 @@ export class FormIsClosedError extends Error {
 export class FileUploadError extends Error {
   public file: FileInput;
   public status?: number;
+  public type?: string;
 
-  constructor(message: string, file: FileInput, status?: number) {
+  constructor(
+    message: string,
+    file: FileInput,
+    status?: number,
+    type: "default" | "mime" | "size" = "default"
+  ) {
     super(message ?? "FileUploadError");
     this.name = "FileUploadError";
     this.file = file;
     this.status = status;
+    this.type = type;
   }
 }
 

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/fileUploader.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/fileUploader.ts
@@ -94,7 +94,7 @@ export const uploadFile = async (
   const isValidMimeType = await isMimeTypeValid(file);
 
   if (!isValidMimeType) {
-    throw new FileUploadError(`Failed to upload file: ${file.name}`, file, 400);
+    throw new FileUploadError(`Failed to upload file: ${file.name}`, file, 400, "mime");
   }
 
   Object.entries(preSigned.fields ?? {}).forEach(([key, value]) => {

--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -55,6 +55,10 @@
       "file-size-too-large": {
         "message": "'{{fileName}}' is too big. Choose a file size that is less than {{maxSizeInMb}} MB."
       },
+      "mime": {
+        "heading": "There was a problem submitting your form",
+        "message": "The file {{fileName}} has an invalid mime type."
+      },
       "network-error": {
         "heading": "There was a problem submitting your form",
         "message": "Check your network connection and try to submit again later."

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -54,6 +54,10 @@
       "file-size-too-large": {
         "message": "Le fichier « {{fileName}} » est trop volumineux. Choisissez un fichier dont la taille est inférieure à {{maxSizeInMb}} Mo."
       },
+      "mime": {
+        "heading": "There was a problem submitting your form [FR]",
+        "message": "The file {{fileName}} has an invalid mime type. [FR]"
+      },
       "network-error": {
         "heading": "Il y a eu un problème lors de la soumission de votre formulaire.",
         "message": "Vérifiez votre connexion réseau et réessayez plus tard."

--- a/lib/fileInput/handleUploadError.ts
+++ b/lib/fileInput/handleUploadError.ts
@@ -31,7 +31,7 @@ export const handleUploadError = (
       }
     }
 
-    let message = t("input-validation.file-upload.default.message", {
+    let message = t(`input-validation.file-upload.${error.type}.message`, {
       fileName: error.file.name,
     });
 


### PR DESCRIPTION
# Summary | Résumé


Adds a way + strings to specify mime errors for file uploads.
