### PR TITLE
chore: Fix close message ref

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/components/close/ClosedMessage.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/manage/components/close/ClosedMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useRef, useEffect } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useTranslation } from "@i18n/client";
 
@@ -33,8 +33,10 @@ export const ClosedMessage = ({
   // Track the current state for saving
   const currentDetailsRef = useRef<ClosedDetails | undefined>(closedDetails);
 
-  // Update current details ref whenever closedDetails changes
-  currentDetailsRef.current = closedDetails;
+  // Update current details ref whenever closedDetails changes (do not assign during render)
+  useEffect(() => {
+    currentDetailsRef.current = closedDetails;
+  }, [closedDetails]);
 
   const handleSave = useCallback(async () => {
     if (valid && onSave) {


### PR DESCRIPTION
# Summary | Résumé

Fixes issue with Close message ref

See: 
https://react.dev/reference/eslint-plugin-react-hooks/lints/refs#valid


**Before:**
<img width="918" height="427" alt="Screenshot 2025-12-16 at 12 27 20 PM" src="https://github.com/user-attachments/assets/6e7f7fee-ebb7-4ae1-80f6-d0b38c51cadf" />

**After:**

<img width="571" height="195" alt="Screenshot 2025-12-16 at 12 32 58 PM" src="https://github.com/user-attachments/assets/5480f53b-b9a9-4de4-8363-3baaa4d85f1f" />


