### PR TITLE
chore: Remove http instrumentation

### DIFF
--- a/instrumentation.node.ts
+++ b/instrumentation.node.ts
@@ -6,9 +6,7 @@ import { AWSXRayPropagator } from "@opentelemetry/propagator-aws-xray";
 import { awsEcsDetector } from "@opentelemetry/resource-detector-aws";
 import { AwsInstrumentation } from "@opentelemetry/instrumentation-aws-sdk";
 import { FetchInstrumentation } from "@vercel/otel";
-import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { IncomingMessage } from "http";
 
 const resource = resourceFromAttributes({
   [ATTR_SERVICE_NAME]: "gc-forms-app",
@@ -18,31 +16,7 @@ const sdk = new NodeSDK({
   resource,
   spanProcessor: new SimpleSpanProcessor(new OTLPTraceExporter()),
   textMapPropagator: new AWSXRayPropagator(),
-  instrumentations: [
-    new FetchInstrumentation(),
-    new HttpInstrumentation({
-      enabled: true,
-      ignoreIncomingRequestHook: (request: IncomingMessage) => {
-        const ignorePatterns = [
-          /^\/_next\//, // starts with /_next/
-          /^\/__nextjs_\//, // starts with /__nextjs_/
-          /^\/img\//, // starts with /img/
-          /^\/static\//, // starts with /static/
-          /\?_rsc=/, // contains ?_rsc=
-          /^\/favicon.ico/, // starts with favicon.ico
-        ];
-
-        const url = request.url;
-
-        if (typeof url === "string" && ignorePatterns.some((pattern) => pattern.test(url))) {
-          return true;
-        }
-
-        return false;
-      },
-    }),
-    new AwsInstrumentation(),
-  ],
+  instrumentations: [new FetchInstrumentation(), new AwsInstrumentation()],
 });
 
 sdk.start();

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@opentelemetry/exporter-jaeger": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.63.0",
-    "@opentelemetry/instrumentation-http": "^0.203.0",
     "@opentelemetry/propagator-aws-xray": "^2.1.3",
     "@opentelemetry/resource-detector-aws": "^2.8.0",
     "@opentelemetry/resources": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,20 +4229,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-http@npm:^0.203.0":
-  version: 0.203.0
-  resolution: "@opentelemetry/instrumentation-http@npm:0.203.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.0.1"
-    "@opentelemetry/instrumentation": "npm:0.203.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-    forwarded-parse: "npm:2.1.2"
-  peerDependencies:
-    "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/424eeb5b162b480a8a6157ca147ecd074de3e6d31298fed115e4d6f47ca3f65ba0a79a43f3a998ebd9f0f6e96da1092500408590150c308c5ef91c0b760ae467
-  languageName: node
-  linkType: hard
-
 "@opentelemetry/instrumentation@npm:0.203.0":
   version: 0.203.0
   resolution: "@opentelemetry/instrumentation@npm:0.203.0"
@@ -13544,13 +13530,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"forwarded-parse@npm:2.1.2":
-  version: 2.1.2
-  resolution: "forwarded-parse@npm:2.1.2"
-  checksum: 10c0/0c6b4c631775f272b4475e935108635495e8a5b261d1b4a5caef31c47c5a0b04134adc564e655aadfef366a02647fa3ae90a1d3ac19929f3ade47f9bed53036a
-  languageName: node
-  linkType: hard
-
 "fraction.js@npm:^5.3.4":
   version: 5.3.4
   resolution: "fraction.js@npm:5.3.4"
@@ -13696,7 +13675,6 @@ __metadata:
     "@opentelemetry/exporter-jaeger": "npm:^2.0.1"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.203.0"
     "@opentelemetry/instrumentation-aws-sdk": "npm:^0.63.0"
-    "@opentelemetry/instrumentation-http": "npm:^0.203.0"
     "@opentelemetry/propagator-aws-xray": "npm:^2.1.3"
     "@opentelemetry/resource-detector-aws": "npm:^2.8.0"
     "@opentelemetry/resources": "npm:^2.0.1"


### PR DESCRIPTION
# Summary | Résumé
Removes the HTTP Instrumentation from Open Telementry as NextJS already captures the spans by default.