### PR TITLE
chore: response pilot add test

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/result/Confirmation.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/result/Confirmation.tsx
@@ -32,7 +32,7 @@ export const Confirmation = ({ locale, id }: { locale: string; id: string }) => 
     setHasMaliciousAttachments(false);
     resetProcessingCompleted();
     setHasError(false);
-  }, [resetProcessingCompleted, setHasError]);
+  }, [resetProcessingCompleted, setHasError, setHasMaliciousAttachments]);
 
   const handleGoBack = () => {
     router.push(`/${locale}/form-builder/${id}/responses-pilot?reset=true`);

--- a/tests/browser/responses-pilot/Confirmation.browser.vitest.tsx
+++ b/tests/browser/responses-pilot/Confirmation.browser.vitest.tsx
@@ -142,4 +142,27 @@ describe("Confirmation - Browser Mode", () => {
     const message = page.getByText(/2 responses were downloaded/);
     await expect.element(message).toBeInTheDocument();
   });
+
+  it("should show malicious attachments warning when flagged", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    const mockProcessedSubmissionIds = new Set(["sub-1"]);
+
+    await render(<Confirmation locale="en" id="test-form" />, {
+      mockApiClient,
+      overrides: {
+        hasMaliciousAttachments: true,
+        processedSubmissionIds: mockProcessedSubmissionIds,
+      },
+    });
+
+    const title = page.getByText(enTranslations.confirmationPage.maliciousAttachmentsWarningTitle);
+    await expect.element(title).toBeInTheDocument();
+
+    const body = page.getByText(enTranslations.confirmationPage.maliciousAttachmentsWarningBody);
+    await expect.element(body).toBeInTheDocument();
+  });
 });

--- a/tests/browser/responses-pilot/ContextSetters.tsx
+++ b/tests/browser/responses-pilot/ContextSetters.tsx
@@ -6,6 +6,7 @@ interface ContextSettersProps {
   directoryHandle?: FileSystemDirectoryHandle | { name: string };
   processedSubmissionIds?: Set<string>;
   hasError?: boolean;
+  hasMaliciousAttachments?: boolean;
 }
 
 // Test helper that sets multiple context values on mount
@@ -13,6 +14,7 @@ export function ContextSetters({
   directoryHandle,
   processedSubmissionIds,
   hasError,
+  hasMaliciousAttachments,
 }: ContextSettersProps) {
   const context = useResponsesContext();
 
@@ -26,7 +28,10 @@ export function ContextSetters({
     if (hasError !== undefined) {
       context.setHasError(hasError);
     }
-  }, [directoryHandle, processedSubmissionIds, hasError, context]);
+    if (hasMaliciousAttachments !== undefined) {
+      context.setHasMaliciousAttachments(hasMaliciousAttachments);
+    }
+  }, [directoryHandle, processedSubmissionIds, hasError, hasMaliciousAttachments, context]);
 
   return null;
 }

--- a/tests/browser/responses-pilot/testUtils.tsx
+++ b/tests/browser/responses-pilot/testUtils.tsx
@@ -42,6 +42,7 @@ export function TestWrapper({
     | undefined;
   const processedSubmissionIds = overrides?.processedSubmissionIds as Set<string> | undefined;
   const hasError = overrides?.hasError as boolean | undefined;
+  const hasMaliciousAttachments = overrides?.hasMaliciousAttachments as boolean | undefined;
 
   return (
     <BrowserResponsesAppProvider overrides={overrides}>
@@ -52,6 +53,7 @@ export function TestWrapper({
           directoryHandle={directoryHandle}
           processedSubmissionIds={processedSubmissionIds}
           hasError={hasError}
+          hasMaliciousAttachments={hasMaliciousAttachments}
         />
         <h1 className="mb-4">Responses</h1>
         <PilotBadge className="mb-8" />


### PR DESCRIPTION
# Summary | Résumé

Adds browser mode test for MaliciousAttachments on Confirmation screen.

ref: https://github.com/cds-snc/platform-forms-client/pull/6468

