### PR TITLE
chore: Move regex functions into core and update imports

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/CustomRegexOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/CustomRegexOptions.tsx
@@ -6,8 +6,7 @@ import { Input } from "@formBuilder/components/shared/Input";
 import { ErrorMessage } from "@clientComponents/forms";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { InfoDetails } from "../../../../components/shared/InfoDetails";
-import { isValidRegex } from "@root/lib/regex/isValidRegex";
-import { isSafeRegex } from "@root/lib/regex/isSafeRegex";
+import { isSafeRegex, isValidRegex } from "@gcforms/core";
 
 export const CustomRegexOptions = ({
   item,
@@ -80,7 +79,7 @@ export const CustomRegexOptions = ({
   return (
     <>
       <InfoDetails summary={t("moreDialog.customRegex.title")} className="mb-4">
-        <section className="mb-4 mt-6">
+        <section className="mt-6 mb-4">
           <div className="mb-2">
             <p>{t("moreDialog.customRegex.description")}</p>
           </div>
@@ -109,7 +108,7 @@ export const CustomRegexOptions = ({
                   <li key={pattern}>
                     <button
                       type="button"
-                      className="rounded-lg border border-violet-800 bg-violet-100 px-2 py-1 font-mono text-sm hover:border-black hover:bg-gray-100 focus:outline focus:outline-[3px] focus:outline-offset-2 focus:outline-blue-focus"
+                      className="focus:outline-blue-focus rounded-lg border border-violet-800 bg-violet-100 px-2 py-1 font-mono text-sm hover:border-black hover:bg-gray-100 focus:outline focus:outline-[3px] focus:outline-offset-2"
                       onClick={() => validateAndSetPattern(pattern)}
                     >
                       {pattern}

--- a/lib/regex/isSafeRegex.ts
+++ b/lib/regex/isSafeRegex.ts
@@ -1,8 +1,0 @@
-import { checkSync } from "recheck";
-
-export const isSafeRegex = (pattern: string): boolean => {
-  if (!pattern) return true;
-
-  const result = checkSync(pattern, "", { timeout: 1000 });
-  return result.status === "safe";
-};

--- a/lib/regex/isValidRegex.ts
+++ b/lib/regex/isValidRegex.ts
@@ -1,9 +1,0 @@
-export const isValidRegex = (pattern: string): boolean => {
-  if (!pattern) return true;
-  try {
-    new RegExp(pattern);
-    return true;
-  } catch {
-    return false;
-  }
-};

--- a/lib/regex/validateCustomRegex.ts
+++ b/lib/regex/validateCustomRegex.ts
@@ -1,6 +1,5 @@
+import { isSafeRegex, isValidRegex } from "@gcforms/core";
 import { FormElement } from "../types";
-import { isSafeRegex } from "./isSafeRegex";
-import { isValidRegex } from "./isValidRegex";
 
 export const validateCustomRegex = (elements: FormElement[]) => {
   for (const element of elements) {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## [2.2.3] - 2026-04-01
+
+- Move regex validation utils into package
+
 ## [2.2.2] - 2026-03-30
 
 - Enable Custom Regex validation
-- 
+
 ## [2.2.1] - 2026-03-31
 
 - Fix shared toast status styling after the Tailwind CSS v4 update by preserving React Toastify root classes and restoring toast background colors.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/core",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,3 +51,6 @@ export {
   ensureChoiceId,
   getElementsUsingChoiceId,
 } from "./helpers";
+
+export { isSafeRegex } from "./validation/regex";
+export { isValidRegex } from "./validation/regex";

--- a/packages/core/src/validation/regex.ts
+++ b/packages/core/src/validation/regex.ts
@@ -1,3 +1,22 @@
+import { checkSync } from "recheck";
+
+export const isSafeRegex = (pattern: string): boolean => {
+  if (!pattern) return true;
+
+  const result = checkSync(pattern, "", { timeout: 1000 });
+  return result.status === "safe";
+};
+
+export const isValidRegex = (pattern: string): boolean => {
+  if (!pattern) return true;
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * getRegexByType [private] defines a mapping between the types of fields that need to be validated
  * Also, defines the regex for validation, with a matching bilingual error message

--- a/packages/core/src/validation/validation.ts
+++ b/packages/core/src/validation/validation.ts
@@ -11,7 +11,7 @@ import { isInputTooLong } from "./text";
 import { isValidDate } from "./date";
 import { getRegexByType } from "./regex";
 import { isFileExtensionValid, isIndividualFileSizeValid } from "./file";
-import { isSafeRegex } from "@root/lib/regex/isSafeRegex";
+import { isSafeRegex } from "./regex";
 
 export const isFieldResponseValid = (
   value: unknown,


### PR DESCRIPTION
# Summary | Résumé

Built the regex utils in lib but then imported them into packages/core, which is problematic when using the package in other repositories.

This PR moves the generic lib functions into the package.
Note that validateCustomRegex remains in the main lib folder, as it is implementation specific to the form-builder.