### PR TITLE
chore: fix force block for rules dialog

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/RulesDialog/RulesForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/RulesDialog/RulesForm.tsx
@@ -135,7 +135,7 @@ export const RulesForm = ({
             className={`border-x-4 border-gray-800 px-5 ${showLogicDetails ? "" : "hidden"}`}
           >
             <div className="my-4">
-              <Markdown options={{ forceBlock: true }}>{t("logic.tryitout.text")}</Markdown>
+              <Markdown options={{ forceBlock: false }}>{t("logic.tryitout.text")}</Markdown>
             </div>
             <Button theme={"primary"} onClick={tryLogicView}>
               {t("logic.tryitout.open")}


### PR DESCRIPTION
# Summary | Résumé

fixes nested `p` tag issue

Sets markdown force to false to prevent paragraph tag from containing children paragraphs 

<img width="500" height="601" alt="Screenshot 2026-01-07 at 9 12 48 AM" src="https://github.com/user-attachments/assets/c6f9b6b4-9e00-4f83-9108-fcdc702e329f" />
