### PR TITLE
chore: response pilot - add browser mode tests for results screen

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/result/Confirmation.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/result/Confirmation.tsx
@@ -2,17 +2,13 @@
 import { useCallback, useState } from "react";
 import { Button } from "@root/components/clientComponents/globals";
 import { useResponsesContext } from "../context/ResponsesContext";
-import { useRouter } from "next/navigation";
-import { useTranslation } from "@i18n/client";
+import { useResponsesApp } from "../context";
 import { Responses } from "../Responses";
 import { CheckForResponsesButton } from "../components/CheckForResponsesButton";
 import { FocusHeader } from "@root/app/(gcforms)/[locale]/(support)/components/client/FocusHeader";
 
 export const Confirmation = ({ locale, id }: { locale: string; id: string }) => {
-  const router = useRouter();
-
-  const { t } = useTranslation("response-api");
-
+  const { t, router } = useResponsesApp();
   const { directoryHandle } = useResponsesContext();
   const dirName = directoryHandle?.name || "";
   const [hasCheckedForResponses, setHasCheckedForResponses] = useState(false);
@@ -33,8 +29,7 @@ export const Confirmation = ({ locale, id }: { locale: string; id: string }) => 
     setHasCheckedForResponses(true);
     resetProcessingCompleted();
     setHasError(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [resetProcessingCompleted, setHasError]);
 
   const handleGoBack = () => {
     router.push(`/${locale}/form-builder/${id}/responses-pilot?reset=true`);

--- a/tests/browser/responses-pilot/Confirmation.browser.vitest.tsx
+++ b/tests/browser/responses-pilot/Confirmation.browser.vitest.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { page } from "@vitest/browser/context";
+import { Confirmation } from "@responses-pilot/result/Confirmation";
+import { render } from "./testUtils";
+import { GCFormsApiClient } from "@responses-pilot/lib/apiClient";
+import { setupFonts } from "./testHelpers";
+import enTranslations from "@root/i18n/translations/en/response-api.json";
+
+import "@root/styles/app.scss";
+
+describe("Confirmation - Browser Mode", () => {
+  beforeAll(() => {
+    setupFonts();
+  });
+
+  it("should show success and downloaded responses count", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockDirectoryHandle = {
+      name: "my-responses-folder",
+    };
+
+    const mockProcessedSubmissionIds = new Set(["sub-1", "sub-2", "sub-3"]);
+
+    await render(<Confirmation locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: {
+        processedSubmissionIds: mockProcessedSubmissionIds,
+        directoryHandle: mockDirectoryHandle,
+      },
+    });
+
+    await expect.element(page.getByTestId("confirmation-page-title")).toBeInTheDocument();
+    await expect
+      .element(page.getByText(enTranslations.confirmationPage.successTitle))
+      .toBeInTheDocument();
+
+    // Should show "3 responses were downloaded"
+    const message = page.getByText(/3 responses were downloaded/);
+    await expect.element(message).toBeInTheDocument();
+
+    const savedToText = page.getByText(enTranslations.confirmationPage.savedTo);
+    await expect.element(savedToText).toBeInTheDocument();
+
+    const dirName = page.getByText("/my-responses-folder");
+    await expect.element(dirName).toBeInTheDocument();
+
+    const checkButton = page.getByText(enTranslations.checkForNewResponsesButton);
+    await expect.element(checkButton).toBeInTheDocument();
+  });
+
+  it("should show singular form for one response", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockProcessedSubmissionIds = new Set(["sub-1"]);
+
+    await render(<Confirmation locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: { processedSubmissionIds: mockProcessedSubmissionIds },
+    });
+
+    // Should show "1 response was downloaded"
+    const message = page.getByText(/1 response was downloaded/);
+    await expect.element(message).toBeInTheDocument();
+  });
+
+  it("should navigate to start when back button is clicked", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockRouter = {
+      push: vi.fn(),
+    };
+
+    const mockProcessedSubmissionIds = new Set(["sub-1", "sub-2", "sub-3"]);
+
+    await render(<Confirmation locale="en" id="test-form" />, {
+      mockApiClient,
+
+      overrides: { router: mockRouter, processedSubmissionIds: mockProcessedSubmissionIds },
+    });
+
+    const backButton = page.getByText(enTranslations.backToStart);
+    await backButton.click();
+
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      "/en/form-builder/test-form/responses-pilot?reset=true"
+    );
+  });
+
+  it("should show error title when error occurred with no downloads", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockProcessedSubmissionIds = new Set<string>();
+
+    await render(<Confirmation locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: {
+        hasError: true,
+        processedSubmissionIds: mockProcessedSubmissionIds,
+      },
+    });
+
+    const errorTitle = page.getByText(enTranslations.confirmationPage.errorTitle);
+    await expect.element(errorTitle).toBeInTheDocument();
+
+    const errorMessage = page.getByText(enTranslations.confirmationPage.errorOccurred);
+    await expect.element(errorMessage).toBeInTheDocument();
+  });
+
+  it("should show partial success title when error occurred with some downloads", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockProcessedSubmissionIds = new Set(["sub-1", "sub-2"]);
+
+    await render(<Confirmation locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: {
+        hasError: true,
+        processedSubmissionIds: mockProcessedSubmissionIds,
+      },
+    });
+
+    const partialTitle = page.getByText(enTranslations.confirmationPage.partialSuccessTitle);
+    await expect.element(partialTitle).toBeInTheDocument();
+
+    // Should still show count
+    const message = page.getByText(/2 responses were downloaded/);
+    await expect.element(message).toBeInTheDocument();
+  });
+});

