### PR TITLE
chore: clean up open telemetry warnings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -72,7 +72,11 @@ const nextConfig = {
       },
     ];
   },
-  serverExternalPackages: ["@aws-sdk/lib-dynamodb", "pino"],
+  serverExternalPackages: [
+    "@aws-sdk/lib-dynamodb",
+    "pino",
+    "@opentelemetry/sdk-node",
+  ],
   experimental: {
     // PPR is only supported in Next.js Canary branches
     // ppr: true,
@@ -88,7 +92,7 @@ const nextConfig = {
         as: "*.js",
       },
     },
-  }
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# Summary | Résumé

Our test build outputs are ending up with noise from sdk-node imports 

In some case we're seeing failed test runs with these warnings.

This PR looks to avoid the noise :)

```
./node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/node
Package import-in-the-middle can't be external
The request import-in-the-middle matches serverExternalPackages (or the default list).
The package resolves to a different version when requested from the project directory (2.0.0) compared to the package requested from the importing module (1.15.0).
Make sure to install the same version of the package in both locations.


./node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/node
Package require-in-the-middle can't be external
The request require-in-the-middle matches serverExternalPackages (or the default list).
The package resolves to a different version when requested from the project directory (8.0.1) compared to the package requested from the importing module (7.5.2).
Make sure to install the same version of the package in both locations.


./node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/node
Package require-in-the-middle can't be external
The request require-in-the-middle matches serverExternalPackages (or the default list).
The package resolves to a different version when requested from the project directory (8.0.1) compared to the package requested from the importing module (7.5.2).
Make sure to install the same version of the package in both locations.
```