### PR TITLE
chore: import env for prisma config

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
 export default defineConfig({


### PR DESCRIPTION
# Summary | Résumé

Add missing import 

Fixes:

```
Error: Prisma schema validation - (get-config wasm)
Error code: P1012
error: Environment variable not found: DATABASE_URL.
  -->  prisma/schema.prisma:7
   | 
 6 |   provider = "postgresql"
 7 |   url      = env("DATABASE_URL")
```