### PR TITLE
chore: wrap waf check

### DIFF
--- a/lib/auth/nextAuth.ts
+++ b/lib/auth/nextAuth.ts
@@ -174,12 +174,17 @@ const {
         return;
       }
 
-      const requestHeaders = await headers();
+      try {
+        const requestHeaders = await headers();
 
-      if (requestHeaders.get("x-amzn-waf-cognito-login-outside-of-canada")) {
-        logMessage.info(
-          `[next-auth][sign-in] User ${user.email} (${internalUser.id}) signed in from outside of Canada`
-        );
+        if (requestHeaders.get("x-amzn-waf-cognito-login-outside-of-canada")) {
+          logMessage.info(
+            `[next-auth][sign-in] User ${user.email} (${internalUser.id}) signed in from outside of Canada`
+          );
+        }
+      } catch (error) {
+        // headers() can fail during build time, log but don't prevent sign-in
+        logMessage.debug(`Could not access request headers during sign-in event: ${error}`);
       }
 
       // Update lastLogin in the database


### PR DESCRIPTION
# Summary | Résumé

Adds a try / catch to waf check to avoid built time errors when headers are not available

```
N: fetch failed. Read more at https://errors.authjs.dev#autherror
    at P (.next/server/chunks/280.js:1:55849)
    at async $ (.next/server/chunks/280.js:1:57437) {
  type: 'AuthError',
  kind: 'error'
```