### PR TITLE
chore: update content for accuracy

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -611,7 +611,7 @@
   "publishingDisablesEditing": "Publishing disables editing.",
   "publishingDisablesEditingDescription": "Once you publish, you cannot make changes to this form. If changes are needed after publishing, use the form file to create and publish a new form.",
   "publishingLocksSettings": "Publishing locks some settings.",
-  "publishingLocksSettingsDescription": "Many form settings will no longer be changeable such as the form's classification, branding, and intended use.",
+  "publishingLocksSettingsDescription": "Many form settings will no longer be changeable such as the form's classification and intended use.",
   "publishingRemovesTestResponses": "Publishing removes test responses.",
   "publishingRemovesTestResponsesDescription": "Any prior responses will be removed from the system.",
   "publishYourForm": "Publish your form",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -611,7 +611,7 @@
   "publishingDisablesEditing": "La publication désactive toute modification.",
   "publishingDisablesEditingDescription": "Une fois publié, vous ne pouvez plus apporter des modifications à ce formulaire. Si des modifications sont nécessaires après la publication, utilisez le fichier du formulaire pour créer et publier un nouveau formulaire.",
   "publishingLocksSettings": "La publication verrouille certains paramètres.",
-  "publishingLocksSettingsDescription": "Plusieurs paramètres du formulaire ne seront plus modifiables, tels que la classification, l'image de marque et l'usage prévu du formulaire.",
+  "publishingLocksSettingsDescription": "Plusieurs paramètres du formulaire ne seront plus modifiables, tels que la classification et l'usage prévu du formulaire.",
   "publishingRemovesTestResponses": "La publication supprime les réponses test.",
   "publishingRemovesTestResponsesDescription": "Toutes les réponses antérieures seront supprimées du système.",
   "publishYourForm": "Publier votre formulaire",


### PR DESCRIPTION
## Description

Previously we said "branding" was locked upon publishing. 

Fix this on the publishing page for accuracy.