### PR TITLE
Pass Id to removeElement

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/headless-treeview/handlers/handleDelete.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/headless-treeview/handlers/handleDelete.ts
@@ -32,7 +32,7 @@ export const handleDelete = async (
   if (confirm) {
     const children = item.getChildren();
     children.forEach((child) => {
-      removeElement(Number(child));
+      removeElement(Number(child.getId()));
     });
 
     deleteGroup(item.getId());


### PR DESCRIPTION
# Summary | Résumé

Fixes #6244

When deleting a page, we recursively need to delete any elements on that page as well. When we refactored the TreeView, we missed updating this reference the the element- previously was a simple id, is now an item object that we have to retrieve the id from.

BEGIN_COMMIT_OVERRIDE
fix: pass Id to removeElement
END_COMMIT_OVERRIDE
