### PR TITLE
chore: create dedicated use hook for edit presence

### DIFF
--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -6,24 +6,15 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { FormRecord } from "@lib/types";
 import { clearTemplateStore } from "@lib/store/utils";
 import { useTemplateContext } from "@lib/hooks/form-builder/useTemplateContext";
-import { useLeaderTab } from "@lib/hooks/form-builder/useLeaderTab";
+import { useEditLockPresence } from "@lib/hooks/form-builder/useEditLockPresence";
+import { isEditLockStatus, type EditLockStatusPayload } from "@lib/editLockStatus";
 import {
-  isEditLockStatus,
-  type EditLockPresenceStatus,
-  type EditLockStatusPayload,
-  type EditLockVisibilityState,
-} from "@lib/editLockStatus";
-import {
-  CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS,
-  CLIENT_SIDE_EDIT_LOCK_AWAY_MS,
-  CLIENT_SIDE_EDIT_LOCK_IDLE_MS,
   EDIT_LOCK_DETECT_PRESENCE,
   EDIT_LOCK_HEARTBEAT_MS,
 } from "@lib/formBuilderEditLockPresence";
 
 const SERVER_STATE_SYNC_MAX_ATTEMPTS = 10;
 const SERVER_STATE_SYNC_RETRY_MS = 500;
