### PR TITLE
chore: remove references to .numbers file type in UI elements

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/FileTypeOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/FileTypeOptions.tsx
@@ -17,13 +17,13 @@ export const FileTypeOptions = ({
 }) => {
   const { t } = useTranslation("form-builder");
 
-  // item.properties.fileType = types of files ["xls","xlsx","csv","numbers"]
+  // item.properties.fileType = types of files ["xls","xlsx","csv"]
   // First ensure fileType is an array
   const fileTypes: string[] = Array.isArray(item.properties.fileType)
     ? item.properties.fileType
     : item.properties.fileType
-    ? [item.properties.fileType]
-    : [];
+      ? [item.properties.fileType]
+      : [];
 
   // Convert file types to file groups ["documents", "images", "spreadsheets"]
   const [selectedGroups, setSelectedGroups] = useState<string[]>(fileTypesToFileGroups(fileTypes));

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -18,7 +18,7 @@
       },
       "spreadsheets": {
         "label": "Spreadsheets",
-        "description": "xls, xlsx, csv, numbers"
+        "description": "xls, xlsx, csv"
       }
     }
   },

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -19,7 +19,7 @@
     },
     "spreadsheets": {
       "label": "Feuilles de calcul",
-      "description": "xls, xlsx, csv, numbers"
+      "description": "xls, xlsx, csv"
     }
   },
   "addElement": "Ajouter un élément",

--- a/lib/fileInput/constants.ts
+++ b/lib/fileInput/constants.ts
@@ -6,6 +6,6 @@ export const FILE_GROUPS = {
     types: ["jpg", "jpeg", "png", "svg"],
   },
   spreadsheets: {
-    types: ["xls", "xlsx", "csv", "numbers"],
+    types: ["xls", "xlsx", "csv"],
   },
 };

--- a/lib/fileInput/fileGroupsToFileTypes.ts
+++ b/lib/fileInput/fileGroupsToFileTypes.ts
@@ -4,7 +4,7 @@
  * Converts an array of file groups to an array of file types.
  * Each file group is mapped to its corresponding file types based on predefined file groups.
  * If a file group does not belong to any predefined group, it is ignored.
- * @returns  An array of unique file types (e.g., ["pdf", "txt", "doc", "docx", "jpg", "jpeg", "png", "svg", "xls", "xlsx", "csv", "numbers"]).
+ * @returns  An array of unique file types (e.g., ["pdf", "txt", "doc", "docx", "jpg", "jpeg", "png", "svg", "xls", "xlsx", "csv"]).
  */
 export const fileGroupsToFileTypes = (fileGroups: string[]) => {
   const fileTypes = new Set<string>();
@@ -35,7 +35,7 @@ export const fileGroupToFileTypes = (fileGroup: string) => {
     return ["jpg", "jpeg", "png", "svg"];
   }
   if (fileGroup === "spreadsheets") {
-    return ["xls", "xlsx", "csv", "numbers"];
+    return ["xls", "xlsx", "csv"];
   }
 
   return [];


### PR DESCRIPTION
# Summary | Résumé

- Removes references to `.numbers` file type in UI elements