### PR TITLE
chore: optimize rainbow cleanup action by removing duplicate from list of deployment ids

### DIFF
--- a/.github/workflows/prod-rainbow-cleanup.yml
+++ b/.github/workflows/prod-rainbow-cleanup.yml
@@ -88,7 +88,7 @@ jobs:
               deployment_ids+=($batch_ids)
             done
 
-            json_array=$(printf '%s\n' "${deployment_ids[@]}" | jq -R . | jq -s .)
+            json_array=$(printf "%s\n" "${deployment_ids[@]}" | sort -u | jq -R . | jq -s .)
 
             echo "ids=$(echo $json_array | sed 's/ //g')" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/staging-rainbow-cleanup.yml
+++ b/.github/workflows/staging-rainbow-cleanup.yml
@@ -88,7 +88,7 @@ jobs:
               deployment_ids+=($batch_ids)
             done
 
-            json_array=$(printf '%s\n' "${deployment_ids[@]}" | jq -R . | jq -s .)
+            json_array=$(printf "%s\n" "${deployment_ids[@]}" | sort -u | jq -R . | jq -s .)
 
             echo "ids=$(echo $json_array | sed 's/ //g')" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
# Summary | Résumé

- Adds small optimization to the Rainbow cleanup Github action in order to avoid deleting the same resources in parallel