### PR TITLE
chore: Rainbow cleanup Github action can handle successful deployment scenario

### DIFF
--- a/.github/workflows/prod-rainbow-cleanup.yml
+++ b/.github/workflows/prod-rainbow-cleanup.yml
@@ -77,8 +77,8 @@ jobs:
               echo "ids=$(echo $json_array | sed 's/ //g')" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "Unsupported workflow trigger event"
-            exit 1
+            echo "Unsupported workflow trigger event, will skip next step..."
+            echo 'ids=' >> "$GITHUB_OUTPUT"
           fi
 
   cleanup-deployment-ids:

--- a/.github/workflows/staging-rainbow-cleanup.yml
+++ b/.github/workflows/staging-rainbow-cleanup.yml
@@ -77,8 +77,8 @@ jobs:
               echo "ids=$(echo $json_array | sed 's/ //g')" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "Unsupported workflow trigger event"
-            exit 1
+            echo "Unsupported workflow trigger event, will skip next step..."
+            echo 'ids=' >> "$GITHUB_OUTPUT"
           fi
 
   cleanup-deployment-ids:


### PR DESCRIPTION
# Summary | Résumé

- Fixes issue with Rainbow cleanup Github action could not handle scenario where the trigger (Deploy to Prod/Staging) completed with a success result.