### PR TITLE
chore: add prisma config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "gcforms",
   "version": "4.2.0",
   "private": true,
-  "prisma": {
-    "seed": "tsx prisma/seeds/seed_cli.ts --environment=development"
-  },
   "workspaces": [
     "utils/*",
     "packages/*"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    seed: "tsx prisma/seeds/seed_cli.ts --environment=development",
+  },
+});


### PR DESCRIPTION
# Summary | Résumé

Update to use config file for prisma vs package.json 

```bash
warn The configuration property `package.json#prisma` is deprecated and will be removed in Prisma 7. Please migrate to a Prisma config file (e.g., `prisma.config.ts`).
For more information, see: https://pris.ly/prisma-config
```