### PR TITLE
chore: remove .numbers file type support

### DIFF
--- a/lib/tests/validation/fileValidationClientSide.test.ts
+++ b/lib/tests/validation/fileValidationClientSide.test.ts
@@ -9,7 +9,6 @@ describe("File extension validator", () => {
     ["docx", true],
     ["jpg", true],
     ["png", true],
-    ["numbers", true],
     ["PDF", true],
     ["CSV", true],
     ["ca", false],

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## [1.0.11] - 2025-10-29
+
+- Remove `.numbers` file type support
 
 ## [1.0.10] - 2025-10-28
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/core",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/validation/file.ts
+++ b/packages/core/src/validation/file.ts
@@ -18,7 +18,6 @@ export const ALLOWED_FILE_TYPES = [
     mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     extensions: ["xlsx"],
   },
-  { mime: "application/vnd.apple.numbers", extensions: ["numbers"] },
   { mime: "application/xml", extensions: ["xml"] },
   { mime: "text/xml", extensions: ["xml"] },
 ];


### PR DESCRIPTION
# Summary | Résumé

- Removes `.numbers` file type support