### PR TITLE
chore: upgrade generate-sbom Github action from v4.0.1 to v4.0.2

### DIFF
--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -70,7 +70,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v4.0.1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@8d2322011f6b68da2fc47e60f23b41c1907e33e8 # v4.0.2
         env:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
           ECR_REGISTRY: ${{ steps.login-ecr-staging.outputs.registry }}


### PR DESCRIPTION
# Summary | Résumé

- Upgrades `generate-sbom` Github action from v4.0.1 to v4.0.2