### PR TITLE
chore: add code to gate heartbeat

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -17,6 +17,7 @@ import { FormRecord } from "@lib/types";
 import { logMessage } from "@lib/logger";
 import { checkKeyExists } from "@lib/serviceAccount";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
+import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
 import {
   FormBuilderConfigProvider,
   FormBuilderConfig,
@@ -45,6 +46,10 @@ export default async function Layout(props: {
 
   const allowGroupsFlag = allowGrouping();
   const allowLockedEditingFlag = await allowLockedEditing();
+  const enforceEditLockFlag =
+    allowLockedEditingFlag && formID && formID !== "0000"
+      ? await shouldEnforceTemplateEditLock(formID)
+      : false;
 
   if (session && formID && formID !== "0000") {
     const templateWithUsers = await getTemplateWithAssociatedUsers(formID).catch((e) => {
@@ -112,7 +117,7 @@ export default async function Layout(props: {
                     </div>
                     <GroupStoreProvider>
                       <div className="relative flex w-full gap-7">
-                        <EditLockClient formId={id} lockedEditingEnabled={allowLockedEditingFlag}>
+                        <EditLockClient formId={id} lockedEditingEnabled={enforceEditLockFlag}>
                           <main
                             id="content"
                             className="form-builder my-7 min-h-[calc(100vh-300px)] w-full"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -4,6 +4,7 @@ import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/L
 import { authCheckAndThrow } from "@lib/actions";
 import { Language } from "@lib/types/form-builder-types";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
+import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
 import { SettingsNavigation } from "./components/SettingsNavigation";
 import { WaitForId } from "../components/WaitForId";
 import { EditLockClient } from "@formBuilder/components/shared/edit-lock/EditLockClient";
@@ -20,6 +21,9 @@ export default async function Layout(props: {
 
   const { t } = await serverTranslation("form-builder", { lang: locale });
   const allowLockedEditingFlag = await allowLockedEditing();
+  const enforceEditLockFlag = allowLockedEditingFlag
+    ? await shouldEnforceTemplateEditLock(id)
+    : false;
 
   const { session } = await authCheckAndThrow().catch(() => ({ session: null }));
 
@@ -39,7 +43,7 @@ export default async function Layout(props: {
       <SettingsNavigation id={id} />
       <EditLockClient
         formId={id}
-        lockedEditingEnabled={allowLockedEditingFlag}
+        lockedEditingEnabled={enforceEditLockFlag}
         restrictToEditPaths={false}
         reloadOnTakeover={true}
       >

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -44,6 +44,20 @@ type EditLockStatus = {
   } | null;
 };
 
+const isEditLockStatus = (value: unknown): value is EditLockStatus => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<EditLockStatus>;
+  return (
+    typeof candidate.locked === "boolean" &&
+    typeof candidate.lockedByOther === "boolean" &&
+    typeof candidate.isOwner === "boolean" &&
+    (candidate.lock === null || typeof candidate.lock === "object")
+  );
+};
+
 export const useEditLock = ({
   formId,
   enabled,
@@ -63,14 +77,22 @@ export const useEditLock = ({
   const heartbeatRef = useRef<number | null>(null);
   const pollRef = useRef<number | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const startHeartbeatRef = useRef<() => void>(() => undefined);
+  const startPollingRef = useRef<() => void>(() => undefined);
   const lockLoopTokenRef = useRef(0);
   const lastActivityAtRef = useRef(0);
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
   const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
 
+  const clearLockState = useCallback(() => {
+    setIsLockedByOther(false);
+    setEditLock(null);
+    isOwnerRef.current = false;
+  }, [setEditLock, setIsLockedByOther]);
+
   const updateStore = useCallback(
     (status: EditLockStatus) => {
-      setIsLockedByOther(!status.isOwner);
+      setIsLockedByOther(status.lockedByOther);
       setEditLock(
         status.lock
           ? {
@@ -84,7 +106,7 @@ export const useEditLock = ({
               visibilityState: status.lock.visibilityState ?? null,
               presenceStatus: status.lock.presenceStatus ?? null,
               isOwner: status.isOwner,
-              lockedByOther: !status.isOwner,
+              lockedByOther: status.lockedByOther,
             }
           : null
       );
@@ -138,7 +160,9 @@ export const useEditLock = ({
             : undefined,
         }),
       });
-      return res.json();
+
+      const payload = (await res.json().catch(() => null)) as unknown;
+      return isEditLockStatus(payload) ? payload : null;
     },
     [formId, sessionId]
   );
@@ -148,7 +172,9 @@ export const useEditLock = ({
       method: "GET",
       cache: "no-store",
     });
-    return res.json();
+
+    const payload = (await res.json().catch(() => null)) as unknown;
+    return isEditLockStatus(payload) ? payload : null;
   }, [formId]);
 
   const refreshForm = useCallback(
@@ -220,52 +246,101 @@ export const useEditLock = ({
     await takeoverSaveRef.current;
   }, [postAction, saveDraft]);
 
-  const startHeartbeat = useCallback(() => {
+  const startHeartbeat = useCallback((): void => {
     clearTimers();
     const loopToken = lockLoopTokenRef.current;
     heartbeatRef.current = window.setInterval(async () => {
-      const heartbeatResult = (await postAction("heartbeat")) as EditLockStatus;
+      const heartbeatResult = await postAction("heartbeat");
       if (lockLoopTokenRef.current !== loopToken) {
         return;
       }
-      updateStore(heartbeatResult);
-    }, EDIT_LOCK_HEARTBEAT_MS);
-  }, [clearTimers, postAction, updateStore]);
 
-  const startPolling = useCallback(() => {
+      if (!heartbeatResult) {
+        clearTimers();
+        clearLockState();
+        return;
+      }
+
+      updateStore(heartbeatResult);
+
+      if (!heartbeatResult.locked) {
+        const retryResult = await postAction("acquire");
+        if (lockLoopTokenRef.current !== loopToken) {
+          return;
+        }
+
+        if (!retryResult) {
+          clearTimers();
+          clearLockState();
+          return;
+        }
+
+        updateStore(retryResult);
+        if (retryResult.isOwner) {
+          return;
+        }
+
+        startPollingRef.current();
+      }
+    }, EDIT_LOCK_HEARTBEAT_MS);
+  }, [clearLockState, clearTimers, postAction, updateStore]);
+
+  const startPolling = useCallback((): void => {
     clearTimers();
     const loopToken = lockLoopTokenRef.current;
     pollRef.current = window.setInterval(async () => {
       const wasOwner = isOwnerRef.current;
-      const pollResult = (await getStatus()) as EditLockStatus;
+      const pollResult = await getStatus();
       if (lockLoopTokenRef.current !== loopToken) {
         return;
       }
+
+      if (!pollResult) {
+        clearTimers();
+        clearLockState();
+        return;
+      }
+
       updateStore(pollResult);
       if (pollResult.locked && !pollResult.isOwner && wasOwner) {
         void syncServerState();
       }
       if (!pollResult.locked) {
-        const retryResult = (await postAction("acquire")) as EditLockStatus;
+        const retryResult = await postAction("acquire");
         if (lockLoopTokenRef.current !== loopToken) {
           return;
         }
+
+        if (!retryResult) {
+          clearTimers();
+          clearLockState();
+          return;
+        }
+
         updateStore(retryResult);
         if (retryResult.isOwner) {
-          startHeartbeat();
+          startHeartbeatRef.current();
           void refreshForm();
         }
       }
     }, EDIT_LOCK_HEARTBEAT_MS);
   }, [
+    clearLockState,
     clearTimers,
     getStatus,
     postAction,
     refreshForm,
-    startHeartbeat,
     syncServerState,
     updateStore,
   ]);
+
+  useEffect(() => {
+    startHeartbeatRef.current = startHeartbeat;
+  }, [startHeartbeat]);
+
+  useEffect(() => {
+    startPollingRef.current = startPolling;
+  }, [startPolling]);
 
   const startTimers = useCallback(
     (statusResult: EditLockStatus, cancelled = false) => {
@@ -283,18 +358,28 @@ export const useEditLock = ({
     if (!enabled) {
       clearTimers();
       clearEvents();
-      setIsLockedByOther(false);
-      setEditLock(null);
+      clearLockState();
       return;
     }
 
-    if (status !== "authenticated") return;
+    if (status !== "authenticated") {
+      clearTimers();
+      clearEvents();
+      clearLockState();
+      return;
+    }
 
     let cancelled = false;
 
     const acquire = async () => {
-      const statusResult = (await postAction("acquire")) as EditLockStatus;
+      const statusResult = await postAction("acquire");
       if (cancelled) return;
+
+      if (!statusResult) {
+        clearLockState();
+        return;
+      }
+
       updateStore(statusResult);
       startTimers(statusResult, cancelled);
       if (!statusResult.isOwner) {
@@ -315,14 +400,13 @@ export const useEditLock = ({
   }, [
     enabled,
     formId,
+    clearLockState,
     clearTimers,
     clearEvents,
     getStatus,
     postAction,
     refreshForm,
     sessionId,
-    setEditLock,
-    setIsLockedByOther,
     startTimers,
     status,
     syncServerState,

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -95,11 +95,15 @@ const ownerLockStatus = {
 function EditLockHarness({
   onTakeoverReady,
   onChangeKey,
+  onLockStateChange,
 }: {
   onTakeoverReady?: (takeover: () => Promise<void>) => void;
   onChangeKey?: (changeKey: string) => void;
+  onLockStateChange?: (state: { isLockedByOther: boolean; hasEditLock: boolean }) => void;
 }) {
   const changeKey = useTemplateStore((s) => s.changeKey);
+  const isLockedByOther = useTemplateStore((s) => s.isLockedByOther);
+  const editLock = useTemplateStore((s) => s.editLock);
   const { takeover } = useEditLock({
     formId: "test-form-id",
     enabled: true,
@@ -113,6 +117,13 @@ function EditLockHarness({
   useEffect(() => {
     onChangeKey?.(changeKey);
   }, [changeKey, onChangeKey]);
+
+  useEffect(() => {
+    onLockStateChange?.({
+      isLockedByOther,
+      hasEditLock: editLock !== null,
+    });
+  }, [editLock, isLockedByOther, onLockStateChange]);
 
   useEffect(() => {
     return () => {
@@ -255,5 +266,47 @@ describe("useEditLock", () => {
 
     expect(changeKeys.at(-1)).toBeDefined();
     expect(changeKeys.at(-1)).not.toBe(changeKeys[0]);
+  });
+
+  it("does not mark the form as locked by another user when the edit-lock endpoint is unauthorized", async () => {
+    const lockStates: Array<{ isLockedByOther: boolean; hasEditLock: boolean }> = [];
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/edit-lock") && init?.method === "POST") {
+        return {
+          ok: false,
+          json: async () => ({ error: "Unauthorized" }),
+        } as Response;
+      }
+
+      if (url.endsWith("/edit-lock") && init?.method === "GET") {
+        return {
+          ok: false,
+          json: async () => ({ error: "Unauthorized" }),
+        } as Response;
+      }
+
+      if (url.endsWith("/api/templates/test-form-id")) {
+        return {
+          ok: true,
+          json: async () => ({ form: { elements: [] }, updatedAt: new Date().toISOString() }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(<EditLockHarness onLockStateChange={(state) => lockStates.push(state)} />);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    expect(lockStates.at(-1)).toEqual({ isLockedByOther: false, hasEditLock: false });
   });
 });


### PR DESCRIPTION
# Summary | Résumé

- Single-user forms should not enforce edit locks at  all; that threshold already exists server-side.  
- A stale tab could still end up in a false locked state because the client-side edit-lock hook was mounted too  broadly and did not defensively handle unauthorized or malformed edit-lock responses.                           │
- Edit-lock client mounting is now gated by the server’s actual `shouldEnforceTemplateEditLock(...)` result