### PR TITLE
fix: remove MessageDeduplicationId from SQS message we send to the reliability_reprocessing_queue queue

### DIFF
--- a/app/api/notify-callback/route.ts
+++ b/app/api/notify-callback/route.ts
@@ -160,7 +160,6 @@ export const POST = middleware([validAuthorizationHeader()], async (req, props) 
 
     const sendMessageCommand = new SendMessageCommand({
       MessageBody: JSON.stringify({ submissionID: submissionID }),
-      MessageDeduplicationId: submissionID,
       MessageGroupId: "Group-" + submissionID,
       QueueUrl: queueUrl,
     });


### PR DESCRIPTION
# Summary | Résumé

- Fixes compatibility issue with SQS `reliability_reprocessing_queue` queue type (Standard instead of FIFO)