### PR TITLE
chore: Event cleanup after takeover

### DIFF
--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -80,8 +80,10 @@ export const useEditLock = ({
   const startHeartbeatRef = useRef<() => void>(() => undefined);
   const startPollingRef = useRef<() => void>(() => undefined);
   const lockLoopTokenRef = useRef(0);
+  const updatedAtRef = useRef(updatedAt);
   const lastActivityAtRef = useRef(0);
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
+  const suppressReleaseRef = useRef(false);
   const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
 
   const clearLockState = useCallback(() => {
@@ -111,6 +113,9 @@ export const useEditLock = ({
           : null
       );
       isOwnerRef.current = status.isOwner;
+      if (status.isOwner) {
+        suppressReleaseRef.current = false;
+      }
     },
     [setEditLock, setIsLockedByOther]
   );
@@ -218,14 +223,20 @@ export const useEditLock = ({
     [formId, resetState, setFromRecord, setUpdatedAt]
   );
 
+  useEffect(() => {
+    updatedAtRef.current = updatedAt;
+  }, [updatedAt]);
+
   const syncServerState = useCallback(async () => {
-    await refreshForm(updatedAt);
-  }, [refreshForm, updatedAt]);
+    await refreshForm(updatedAtRef.current);
+  }, [refreshForm]);
 
   const flushDraftBeforeTakeover = useCallback(async () => {
     if (!isOwnerRef.current) {
       return;
     }
+
+    suppressReleaseRef.current = true;
 
     if (!takeoverSaveRef.current) {
       takeoverSaveRef.current = (async () => {
@@ -393,7 +404,7 @@ export const useEditLock = ({
       cancelled = true;
       clearTimers();
       clearEvents();
-      if (isOwnerRef.current) {
+      if (isOwnerRef.current && !suppressReleaseRef.current) {
         postAction("release");
       }
     };

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -225,7 +225,9 @@ describe("useEditLock", () => {
       .map(([, init]) => JSON.parse(String(init?.body)) as { action: string });
 
     expect(lockPostBodies.filter(({ action }) => action === "release")).toHaveLength(0);
-    expect(lockPostBodies.filter(({ action }) => action === "takeover-save-complete")).toHaveLength(1);
+    expect(lockPostBodies.filter(({ action }) => action === "takeover-save-complete")).toHaveLength(
+      1
+    );
   });
 
   it("refreshes until it sees a newer server version after takeover", async () => {

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -199,6 +199,35 @@ describe("useEditLock", () => {
     expect(saveDraftIfNeeded).not.toHaveBeenCalled();
   });
 
+  it("does not release on unmount during a takeover handoff", async () => {
+    const saveDraftDeferred = Promise.resolve({ status: "saved" as const });
+    saveDraft.mockImplementationOnce(() => saveDraftDeferred);
+
+    const rendered = await render(<EditLockHarness />);
+
+    await vi.waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    MockEventSource.instances[0].emit("takeover-requested");
+    rendered.unmount();
+
+    await saveDraftDeferred;
+
+    await vi.waitFor(() => {
+      expect(saveDraft).toHaveBeenCalledTimes(1);
+    });
+
+    const lockPostBodies = fetchMock.mock.calls
+      .filter(([input, init]) => {
+        return String(input).endsWith("/edit-lock") && init?.method === "POST";
+      })
+      .map(([, init]) => JSON.parse(String(init?.body)) as { action: string });
+
+    expect(lockPostBodies.filter(({ action }) => action === "release")).toHaveLength(0);
+    expect(lockPostBodies.filter(({ action }) => action === "takeover-save-complete")).toHaveLength(1);
+  });
+
   it("refreshes until it sees a newer server version after takeover", async () => {
     const staleUpdatedAt = "2026-03-31T12:00:00.000Z";
     const freshUpdatedAt = "2026-03-31T12:00:03.000Z";
@@ -266,6 +295,67 @@ describe("useEditLock", () => {
 
     expect(changeKeys.at(-1)).toBeDefined();
     expect(changeKeys.at(-1)).not.toBe(changeKeys[0]);
+  });
+
+  it("does not release and reacquire after takeover refresh updates updatedAt", async () => {
+    const freshUpdatedAt = "2026-03-31T12:00:03.000Z";
+    templateUpdatedAt = Date.parse("2026-03-31T12:00:00.000Z");
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/edit-lock") && init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/edit-lock") && init?.method === "GET") {
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/api/templates/test-form-id")) {
+        return {
+          ok: true,
+          json: async () => ({
+            form: { elements: [] },
+            updatedAt: freshUpdatedAt,
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    let takeover: (() => Promise<void>) | undefined;
+
+    await render(<EditLockHarness onTakeoverReady={(nextTakeover) => (takeover = nextTakeover)} />);
+
+    await vi.waitFor(() => {
+      expect(takeover).toBeDefined();
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    await takeover?.();
+
+    await vi.waitFor(() => {
+      expect(setUpdatedAt).toHaveBeenCalledWith(Date.parse(freshUpdatedAt));
+    });
+
+    const lockPostBodies = fetchMock.mock.calls
+      .filter(([input, init]) => {
+        return String(input).endsWith("/edit-lock") && init?.method === "POST";
+      })
+      .map(([, init]) => JSON.parse(String(init?.body)) as { action: string });
+
+    expect(lockPostBodies.filter(({ action }) => action === "acquire")).toHaveLength(1);
+    expect(lockPostBodies.filter(({ action }) => action === "takeover")).toHaveLength(1);
+    expect(lockPostBodies.filter(({ action }) => action === "release")).toHaveLength(0);
+    expect(MockEventSource.instances).toHaveLength(1);
   });
 
   it("does not mark the form as locked by another user when the edit-lock endpoint is unauthorized", async () => {


### PR DESCRIPTION
# Summary | Résumé

This change stabilizes edit-lock takeover handling in the form builder.

It prevents an unintended release and reacquire cycle after takeover refreshes, and suppresses stale release events during handoff.

I setup a local debug tool to monitor the events 

Before: 

Noticed 3 and in some cases more update events 

These turned out to be release and reacquire cycles

<img width="700" height="591" alt="before" src="https://github.com/user-attachments/assets/65250954-5893-4e6a-91a1-6a6946c477e1" />


