### PR TITLE
fix: PR review Lambda function permissions

### DIFF
--- a/.github/workflows/pr-review-client-deploy.yml
+++ b/.github/workflows/pr-review-client-deploy.yml
@@ -123,10 +123,15 @@ jobs:
             aws lambda wait function-active --function-name $FUNCTION_NAME-$PR_NUMBER
             aws lambda add-permission \
               --function-name $FUNCTION_NAME-$PR_NUMBER \
-              --statement-id FunctionURLAllowPublicAccess \
+              --statement-id AllowPublicInvokeFunctionUrl \
               --action lambda:InvokeFunctionUrl \
               --principal "*" \
               --function-url-auth-type NONE > /dev/null 2>&1
+            aws lambda add-permission \
+              --function-name $FUNCTION_NAME-$PR_NUMBER \
+              --statement-id AllowPublicInvokeFunction \
+              --action lambda:InvokeFunction \
+              --principal "*" > /dev/null 2>&1
 
             URL="$(aws lambda create-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER --auth-type NONE | jq .FunctionUrl)"
             echo "URL=$URL" >> $GITHUB_ENV


### PR DESCRIPTION
# Summary
Update the PR review environment's Lambda function permissions to include `lambda:InvokeFunction`.

This is a recent change from AWS requiring public function URLs to include both the `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` actions:
https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html

> Starting in October 2025, new function URLs will require both lambda:InvokeFunctionUrl and lambda:InvokeFunction permissions.

# Test instructions | Instructions pour tester la modification

- Expect the PR review environment for this PR to deploy and work as expected.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

None

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [ ] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [x] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [ ] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?

# Related
- https://github.com/cds-snc/platform-core-services/issues/886
