### PR TITLE
fix:  Apostrophe in FR Attestation turns into #39 character on the Review Page

### DIFF
--- a/components/clientComponents/forms/Review/FormElements/BaseElementArray.tsx
+++ b/components/clientComponents/forms/Review/FormElements/BaseElementArray.tsx
@@ -1,5 +1,4 @@
 import { FormItem } from "../helpers";
-import { escapeHtml } from "@lib/utils/escapeHtml";
 
 export const BaseElementArray = ({
   formItem,
@@ -21,12 +20,12 @@ export const BaseElementArray = ({
             <ul className="list-none px-0">
               {formItem.values.map((value, index) => (
                 <li key={`${value}-${index}`} className="mb-4">
-                  {escapeHtml(value as string)}
+                  {value as string}
                 </li>
               ))}
             </ul>
           ) : (
-            escapeHtml(formItem.values.join(", "))
+            formItem.values.join(", ")
           )
         ) : (
           "-"

--- a/components/clientComponents/forms/Review/FormElements/BaseElementArray.vitest.tsx
+++ b/components/clientComponents/forms/Review/FormElements/BaseElementArray.vitest.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import "@testing-library/jest-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BaseElementArray } from "./BaseElementArray";
+
+describe("BaseElementArray", () => {
+  afterEach(() => cleanup());
+
+  it("renders apostrophes in checkbox review values without exposing HTML entities", () => {
+    render(
+      <BaseElementArray
+        splitValues={true}
+        formItem={{
+          type: "checkbox",
+          label: "J'accepte :",
+          values: ["j'accepte", "condition d'aujourd'hui"],
+          element: undefined,
+        }}
+      />
+    );
+
+    expect(screen.getByText("j'accepte")).toBeInTheDocument();
+    expect(screen.getByText("condition d'aujourd'hui")).toBeInTheDocument();
+    expect(screen.queryByText("j&#39;accepte")).not.toBeInTheDocument();
+  });
+
+  it("renders user-provided HTML-like content as text instead of markup", () => {
+    render(
+      <BaseElementArray
+        splitValues={true}
+        formItem={{
+          type: "checkbox",
+          label: "Unsafe example",
+          values: ["<script>alert('xss')</script>", "a & b"],
+          element: undefined,
+        }}
+      />
+    );
+
+    expect(screen.getByText("<script>alert('xss')</script>")).toBeInTheDocument();
+    expect(document.querySelector("script")).toBeNull();
+    expect(screen.getByText("a & b")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

Fix Double-Escaped Checkbox Values in Review Output

**Bug**

<img width="471" height="355" alt="issue" src="https://github.com/user-attachments/assets/b5d997ab-4911-4bda-a556-66381ba5cf36" />

The shared review array renderer pre-escaped values with `escapeHtml(...)` and then rendered them as normal React text. React escaped the text again, so a value like `j'accepte` appeared as `j&#39;accepte` i


This fix removes the manual `escapeHtml(...)` and lets React render the values as plain text nodes.

The previous implementation was escaping the string too early, and React then escaped the escaped string again. That double-encoding caused HTML entities like `&#39;` to appear visibly to the user.


