### PR TITLE
fix: template dirty check

### DIFF
--- a/lib/hooks/form-builder/useTemplateContext.tsx
+++ b/lib/hooks/form-builder/useTemplateContext.tsx
@@ -148,12 +148,13 @@ export function SaveTemplateProvider({ children }: { children: React.ReactNode }
   ]);
 
   const saveDraftIfNeeded = useCallback(async (): Promise<SaveDraftResult> => {
-    if (!templateIsDirty.current) {
+    const id = getId();
+    if (!templateIsDirty.current && id !== "") {
       return { status: "skipped" };
     }
 
     return saveDraft();
-  }, [saveDraft]);
+  }, [saveDraft, getId]);
 
   useSubscibeToTemplateStore(
     (s) =>


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where an imported form would do a "dirty" check when the form had not been created yet.