### PR TITLE
chore: modify PostgresConnector constructor to use future Postgres JSON connection object

### DIFF
--- a/packages/connectors/CHANGELOG.md
+++ b/packages/connectors/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-04-09
+
+### Changed
+
+- PostgresConnector constructor now requires a Postgres JSON connection object instead of basic connection URL
+
 ## [2.2.19] - 2026-03-24
 
 - Update TypeScript to 6.0.2

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/connectors",
-  "version": "2.2.19",
+  "version": "3.0.0",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/connectors/src/postgres-connector.ts
+++ b/packages/connectors/src/postgres-connector.ts
@@ -4,20 +4,20 @@ import postgres, { Sql } from "postgres";
 export class PostgresConnector {
   private postgresInstance: Sql;
 
-  public static defaultUsingPostgresConnectionUrlFromAwsSecret(
-    postgresConnectionUrlSecretIdentifier: string
+  public static defaultUsingPostgresJsonConnectionObjectFromAwsSecret(
+    secretArn: string
   ): Promise<PostgresConnector> {
-    return getAwsSecret(postgresConnectionUrlSecretIdentifier).then((postgresConnectionUrl) => {
-      if (postgresConnectionUrl === undefined) {
-        throw new Error("Postgres connection URL is undefined");
+    return getAwsSecret(secretArn).then((value) => {
+      if (value === undefined) {
+        throw new Error("Postgres JSON connection object is undefined");
       }
 
-      return new PostgresConnector(postgresConnectionUrl);
+      return new PostgresConnector(value);
     });
   }
 
-  private constructor(connectionUrl: string) {
-    this.postgresInstance = postgres(connectionUrl, { ssl: "prefer" });
+  private constructor(jsonConnectionObject: string) {
+    this.postgresInstance = postgres(JSON.parse(jsonConnectionObject));
   }
 
   public executeSqlStatement(): Sql {


### PR DESCRIPTION
# Summary | Résumé

Context: [link to migration plan](https://github.com/cds-snc/platform-forms-client/issues/6731#issuecomment-4216960830)

- Modifies the PostgresConnector constructor to use future Postgres JSON connection object