### PR TITLE
chore: add support for full Rainbow deployment cleanup in Github workflow for Production

### DIFF
--- a/.github/workflows/prod-rainbow-cleanup.yml
+++ b/.github/workflows/prod-rainbow-cleanup.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       deployment-identifier:
-        description: "Deployment identifier"
+        description: "Deployment identifier (type 'all' to delete all Rainbow deployments)"
         type: string
         required: true
   schedule:
@@ -25,33 +25,10 @@ permissions:
   contents: read
 
 jobs:
-  cleanup-workflow-run-or-dispatch:
+  generate-list-of-deployment-ids:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-
-      - name: Configure AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-apply
-          role-session-name: RainbowCleanup
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Cleanup triggered by GC Forms deployment failure
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
-        run: ./scripts/clean-up-rainbow-deployment.sh ${{ github.event.workflow_run.head_sha }} ${{ env.LOAD_BALANCER_LISTENER_ARN }} > /dev/null 2>&1
-
-      - name: Cleanup triggered manually
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: ./scripts/clean-up-rainbow-deployment.sh ${{ inputs.deployment-identifier }} ${{ env.LOAD_BALANCER_LISTENER_ARN }} > /dev/null 2>&1
-
-  cleanup-schedule-1:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' }}
     outputs:
-      ids: ${{ steps.find-rainbow-deployments-ids.outputs.ids }}
+      ids: ${{ steps.determine-rainbow-deployments-ids-to-clean-up.outputs.ids }}
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -63,44 +40,55 @@ jobs:
           role-session-name: RainbowCleanup
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Find rainbow deployments to clean up
-        id: find-rainbow-deployments-ids
+      - name: Determine rainbow deployments to clean up
+        id: determine-rainbow-deployments-ids-to-clean-up
         run: |
-          arn_list=($(
-            aws elbv2 describe-rules \
-              --listener-arn ${{ env.LOAD_BALANCER_LISTENER_ARN }} \
-              --no-paginate \
-              --query "Rules[?contains(Actions[0].ForwardConfig.TargetGroups[0].TargetGroupArn, 'rainbow')]" \
-              | jq -r '.[] | select(.Priority | tonumber > ${{ env.MAXIMUM_NUMBER_OF_RAINBOW_DEPLOYMENTS_TO_KEEP_ALIVE }}) | .RuleArn'
-          ))
+          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.conclusion }}" == "failure" ]]; then
+            echo 'ids=["${{ github.event.workflow_run.head_sha }}"]' >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.deployment-identifier }}" != "all" ]]; then
+            echo 'ids=["${{ inputs.deployment-identifier }}"]' >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.deployment-identifier }}" == "all" ]]; then
+            maxNumberOfRulesToSelect=$([[ "${{ inputs.deployment-identifier }}" == "all" ]] && echo -1 || echo "${{ env.MAXIMUM_NUMBER_OF_RAINBOW_DEPLOYMENTS_TO_KEEP_ALIVE }}")
 
-          if [ ${#arn_list[@]} -gt 0 ]; then
-            deployment_ids=()
+            arn_list=($(
+              aws elbv2 describe-rules \
+                --listener-arn ${{ env.LOAD_BALANCER_LISTENER_ARN }} \
+                --no-paginate \
+                --query "Rules[?contains(Actions[0].ForwardConfig.TargetGroups[0].TargetGroupArn, 'rainbow')]" \
+                | jq --argjson max "$maxNumberOfRulesToSelect" -r '.[] | select(.Priority | tonumber > $max) | .RuleArn'
+            ))
 
-            # Process ARNs in batches of 20
-            for ((i=0; i<${#arn_list[@]}; i+=20)); do
-              batch=("${arn_list[@]:i:20}")
+            if [ ${#arn_list[@]} -gt 0 ]; then
+              deployment_ids=()
 
-              batch_ids=$(aws elbv2 describe-tags \
-                --resource-arns "${batch[@]}" \
-                | jq -r '[.TagDescriptions[].Tags[] | select(.Key == "Name") | .Value | sub("^rainbow-"; "")][]')
+              # Process ARNs in batches of 20
+              for ((i=0; i<${#arn_list[@]}; i+=20)); do
+                batch=("${arn_list[@]:i:20}")
 
-              deployment_ids+=($batch_ids)
-            done
+                batch_ids=$(aws elbv2 describe-tags \
+                  --resource-arns "${batch[@]}" \
+                  | jq -r '[.TagDescriptions[].Tags[] | select(.Key == "Name") | .Value | sub("^rainbow-"; "")][]')
 
-            json_array=$(printf "%s\n" "${deployment_ids[@]}" | sort -u | jq -R . | jq -s .)
+                deployment_ids+=($batch_ids)
+              done
 
-            echo "ids=$(echo $json_array | sed 's/ //g')" >> "$GITHUB_OUTPUT"
+              json_array=$(printf "%s\n" "${deployment_ids[@]}" | sort -u | jq -R . | jq -s .)
+
+              echo "ids=$(echo $json_array | sed 's/ //g')" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Unsupported workflow trigger event"
+            exit 1
           fi
 
-  cleanup-schedule-2:
+  cleanup-deployment-ids:
     runs-on: ubuntu-latest
-    needs: cleanup-schedule-1
-    if: ${{ needs.cleanup-schedule-1.outputs.ids != '' }}
+    needs: generate-list-of-deployment-ids
+    if: ${{ needs.generate-list-of-deployment-ids.outputs.ids != '' }}
     strategy:
       max-parallel: 1
       matrix:
-        deployment-identifier: ${{ fromJSON(needs.cleanup-schedule-1.outputs.ids) }}
+        deployment-identifier: ${{ fromJSON(needs.generate-list-of-deployment-ids.outputs.ids) }}
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -112,5 +100,5 @@ jobs:
           role-session-name: RainbowCleanup
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Cleanup triggered by scheduler
+      - name: Cleanup rainbow deployment
         run: ./scripts/clean-up-rainbow-deployment.sh ${{ matrix.deployment-identifier }} ${{ env.LOAD_BALANCER_LISTENER_ARN }} > /dev/null 2>&1

--- a/.github/workflows/staging-rainbow-cleanup.yml
+++ b/.github/workflows/staging-rainbow-cleanup.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       deployment-identifier:
-        description: "Deployment identifier"
+        description: "Deployment identifier (type 'all' to delete all Rainbow deployments)"
         type: string
         required: true
   schedule:


### PR DESCRIPTION
# Summary | Résumé

- Adds support for full Rainbow deployment cleanup in Github workflow in Production