### PR TITLE
fix: allow save security attribute when api key exists

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiKeyButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ApiKeyButton.tsx
@@ -51,6 +51,7 @@ export const ApiKeyButton = ({
         <>
           <GenerateApiKeyButton
             loading={false}
+            className="mr-2"
             theme={theme}
             disabled={Boolean(apiKeyId)}
             onClick={() => {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -101,9 +101,9 @@ export const ResponseDelivery = () => {
   const [purposeOption, setPurposeOption] = useState(formPurpose as PurposeOption);
 
   /*--------------------------------------------*
-   * Save Delivery Option
+   * Save security attribute
    *--------------------------------------------*/
-  const saveDeliveryOptions = useCallback(async () => {
+  const saveSecurityAttribute = useCallback(async () => {
     updateSecurityAttribute(classification);
 
     const resultAttribute = (await updateTemplateSecurityAttribute({
@@ -196,14 +196,18 @@ export const ResponseDelivery = () => {
             <h2 className="mb-6">{t("settingsResponseDelivery.selectClassification")}</h2>
             <div className="mb-10">
               <ClassificationSelect
-                className="max-w-[400px] truncate bg-gray-soft p-1 pr-10"
+                className="!mb-8 max-w-[400px] truncate bg-gray-soft p-1 pr-10"
                 lang={lang}
                 isPublished={isPublished}
                 classification={classification}
                 handleUpdateClassification={handleUpdateClassification}
               />
+              <div>
+                <Button disabled={isPublished} theme="secondary" onClick={saveSecurityAttribute}>
+                  {t("settingsResponseDelivery.saveButton")}
+                </Button>
+              </div>
             </div>
-
             <div className="mb-10">
               <h2 className="mb-6">{t("settingsResponseDelivery.title")}</h2>
 
@@ -296,12 +300,7 @@ export const ResponseDelivery = () => {
                 </div>
               )}
 
-              <>
-                <Button disabled={isPublished} theme="secondary" onClick={saveDeliveryOptions}>
-                  {t("settingsResponseDelivery.saveButton")}
-                </Button>
-                <ResponseDeliveryHelpButtonWithApi />
-              </>
+              <ResponseDeliveryHelpButtonWithApi />
             </div>
 
             {/*--------------------------------------------*

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -103,23 +103,26 @@ export const ResponseDelivery = () => {
   /*--------------------------------------------*
    * Save security attribute
    *--------------------------------------------*/
-  const saveSecurityAttribute = useCallback(async () => {
-    updateSecurityAttribute(classification);
+  const saveSecurityAttribute = useCallback(
+    async (classification: ClassificationType) => {
+      updateSecurityAttribute(classification);
 
-    const resultAttribute = (await updateTemplateSecurityAttribute({
-      id,
-      securityAttribute: classification,
-    })) as FormServerError;
+      const resultAttribute = (await updateTemplateSecurityAttribute({
+        id,
+        securityAttribute: classification,
+      })) as FormServerError;
 
-    if (resultAttribute?.error) {
-      toast.error(<ErrorSaving errorCode={FormServerErrorCodes.DELIVERY_OPTION} />, "wide");
-      return;
-    }
+      if (resultAttribute?.error) {
+        toast.error(<ErrorSaving errorCode={FormServerErrorCodes.DELIVERY_OPTION} />, "wide");
+        return;
+      }
 
-    toast.success(t("settingsResponseDelivery.savedSuccessMessage"));
+      toast.success(t("settingsResponseDelivery.savedSuccessMessage"));
 
-    refreshData && refreshData();
-  }, [t, refreshData, id, classification, updateSecurityAttribute]);
+      refreshData && refreshData();
+    },
+    [t, refreshData, id, updateSecurityAttribute]
+  );
 
   /*--------------------------------------------*
    * Save form purpose option
@@ -165,8 +168,9 @@ export const ResponseDelivery = () => {
         setDeliveryOptionValue(DeliveryOption.vault);
       }
       setClassification(value);
+      saveSecurityAttribute(value);
     },
-    [deliveryOptionValue]
+    [deliveryOptionValue, saveSecurityAttribute]
   );
 
   const handleDeleteApiKey = useCallback(() => {
@@ -196,17 +200,12 @@ export const ResponseDelivery = () => {
             <h2 className="mb-6">{t("settingsResponseDelivery.selectClassification")}</h2>
             <div className="mb-10">
               <ClassificationSelect
-                className="!mb-8 max-w-[400px] truncate bg-gray-soft p-1 pr-10"
+                className="max-w-[400px] truncate bg-gray-soft p-1 pr-10"
                 lang={lang}
                 isPublished={isPublished}
                 classification={classification}
                 handleUpdateClassification={handleUpdateClassification}
               />
-              <div>
-                <Button disabled={isPublished} theme="secondary" onClick={saveSecurityAttribute}>
-                  {t("settingsResponseDelivery.saveButton")}
-                </Button>
-              </div>
             </div>
             <div className="mb-10">
               <h2 className="mb-6">{t("settingsResponseDelivery.title")}</h2>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -200,7 +200,6 @@ export const ResponseDelivery = () => {
                 lang={lang}
                 isPublished={isPublished}
                 classification={classification}
-                disabled={hasApiKey}
                 handleUpdateClassification={handleUpdateClassification}
               />
             </div>
@@ -296,19 +295,13 @@ export const ResponseDelivery = () => {
                   <ApiDocNotes />
                 </div>
               )}
-              {deliveryOptionValue !== DeliveryOption.api && !hasApiKey && (
-                <>
-                  <Button
-                    // disabled={!isValid || isPublished}
-                    disabled={isPublished}
-                    theme="secondary"
-                    onClick={saveDeliveryOptions}
-                  >
-                    {t("settingsResponseDelivery.saveButton")}
-                  </Button>
-                  <ResponseDeliveryHelpButtonWithApi />
-                </>
-              )}
+
+              <>
+                <Button disabled={isPublished} theme="secondary" onClick={saveDeliveryOptions}>
+                  {t("settingsResponseDelivery.saveButton")}
+                </Button>
+                <ResponseDeliveryHelpButtonWithApi />
+              </>
             </div>
 
             {/*--------------------------------------------*

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/ResponseDelivery.tsx
@@ -298,8 +298,9 @@ export const ResponseDelivery = () => {
                   <ApiDocNotes />
                 </div>
               )}
-
-              <ResponseDeliveryHelpButtonWithApi />
+              <div>
+                <ResponseDeliveryHelpButtonWithApi />
+              </div>
             </div>
 
             {/*--------------------------------------------*

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/dialogs/ResponseDeliveryHelpDialogApiWithApi.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/dialogs/ResponseDeliveryHelpDialogApiWithApi.tsx
@@ -117,7 +117,7 @@ export const ResponseDeliveryHelpButtonWithApi = () => {
 
   return (
     <>
-      <InfoIcon className="ml-4 inline-block size-5" />
+      <InfoIcon className="inline-block size-5" />
       <div className="ml-2 inline-block">
         <Button onClick={handleOpenDialog} theme="link">
           {t("settingsResponseDelivery.responseDeliveryHelpWithApi.cta")}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Summary | Résumé


Fixes: https://github.com/cds-snc/platform-forms-client/issues/5787

- Update not disable the classification select and allow saving when an api key exists.
- Remove save button 
- Update save callback name
- Auto-save when classification is changed



https://github.com/user-attachments/assets/0e8d1a45-3c45-47e5-98e7-a4ad8122a8b5

