### PR TITLE
chore: use shared channel for edit lock events

### DIFF
--- a/lib/editLockEventStreams.ts
+++ b/lib/editLockEventStreams.ts
@@ -2,10 +2,35 @@ import { createRedisSubscriber } from "@lib/integration/redisConnector";
 import { EditLockEvent } from "./editLocks";
 import type Redis from "ioredis";
 
-const EDIT_LOCK_CHANNEL_PREFIX = "edit-lock-events";
+const EDIT_LOCK_CHANNEL = "edit-lock-events";
 
 type EditLockRouteSubscriber = (event: EditLockEvent) => void;
 type EditLockStreamCloser = () => void | Promise<void>;
+
+type EditLockRedisEventMessage = {
+  templateId: string;
+  event: EditLockEvent;
+};
+
+type ParsedEditLockRedisEventMessage = Partial<
+  EditLockRedisEventMessage & {
+    type?: EditLockEvent["type"];
+  }
+>;
+
+const getParsedEventType = (
+  parsed: ParsedEditLockRedisEventMessage
+): EditLockEvent["type"] | null => {
+  if (parsed.event?.type === "takeover-requested" || parsed.event?.type === "updated") {
+    return parsed.event.type;
+  }
+
+  if (parsed.type === "takeover-requested" || parsed.type === "updated") {
+    return parsed.type;
+  }
+
+  return null;
+};
 
 type EditLockEventStreamsGlobal = typeof globalThis & {
   __editLockEventStreamsState?: {
@@ -16,20 +41,25 @@ type EditLockEventStreamsGlobal = typeof globalThis & {
   };
 };
 
-const parseEvent = (raw: string): EditLockEvent => {
+const parseEventMessage = (raw: string): EditLockRedisEventMessage | null => {
   try {
-    const parsed = JSON.parse(raw) as Partial<EditLockEvent>;
-    if (parsed.type === "takeover-requested") {
-      return { type: "takeover-requested" };
+    const parsed = JSON.parse(raw) as ParsedEditLockRedisEventMessage;
+
+    const templateId = typeof parsed.templateId === "string" ? parsed.templateId : null;
+    const eventType = getParsedEventType(parsed);
+
+    if (templateId && eventType) {
+      return {
+        templateId,
+        event: { type: eventType },
+      };
     }
   } catch {
     // no-op
   }
 
-  return { type: "updated" };
+  return null;
 };
-
-const getChannel = (templateId: string) => `${EDIT_LOCK_CHANNEL_PREFIX}:${templateId}`;
 
 const getState = () => {
   const globalWithState = globalThis as EditLockEventStreamsGlobal;
@@ -57,13 +87,21 @@ const getSharedRedisSubscriber = async () => {
 
         // Broadcast Redis events to local listeners, for example: { type: "updated" }.
         subscriber.on("message", (messageChannel, message) => {
-          const subscribers = getState().channelSubscribers.get(messageChannel);
+          if (messageChannel !== EDIT_LOCK_CHANNEL) {
+            return;
+          }
+
+          const parsedMessage = parseEventMessage(message);
+          if (!parsedMessage) {
+            return;
+          }
+
+          const subscribers = getState().channelSubscribers.get(parsedMessage.templateId);
           if (!subscribers) {
             return;
           }
 
-          const event = parseEvent(message);
-          subscribers.forEach((channelSubscriber) => channelSubscriber(event));
+          subscribers.forEach((channelSubscriber) => channelSubscriber(parsedMessage.event));
         });
 
         state.redisSubscriber = subscriber;
@@ -82,22 +120,21 @@ const subscribeToRedisEditLockEvents = async (
   templateId: string,
   subscriber: EditLockRouteSubscriber
 ) => {
-  const channel = getChannel(templateId);
   const { channelSubscribers } = getState();
-  const subscribers = channelSubscribers.get(channel) ?? new Set<EditLockRouteSubscriber>();
-  const shouldSubscribeToChannel = subscribers.size === 0;
+  const subscribers = channelSubscribers.get(templateId) ?? new Set<EditLockRouteSubscriber>();
+  const shouldSubscribeToChannel = channelSubscribers.size === 0;
 
   subscribers.add(subscriber);
-  channelSubscribers.set(channel, subscribers);
+  channelSubscribers.set(templateId, subscribers);
 
   const redisSubscriber = await getSharedRedisSubscriber();
 
   if (shouldSubscribeToChannel) {
-    await redisSubscriber.subscribe(channel);
+    await redisSubscriber.subscribe(EDIT_LOCK_CHANNEL);
   }
 
   return async () => {
-    const currentSubscribers = channelSubscribers.get(channel);
+    const currentSubscribers = channelSubscribers.get(templateId);
     if (!currentSubscribers) {
       return;
     }
@@ -108,8 +145,13 @@ const subscribeToRedisEditLockEvents = async (
       return;
     }
 
-    channelSubscribers.delete(channel);
-    await redisSubscriber.unsubscribe(channel);
+    channelSubscribers.delete(templateId);
+
+    if (channelSubscribers.size > 0) {
+      return;
+    }
+
+    await redisSubscriber.unsubscribe(EDIT_LOCK_CHANNEL);
   };
 };
 

--- a/lib/editLockEventStreams.ts
+++ b/lib/editLockEventStreams.ts
@@ -2,6 +2,8 @@ import { createRedisSubscriber } from "@lib/integration/redisConnector";
 import { EditLockEvent } from "./editLocks";
 import type Redis from "ioredis";
 
+// Redis carries all edit-lock events on one shared channel; templateId in the
+// payload lets each app instance fan them back out to the right SSE listeners.
 const EDIT_LOCK_CHANNEL = "edit-lock-events";
 
 type EditLockRouteSubscriber = (event: EditLockEvent) => void;
@@ -43,6 +45,8 @@ type EditLockEventStreamsGlobal = typeof globalThis & {
 
 const parseEventMessage = (raw: string): EditLockRedisEventMessage | null => {
   try {
+    // Normalize the Redis payload before routing so malformed messages can be
+    // ignored without affecting the rest of the shared subscription.
     const parsed = JSON.parse(raw) as ParsedEditLockRedisEventMessage;
 
     const templateId = typeof parsed.templateId === "string" ? parsed.templateId : null;
@@ -85,7 +89,8 @@ const getSharedRedisSubscriber = async () => {
       try {
         const subscriber = await createRedisSubscriber();
 
-        // Broadcast Redis events to local listeners, for example: { type: "updated" }.
+        // One Redis subscription fans events back out to the local listeners for
+        // whichever template each SSE route is currently serving.
         subscriber.on("message", (messageChannel, message) => {
           if (messageChannel !== EDIT_LOCK_CHANNEL) {
             return;
@@ -122,6 +127,8 @@ const subscribeToRedisEditLockEvents = async (
 ) => {
   const { channelSubscribers } = getState();
   const subscribers = channelSubscribers.get(templateId) ?? new Set<EditLockRouteSubscriber>();
+  // Subscribe to Redis once for the process, then manage per-template listeners
+  // locally so opening more forms does not create more Redis channels.
   const shouldSubscribeToChannel = channelSubscribers.size === 0;
 
   subscribers.add(subscriber);
@@ -151,6 +158,7 @@ const subscribeToRedisEditLockEvents = async (
       return;
     }
 
+    // Drop the shared Redis subscription when the last local listener goes away.
     await redisSubscriber.unsubscribe(EDIT_LOCK_CHANNEL);
   };
 };

--- a/lib/editLockEventStreams.ts
+++ b/lib/editLockEventStreams.ts
@@ -3,7 +3,7 @@ import { EditLockEvent } from "./editLocks";
 import type Redis from "ioredis";
 
 // Redis carries all edit-lock events on one shared channel; templateId in the
-// payload lets each app instance fan them back out to the right SSE listeners.
+// payload allows to fan them back out to the right SSE listeners.
 const EDIT_LOCK_CHANNEL = "edit-lock-events";
 
 type EditLockRouteSubscriber = (event: EditLockEvent) => void;

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -15,7 +15,7 @@ export {
 } from "@lib/formBuilderEditLockPresence";
 
 const EDIT_LOCK_KEY_PREFIX = "edit-lock";
-const EDIT_LOCK_CHANNEL_PREFIX = "edit-lock-events";
+const EDIT_LOCK_CHANNEL = "edit-lock-events";
 const EDIT_LOCK_TAKEOVER_SAVE_ACK_PREFIX = "edit-lock-takeover-save";
 const EDIT_LOCK_ASSIGNED_USERS_CACHE_PREFIX = "edit-lock-assigned-users-threshold";
 const EDIT_LOCK_TAKEOVER_SAVE_ACK_POLL_MS = 100;
@@ -110,13 +110,14 @@ const getEditLockTakeoverSaveAcks = (): Map<string, number> => {
 const redisEnabled = () => Boolean(process.env.REDIS_URL);
 
 const getEditLockKey = (templateId: string) => `${EDIT_LOCK_KEY_PREFIX}:${templateId}`;
-const getEditLockChannel = (templateId: string) => `${EDIT_LOCK_CHANNEL_PREFIX}:${templateId}`;
 const getEditLockTakeoverSaveAckKey = (templateId: string, sessionId: string) =>
   `${EDIT_LOCK_TAKEOVER_SAVE_ACK_PREFIX}:${templateId}:${sessionId}`;
 const getEditLockAssignedUsersCacheKey = (templateId: string) =>
   `${EDIT_LOCK_ASSIGNED_USERS_CACHE_PREFIX}:${templateId}`;
 const editLockTtlSeconds = Math.ceil(EDIT_LOCK_TTL_MS / 1000);
 const updatedEvent: EditLockEvent = { type: "updated" };
+const toEditLockRedisEventMessage = (templateId: string, event: EditLockEvent) =>
+  JSON.stringify({ templateId, event });
 const wait = async (timeMs: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, timeMs);
@@ -213,7 +214,7 @@ const readRedisLock = async (templateId: string) => {
 const publishEditLockEvent = async (templateId: string, event: EditLockEvent = updatedEvent) => {
   if (redisEnabled()) {
     const redis = await getRedisInstance();
-    await redis.publish(getEditLockChannel(templateId), JSON.stringify(event));
+    await redis.publish(EDIT_LOCK_CHANNEL, toEditLockRedisEventMessage(templateId, event));
     return;
   }
 

--- a/lib/tests/editLockEventStreams.vitest.ts
+++ b/lib/tests/editLockEventStreams.vitest.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+
+class MockRedisSubscriber extends EventEmitter {
+  subscribedChannels = new Set<string>();
+  subscribe = vi.fn(async (channel: string) => {
+    this.subscribedChannels.add(channel);
+    return 1;
+  });
+  unsubscribe = vi.fn(async (channel: string) => {
+    this.subscribedChannels.delete(channel);
+    return 0;
+  });
+}
+
+let mockRedisSubscriber: MockRedisSubscriber | null = null;
+const publish = vi.fn(async (channel: string, message: string) => {
+  if (mockRedisSubscriber?.subscribedChannels.has(channel)) {
+    mockRedisSubscriber.emit("message", channel, message);
+  }
+
+  return 1;
+});
+
+vi.mock("@lib/integration/redisConnector", () => ({
+  getRedisInstance: vi.fn(async () => ({
+    publish,
+  })),
+  createRedisSubscriber: vi.fn(async () => {
+    mockRedisSubscriber = new MockRedisSubscriber();
+    return mockRedisSubscriber;
+  }),
+}));
+
+import { requestEditLockTakeoverSave } from "@lib/editLocks";
+import { subscribeToSharedEditLockEvents } from "@lib/editLockEventStreams";
+
+describe("editLockEventStreams", () => {
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.REDIS_URL = "redis://test";
+    mockRedisSubscriber = null;
+    delete (globalThis as typeof globalThis & { __editLockEventStreamsState?: unknown })
+      .__editLockEventStreamsState;
+  });
+
+  afterAll(() => {
+    if (originalRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+      return;
+    }
+
+    process.env.REDIS_URL = originalRedisUrl;
+  });
+
+  it("uses one shared Redis channel and fans out events by template id", async () => {
+    const formOneEvents: string[] = [];
+    const formTwoEvents: string[] = [];
+
+    const unsubscribeFormOne = await subscribeToSharedEditLockEvents("form-1", (event) => {
+      formOneEvents.push(event.type);
+    });
+    const unsubscribeFormTwo = await subscribeToSharedEditLockEvents("form-2", (event) => {
+      formTwoEvents.push(event.type);
+    });
+
+    expect(mockRedisSubscriber?.subscribe).toHaveBeenCalledTimes(1);
+    expect(mockRedisSubscriber?.subscribe).toHaveBeenCalledWith("edit-lock-events");
+
+    await requestEditLockTakeoverSave("form-1");
+
+    expect(formOneEvents).toEqual(["takeover-requested"]);
+    expect(formTwoEvents).toEqual([]);
+
+    await unsubscribeFormOne();
+    expect(mockRedisSubscriber?.unsubscribe).not.toHaveBeenCalled();
+
+    await unsubscribeFormTwo();
+    expect(mockRedisSubscriber?.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockRedisSubscriber?.unsubscribe).toHaveBeenCalledWith("edit-lock-events");
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

Updates edit lock redis setup to use a shared single channel to broadcast events

<img width="1113" height="721" alt="Screenshot 2026-04-16 at 10 33 53 AM" src="https://github.com/user-attachments/assets/f84c80df-1afe-4878-8083-6d193f9c730e" />




## Testing

Using Redis insights you should now see 1 channel `edit-lock-events` vs previous one channel per form

- Setup 2 users and 2 shared forms 
- Ensure take-overs etc... work as before 
- Monitor the events using Redis insights --- note the events should contain a template id ...



