### PR TITLE
chore: Add edit draft logic for re-acquire

### DIFF
--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -35,7 +35,7 @@ export const useEditLock = ({
   const setEditLock = useTemplateStore((s) => s.setEditLock);
   const setIsLockedByOther = useTemplateStore((s) => s.setIsLockedByOther);
   const setFromRecord = useTemplateStore((s) => s.setFromRecord);
-  const { resetState, saveDraft, saveDraftIfNeeded, setUpdatedAt, updatedAt } =
+  const { templateIsDirty, resetState, saveDraft, saveDraftIfNeeded, setUpdatedAt, updatedAt } =
     useTemplateContext();
 
   const isOwnerRef = useRef(false);
@@ -183,6 +183,14 @@ export const useEditLock = ({
     await refreshForm(updatedAtRef.current);
   }, [refreshForm]);
 
+  const refreshAfterReacquireIfClean = useCallback(async () => {
+    if (templateIsDirty.current) {
+      return;
+    }
+
+    await refreshForm(updatedAtRef.current);
+  }, [refreshForm, templateIsDirty]);
+
   const flushDraftBeforeTakeover = useCallback(async () => {
     if (!isOwnerRef.current) {
       return;
@@ -266,7 +274,7 @@ export const useEditLock = ({
 
         updateStore(retryResult);
         if (retryResult.isOwner) {
-          void refreshForm();
+          void refreshAfterReacquireIfClean();
           return;
         }
 
@@ -281,7 +289,7 @@ export const useEditLock = ({
     clearLockState,
     clearTimers,
     postAction,
-    refreshForm,
+    refreshAfterReacquireIfClean,
     syncServerState,
     updateStore,
   ]);
@@ -321,7 +329,7 @@ export const useEditLock = ({
         updateStore(retryResult);
         if (retryResult.isOwner) {
           startHeartbeatRef.current();
-          void refreshForm();
+          void refreshAfterReacquireIfClean();
         }
       }
     }, EDIT_LOCK_HEARTBEAT_MS);
@@ -330,7 +338,7 @@ export const useEditLock = ({
     clearTimers,
     getStatus,
     postAction,
-    refreshForm,
+    refreshAfterReacquireIfClean,
     syncServerState,
     updateStore,
   ]);
@@ -400,14 +408,10 @@ export const useEditLock = ({
     };
   }, [
     enabled,
-    formId,
     clearLockState,
     clearTimers,
     clearEvents,
-    getStatus,
     postAction,
-    refreshForm,
-    sessionId,
     startTimers,
     status,
     syncServerState,

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -35,7 +35,8 @@ export const useEditLock = ({
   const setEditLock = useTemplateStore((s) => s.setEditLock);
   const setIsLockedByOther = useTemplateStore((s) => s.setIsLockedByOther);
   const setFromRecord = useTemplateStore((s) => s.setFromRecord);
-  const { resetState, saveDraft, setUpdatedAt, updatedAt } = useTemplateContext();
+  const { resetState, saveDraft, saveDraftIfNeeded, setUpdatedAt, updatedAt } =
+    useTemplateContext();
 
   const isOwnerRef = useRef(false);
   const heartbeatRef = useRef<number | null>(null);
@@ -208,10 +209,26 @@ export const useEditLock = ({
     await takeoverSaveRef.current;
   }, [postAction, saveDraft]);
 
+  const autoSaveIfOwner = useCallback(
+    async (wasOwner: boolean) => {
+      if (!wasOwner) {
+        return;
+      }
+
+      try {
+        await saveDraftIfNeeded();
+      } catch {
+        // no-op: losing the lock should still fall back to state sync even if save fails
+      }
+    },
+    [saveDraftIfNeeded]
+  );
+
   const startHeartbeat = useCallback((): void => {
     clearTimers();
     const loopToken = lockLoopTokenRef.current;
     heartbeatRef.current = window.setInterval(async () => {
+      const wasOwner = isOwnerRef.current;
       const heartbeatResult = await postAction("heartbeat");
       if (lockLoopTokenRef.current !== loopToken) {
         return;
@@ -223,7 +240,17 @@ export const useEditLock = ({
         return;
       }
 
+      if (!heartbeatResult.isOwner) {
+        await autoSaveIfOwner(wasOwner);
+      }
+
       updateStore(heartbeatResult);
+
+      if (heartbeatResult.locked && !heartbeatResult.isOwner && wasOwner) {
+        startPollingRef.current();
+        void syncServerState();
+        return;
+      }
 
       if (!heartbeatResult.locked) {
         const retryResult = await postAction("acquire");
@@ -243,9 +270,12 @@ export const useEditLock = ({
         }
 
         startPollingRef.current();
+        if (wasOwner) {
+          void syncServerState();
+        }
       }
     }, EDIT_LOCK_HEARTBEAT_MS);
-  }, [clearLockState, clearTimers, postAction, updateStore]);
+  }, [autoSaveIfOwner, clearLockState, clearTimers, postAction, syncServerState, updateStore]);
 
   const startPolling = useCallback((): void => {
     clearTimers();

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -266,6 +266,7 @@ export const useEditLock = ({
 
         updateStore(retryResult);
         if (retryResult.isOwner) {
+          void refreshForm();
           return;
         }
 
@@ -275,7 +276,15 @@ export const useEditLock = ({
         }
       }
     }, EDIT_LOCK_HEARTBEAT_MS);
-  }, [autoSaveIfOwner, clearLockState, clearTimers, postAction, syncServerState, updateStore]);
+  }, [
+    autoSaveIfOwner,
+    clearLockState,
+    clearTimers,
+    postAction,
+    refreshForm,
+    syncServerState,
+    updateStore,
+  ]);
 
   const startPolling = useCallback((): void => {
     clearTimers();

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -736,4 +736,84 @@ describe("useEditLock", () => {
     // Always restore real timers so this test does not leak clock state.
     vi.useRealTimers();
   });
+
+  it("reloads the server version before continuing when heartbeat reacquires the lock", async () => {
+    // Fake timers let the test trigger one heartbeat after the lock disappears.
+    vi.useFakeTimers();
+
+    const unlockedStatus = {
+      locked: false,
+      lockedByOther: false,
+      isOwner: false,
+      lock: null,
+    };
+
+    const freshUpdatedAt = "2026-03-31T12:00:05.000Z";
+    let heartbeatCallCount = 0;
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/edit-lock") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { action: string };
+
+        if (body.action === "heartbeat") {
+          heartbeatCallCount += 1;
+          return {
+            ok: true,
+            json: async () => (heartbeatCallCount === 1 ? unlockedStatus : ownerLockStatus),
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/edit-lock") && init?.method === "GET") {
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/api/templates/test-form-id")) {
+        return {
+          ok: true,
+          json: async () => ({
+            form: { elements: [] },
+            updatedAt: freshUpdatedAt,
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(<EditLockHarness />);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    // Advance one heartbeat tick: the lock is missing, the same browser wins
+    // the reacquire, and it should reload before continuing to edit.
+    await vi.advanceTimersByTimeAsync(EDIT_LOCK_HEARTBEAT_MS);
+
+    await vi.waitFor(() => {
+      expect(setUpdatedAt).toHaveBeenCalledWith(Date.parse(freshUpdatedAt));
+    });
+
+    const formFetchCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).endsWith("/api/templates/test-form-id")
+    );
+
+    expect(formFetchCalls).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
 });

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "../testUtils";
 import { setupFonts } from "../../helpers/setupFonts";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
+import { EDIT_LOCK_HEARTBEAT_MS } from "@lib/formBuilderEditLockPresence";
 
 const saveDraft = vi.fn(async () => ({ status: "saved" as const }));
 const saveDraftIfNeeded = vi.fn(async () => ({ status: "skipped" as const }));
@@ -11,6 +12,7 @@ const setUpdatedAt = vi.fn();
 let templateUpdatedAt: number | undefined;
 let fetchMock: ReturnType<typeof vi.fn>;
 
+// Keep useEditLock in an authenticated editing state for every test case.
 vi.mock("next-auth/react", () => ({
   useSession: () => ({
     data: { user: { id: "user-1" } },
@@ -24,6 +26,7 @@ vi.mock("next-auth/react", () => ({
   getSession: vi.fn(),
 }));
 
+// Expose the template-context side effects so tests can assert save and refresh behavior.
 vi.mock("@lib/hooks/form-builder/useTemplateContext", () => ({
   useTemplateContext: () => ({
     resetState,
@@ -36,6 +39,7 @@ vi.mock("@lib/hooks/form-builder/useTemplateContext", () => ({
 
 import { useEditLock } from "@lib/hooks/form-builder/useEditLock";
 
+// EventSource is mocked so tests can drive lock-status and takeover events directly.
 class MockEventSource {
   static instances: MockEventSource[] = [];
 
@@ -73,6 +77,7 @@ class MockEventSource {
   }
 }
 
+// BroadcastChannel is mocked to keep any cross-tab coordination deterministic in tests.
 class MockBroadcastChannel {
   static channels = new Map<string, Set<MockBroadcastChannel>>();
 
@@ -134,6 +139,8 @@ const setDocumentFocus = (isFocused: boolean) => {
   });
 };
 
+// Shared happy-path lock payload: the current browser tab is User A and starts
+// each test as the active lock owner unless a test overrides the response.
 const ownerLockStatus = {
   locked: true,
   lockedByOther: false,
@@ -153,6 +160,8 @@ const ownerLockStatus = {
   },
 };
 
+// Minimal component that mounts useEditLock and exposes the bits that the tests
+// need to observe, such as lock ownership changes and the imperative takeover action.
 function EditLockHarness({
   onTakeoverReady,
   onChangeKey,
@@ -209,6 +218,9 @@ describe("useEditLock", () => {
     vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
     setDocumentVisibility("visible");
     setDocumentFocus(true);
+
+    // Default network behavior for most tests: User A owns the lock and all
+    // edit-lock reads and writes reflect that stable server state.
     fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
 
@@ -511,5 +523,217 @@ describe("useEditLock", () => {
       presenceStatus: "away",
     });
     expect(body.activity?.lastActivityAt).toEqual(expect.any(String));
+  });
+
+  it("syncs and switches to polling when a heartbeat shows another user won the lock", async () => {
+    // useEditLock drives heartbeats with setInterval, so fake timers let the test
+    // freeze time at mount and then trigger exactly one heartbeat on demand.
+    vi.useFakeTimers();
+
+    // User A started as the lock owner, but after a Redis restart User B wins
+    // the reacquire race and becomes the new owner.
+    const lockedByOtherStatus = {
+      locked: true,
+      lockedByOther: true,
+      isOwner: false,
+      lock: {
+        ...ownerLockStatus.lock,
+        lockedByUserId: "user-2",
+        lockedByName: "User Two",
+        lockedByEmail: "user.two@example.com",
+        sessionId: "session-2",
+      },
+    };
+
+    const freshUpdatedAt = "2026-03-31T12:00:03.000Z";
+    const lockStates: Array<{ isLockedByOther: boolean; hasEditLock: boolean }> = [];
+    let heartbeatCallCount = 0;
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/edit-lock") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { action: string };
+
+        // The first acquire is the initial mount where User A legitimately owns
+        // the form. After that, the server consistently reports that User B owns it.
+        if (body.action === "acquire") {
+          return {
+            ok: true,
+            json: async () => ownerLockStatus,
+          } as Response;
+        }
+
+        if (body.action === "heartbeat") {
+          // The first heartbeat is where User A learns that ownership already moved.
+          heartbeatCallCount += 1;
+          return {
+            ok: true,
+            json: async () =>
+              heartbeatCallCount === 1 ? lockedByOtherStatus : lockedByOtherStatus,
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => lockedByOtherStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/edit-lock") && init?.method === "GET") {
+        return {
+          ok: true,
+          json: async () => lockedByOtherStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/api/templates/test-form-id")) {
+        return {
+          ok: true,
+          json: async () => ({
+            form: { elements: [] },
+            updatedAt: freshUpdatedAt,
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(<EditLockHarness onLockStateChange={(state) => lockStates.push(state)} />);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    // Move the fake clock forward by one heartbeat interval so the callback
+    // inside useEditLock runs exactly once.
+    await vi.advanceTimersByTimeAsync(EDIT_LOCK_HEARTBEAT_MS);
+
+    await vi.waitFor(() => {
+      // Once ownership is lost, useEditLock should refresh the form from the server
+      // and move into the locked-by-other fallback flow.
+      expect(setUpdatedAt).toHaveBeenCalledWith(Date.parse(freshUpdatedAt));
+    });
+
+    expect(saveDraftIfNeeded).toHaveBeenCalledTimes(1);
+    expect(lockStates.at(-1)).toEqual({ isLockedByOther: true, hasEditLock: true });
+
+    // Reset the timer implementation so later tests use real browser timing again.
+    vi.useRealTimers();
+  });
+
+  it("attempts an auto-save before reacquiring when heartbeat shows the lock disappeared", async () => {
+    // Fake timers give the test full control over when the heartbeat interval fires.
+    vi.useFakeTimers();
+
+    // Redis lost the lock key, so the heartbeat briefly sees "no owner".
+    const unlockedStatus = {
+      locked: false,
+      lockedByOther: false,
+      isOwner: false,
+      lock: null,
+    };
+
+    const lockedByOtherStatus = {
+      locked: true,
+      lockedByOther: true,
+      isOwner: false,
+      lock: {
+        ...ownerLockStatus.lock,
+        lockedByUserId: "user-2",
+        lockedByName: "User Two",
+        lockedByEmail: "user.two@example.com",
+        sessionId: "session-2",
+      },
+    };
+
+    const freshUpdatedAt = "2026-03-31T12:00:04.000Z";
+    const lockStates: Array<{ isLockedByOther: boolean; hasEditLock: boolean }> = [];
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/edit-lock") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { action: string };
+
+        if (body.action === "acquire") {
+          // First acquire is the initial mount for User A. The second acquire is
+          // the post-restart race, where User B has already taken over.
+          const acquireCount = fetchMock.mock.calls.filter(([, requestInit]) => {
+            if (!requestInit || requestInit.method !== "POST") {
+              return false;
+            }
+
+            const requestBody = JSON.parse(String(requestInit.body)) as { action: string };
+            return requestBody.action === "acquire";
+          }).length;
+
+          return {
+            ok: true,
+            json: async () => (acquireCount === 1 ? ownerLockStatus : lockedByOtherStatus),
+          } as Response;
+        }
+
+        if (body.action === "heartbeat") {
+          return {
+            ok: true,
+            json: async () => unlockedStatus,
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => lockedByOtherStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/edit-lock") && init?.method === "GET") {
+        return {
+          ok: true,
+          json: async () => lockedByOtherStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/api/templates/test-form-id")) {
+        return {
+          ok: true,
+          json: async () => ({
+            form: { elements: [] },
+            updatedAt: freshUpdatedAt,
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(<EditLockHarness onLockStateChange={(state) => lockStates.push(state)} />);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    // Advance one heartbeat tick: useEditLock sees the missing lock, tries an
+    // auto-save, then attempts to reacquire and learns User B won.
+    await vi.advanceTimersByTimeAsync(EDIT_LOCK_HEARTBEAT_MS);
+
+    await vi.waitFor(() => {
+      // User A should attempt a last-minute save before falling back to the
+      // locked-by-other state after losing the reacquire race.
+      expect(saveDraftIfNeeded).toHaveBeenCalledTimes(1);
+      expect(setUpdatedAt).toHaveBeenCalledWith(Date.parse(freshUpdatedAt));
+    });
+
+    expect(lockStates.at(-1)).toEqual({ isLockedByOther: true, hasEditLock: true });
+
+    // Always restore real timers so this test does not leak clock state.
+    vi.useRealTimers();
   });
 });

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -9,6 +9,7 @@ const saveDraft = vi.fn(async () => ({ status: "saved" as const }));
 const saveDraftIfNeeded = vi.fn(async () => ({ status: "skipped" as const }));
 const resetState = vi.fn();
 const setUpdatedAt = vi.fn();
+const templateIsDirty = { current: false };
 let templateUpdatedAt: number | undefined;
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -29,6 +30,7 @@ vi.mock("next-auth/react", () => ({
 // Expose the template-context side effects so tests can assert save and refresh behavior.
 vi.mock("@lib/hooks/form-builder/useTemplateContext", () => ({
   useTemplateContext: () => ({
+    templateIsDirty,
     resetState,
     saveDraft,
     saveDraftIfNeeded,
@@ -213,6 +215,7 @@ describe("useEditLock", () => {
     vi.clearAllMocks();
     MockEventSource.reset();
     MockBroadcastChannel.reset();
+    templateIsDirty.current = false;
     templateUpdatedAt = Date.parse("2026-03-31T12:00:00.000Z");
     vi.stubGlobal("EventSource", MockEventSource);
     vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
@@ -547,7 +550,6 @@ describe("useEditLock", () => {
 
     const freshUpdatedAt = "2026-03-31T12:00:03.000Z";
     const lockStates: Array<{ isLockedByOther: boolean; hasEditLock: boolean }> = [];
-    let heartbeatCallCount = 0;
 
     fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -566,11 +568,9 @@ describe("useEditLock", () => {
 
         if (body.action === "heartbeat") {
           // The first heartbeat is where User A learns that ownership already moved.
-          heartbeatCallCount += 1;
           return {
             ok: true,
-            json: async () =>
-              heartbeatCallCount === 1 ? lockedByOtherStatus : lockedByOtherStatus,
+            json: async () => lockedByOtherStatus,
           } as Response;
         }
 
@@ -737,7 +737,78 @@ describe("useEditLock", () => {
     vi.useRealTimers();
   });
 
-  it("reloads the server version before continuing when heartbeat reacquires the lock", async () => {
+  it("keeps local draft state intact when heartbeat reacquires the lock", async () => {
+    // Fake timers let the test trigger one heartbeat after the lock disappears.
+    vi.useFakeTimers();
+    templateIsDirty.current = true;
+
+    const unlockedStatus = {
+      locked: false,
+      lockedByOther: false,
+      isOwner: false,
+      lock: null,
+    };
+
+    let heartbeatCallCount = 0;
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/edit-lock") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { action: string };
+
+        if (body.action === "heartbeat") {
+          heartbeatCallCount += 1;
+          return {
+            ok: true,
+            json: async () => (heartbeatCallCount === 1 ? unlockedStatus : ownerLockStatus),
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      if (url.endsWith("/edit-lock") && init?.method === "GET") {
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(<EditLockHarness />);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    // Advance one heartbeat tick: the lock is missing, the same browser wins
+    // the reacquire, and local draft state should remain untouched.
+    await vi.advanceTimersByTimeAsync(EDIT_LOCK_HEARTBEAT_MS);
+
+    await vi.waitFor(() => {
+      expect(heartbeatCallCount).toBe(1);
+    });
+
+    const formFetchCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).endsWith("/api/templates/test-form-id")
+    );
+
+    expect(setUpdatedAt).not.toHaveBeenCalled();
+    expect(formFetchCalls).toHaveLength(0);
+
+    vi.useRealTimers();
+  });
+
+  it("reloads the server version when heartbeat reacquires the lock and there are no local edits", async () => {
     // Fake timers let the test trigger one heartbeat after the lock disappears.
     vi.useFakeTimers();
 
@@ -801,10 +872,11 @@ describe("useEditLock", () => {
     });
 
     // Advance one heartbeat tick: the lock is missing, the same browser wins
-    // the reacquire, and it should reload before continuing to edit.
+    // the reacquire, and the clean client can safely resync from the server.
     await vi.advanceTimersByTimeAsync(EDIT_LOCK_HEARTBEAT_MS);
 
     await vi.waitFor(() => {
+      expect(heartbeatCallCount).toBe(1);
       expect(setUpdatedAt).toHaveBeenCalledWith(Date.parse(freshUpdatedAt));
     });
 


### PR DESCRIPTION
# Summary | Résumé

- Added saveDraftIfNeeded handling to the edit-lock heartbeat flow in useEditLock.
- If the current owner learns during heartbeat that another user now owns the lock, it attempts an auto-save, switches to polling, and syncs the latest server state.
- If heartbeat sees that the Redis lock disappeared, it attempts an auto-save before the reacquire attempt.
- If another user wins that reacquire race, it falls back to polling and reloads the latest server version.
- If the same browser wins the reacquire and there are local unsaved edits, it keeps the in-memory draft and does not reload from the server.
- If the same browser wins the reacquire and there are no local unsaved edits, it reloads the latest server version before editing continues.
- The clean-client reload path uses the current updatedAt as a minimum timestamp so it does not step back to an older saved snapshot.
- Added focused browser regression coverage for both successful reacquire cases: preserving dirty local state and reloading clean local state.
