### PR TITLE
chore: add const to turn on / off leader tab

### DIFF
--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -23,6 +23,7 @@ import {
 
 const SERVER_STATE_SYNC_MAX_ATTEMPTS = 10;
 const SERVER_STATE_SYNC_RETRY_MS = 500;
+const EDIT_LOCK_LEADER_TAB_ENABLED = false;
 
 const wait = async (timeMs: number) =>
   new Promise((resolve) => {
@@ -58,10 +59,10 @@ export const useEditLock = ({
   const suppressReleaseRef = useRef(false);
   const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
   const { isLeaderTab } = useLeaderTab({
-    enabled: enabled && status === "authenticated",
+    enabled: EDIT_LOCK_LEADER_TAB_ENABLED && enabled && status === "authenticated",
     coordinationKey: formId,
   });
-  const effectiveEnabled = enabled && isLeaderTab;
+  const effectiveEnabled = enabled && (!EDIT_LOCK_LEADER_TAB_ENABLED || isLeaderTab);
 
   const clearLockState = useCallback(() => {
     setIsLockedByOther(false);

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -467,14 +467,16 @@ describe("useEditLock", () => {
     expect(lockStates.at(-1)).toEqual({ isLockedByOther: false, hasEditLock: false });
   });
 
-  it("does not open an EventSource when the tab is not active", async () => {
+  it("opens an EventSource even when the tab is not active if leader-tab coordination is disabled", async () => {
     setDocumentVisibility("hidden");
     setDocumentFocus(false);
 
     await render(<EditLockHarness />);
 
     await vi.waitFor(() => {
-      expect(MockEventSource.instances).toHaveLength(0);
+      expect(MockEventSource.instances).toHaveLength(1);
     });
+
+    expect(MockBroadcastChannel.channels.size).toBe(0);
   });
 });


### PR DESCRIPTION
# Summary | Résumé

Adds a const so we can turn on / off the leader tab for edit lock as we see fit.