### PR TITLE
chore: fix manage access remove button label

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ManageFormAccessDialog/UserActions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/ManageFormAccessDialog/UserActions.tsx
@@ -87,7 +87,7 @@ export const UserActions = ({
               <ConfirmAction
                 callback={() => handleRemoveUser(user.id)}
                 confirmString={t("areYouSure")}
-                buttonLabel={t("remove", { email: user.email })}
+                buttonLabel={t("removeButtonLabel", { email: user.email })}
               />
             </Tooltip.Simple>
           )}

--- a/i18n/translations/en/manage-form-access.json
+++ b/i18n/translations/en/manage-form-access.json
@@ -29,6 +29,7 @@
   "optionalMessage": "Message (optional)",
   "peopleWithAccess": "People with access",
   "remove": "Remove invitation for {{email}}",
+  "removeButtonLabel": "Remove",
   "resend": "Re-send invitation to {{email}}",
   "templateNotFound": "Template not found {{templateId}}",
   "userAlreadyHasAccess": "{{email}} already has access",

--- a/i18n/translations/fr/manage-form-access.json
+++ b/i18n/translations/fr/manage-form-access.json
@@ -29,6 +29,7 @@
   "optionalMessage": "Message (optionnel)",
   "peopleWithAccess": "Personnes ayant accès",
   "remove": "Supprimer l'invitation pour {{email}}",
+  "removeButtonLabel": "Supprimer",
   "resend": "Renvoyer l'invitation pour {{email}}",
   "templateNotFound": "Gabarit non trouvé {{templateId}}",
   "userAlreadyHasAccess": "{{email}} a déjà accès",


### PR DESCRIPTION
# Summary | Résumé

Adds a district label text key for the remove button under manage access 

**Before:** 
<img width="731" height="184" alt="Screenshot 2026-04-16 at 1 39 14 PM" src="https://github.com/user-attachments/assets/0df86c8e-cb83-4128-ab2c-be5e005660b4" />

**Fixed**
<img width="576" height="237" alt="Screenshot 2026-04-16 at 2 00 47 PM" src="https://github.com/user-attachments/assets/8fc6e944-0242-4da6-bbfa-2d6cc793042d" />
