### PR TITLE
chore: upgrade to @cdssnc/sanitize-pii@2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@bufbuild/protobuf": "^2.2.3",
     "@casl/ability": "6.7.3",
     "@cdssnc/gcds-tokens": "2.12.0",
-    "@cdssnc/sanitize-pii": "^2.0.1",
+    "@cdssnc/sanitize-pii": "^2.0.2",
     "@gcforms/announce": "workspace:*",
     "@gcforms/connectors": "workspace:*",
     "@gcforms/core": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,10 +1726,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cdssnc/sanitize-pii@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@cdssnc/sanitize-pii@npm:2.0.1"
-  checksum: 10c0/6440558c5cdab932dbf5cf91a6f4cb928727b29de94d165511e823f0c1db5f10a6e56aca5ecf6105890aca62a7d7486507dc8a61c56ba881a08b4f835c9d5624
+"@cdssnc/sanitize-pii@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@cdssnc/sanitize-pii@npm:2.0.2"
+  checksum: 10c0/337338d6539ce476eb3837ee2f8ffafc44d28b3ccae9632a10bb127164c1e7585ef709a1604d8f645a9ea18dc8d76fd8ab6349ad155ab5780172bce65f223821
   languageName: node
   linkType: hard
 
@@ -13194,7 +13194,7 @@ __metadata:
     "@bufbuild/protobuf": "npm:^2.2.3"
     "@casl/ability": "npm:6.7.3"
     "@cdssnc/gcds-tokens": "npm:2.12.0"
-    "@cdssnc/sanitize-pii": "npm:^2.0.1"
+    "@cdssnc/sanitize-pii": "npm:^2.0.2"
     "@eslint/eslintrc": "npm:^3"
     "@gcforms/announce": "workspace:*"
     "@gcforms/connectors": "workspace:*"


### PR DESCRIPTION
# Summary | Résumé
Upgrade to the latest version of the sanitize PII module which removes the 7+ digit redaction pattern.  This is being done as it was catching non-sensitive data like timestamp error codes in support tickets.

# Related
- https://github.com/cds-snc/platform-core-services/issues/809
- https://github.com/cds-snc/sanitize-pii/pull/41

# Test instructions | Instructions pour tester la modification

After merge, submit a support ticket with a timestamp error code and confirm that it is not redacted.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

None

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [ ] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
