### PR TITLE
chore: Reduce logging volume when processing responses

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-beta/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-beta/context/ResponsesContext.tsx
@@ -210,13 +210,13 @@ export const ResponsesProvider = ({
       const decryptionKey = await importPrivateKeyDecrypt(privateApiKey.key);
 
       while (formResponses.length > 0 && !interruptRef.current) {
+        logger.info(`Processing next ${formResponses.length} submissions`);
         for (const response of formResponses) {
           if (interruptRef.current) {
             logger.info("Processing interrupted by user");
             break;
           }
 
-          logger.info(`Processing submission ID: ${response.name}`);
           setCurrentSubmissionId(response.name);
 
           try {


### PR DESCRIPTION
# Summary | Résumé

When processing a large volume of responses, the logs can get filled up with "Processing submission ID: [responseID]" entries that are not very useful.

Will simplify to just log once for each 100 entries.