### PR TITLE
chore: revert md-jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.set": "4.3.2",
     "lodash.unset": "4.5.2",
-    "markdown-to-jsx": "9.6.0",
+    "markdown-to-jsx": "7.7.13",
     "native-file-system-adapter": "^3.0.1",
     "next": "16.1.4",
     "next-auth": "5.0.0-beta.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12974,7 +12974,7 @@ __metadata:
     lodash.merge: "npm:^4.6.2"
     lodash.set: "npm:4.3.2"
     lodash.unset: "npm:4.5.2"
-    markdown-to-jsx: "npm:9.6.0"
+    markdown-to-jsx: "npm:7.7.13"
     native-file-system-adapter: "npm:^3.0.1"
     next: "npm:16.1.4"
     next-auth: "npm:5.0.0-beta.29"
@@ -15258,23 +15258,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx@npm:9.6.0":
-  version: 9.6.0
-  resolution: "markdown-to-jsx@npm:9.6.0"
+"markdown-to-jsx@npm:7.7.13":
+  version: 7.7.13
+  resolution: "markdown-to-jsx@npm:7.7.13"
   peerDependencies:
-    react: ">= 16.0.0"
-    solid-js: ">=1.0.0"
-    vue: ">=3.0.0"
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-native:
-      optional: true
-    solid-js:
-      optional: true
-    vue:
-      optional: true
-  checksum: 10c0/a12c51904262151e80b6a75f11cfa54098da69a0913d294cd35412c5c7846fad3686a0fef0ba83f1ef27bd0c6036c0c30218ba924dfd2864e3a192b3e220bb49
+    react: ">= 0.14.0"
+  checksum: 10c0/6e423b36f62cc387b87cc17ab603108b8a3095d0fc6b4294d7149aba9ca52a356a937638cb883c44e63ea8d40212f6f81ffc683020afcbc9f84bdd2856061aa9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary | Résumé

Reverting to avoid larger update i.e. import Markdown from 'markdown-to-jsx/react'

https://www.npmjs.com/package/markdown-to-jsx#from-v8x-to-v9x