### PR TITLE
fix: Docker vulnerability scan to no longer pull image

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -5,13 +5,7 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
-env:
-  AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
-  AWS_REGION: ca-central-1
-  ECR_REPOSITORY: form_viewer_staging
-
 permissions:
-  id-token: write
   contents: write
   security-events: write
 
@@ -19,27 +13,25 @@ jobs:
   docker-vulnerability-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-forms-client-plan
-          role-session-name: ECRPull
-          aws-region: ${{ env.AWS_REGION }}
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Login to Staging Amazon ECR
-        id: login-ecr-staging
-        uses: aws-actions/amazon-ecr-login@cc05f4a4db45f6b446eee901ef3620a08754cbcf
+      - name: Build Form Viewer
+        run: |
+          docker build --platform=linux/amd64 --provenance false -t forms-client \
+            --build-arg COGNITO_APP_CLIENT_ID="COGNITO_APP_CLIENT_ID" \
+            --build-arg COGNITO_USER_POOL_ID="COGNITO_USER_POOL_ID" \
+            --build-arg HCAPTCHA_SITE_KEY="HCAPTCHA_SITE_KEY" \
+            --build-arg ZITADEL_URL="ZITADEL_URL" \
+            --build-arg ZITADEL_PROJECT_ID="ZITADEL_PROJECT_ID" \
+            --build-arg API_URL="API_URL" \
+            --build-arg NEXT_DEPLOYMENT_ID=$GITHUB_SHA .
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@5a93d1deec72d4cb2737cb8418364fedba1c695c # v3.2.1
+        uses: cds-snc/security-tools/.github/actions/docker-scan@837a88b6337d4842543184c8eac97a8adac8f302 # v4.0.3
         env:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
-          ECR_REGISTRY: ${{ steps.login-ecr-staging.outputs.registry }}
         with:
-          docker_image: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest"
+          docker_image: "forms-client"
           dockerfile_path: "Dockerfile"
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Logout of Staging Amazon ECR
-        if: always()
-        run: docker logout ${{ steps.login-ecr-staging.outputs.registry }}

--- a/.github/workflows/staging-post-deployment.yml
+++ b/.github/workflows/staging-post-deployment.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: write
   security-events: write
 


### PR DESCRIPTION
# Summary | Résumé
Update the Docker vulnerability scan so that it builds the image rather then needing AWS credentials to pull an image.  This follows the new pattern established by the SBOM workflow and reduces the risk of account compromise through a workflow.  It also fixes the current issue where the [v0.65.0 of Trivy is no longer available ](https://github.com/cds-snc/platform-forms-client/actions/runs/23578018370/job/68654780984#logs)after their breach.

Additionally this PR removes the `id-token` permission from the SBOM workflow as it's no longer required (only needed when OIDC credentials are used).

# Test instructions | Instructions pour tester la modification

Expect the Docker vulnerability scan to complete without error.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

n/a

# Pull Request Checklist

Please complete the following items in the checklist before you request a review:

- [x] Have you completely tested the functionality of change introduced in this PR? Is the PR solving the problem it's meant to solve within the scope of the related issue?
- [x] The PR does not introduce any new issues such as failed tests, console warnings or new bugs.
- [ ] If this PR adds a package have you ensured its licensed correctly and does not add additional security issues?
- [x] Is the code clean, readable and maintainable? Is it easy to understand and comprehend.
- [x] Does your code have adequate comprehensible comments? Do new functions have [docstrings](https://tsdoc.org/)?
- [ ] Have you modified the change log and updated any relevant documentation?
- [ ] Is there adequate test coverage? Both unit tests and end-to-end tests where applicable?
- [ ] If your PR is touching any UI is it accessible? Have you tested it with a screen reader? Have you tested it with automated testing tools such as axe?
