### PR TITLE
* Remove mime-check for txt files. (csv/txt)

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/fileUploader.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/fileUploader.ts
@@ -9,6 +9,11 @@ import { Responses, FileInputResponse } from "@lib/types";
 import { FileUploadError } from "../client/exceptions";
 
 export async function isMimeTypeValid(file: FileInput): Promise<boolean> {
+  // We can't use file-type to detect CSV or TXT files, so we'll check the extension.
+  const lowerCaseName = file.name.toLowerCase();
+  if (lowerCaseName.endsWith(".csv") || lowerCaseName.endsWith(".txt")) {
+    return true;
+  }
   const fileTypeResult = await fileTypeFromBuffer(file.content);
   const mimeType = fileTypeResult?.mime;
 


### PR DESCRIPTION
The "file-type" package explicitly notes that it cannot detect the mime-type of text files. (eg: CSV, TXT, SVG) 

As we allow CSV and TXT, it removes the mime-check for these extensions.

Fixes #6014