### PR TITLE
chore: add edit lock logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ typings/
 # dotenv environment variables file
 .env*.local
 .env
+.logger-suppress-patterns.local
 
 # next.js build output
 .next

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockBanner.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockBanner.tsx
@@ -88,12 +88,14 @@ export const EditLockBanner = ({ takeover }: { takeover: () => Promise<void> }) 
       ? expiresAt.getTime() - timeTick <= CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS
       : false;
 
+  const hasPresenceDetails = EDIT_LOCK_DETECT_PRESENCE && Boolean(editLock?.presenceStatus);
+
   // If the lock is stale, show "stale" status to encourage takeover. Otherwise, show the actual presence status reported by the server.
   const presenceKey = isStale ? "stale" : (editLock?.presenceStatus ?? "away");
 
   // If the lock is stale, show "stale" status to encourage takeover. Otherwise, show the actual presence status reported by the server.
   const lastActivity =
-    EDIT_LOCK_DETECT_PRESENCE && editLock?.lastActivityAt
+    hasPresenceDetails && editLock?.lastActivityAt
       ? formatRelativeTime(editLock.lastActivityAt, i18n.language)
       : null;
 
@@ -131,7 +133,7 @@ export const EditLockBanner = ({ takeover }: { takeover: () => Promise<void> }) 
                 <PilotBadge className="mb-3" />
                 <p className="mb-2 text-xl font-semibold text-slate-900">{t("editLock.title")}</p>
                 <p className="text-base text-slate-900">{t("editLock.lockedMessage", { name })}</p>
