### PR TITLE
fix: skip to right panel

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/RightPanel.tsx
@@ -144,6 +144,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
       <div className={cn("fixed right-0", fixedRange, open && "hidden")}>
         <div className="mr-4 mt-4">
           <CircleButton
+            id={!open ? "rightPanelTitle" : ""}
             title={t("rightPanel.openPanel")}
             onClick={() => {
               togglePanel && togglePanel(true);
@@ -172,7 +173,7 @@ export const RightPanel = ({ id, lang }: { id: string; lang: Language }) => {
                   <div className="p-6">
                     <div className="flex justify-between">
                       <div>
-                        <h2 id="rightPanelTitle" className="text-base" tabIndex={-1}>
+                        <h2 id={open ? "rightPanelTitle" : ""} className="text-base" tabIndex={-1}>
                           {t("rightPanel.openPanel")}
                         </h2>
                       </div>

--- a/components/clientComponents/globals/Buttons/CircleButton.tsx
+++ b/components/clientComponents/globals/Buttons/CircleButton.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from "@formBuilder/components/shared/Tooltip";
 import { Button } from "@clientComponents/globals";
 
 type CircleProps = {
+  id: string;
   children: JSX.Element | string;
   className?: string;
   title?: string;
@@ -18,11 +19,13 @@ export const CircleButton = ({
   onClick,
   className,
   dataTestId,
+  id,
 }: CircleProps) => {
   return (
     <div className="relative z-10 flex size-[50px]">
       <Tooltip.Simple text={title} side="left">
         <Button
+          id={id}
           theme="secondary"
           aria-label={title}
           onClick={onClick}


### PR DESCRIPTION
# Summary | Résumé

Update to ensure id exists when panel is in an open or a closed state.

Fixes: #6041

https://github.com/user-attachments/assets/0e598809-512e-418f-8255-fa5d2a8727c7




