### PR TITLE
chore: fix NextJS deployment identifier compatibility issue

### DIFF
--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -8,7 +8,7 @@ env:
   AWS_ACCOUNT_ID: ${{ vars.PRODUCTION_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   ECR_REPOSITORY: form_viewer_production
-  TAG_VERSION: ${{  github.ref_name }}
+  TAG_VERSION: ${{ github.ref_name }}
   COGNITO_APP_CLIENT_ID: ${{secrets.PRODUCTION_COGNITO_APP_CLIENT_ID}}
   COGNITO_USER_POOL_ID: ${{ secrets.PRODUCTION_COGNITO_USER_POOL_ID}}
   HCAPTCHA_SITE_KEY: ${{ vars.PRODUCTION_HCAPTCHA_SITE_KEY }}
@@ -31,15 +31,18 @@ jobs:
 
       - name: Build Form Viewer
         run: |
+          # We need to replace all dots with hyphens in tag version (v4.10.0 becomes v4-10-0)
+          NEXTJS_COMPATIBLE_DEPLOYMENT_IDENTIFIER=${TAG_VERSION//./-}
+
           docker build --platform=linux/amd64 --provenance false -t base \
-          --build-arg COGNITO_APP_CLIENT_ID=$COGNITO_APP_CLIENT_ID \
-          --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID \
-          --build-arg INDEX_SITE=true \
-          --build-arg HCAPTCHA_SITE_KEY=$HCAPTCHA_SITE_KEY \
-          --build-arg ZITADEL_URL=$ZITADEL_URL \
-          --build-arg ZITADEL_PROJECT_ID=$ZITADEL_PROJECT_ID \
-          --build-arg API_URL=$API_URL \
-          --build-arg NEXT_DEPLOYMENT_ID=$TAG_VERSION .
+            --build-arg COGNITO_APP_CLIENT_ID=$COGNITO_APP_CLIENT_ID \
+            --build-arg COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID \
+            --build-arg INDEX_SITE=true \
+            --build-arg HCAPTCHA_SITE_KEY=$HCAPTCHA_SITE_KEY \
+            --build-arg ZITADEL_URL=$ZITADEL_URL \
+            --build-arg ZITADEL_PROJECT_ID=$ZITADEL_PROJECT_ID \
+            --build-arg API_URL=$API_URL \
+            --build-arg NEXT_DEPLOYMENT_ID=$NEXTJS_COMPATIBLE_DEPLOYMENT_IDENTIFIER .
 
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1

--- a/.github/workflows/rainbow-deployment/action.yml
+++ b/.github/workflows/rainbow-deployment/action.yml
@@ -99,16 +99,20 @@ runs:
           --target-group-arn $target_group_arn \
           --targets Id=$lambda_arn
 
+        # We need to replace all dots with hyphens in release identifier for when a tag is being passed (v4.10.0 becomes v4-10-0)
+        DEPLOYMENT_IDENTIFIER=${{ inputs.latest-release-identifier }}
+        NEXTJS_COMPATIBLE_DEPLOYMENT_IDENTIFIER=${DEPLOYMENT_IDENTIFIER//./-}
+
         aws elbv2 create-rule \
           --listener-arn ${{ inputs.load-balancer-listener-arn }} \
-          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"http-header\",\"HttpHeaderConfig\":{\"HttpHeaderName\":\"x-deployment-id\",\"Values\":[\"${{ inputs.latest-release-identifier }}\"]}}]" \
+          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"http-header\",\"HttpHeaderConfig\":{\"HttpHeaderName\":\"x-deployment-id\",\"Values\":[\"${NEXTJS_COMPATIBLE_DEPLOYMENT_IDENTIFIER}\"]}}]" \
           --priority 1 \
           --actions Type=forward,TargetGroupArn=$target_group_arn \
           --tags Key=Name,Value=rainbow-${{ inputs.deployment-identifier }} > /dev/null 2>&1
 
         aws elbv2 create-rule \
           --listener-arn ${{ inputs.load-balancer-listener-arn }} \
-          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"query-string\",\"QueryStringConfig\":{\"Values\":[{\"Key\":\"dpl\",\"Value\":\"${{ inputs.latest-release-identifier }}\"}]}}]" \
+          --conditions "[{\"Field\":\"host-header\",\"Values\":[\"${{ inputs.hostname }}\"]},{\"Field\":\"query-string\",\"QueryStringConfig\":{\"Values\":[{\"Key\":\"dpl\",\"Value\":\"${NEXTJS_COMPATIBLE_DEPLOYMENT_IDENTIFIER}\"}]}}]" \
           --priority 2 \
           --actions Type=forward,TargetGroupArn=$target_group_arn \
           --tags Key=Name,Value=rainbow-${{ inputs.deployment-identifier }} > /dev/null 2>&1


### PR DESCRIPTION
# Summary | Résumé

It appears that something changed with a recent NextJS update and we are not able to have dots in the `deploymentId` value (https://nextjs.org/docs/messages/deploymentid-invalid-characters#possible-ways-to-fix-it).

For our Production environment we used to set it to the latest tag name. With this update `v4.10.0` will now become `v4-10-0`

- Replaces dots with hyphens in the `deploymentId` value when deploying Rainbow Lambda functions