### PR TITLE
chore: migrate to explicit ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,87 +10,86 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [
-  ...tailwind.configs["flat/recommended"],
-  ...compat.config(
-    { 
-    extends: [
-      "next/core-web-vitals",
-      "next/typescript",
-      "prettier"
-    ],
-    rules: {
-      "no-console": "error",
-      "no-await-in-loop": "error",
-      "no-return-await": "error",
-      "@typescript-eslint/no-require-imports": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        {
-          vars: "all",
-          args: "after-used",
-          ignoreRestSiblings: true,
-          argsIgnorePattern: "^_",
-          caughtErrors: "none", // This allows unused catch parameters
-        },
-      ]
-    },
-    ignorePatterns: [
-      "/utils",
-      "/public/static/scripts/",
-      "/__tests__/api/",
-      "node_modules/",
-      "dist/",
-      "coverage/",
-    ],
-    settings: {
-      tailwindcss: {
-        whitelist: [
-          "(gc\\-).*",
-          "(gcds\\-).*",
-          "form-builder",
-          "form-builder-editor",
-          "page-container",
-          "visually-hidden",
-          "buttons",
-          "required",
-          "focus-group",
-          "canada-flag",
-          "account-wrapper",
-          "input-sizer",
-          "stacked",
-          "disabled",
-          "origin-radix-dropdown-menu",
-          "radio-label-text",
-          "checkbox-label-text",
-          "example-text",
-          "section",
-          "maple-leaf-loader",
-          "flow-container",
-          "rich-text-wrapper",
-          "editor",
-          "editor-input",
-          "link-editor",
-          "link-input",
-          "choice",
-          "text-entry",
-          "action",
-          "wave",
-          "bkd-soft",
-          "legend-fieldset",
-          "confirmation",
-          "active",
-          "brand__container",
-          "fip_flag",
-          "fip_text",
-          "brand__toggle",
-          "brand__signature",
-          "container-xl"
-        ],
+const eslintConfig = [{
+  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts"]
+}, ...tailwind.configs["flat/recommended"], ...compat.config(
+  { 
+  extends: [
+    "next/core-web-vitals",
+    "next/typescript",
+    "prettier"
+  ],
+  rules: {
+    "no-console": "error",
+    "no-await-in-loop": "error",
+    "no-return-await": "error",
+    "@typescript-eslint/no-require-imports": "off",
+    "@typescript-eslint/no-unused-expressions": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        vars: "all",
+        args: "after-used",
+        ignoreRestSiblings: true,
+        argsIgnorePattern: "^_",
+        caughtErrors: "none", // This allows unused catch parameters
       },
+    ]
+  },
+  ignorePatterns: [
+    "/utils",
+    "/public/static/scripts/",
+    "/__tests__/api/",
+    "node_modules/",
+    "dist/",
+    "coverage/",
+  ],
+  settings: {
+    tailwindcss: {
+      whitelist: [
+        "(gc\\-).*",
+        "(gcds\\-).*",
+        "form-builder",
+        "form-builder-editor",
+        "page-container",
+        "visually-hidden",
+        "buttons",
+        "required",
+        "focus-group",
+        "canada-flag",
+        "account-wrapper",
+        "input-sizer",
+        "stacked",
+        "disabled",
+        "origin-radix-dropdown-menu",
+        "radio-label-text",
+        "checkbox-label-text",
+        "example-text",
+        "section",
+        "maple-leaf-loader",
+        "flow-container",
+        "rich-text-wrapper",
+        "editor",
+        "editor-input",
+        "link-editor",
+        "link-input",
+        "choice",
+        "text-entry",
+        "action",
+        "wave",
+        "bkd-soft",
+        "legend-fieldset",
+        "confirmation",
+        "active",
+        "brand__container",
+        "fip_flag",
+        "fip_text",
+        "brand__toggle",
+        "brand__signature",
+        "container-xl"
+      ],
     },
-  }),
-];
+  },
+})];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start:test": "yarn prisma:test && APP_ENV=test NEXT_PUBLIC_APP_ENV=test next start",
     "dev:test": "prisma migrate reset -f --skip-seed && yarn prisma:test && APP_ENV=test NEXT_PUBLIC_APP_ENV=test next dev --turbo",
     "build:test": "APP_ENV=test NEXT_PUBLIC_APP_ENV=test next build",
-    "lint": "next lint && tsc --noEmit",
+    "lint": "eslint . && tsc --noEmit",
     "lint:report": "eslint --output-file eslint_report.json --format json . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint --fix .",
     "format": "prettier --write .",


### PR DESCRIPTION
# Summary | Résumé

Update to remove `next lint` per https://nextjs.org/blog/next-15-5#next-lint-deprecation

> Starting with Next.js 15.5, the next lint command shows a deprecation warning and will be removed in Next.js 16. This modernizes the linting experience by transitioning to explicit ESLint configurations and introducing Biome as a fast alternative.

Updated via code mod `npx @next/codemod@latest next-lint-to-eslint-cli `

