### PR TITLE
fix: api key detection / sync issues

### DIFF
--- a/lib/serviceAccount.ts
+++ b/lib/serviceAccount.ts
@@ -112,8 +112,6 @@ export const checkKeyExists = async (templateId: string) => {
   }
 
   const remoteKeys = await ZitadelConnector.getMachineUserKeysById(userId);
-  logMessage.info(`DB public key Id: ${publicKeyId}`);
-  logMessage.info(`Remote Keys: ${remoteKeys.map(({ id }) => id)}`);
   return remoteKeys.some(({ id }) => id === publicKeyId) ? publicKeyId : undefined;
 };
 


### PR DESCRIPTION
# Summary | Résumé
Fixes an issue with how keys were being queried from Zitadel.  Only returns keys that are specified by the userId and not all keys that calling user has permission to access.