### PR TITLE
chore: response pilot add processing screen

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -58,6 +58,7 @@ interface ResponsesContextType {
   interrupt: boolean;
   setInterrupt: Dispatch<SetStateAction<boolean>>;
   currentSubmissionId: string | null;
+  setCurrentSubmissionId: Dispatch<SetStateAction<string | null>>;
   resetState: () => void;
   resetNewSubmissions: () => void;
   logger: ResponseDownloadLogger;
@@ -341,6 +342,7 @@ export const ResponsesProvider = ({
         interrupt: isProcessingInterrupted,
         setInterrupt,
         currentSubmissionId,
+        setCurrentSubmissionId,
         resetState,
         resetNewSubmissions,
         logger: loggerRef.current,

--- a/tests/browser/responses-pilot/CurrentSubmissionIdSetter.tsx
+++ b/tests/browser/responses-pilot/CurrentSubmissionIdSetter.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useResponsesContext } from "@responses-pilot/context/ResponsesContext";
+
+// Test helper that sets currentSubmissionId on mount
+export function CurrentSubmissionIdSetter({ submissionId }: { submissionId: string }) {
+  const { setCurrentSubmissionId } = useResponsesContext();
+
+  useEffect(() => {
+    setCurrentSubmissionId(submissionId);
+  }, [submissionId, setCurrentSubmissionId]);
+
+  return null;
+}

--- a/tests/browser/responses-pilot/ProcessingDownloads.browser.vitest.tsx
+++ b/tests/browser/responses-pilot/ProcessingDownloads.browser.vitest.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { page } from "@vitest/browser/context";
+import { ProcessingDownloads } from "@responses-pilot/processing/ProcessingDownloads";
+import { render } from "./testUtils";
+import { GCFormsApiClient } from "@responses-pilot/lib/apiClient";
+import { setupFonts } from "./testHelpers";
+import enTranslations from "@root/i18n/translations/en/response-api.json";
+
+import "@root/styles/app.scss";
+
+describe("ProcessingDownloads - Browser Mode", () => {
+  beforeAll(() => {
+    setupFonts();
+  });
+
+  it("should render the processing page with title", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, { mockApiClient });
+
+    await expect.element(page.getByTestId("processing-page-title")).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId("processing-page-title"))
+      .toHaveTextContent(enTranslations.processingPage.processingTitle);
+  });
+
+  it("should show please wait message when no submission is being processed", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, { mockApiClient });
+
+    const message = page.getByText(enTranslations.processingPage.pleaseWait);
+    await expect.element(message).toBeInTheDocument();
+  });
+
+  it("should show cancel button", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, { mockApiClient });
+
+    const cancelButton = page.getByText("Pause download");
+    await expect.element(cancelButton).toBeInTheDocument();
+  });
+
+  it("should show loader icon", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, { mockApiClient });
+
+    // Loader should be present (MapleLeafLoader component)
+    const loaderContainer = document.querySelector('svg');
+    expect(loaderContainer).not.toBeNull();
+  });
+
+  it("should have live region with polite and status role", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, { mockApiClient });
+
+    const liveRegion = document.querySelector('[aria-live="polite"][role="status"]');
+    expect(liveRegion).not.toBeNull();
+  });
+
+  it("should call router push when cancel button is clicked", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockRouter = {
+      push: vi.fn(),
+    };
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: { router: mockRouter },
+    });
+
+    const cancelButton = page.getByText("Pause download");
+    await cancelButton.click();
+
+    // Wait for async operations
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    // Router should be called to navigate to result page
+    expect(mockRouter.push).toHaveBeenCalledWith("/en/form-builder/test-form/responses-pilot/result");
+  });
+
+  it("should display current submission id when processing", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    // Mock the context to provide a currentSubmissionId
+    const mockCurrentSubmissionId = "test-submission-123";
+
+    await render(<ProcessingDownloads locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: { currentSubmissionId: mockCurrentSubmissionId },
+    });
+
+    // Should show the submission id in the message
+    const message = page.getByText(/Processing submission test-submission-123/);
+    await expect.element(message).toBeInTheDocument();
+
+    // Screen reader text should still say "Please wait..."
+    const srOnlyText = document.querySelector(".sr-only");
+    expect(srOnlyText?.textContent).toBe("Please wait...");
+  });
+});

--- a/tests/browser/responses-pilot/testUtils.tsx
+++ b/tests/browser/responses-pilot/testUtils.tsx
@@ -5,6 +5,7 @@ import { ResponsesProvider } from "@responses-pilot/context/ResponsesContext";
 import { ContentWrapper } from "@responses-pilot/ContentWrapper";
 import { PilotBadge } from "@clientComponents/globals/PilotBadge";
 import { ApiClientSetter } from "./AplClientSetter";
+import { CurrentSubmissionIdSetter } from "./CurrentSubmissionIdSetter";
 import { GCFormsApiClient } from "@responses-pilot/lib/apiClient";
 import { ToastContainer } from "@formBuilder/components/shared/Toast";
 
@@ -32,10 +33,13 @@ export function TestWrapper({
   overrides,
   children,
 }: RenderWithProvidersOptions) {
+  const currentSubmissionId = overrides?.currentSubmissionId as string | undefined;
+
   return (
     <BrowserResponsesAppProvider overrides={overrides}>
       <ResponsesProvider locale={locale} formId={formId}>
         {mockApiClient && <ApiClientSetter mockClient={mockApiClient} />}
+        {currentSubmissionId && <CurrentSubmissionIdSetter submissionId={currentSubmissionId} />}
         <h1 className="mb-4">Responses</h1>
         <PilotBadge className="mb-8" />
         <ContentWrapper>{children}</ContentWrapper>


### PR DESCRIPTION
# Summary | Résumé

Add browser mode test for processing screen