### PR TITLE
fix: dynamic row - controlled or uncontrolled input element 

### DIFF
--- a/components/clientComponents/forms/DynamicRow/DynamicRow.tsx
+++ b/components/clientComponents/forms/DynamicRow/DynamicRow.tsx
@@ -55,9 +55,25 @@ export const DynamicGroup = (props: DynamicGroupProps): React.ReactElement => {
     maxNumberOfRows,
   } = props;
   const [field, , helpers] = useField(props);
-  const [rows, setRows] = useState(() => Array(field.value.length).fill(rowElements));
+
+  // Helper function to create initial values for a new row
+  const createInitialRowValue = () => {
+    const initialValue: Record<string, string> = {};
+    rowElements.forEach((element, index) => {
+      // Initialize each field with an empty string to prevent controlled/uncontrolled warnings
+      initialValue[index.toString()] = "";
+    });
+    return initialValue;
+  };
+
+  // Ensure field.value is always a non-empty array to prevent controlled/uncontrolled switching
+  // and to ensure there's always at least one row to display
+  const fieldValue =
+    Array.isArray(field.value) && field.value.length > 0 ? field.value : [createInitialRowValue()]; // Initialize with proper field defaults
+
+  const [rows, setRows] = useState(() => Array(fieldValue.length).fill(rowElements));
   const rowRefs = useRef<Array<React.RefObject<HTMLFieldSetElement | null>>>(
-    Array(field.value.length).fill(createRef<HTMLFieldSetElement>())
+    Array(fieldValue.length).fill(createRef<HTMLFieldSetElement>())
   );
   const focusedRow = useRef<number | null>(null);
   const [hasReachedMaxNumberOfRows, setHasReachedMaxNumberOfRows] = useState<boolean>(false);
@@ -86,15 +102,15 @@ export const DynamicGroup = (props: DynamicGroupProps): React.ReactElement => {
 
   const addRow = () => {
     if (hasReachedMaxNumberOfRows) return;
-    // Set the newly added row'initial value (plucked out of initialValues)
-    const newValue = [...field.value];
-    newValue.push({}); // Push an empty object to the value array
+    // Set the newly added row's initial value with proper defaults for all fields
+    const newValue = [...fieldValue];
+    newValue.push(createInitialRowValue()); // Push an object with proper field defaults
     helpers.setValue(newValue);
     // Add the new row to the rows state
     setRows([...rows, rowElements]);
     // Add a new ref to the rowRefs state
     rowRefs.current.push(createRef<HTMLFieldSetElement>());
-    // Do not subtract one because the rows state has not yet updated it's length when this is called
+    // Do not subtract one because the rows state has not yet updated its length when this is called
     focusedRow.current = rows.length;
     // Let an AT user know a new repeating set was added
     announce(t("dynamicRow.addedMessage", { rowTitle: title, count: rows.length + 1 }));
@@ -102,7 +118,7 @@ export const DynamicGroup = (props: DynamicGroupProps): React.ReactElement => {
 
   const deleteRow = (index: number) => {
     // Remove the value from the formik state
-    const newValues = [...field.value];
+    const newValues = [...fieldValue];
     newValues.splice(index, 1);
     helpers.setValue(newValues);
     // Remove the row from the rows state


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where when using a repeating set inputs we're warning about "controlled or uncontrolled input element"


## Fix 

Problem: New rows were initialized with empty objects {}, causing form fields to start with undefined values and transition to "", triggering warnings. 

Updated code ensure empty strings to avoid undefined values

<img width="500" height="436" alt="Screenshot 2025-09-19 at 7 38 45 AM" src="https://github.com/user-attachments/assets/96186486-ce32-4b6e-b391-1ae9f7f2af4e" />




## Current main: 

Console error:



https://github.com/user-attachments/assets/e2c73e50-847f-4025-9d2f-004e6defd12c


The issue also shows up as an error in the Jest test output 

<img width="853" height="482" alt="Screenshot 2025-09-19 at 7 33 20 AM" src="https://github.com/user-attachments/assets/f51f3226-ea64-4602-a0b0-8d8dc810676e" />

<hr>

> A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://react.dev/link/controlled-components



