### PR TITLE
Chore: Replace formBuilder.tsx with Component Model

### DIFF
--- a/components/clientComponents/forms/TextInput/TextInputPlugin.tsx
+++ b/components/clientComponents/forms/TextInput/TextInputPlugin.tsx
@@ -1,0 +1,82 @@
+// Update the path below to the correct location of ComponentPlugin
+import { ComponentPlugin } from "@lib/components/ComponentPlugin";
+import { TextInput } from "./TextInput";
+import { FormElementTypes } from "@lib/types";
+import { getLocalizedProperty } from "@lib/utils";
+import { Label, Description } from "@clientComponents/forms";
+
+export const TextInputPlugin: ComponentPlugin = {
+  meta: {
+    type: FormElementTypes.textField,
+  },
+  render({ element, lang }) {
+    const id = element.id;
+    const isRequired = !!element.properties.required;
+
+    const descriptionPerLocale = element.properties[getLocalizedProperty("description", lang)];
+    const description = descriptionPerLocale ? descriptionPerLocale.toString() : "";
+
+    const placeHolderPerLocale = element.properties[getLocalizedProperty("placeholder", lang)];
+    const placeHolder = placeHolderPerLocale ? placeHolderPerLocale.toString() : "";
+
+    const textType =
+      element.properties?.validation?.type &&
+      ["email", "name", "number", "password", "search", "tel", "url"].includes(
+        element.properties.validation.type
+      )
+        ? element.properties.validation.type
+        : "text";
+
+    const labelText = element.properties[getLocalizedProperty("title", lang)]?.toString();
+    const labelComponent = labelText ? (
+      <Label
+        key={`label-${id}`}
+        id={`label-${id}`}
+        htmlFor={`${id}`}
+        className={isRequired ? "required" : ""}
+        required={isRequired}
+        validation={element.properties.validation}
+        group={["radio", "checkbox"].indexOf(element.type) !== -1}
+        lang={lang}
+      >
+        {labelText}
+      </Label>
+    ) : null;
+
+    const spellCheck =
+      element.properties?.autoComplete &&
+      [
+        "email",
+        "name",
+        "tel",
+        "given-name",
+        "additional-name",
+        "family-name",
+        "address-line1",
+        "address-level2",
+        "address-level1",
+        "postal-code",
+      ].includes(element.properties?.autoComplete)
+        ? false
+        : undefined;
+
+    return (
+      <div className="focus-group gcds-input-wrapper">
+        {labelComponent}
+        {description && <Description id={`${id}`}>{description}</Description>}
+        <TextInput
+          type={textType}
+          spellCheck={spellCheck}
+          id={`${id}`}
+          name={`${id}`}
+          required={isRequired}
+          ariaDescribedBy={description ? `desc-${id}` : undefined}
+          placeholder={placeHolder.toString()}
+          autoComplete={element.properties.autoComplete?.toString()}
+          maxLength={element.properties.validation?.maxLength}
+          allowNegativeNumbers={element.properties.allowNegativeNumbers}
+        />
+      </div>
+    );
+  },
+};

--- a/lib/components/Component.ts
+++ b/lib/components/Component.ts
@@ -1,0 +1,18 @@
+import { ReactElement } from "react";
+import { FormElement, FormElementTypes } from "@lib/types";
+import { TextInputPlugin } from "@clientComponents/forms/TextInput/TextInputPlugin";
+import { ComponentPlugin } from "./ComponentPlugin";
+
+const plugins: ComponentPlugin[] = [TextInputPlugin];
+
+export const elementRegistry = Object.fromEntries(plugins.map((p) => [p.meta.type, p])) as Record<
+  FormElementTypes,
+  ComponentPlugin
+>;
+
+function renderElement(element: FormElement, lang: string): ReactElement | null {
+  return elementRegistry[element.type]?.render({ element, lang }) ?? null;
+}
+export const GeneratePluginElement = (element: FormElement, lang: string): ReactElement | null => {
+  return renderElement(element, lang);
+};

--- a/lib/components/ComponentPlugin.ts
+++ b/lib/components/ComponentPlugin.ts
@@ -1,0 +1,7 @@
+import { FormElement, FormElementTypes } from "@lib/types";
+import { ReactElement } from "react";
+
+export interface ComponentPlugin {
+  meta: { type: FormElementTypes };
+  render(args: { element: FormElement; lang: string }): ReactElement | null;
+}

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -10,7 +10,6 @@ import {
   MultipleChoiceGroup,
   RichText,
   TextArea,
-  TextInput,
   ConditionalWrapper,
   Combobox,
   FormattedDate,
@@ -27,6 +26,8 @@ import { getLocalizedProperty } from "@lib/utils";
 import { managedData } from "@lib/managedData";
 import { AddressComplete } from "@clientComponents/forms/AddressComplete/AddressComplete";
 import { DateFormat } from "@clientComponents/forms/FormattedDate/types";
+
+import { GeneratePluginElement } from "@lib/components/Component";
 
 // This function is used for select/radio/checkbox i18n change of form labels
 function getLocaleChoices(choices: Array<PropertyChoices> | undefined, lang: string) {
@@ -83,31 +84,6 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
     </Label>
   ) : null;
 
-  const textType =
-    element.properties?.validation?.type &&
-    ["email", "name", "number", "password", "search", "tel", "url"].includes(
-      element.properties.validation.type
-    )
-      ? element.properties.validation.type
-      : "text";
-
-  const spellCheck =
-    element.properties?.autoComplete &&
-    [
-      "email",
-      "name",
-      "tel",
-      "given-name",
-      "additional-name",
-      "family-name",
-      "address-line1",
-      "address-level2",
-      "address-level1",
-      "postal-code",
-    ].includes(element.properties?.autoComplete)
-      ? false
-      : undefined;
-
   const placeHolderPerLocale = element.properties[getLocalizedProperty("placeholder", lang)];
   const placeHolder = placeHolderPerLocale ? placeHolderPerLocale.toString() : "";
 
@@ -118,24 +94,7 @@ function _buildForm(element: FormElement, lang: string): ReactElement {
 
   switch (element.type) {
     case FormElementTypes.textField:
-      return (
-        <div className="focus-group gcds-input-wrapper">
-          {labelComponent}
-          {description && <Description id={`${id}`}>{description}</Description>}
-          <TextInput
-            type={textType}
-            spellCheck={spellCheck}
-            id={`${id}`}
-            name={`${id}`}
-            required={isRequired}
-            ariaDescribedBy={description ? `desc-${id}` : undefined}
-            placeholder={placeHolder.toString()}
-            autoComplete={element.properties.autoComplete?.toString()}
-            maxLength={element.properties.validation?.maxLength}
-            allowNegativeNumbers={element.properties.allowNegativeNumbers}
-          />
-        </div>
-      );
+      return GeneratePluginElement(element, lang) ?? <></>;
     case FormElementTypes.textArea:
       return (
         <div className="focus-group gcds-textarea-wrapper">


### PR DESCRIPTION
A refactor of the formBuilder.tsx to adopt a component model with the final intent being components (eg: TextField, Checkbox, AddressComplete, FileInput, etc...) are fully self contained, and logic is not spread across the application.

This PR is an early DRAFT for review to adopt any style changes the team is looking for before pushing a full change.
