### PR TITLE
chore: translation strings for read-only in locked editing

### DIFF
--- a/i18n/translations/fr/my-forms.json
+++ b/i18n/translations/fr/my-forms.json
@@ -55,8 +55,8 @@
       "linkText": "Approuver la suppression de réponses"
     },
     "editLock": {
-      "title": "Ouvrir le formulaire en mode lecture seule",
-      "description": "{{name}} modifie actuellement cette ébauche. Si vous continuez, le formulaire s’ouvrira en mode lecture seule jusqu’à ce que vous preniez le contrôle de la modification."
+      "title": "Ouvrir le formulaire en mode « lecture seule ».",
+      "description": "{{name}} modifie actuellement cette ébauche. Si vous continuez, le formulaire s’ouvrira en mode « lecture seule » jusqu’à ce que vous preniez en charge la modification."
     },
     "unnamedForm": "Fichier sans nom"
   },


### PR DESCRIPTION
Related to https://github.com/cds-snc/platform-forms-client/pull/6981/changes#diff-4192b61232790206661374be5c595987ddc9a5d4f3e158f60e4895a2bec1bd14