### PR TITLE
chore: Change formattedDate from 'Date & Time (UTC)' to 'Date' to match function

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -455,7 +455,7 @@
   "formatH3": "Format Heading 3",
   "formatItalic": "Format italic",
   "formatNumberedList": "Format numbered list",
-  "formattedDate": "Date & Time (UTC)",
+  "formattedDate": "Date",
   "formConfirmationMessage": "Confirmation message",
   "formDeleteResponses": {
     "title": "You must retrieve all responses before archiving this form.",


### PR DESCRIPTION
Correction based on feedback from Support 
https://gcdigital.slack.com/archives/C03T4FAE9FV/p1765984769300929

Not sure why this changed, but it's inaccurate in the "Add form element" modal