### PR TITLE
chore: Remove api/templates from response generator.

### DIFF
--- a/lib/integration/prismaConnector.ts
+++ b/lib/integration/prismaConnector.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, Prisma } from "@prisma/client";
-import { logMessage } from "@lib/logger";
+import { logMessage } from "../logger";
 
 // See https://www.prisma.io/docs/support/help-articles/nextjs-prisma-client-dev-practices
 // Needed to ensure we only instantiate Prisma Client once

--- a/utils/responseGenerator/generate_responses.ts
+++ b/utils/responseGenerator/generate_responses.ts
@@ -3,7 +3,6 @@ import readline from "readline";
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 import { config } from "dotenv";
 import { chunkArray } from "../../lib/utils";
-import axios from "axios";
 import {
   getRandomInt,
   generateResponseForQuestion,
@@ -11,6 +10,7 @@ import {
   TestFile,
 } from "./lib/responseGenerator";
 import { uploadFile } from "./lib/fileUpload";
+import { prisma } from "../../lib/integration/prismaConnector";
 
 interface SubmissionRequestBody {
   [key: string]: Response;
@@ -83,20 +83,20 @@ const main = async () => {
     console.info(`Getting form template from ${appEnv}`);
     process.env.AWS_PROFILE = appEnv;
 
-    // Get the form template
-    const formTemplate = await axios
-      .get(
-        `${
-          appEnv === "staging" ? "https://forms-staging.cdssandbox.xyz" : "http://localhost:3000"
-        }/api/templates/${formID}`
-      )
-      .then(({ data }) => {
-        return data.form;
-      });
+    // Get the form template directly from the database
+    // Note: Ensure your DATABASE_URL points to the correct environment (Local vs Staging Tunnel)
+    const template = await prisma.template.findUnique({
+      where: {
+        id: formID,
+      },
+    });
 
-    if (!formTemplate) {
-      throw new Error("Could not retrieve form template");
+    if (!template || !template.jsonConfig) {
+      throw new Error("Could not retrieve form template or template configuration is missing");
     }
+
+    // The JSON config in the DB matches the structure expected by createResponse
+    const formTemplate = template.jsonConfig as any;
 
     const encoder = new TextEncoder();
 


### PR DESCRIPTION
Makes the util script no longer use the \api\templates endpoint.

Part of #3965