### PR TITLE
fix: attempt at fixing some of the GC Notify API calls timing out

### DIFF
--- a/packages/connectors/CHANGELOG.md
+++ b/packages/connectors/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.12] - 2025-10-09
+
+- Enable HttpAgent keepAlive for GC Notify API calls
 
 ## [2.2.11] - 2025-10-08
 

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/connectors",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/connectors/src/gc-notify-connector.ts
+++ b/packages/connectors/src/gc-notify-connector.ts
@@ -1,9 +1,12 @@
+import { Agent } from "https";
 import { getAwsSecret } from "./getAwsSecret";
 import axios, { AxiosError } from "axios";
 
 const API_URL: string = "https://api.notification.canada.ca";
 
 export type Personalisation = Record<string, string | boolean | Record<string, string | boolean>>;
+
+const httpsAgent = new Agent({ keepAlive: true });
 
 export class GCNotifyConnector {
   private apiUrl: string;
@@ -41,6 +44,7 @@ export class GCNotifyConnector {
   ): Promise<void> {
     try {
       await axios({
+        httpsAgent: httpsAgent,
         url: `${this.apiUrl}/v2/notifications/email`,
         method: "POST",
         timeout: this.timeout,


### PR DESCRIPTION
# Summary | Résumé

- Enables `keepAlive` for HttpAgent used by Axios

Note: this is an attempt at fixing the various timeout issues we have been experiencing with GC Notify API calls.