### PR TITLE
chore: Automatically refresh JWT before it expires

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-beta/load-key/SelectApiKey.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-beta/load-key/SelectApiKey.tsx
@@ -62,7 +62,7 @@ export const SelectApiKey = ({ locale, id }: { locale: string; id: string }) => 
       }
 
       setApiClient(
-        new GCFormsApiClient(keyFile.formId, process.env.NEXT_PUBLIC_API_URL ?? "", token)
+        new GCFormsApiClient(keyFile.formId, process.env.NEXT_PUBLIC_API_URL ?? "", keyFile, token)
       );
 
       setPrivateApiKey(keyFile);


### PR DESCRIPTION
# Summary | Résumé

When downloading many responses using the new beta interface, if the JWT token expires during the download, the process will be interrupted. This PR automatically refreshes the JWT after 20 minutes.