--- a/tests/browser/responses-pilot/ContextSetters.tsx
+++ b/tests/browser/responses-pilot/ContextSetters.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useResponsesContext } from "@responses-pilot/context/ResponsesContext";
+import type { FileSystemDirectoryHandle } from "native-file-system-adapter";
+
+interface ContextSettersProps {
+  directoryHandle?: FileSystemDirectoryHandle | { name: string };
+  processedSubmissionIds?: Set<string>;
+  hasError?: boolean;
+}
+
+// Test helper that sets multiple context values on mount
+export function ContextSetters({
+  directoryHandle,
+  processedSubmissionIds,
+  hasError,
+}: ContextSettersProps) {
+  const context = useResponsesContext();
+
+  useEffect(() => {
+    if (directoryHandle) {
+      context.setDirectoryHandle(directoryHandle as FileSystemDirectoryHandle);
+    }
+    if (processedSubmissionIds) {
+      context.setProcessedSubmissionIds(processedSubmissionIds);
+    }
+    if (hasError !== undefined) {
+      context.setHasError(hasError);
+    }
+  }, [directoryHandle, processedSubmissionIds, hasError, context]);
+
+  return null;
+}

--- a/tests/browser/responses-pilot/testUtils.tsx
+++ b/tests/browser/responses-pilot/testUtils.tsx
@@ -6,8 +6,10 @@ import { ContentWrapper } from "@responses-pilot/ContentWrapper";
 import { PilotBadge } from "@clientComponents/globals/PilotBadge";
 import { ApiClientSetter } from "./AplClientSetter";
 import { CurrentSubmissionIdSetter } from "./CurrentSubmissionIdSetter";
+import { ContextSetters } from "./ContextSetters";
 import { GCFormsApiClient } from "@responses-pilot/lib/apiClient";
 import { ToastContainer } from "@formBuilder/components/shared/Toast";
+import type { FileSystemDirectoryHandle } from "native-file-system-adapter";
 
 // Import to trigger i18next initialization
 import "@root/i18n/client";
@@ -34,12 +36,23 @@ export function TestWrapper({
   children,
 }: RenderWithProvidersOptions) {
   const currentSubmissionId = overrides?.currentSubmissionId as string | undefined;
+  const directoryHandle = overrides?.directoryHandle as
+    | FileSystemDirectoryHandle
+    | { name: string }
+    | undefined;
+  const processedSubmissionIds = overrides?.processedSubmissionIds as Set<string> | undefined;
+  const hasError = overrides?.hasError as boolean | undefined;
 
   return (
     <BrowserResponsesAppProvider overrides={overrides}>
       <ResponsesProvider locale={locale} formId={formId}>
         {mockApiClient && <ApiClientSetter mockClient={mockApiClient} />}
         {currentSubmissionId && <CurrentSubmissionIdSetter submissionId={currentSubmissionId} />}
+        <ContextSetters
+          directoryHandle={directoryHandle}
+          processedSubmissionIds={processedSubmissionIds}
+          hasError={hasError}
+        />
         <h1 className="mb-4">Responses</h1>
         <PilotBadge className="mb-8" />
         <ContentWrapper>{children}</ContentWrapper>


### PR DESCRIPTION
# Summary | Résumé

Adds browser mode test for confirmation / results component