### PR TITLE
fix: redaction of timestamps in support tickets

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@bufbuild/protobuf": "^2.2.3",
     "@casl/ability": "6.7.3",
     "@cdssnc/gcds-tokens": "2.12.0",
-    "@cdssnc/sanitize-pii": "^1.2.1",
+    "@cdssnc/sanitize-pii": "^2.0.1",
     "@gcforms/announce": "workspace:*",
     "@gcforms/connectors": "workspace:*",
     "@gcforms/core": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,10 +1726,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cdssnc/sanitize-pii@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "@cdssnc/sanitize-pii@npm:1.2.2"
-  checksum: 10c0/ae008adb17e0572d6a2628b46aa01c2f91f2c5622c37d364485ccaf377802156ae4824ae6305dd4039846c573bb275a5f10cac08cde3aa60a01254e72a8fb8a9
+"@cdssnc/sanitize-pii@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@cdssnc/sanitize-pii@npm:2.0.1"
+  checksum: 10c0/6440558c5cdab932dbf5cf91a6f4cb928727b29de94d165511e823f0c1db5f10a6e56aca5ecf6105890aca62a7d7486507dc8a61c56ba881a08b4f835c9d5624
   languageName: node
   linkType: hard
 
@@ -13193,7 +13193,7 @@ __metadata:
     "@bufbuild/protobuf": "npm:^2.2.3"
     "@casl/ability": "npm:6.7.3"
     "@cdssnc/gcds-tokens": "npm:2.12.0"
-    "@cdssnc/sanitize-pii": "npm:^1.2.1"
+    "@cdssnc/sanitize-pii": "npm:^2.0.1"
     "@eslint/eslintrc": "npm:^3"
     "@gcforms/announce": "workspace:*"
     "@gcforms/connectors": "workspace:*"


### PR DESCRIPTION
# Summary | Résumé

Update to the latest version of the `@cdssnc/sanitize-pii` module so that error code timestamps are no longer partially redacted and incorrectly identified as phone numbers.

# Related
- https://github.com/cds-snc/sanitize-pii/pull/38
- https://github.com/cds-snc/platform-core-services/issues/809

# Test instructions | Instructions pour tester la modification

1. After deploy, create a support request that includes the [Forms error code format](https://docs.google.com/document/d/1Za03rcuC9YUDtNXuNyHAwUi7wtp-vgVFxBx0Oy2JZz8).
2. Expect that the timestamp portion of the error code is not redacted.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

None.

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