-const EDIT_LOCK_LEADER_TAB_ENABLED = false;
 
 const wait = async (timeMs: number) =>
   new Promise((resolve) => {
@@ -54,15 +45,12 @@ export const useEditLock = ({
   const startPollingRef = useRef<() => void>(() => undefined);
   const lockLoopTokenRef = useRef(0);
   const updatedAtRef = useRef(updatedAt);
-  const lastActivityAtRef = useRef(0);
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
   const suppressReleaseRef = useRef(false);
-  const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
-  const { isLeaderTab } = useLeaderTab({
-    enabled: EDIT_LOCK_LEADER_TAB_ENABLED && enabled && status === "authenticated",
+  const { getActivitySnapshot } = useEditLockPresence({
+    enabled: EDIT_LOCK_DETECT_PRESENCE && enabled && status === "authenticated",
     coordinationKey: formId,
   });
-  const effectiveEnabled = enabled && (!EDIT_LOCK_LEADER_TAB_ENABLED || isLeaderTab);
 
   const clearLockState = useCallback(() => {
     setIsLockedByOther(false);
@@ -117,16 +105,7 @@ export const useEditLock = ({
 
   const postAction = useCallback(
     async (action: "acquire" | "heartbeat" | "release" | "takeover" | "takeover-save-complete") => {
-      const now = Date.now();
-      const lastActivityAt = lastActivityAtRef.current || now;
-      const idleMs = now - lastActivityAt;
-      const visibilityState = visibilityStateRef.current;
-      const presenceStatus: EditLockPresenceStatus =
-        visibilityState === "hidden" || idleMs >= CLIENT_SIDE_EDIT_LOCK_AWAY_MS
-          ? "away"
-          : idleMs >= CLIENT_SIDE_EDIT_LOCK_IDLE_MS
-            ? "idle"
-            : "active";
+      const activity = getActivitySnapshot();
 
       const res = await fetch(`/api/templates/${formId}/edit-lock`, {
         method: "POST",
@@ -134,20 +113,14 @@ export const useEditLock = ({
         body: JSON.stringify({
           action,
           sessionId,
-          activity: EDIT_LOCK_DETECT_PRESENCE
-            ? {
-                lastActivityAt: new Date(lastActivityAt).toISOString(),
-                visibilityState,
-                presenceStatus,
-              }
-            : undefined,
+          activity,
         }),
       });
 
       const payload = (await res.json().catch(() => null)) as unknown;
       return isEditLockStatus(payload) ? payload : null;
     },
-    [formId, sessionId]
+    [formId, getActivitySnapshot, sessionId]
   );
 
   const getStatus = useCallback(async () => {
@@ -344,7 +317,7 @@ export const useEditLock = ({
   );
 
   useEffect(() => {
-    if (!effectiveEnabled) {
+    if (!enabled) {
       clearTimers();
       clearEvents();
       clearLockState();
@@ -387,7 +360,7 @@ export const useEditLock = ({
       }
     };
   }, [
-    effectiveEnabled,
+    enabled,
     formId,
     clearLockState,
     clearTimers,
@@ -403,56 +376,7 @@ export const useEditLock = ({
   ]);
 
   useEffect(() => {
-    if (!EDIT_LOCK_DETECT_PRESENCE || !enabled || status !== "authenticated") {
-      return;
-    }
-
-    const markActivity = (force = false) => {
-      const nextVisibilityState = document.visibilityState === "hidden" ? "hidden" : "visible";
-      const now = Date.now();
-
-      if (
-        !force &&
-        nextVisibilityState === visibilityStateRef.current &&
-        now - lastActivityAtRef.current < CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS
-      ) {
-        return;
-      }
-
-      lastActivityAtRef.current = now;
-      visibilityStateRef.current = nextVisibilityState;
-    };
-
-    const handleVisibilityChange = () => {
-      visibilityStateRef.current = document.visibilityState === "hidden" ? "hidden" : "visible";
-      if (visibilityStateRef.current === "visible") {
-        markActivity(true);
-      }
-    };
-
-    const handleActivity = () => {
-      markActivity();
-    };
-
-    markActivity(true);
-
-    window.addEventListener("pointerdown", handleActivity, { passive: true });
-    window.addEventListener("keydown", handleActivity);
-    window.addEventListener("focus", handleActivity);
-    window.addEventListener("input", handleActivity, { passive: true });
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener("pointerdown", handleActivity);
-      window.removeEventListener("keydown", handleActivity);
-      window.removeEventListener("focus", handleActivity);
-      window.removeEventListener("input", handleActivity);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, [enabled, status]);
-
-  useEffect(() => {
-    if (!effectiveEnabled || status !== "authenticated") {
+    if (!enabled || status !== "authenticated") {
       clearEvents();
       return;
     }
@@ -504,7 +428,7 @@ export const useEditLock = ({
     };
   }, [
     clearEvents,
-    effectiveEnabled,
+    enabled,
     flushDraftBeforeTakeover,
     formId,
     startPolling,
@@ -526,5 +450,5 @@ export const useEditLock = ({
     startTimers(statusResult);
   }, [postAction, refreshForm, startTimers, updateStore, updatedAt]);
 
-  return { takeover, isLeaderTab };
+  return { takeover };
 };

--- a/lib/hooks/form-builder/useEditLockPresence.tsx
+++ b/lib/hooks/form-builder/useEditLockPresence.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useLeaderTab } from "@lib/hooks/form-builder/useLeaderTab";
+import {
+  CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS,
+  CLIENT_SIDE_EDIT_LOCK_AWAY_MS,
+  CLIENT_SIDE_EDIT_LOCK_IDLE_MS,
+} from "@lib/formBuilderEditLockPresence";
+import { type EditLockPresenceStatus, type EditLockVisibilityState } from "@lib/editLockStatus";
+
+type EditLockActivitySnapshot = {
+  lastActivityAt: string;
+  visibilityState: EditLockVisibilityState;
+  presenceStatus: EditLockPresenceStatus;
+};
+
+const getVisibilityState = (): EditLockVisibilityState =>
+  document.visibilityState === "hidden" ? "hidden" : "visible";
+
+const getPresenceStatus = (
+  visibilityState: EditLockVisibilityState,
+  idleMs: number
+): EditLockPresenceStatus => {
+  if (visibilityState === "hidden" || idleMs >= CLIENT_SIDE_EDIT_LOCK_AWAY_MS) {
+    return "away";
+  }
+
+  if (idleMs >= CLIENT_SIDE_EDIT_LOCK_IDLE_MS) {
+    return "idle";
+  }
+
+  return "active";
+};
+
+export const useEditLockPresence = ({
+  enabled,
+  coordinationKey,
+  leaderTabEnabled = false,
+}: {
+  enabled: boolean;
+  coordinationKey: string;
+  leaderTabEnabled?: boolean;
+}) => {
+  "use memo";
+  const { isLeaderTab } = useLeaderTab({
+    enabled: enabled && leaderTabEnabled,
+    coordinationKey,
+  });
+  const lastActivityAtRef = useRef(0);
+  const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
+
+  const isTrackingPresence = enabled && (!leaderTabEnabled || isLeaderTab);
+
+  const markActivity = useCallback((force = false) => {
+    const nextVisibilityState = getVisibilityState();
+    const now = Date.now();
+
+    if (
+      !force &&
+      nextVisibilityState === visibilityStateRef.current &&
+      now - lastActivityAtRef.current < CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS
+    ) {
+      return;
+    }
+
+    lastActivityAtRef.current = now;
+    visibilityStateRef.current = nextVisibilityState;
+  }, []);
+
+  const getActivitySnapshot = useCallback((): EditLockActivitySnapshot | undefined => {
+    if (!isTrackingPresence) {
+      return;
+    }
+
+    const now = Date.now();
+    const lastActivityAt = lastActivityAtRef.current || now;
+    const visibilityState = visibilityStateRef.current;
+    const idleMs = now - lastActivityAt;
+
+    return {
+      lastActivityAt: new Date(lastActivityAt).toISOString(),
+      visibilityState,
+      presenceStatus: getPresenceStatus(visibilityState, idleMs),
+    };
+  }, [isTrackingPresence]);
+
+  useEffect(() => {
+    if (!isTrackingPresence) {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      visibilityStateRef.current = getVisibilityState();
+      if (visibilityStateRef.current === "visible") {
+        markActivity(true);
+      }
+    };
+
+    const handleActivity = () => {
+      markActivity();
+    };
+
+    markActivity(true);
+
+    window.addEventListener("pointerdown", handleActivity, { passive: true });
+    window.addEventListener("keydown", handleActivity);
+    window.addEventListener("focus", handleActivity);
+    window.addEventListener("input", handleActivity, { passive: true });
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("pointerdown", handleActivity);
+      window.removeEventListener("keydown", handleActivity);
+      window.removeEventListener("focus", handleActivity);
+      window.removeEventListener("input", handleActivity);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isTrackingPresence, markActivity]);
+
+  return { getActivitySnapshot, isLeaderTab };
+};

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -479,4 +479,37 @@ describe("useEditLock", () => {
 
     expect(MockBroadcastChannel.channels.size).toBe(0);
   });
+
+  it("includes the derived presence activity in edit-lock requests", async () => {
+    setDocumentVisibility("hidden");
+
+    await render(<EditLockHarness />);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    const acquireRequest = fetchMock.mock.calls.find(([input, init]) => {
+      return String(input).endsWith("/edit-lock") && init?.method === "POST";
+    });
+
+    const body = JSON.parse(String(acquireRequest?.[1]?.body)) as {
+      action: string;
+      activity?: {
+        lastActivityAt: string;
+        visibilityState: string;
+        presenceStatus: string;
+      };
+    };
+
+    expect(body.action).toBe("acquire");
+    expect(body.activity).toMatchObject({
+      visibilityState: "hidden",
+      presenceStatus: "away",
+    });
+    expect(body.activity?.lastActivityAt).toEqual(expect.any(String));
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

Breaks out code for edit lock presence into a dedicated hook.  This helps separate out some logic to become dedicated to activity state. 
