### PR TITLE
fix: Allow for staging and production subdomains in CSP

### DIFF
--- a/lib/cspScripts.ts
+++ b/lib/cspScripts.ts
@@ -38,7 +38,7 @@ export const generateCSP = (): { csp: string; nonce: string } => {
     form-action 'self';
     frame-src www.googletagmanager.com hcaptcha.com *.hcaptcha.com;
     frame-ancestors 'none';
-    connect-src 'self' www.googletagmanager.com www.google-analytics.com ws1.postescanada-canadapost.ca hcaptcha.com *.hcaptcha.com ${process.env.AWS_PROFILE === "development" && "*.forms-staging.cdssandbox.xyz"} *.s3.ca-central-1.amazonaws.com;
+    connect-src 'self' www.googletagmanager.com www.google-analytics.com ws1.postescanada-canadapost.ca hcaptcha.com *.hcaptcha.com *.forms-staging.cdssandbox.xyz *.forms-formulaires.alpha.canada.ca *.s3.ca-central-1.amazonaws.com;
     block-all-mixed-content;
     upgrade-insecure-requests;
   `;


### PR DESCRIPTION
# Summary | Résumé
Allow the browser client to connect to staging and production subdomains.