### PR TITLE
fix: save progress html with repeated sections

### DIFF
--- a/lib/hooks/useFormSubmissionData.tsx
+++ b/lib/hooks/useFormSubmissionData.tsx
@@ -10,6 +10,8 @@ import { getStartLabels } from "@lib/utils/form-builder/i18nHelpers";
 import { type HTMLProps } from "@lib/saveAndResume/types";
 import { copyObjectExcludingFileContent } from "@root/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/fileUploader";
 
+import { getValuesWithMatchedIds, getVisibleGroupsBasedOnValuesRecursive } from "@gcforms/core";
+
 export const useFormSubmissionData = ({
   language,
   type,
@@ -17,18 +19,19 @@ export const useFormSubmissionData = ({
   language: Language;
   type: "confirm" | "progress";
 }) => {
-  const {
-    groups,
-    getValues,
-    formRecord,
-    getGroupHistory,
-    getProgressData,
-    submissionId,
-    submissionDate,
-  } = useGCFormsContext();
+  const { groups, getValues, formRecord, getProgressData, submissionId, submissionDate } =
+    useGCFormsContext();
 
   const formValues: void | FormValues = getValues();
-  const groupHistoryIds = getGroupHistory();
+
+  const valuesWithMatchedIds = getValuesWithMatchedIds(formRecord.form.elements, formValues || {});
+
+  const groupHistoryIds = getVisibleGroupsBasedOnValuesRecursive(
+    formRecord,
+    valuesWithMatchedIds,
+    "start"
+  );
+
   if (!formValues || !groups) throw new Error("Form values or groups are missing");
 
   // Clean up the values for use with the Review component (removing the file contents)


### PR DESCRIPTION
# Summary | Résumé

Use core helps to get history for review list

Fixes: https://github.com/cds-snc/platform-forms-client/issues#workspaces/gcforms-60cb8929764d71000e481cab/issues/zh/380

**Testing**

On current main

The issue only shows up for the downloaded file

You can recreate but creating a form with 2 pages --- each with a text field ... publish the form

Visit the form

fill out the info on Page 1
press "back"

Press continue until you reach the end of the form ...

Download progress no need to submit.