-                {EDIT_LOCK_DETECT_PRESENCE && (
+                {hasPresenceDetails && (
                   <div className="mt-3 flex flex-col gap-1 text-sm text-slate-700">
                     <p>
                       <span className="font-semibold text-slate-900">

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@lib/integration/prismaConnector";
 import { getRedisInstance } from "@lib/integration/redisConnector";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
+import { logMessage } from "@lib/logger";
 import { formCache } from "./cache/formCache";
 import {
   EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS,
@@ -122,6 +123,47 @@ const wait = async (timeMs: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, timeMs);
   });
+
+const describeLockActor = (lock: Pick<EditLockInfo, "lockedByUserId" | "lockedByEmail"> | null) => {
+  if (!lock) {
+    return "none";
+  }
+
+  return [`userId=${lock.lockedByUserId}`, `email=${lock.lockedByEmail ?? "unknown"}`].join(" ");
+};
+
+const describeActionActor = ({
+  userId,
+  userEmail,
+}: {
+  userId: string;
+  userEmail?: string | null;
+}) => [`userId=${userId}`, `email=${userEmail ?? "unknown"}`].join(" ");
+
+const logEditLockAction = ({
+  action,
+  templateId,
+  actor,
+  owner,
+  result,
+}: {
+  action: "acquire" | "takeover" | "release";
+  templateId: string;
+  actor: string;
+  owner?: Pick<EditLockInfo, "lockedByUserId" | "lockedByEmail"> | null;
+  result: string;
+}) => {
+  const parts = [
+    "edit-lock",
+    `action=${action}`,
+    `templateId=${templateId}`,
+    `actor={${actor}}`,
+    `owner={${describeLockActor(owner ?? null)}}`,
+    `result=${result}`,
+  ];
+
+  logMessage.info(parts.join(" "));
+};
 
 const toStoredEditLockInfo = (lock: EditLockInfo): StoredEditLockInfo => ({
   ...lock,
@@ -427,12 +469,11 @@ const toEditLockInfo = (lock: EditLockInfo): Required<EditLockInfo> => ({
 });
 
 const getPresenceSnapshot = (
-  presence: EditLockPresenceInput | undefined,
-  now: Date
+  presence: EditLockPresenceInput | undefined
 ): Required<EditLockPresenceInput> => ({
-  lastActivityAt: presence?.lastActivityAt ?? now,
-  visibilityState: presence?.visibilityState ?? "visible",
-  presenceStatus: presence?.presenceStatus ?? "active",
+  lastActivityAt: presence?.lastActivityAt ?? null,
+  visibilityState: presence?.visibilityState ?? null,
+  presenceStatus: presence?.presenceStatus ?? null,
 });
 
 export const getEditLockDisabledStatus = (): EditLockStatus => ({
@@ -541,7 +582,8 @@ export const acquireEditLock = async ({
 }): Promise<EditLockStatus> => {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + EDIT_LOCK_TTL_MS);
-  const presenceSnapshot = getPresenceSnapshot(presence, now);
+  const presenceSnapshot = getPresenceSnapshot(presence);
+  const actor = describeActionActor({ userId, userEmail });
 
   const updated: EditLockInfo = {
     templateId,
@@ -562,6 +604,13 @@ export const acquireEditLock = async ({
     const existing = await readRedisLock(templateId);
 
     if (existing && existing.lockedByUserId !== userId) {
+      logEditLockAction({
+        action: "acquire",
+        templateId,
+        actor,
+        owner: existing,
+        result: "blocked-by-other-owner",
+      });
       return buildStatus(existing, userId);
     }
 
@@ -575,10 +624,30 @@ export const acquireEditLock = async ({
       );
 
       if (created === null) {
+        logEditLockAction({
+          action: "acquire",
+          templateId,
+          actor,
+          result: "lost-race-retrying-status",
+        });
         return getEditLockStatus(templateId, userId);
       }
+
+      logEditLockAction({
+        action: "acquire",
+        templateId,
+        actor,
+        result: "created-lock",
+      });
     } else {
       await storeRedisLock(updated);
+      logEditLockAction({
+        action: "acquire",
+        templateId,
+        actor,
+        owner: existing,
+        result: "refreshed-existing-owner-lock",
+      });
     }
 
     await publishEditLockEvent(templateId);
@@ -591,11 +660,25 @@ export const acquireEditLock = async ({
   if (existing) {
     const normalized = toEditLockInfo(existing);
     if (!isExpired(normalized, now) && normalized.lockedByUserId !== userId) {
+      logEditLockAction({
+        action: "acquire",
+        templateId,
+        actor,
+        owner: normalized,
+        result: "blocked-by-other-owner",
+      });
       return buildStatus(normalized, userId);
     }
   }
 
   store.set(templateId, updated);
+  logEditLockAction({
+    action: "acquire",
+    templateId,
+    actor,
+    owner: existing ? toEditLockInfo(existing) : null,
+    result: existing ? "replaced-expired-lock" : "created-lock",
+  });
   await publishEditLockEvent(templateId);
   return buildStatus(updated, userId);
 };
@@ -617,7 +700,9 @@ export const takeoverEditLock = async ({
 }): Promise<EditLockStatus> => {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + EDIT_LOCK_TTL_MS);
-  const presenceSnapshot = getPresenceSnapshot(presence, now);
+  const presenceSnapshot = getPresenceSnapshot(presence);
+  const actor = describeActionActor({ userId, userEmail });
+  const existing = redisEnabled() ? await readRedisLock(templateId) : readMemoryLock(templateId);
   const updated: EditLockInfo = {
     templateId,
     lockedByUserId: userId,
@@ -634,12 +719,26 @@ export const takeoverEditLock = async ({
 
   if (redisEnabled()) {
     await storeRedisLock(updated);
+    logEditLockAction({
+      action: "takeover",
+      templateId,
+      actor,
+      owner: existing,
+      result: existing ? "set-lock-to-new-owner" : "set-lock-without-existing-owner",
+    });
     await publishEditLockEvent(templateId);
     return buildStatus(updated, userId);
   }
 
   const store = getEditLockStore();
   store.set(templateId, updated);
+  logEditLockAction({
+    action: "takeover",
+    templateId,
+    actor,
+    owner: existing,
+    result: existing ? "set-lock-to-new-owner" : "set-lock-without-existing-owner",
+  });
   await publishEditLockEvent(templateId);
   return buildStatus(updated, userId);
 };
@@ -657,7 +756,7 @@ export const heartbeatEditLock = async ({
 }): Promise<EditLockStatus> => {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + EDIT_LOCK_TTL_MS);
-  const presenceSnapshot = getPresenceSnapshot(presence, now);
+  const presenceSnapshot = getPresenceSnapshot(presence);
 
   if (redisEnabled()) {
     return withRedisWatch(templateId, async (current, redis) => {
@@ -728,14 +827,29 @@ export const releaseEditLock = async ({
   userId: string;
   sessionId?: string | null;
 }): Promise<{ released: boolean }> => {
+  const actor = describeActionActor({ userId });
+
   if (redisEnabled()) {
     return withRedisWatch(templateId, async (current, redis) => {
       if (!current) {
+        logEditLockAction({
+          action: "release",
+          templateId,
+          actor,
+          result: "no-lock-present",
+        });
         const execResult = await redis.multi().exec();
         return execResult ? { released: false } : null;
       }
 
       if (current.lockedByUserId !== userId || (sessionId && current.sessionId !== sessionId)) {
+        logEditLockAction({
+          action: "release",
+          templateId,
+          actor,
+          owner: current,
+          result: "denied-not-owner",
+        });
         const execResult = await redis.multi().exec();
         return execResult ? { released: false } : null;
       }
@@ -745,6 +859,13 @@ export const releaseEditLock = async ({
         return null;
       }
 
+      logEditLockAction({
+        action: "release",
+        templateId,
+        actor,
+        owner: current,
+        result: "released-lock",
+      });
       await publishEditLockEvent(templateId);
       return { released: true };
     });
@@ -753,15 +874,35 @@ export const releaseEditLock = async ({
   const store = getEditLockStore();
   const existing = store.get(templateId);
   if (!existing) {
+    logEditLockAction({
+      action: "release",
+      templateId,
+      actor,
+      result: "no-lock-present",
+    });
     return { released: false };
   }
 
   const normalized = toEditLockInfo(existing);
   if (normalized.lockedByUserId !== userId || (sessionId && normalized.sessionId !== sessionId)) {
+    logEditLockAction({
+      action: "release",
+      templateId,
+      actor,
+      owner: normalized,
+      result: "denied-not-owner",
+    });
     return { released: false };
   }
 
   store.delete(templateId);
+  logEditLockAction({
+    action: "release",
+    templateId,
+    actor,
+    owner: normalized,
+    result: "released-lock",
+  });
   await publishEditLockEvent(templateId);
   return { released: true };
 };

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -1,5 +1,6 @@
-// Keep the edit lock alive for 60 seconds after the last successful heartbeat.
-export const EDIT_LOCK_TTL_MS = 60_000;
+// Keep the edit lock alive for 5 minutes after the last successful heartbeat so brief stalls
+// or delayed requests do not drop ownership while we prefer a quieter, more stable lock.
+export const EDIT_LOCK_TTL_MS = 300_000;
 
 // Only enforce edit locking when more than one assigned person could plausibly edit the form.
 export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
@@ -7,8 +8,9 @@ export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
 // Wrap presence detection behind a single switch so the lock can fall back to the simpler editing-only UX.
 export const EDIT_LOCK_DETECT_PRESENCE = true;
 
-// Refresh the lock every 10 seconds, staying well inside the 60 second lock TTL.
-export const EDIT_LOCK_HEARTBEAT_MS = 10_000;
+// Refresh the lock once per minute to reduce network noise; the longer TTL above provides
+// enough slack that missing a single heartbeat should not immediately drop the lock.
+export const EDIT_LOCK_HEARTBEAT_MS = 60_000;
 
 // Client-side only: throttle local activity updates to at most once per second so rapid input does not
 // churn timestamps before the next heartbeat is sent.
@@ -20,8 +22,8 @@ export const CLIENT_SIDE_EDIT_LOCK_IDLE_MS = 30_000;
 // After 2 minutes without interaction, or as soon as the tab is hidden, we treat the editor as away.
 export const CLIENT_SIDE_EDIT_LOCK_AWAY_MS = 120_000;
 
-// Surface a stale connection warning shortly before the 60 second lock TTL expires.
-export const CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS = 15_000;
+// Surface a stale connection warning during the last 90 seconds of the longer lock TTL.
+export const CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS = 90_000;
 
 // Recompute the banner's relative-time copy every 5 seconds while presence detection is visible.
 export const CLIENT_SIDE_EDIT_LOCK_TIME_TICK_MS = 5_000;

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -15,6 +15,7 @@ import {
 
 const SERVER_STATE_SYNC_MAX_ATTEMPTS = 10;
 const SERVER_STATE_SYNC_RETRY_MS = 500;
+const ENABLE_EDIT_LOCK_PRESENCE = false;
 
 const wait = async (timeMs: number) =>
   new Promise((resolve) => {
@@ -49,7 +50,11 @@ export const useEditLock = ({
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
   const suppressReleaseRef = useRef(false);
   const { getActivitySnapshot } = useEditLockPresence({
-    enabled: EDIT_LOCK_DETECT_PRESENCE && enabled && status === "authenticated",
+    enabled:
+      ENABLE_EDIT_LOCK_PRESENCE &&
+      EDIT_LOCK_DETECT_PRESENCE &&
+      enabled &&
+      status === "authenticated",
     coordinationKey: formId,
   });
 
@@ -120,7 +125,7 @@ export const useEditLock = ({
         body: JSON.stringify({
           action,
           sessionId,
-          activity,
+          ...(activity ? { activity } : {}),
         }),
       });
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,5 +1,57 @@
 import pino from "pino";
 
+const LOGGER_SUPPRESS_PATTERNS_LOCAL_FILE = ".logger-suppress-patterns.local";
+
+const readLoggerSuppressPatternsFromLocalFile = () => {
+  if (typeof window !== "undefined") {
+    return [] as string[];
+  }
+
+  try {
+    const { existsSync, readFileSync } = require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+    const filePath = join(process.cwd(), LOGGER_SUPPRESS_PATTERNS_LOCAL_FILE);
+
+    if (!existsSync(filePath)) {
+      return [] as string[];
+    }
+
+    return readFileSync(filePath, "utf8")
+      .split(/\r?\n/)
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern.length > 0 && !pattern.startsWith("#"));
+  } catch {
+    return [] as string[];
+  }
+};
+
+const parseLoggerFilterPatterns = () => {
+  const rawValue = process.env.LOGGER_SUPPRESS_PATTERNS;
+  const localPatterns = readLoggerSuppressPatternsFromLocalFile();
+
+  if (!rawValue) {
+    return localPatterns;
+  }
+
+  return [
+    ...localPatterns,
+    ...rawValue
+      .split(",")
+      .map((pattern) => pattern.trim())
+      .filter(Boolean),
+  ];
+};
+
+const suppressedLoggerPatterns = parseLoggerFilterPatterns();
+
+const shouldSuppressMessage = (message: string) => {
+  if (suppressedLoggerPatterns.length === 0) {
+    return false;
+  }
+
+  return suppressedLoggerPatterns.some((pattern) => message.includes(pattern));
+};
+
 const pinoLogger = pino({
   level: process.env.NODE_ENV === "development" ? "debug" : "info",
   browser: {
@@ -52,6 +104,12 @@ export type AppLogger = {
  */
 export const logMessage: AppLogger = {
   debug: (message: string | Record<string, unknown>) => {
+    const serializedMessage = typeof message === "string" ? message : JSON.stringify(message);
+
+    if (shouldSuppressMessage(serializedMessage)) {
+      return;
+    }
+
     pinoLogger.debug(message);
   },
   info: (message: string) => pinoLogger.info(message),

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -495,7 +495,7 @@ describe("useEditLock", () => {
     expect(MockBroadcastChannel.channels.size).toBe(0);
   });
 
-  it("includes the derived presence activity in edit-lock requests", async () => {
+  it("does not include presence activity in edit-lock requests", async () => {
     setDocumentVisibility("hidden");
 
     await render(<EditLockHarness />);
@@ -521,11 +521,7 @@ describe("useEditLock", () => {
     };
 
     expect(body.action).toBe("acquire");
-    expect(body.activity).toMatchObject({
-      visibilityState: "hidden",
-      presenceStatus: "away",
-    });
-    expect(body.activity?.lastActivityAt).toEqual(expect.any(String));
+    expect(body.activity).toBeUndefined();
   });
 
   it("syncs and switches to polling when a heartbeat shows another user won the lock", async () => {


### PR DESCRIPTION
# Summary | Résumé

Adds logging for edit lock and a way to suppress errors for local dev

.logger-suppress-patterns.local
```
# Local-only logger suppression patterns
Updating Cached Feature Flags
Updating Cached Privileges
Updating Cached User Status
Using cached ability
Creating new ability
Privilege Check PASS
```
