### PR TITLE
chore: reduce db lookups done by notifications

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
@@ -116,7 +116,12 @@ export async function submitForm(
       language,
     });
 
-    sendNotifications(formId, template.form.titleEn, template.form.titleFr);
+    sendNotifications(
+      formId,
+      template.form.titleEn,
+      template.form.titleFr,
+      !!template.deliveryOption
+    );
 
     return { id: formId, submissionId, fileURLMap };
   } catch (e) {

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -16,10 +16,14 @@ const Status = {
 type Status = (typeof Status)[keyof typeof Status];
 
 // Public facing function to send notifications to all related users on a form submission
-export const sendNotifications = async (formId: string, titleEn: string, titleFr: string) => {
-  // Avoid sending additional notifications to legacy forms that receive delivery by email.
-  const deliveryOption = await _getDeliveryOption(formId);
-  if (deliveryOption) {
+export const sendNotifications = async (
+  formId: string,
+  titleEn: string,
+  titleFr: string,
+  hasDeliveryOption: boolean
+) => {
+  // Avoid sending additional notifications to legacy forms that already receive delivery updates by email
+  if (hasDeliveryOption) {
     return;
   }
 
@@ -97,26 +101,6 @@ export const getNotificationsUsers = async (formId: string) => {
       enabled: foundUser ? true : false,
     };
   });
-};
-
-const _getDeliveryOption = async (formId: string) => {
-  const template = await prisma.template
-    .findUnique({
-      where: {
-        id: formId,
-      },
-      select: {
-        deliveryOption: true,
-      },
-    })
-    .catch((e) => prismaErrors(e, null));
-
-  if (!template) {
-    logMessage.warn(`_getDeliveryOption template not found with id ${formId}`);
-    return null;
-  }
-
-  return template.deliveryOption;
 };
 
 const setMarker = async (formId: string, status: Status = Status.SINGLE_EMAIL_SENT) => {

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1309,6 +1309,7 @@ export const onlyIncludePublicProperties = (template: FormRecord): PublicFormRec
     isPublished: template.isPublished,
     securityAttribute: template.securityAttribute,
     saveAndResume: template.saveAndResume,
+    deliveryOption: template.deliveryOption,
   };
 };
 

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -708,8 +708,7 @@ describe("Template CRUD functions", () => {
       expect(publicFormRecord).toHaveProperty("form");
       expect(publicFormRecord).toHaveProperty("isPublished");
       expect(publicFormRecord).toHaveProperty("securityAttribute");
-
-      expect(publicFormRecord).not.toHaveProperty("deliveryOption");
+      expect(publicFormRecord).toHaveProperty("deliveryOption");
     });
   });
 


### PR DESCRIPTION
# Summary | Résumé

Previously Notifications did a db lookup for delivery options to determine whether or not to send a notification. This was done to keep the code as isolated as possible. The downside though is that deliveryOption is only used by legacy forms so the db call is not needed for most forms.

The update alters the forms template call to include deliveryOption in the "public properties" and passes this down to notifications.

## Testing

Try sending a few form submissions on a form. You should receive notifications.

Create a new form and set the form to receive email delivery (manually). Send a few form submissions. You should not receive notifications.

This is probably easiest to test locally by updating a template through prisma. For example.
<img width="2417" height="240" alt="Screenshot 2025-10-08 at 9 42 37 AM" src="https://github.com/user-attachments/assets/613ac4f4-849b-46c7-bedd-29ee1230d109" />

To know whether you successfully added a deliveryOption you should see an email delivery option in the form setting.
<img width="1191" height="1028" alt="Screenshot 2025-10-08 at 9 44 06 AM" src="https://github.com/user-attachments/assets/c769369a-cec7-40ac-a3ad-77eef6e1674b" />


