### PR TITLE
fix: Add 'wasm unsafe eval' to allow for hash library to run in browser

### DIFF
--- a/lib/cspScripts.ts
+++ b/lib/cspScripts.ts
@@ -29,7 +29,7 @@ export const generateCSP = (): { csp: string; nonce: string } => {
 
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'nonce-${nonce}' 'strict-dynamic';
+    script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval' 'strict-dynamic';
     style-src 'self' 'nonce-${nonce}';
     img-src 'self' blob: data:;
     font-src 'self';


### PR DESCRIPTION
# Summary | Résumé

Adds the `wasm-unsafe-eval` to allow for the hash-wasm library to run in the browser.  The library was initially chosen for it's speed given the large amount of hashes that could require computation based on the API integration work in responses-beta.