### PR TITLE
chore: add draft edit presence enabled setting

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -18,6 +18,7 @@ import { logMessage } from "@lib/logger";
 import { checkKeyExists } from "@lib/serviceAccount";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
+import { getAppSettingAsBoolean } from "@lib/appSettings";
 import {
   FormBuilderConfigProvider,
   FormBuilderConfig,
@@ -46,6 +47,9 @@ export default async function Layout(props: {
 
   const allowGroupsFlag = allowGrouping();
   const allowLockedEditingFlag = await allowLockedEditing();
+  const editLockPresenceEnabled = allowLockedEditingFlag
+    ? await getAppSettingAsBoolean("editLockPresenceEnabled")
+    : false;
   const enforceEditLockFlag =
     allowLockedEditingFlag && formID && formID !== "0000"
       ? await shouldEnforceTemplateEditLock(formID)
@@ -117,7 +121,11 @@ export default async function Layout(props: {
                     </div>
                     <GroupStoreProvider>
                       <div className="relative flex w-full gap-7">
-                        <EditLockClient formId={id} lockedEditingEnabled={enforceEditLockFlag}>
+                        <EditLockClient
+                          formId={id}
+                          lockedEditingEnabled={enforceEditLockFlag}
+                          editLockPresenceEnabled={editLockPresenceEnabled}
+                        >
                           <main
                             id="content"
                             className="form-builder my-7 min-h-[calc(100vh-300px)] w-full"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -5,6 +5,7 @@ import { authCheckAndThrow } from "@lib/actions";
 import { Language } from "@lib/types/form-builder-types";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
+import { getAppSettingAsBoolean } from "@lib/appSettings";
 import { SettingsNavigation } from "./components/SettingsNavigation";
 import { WaitForId } from "../components/WaitForId";
 import { EditLockClient } from "@formBuilder/components/shared/edit-lock/EditLockClient";
@@ -22,6 +23,9 @@ export default async function Layout(props: {
 
   const { t } = await serverTranslation("form-builder", { lang: locale });
   const allowLockedEditingFlag = await allowLockedEditing();
+  const editLockPresenceEnabled = allowLockedEditingFlag
+    ? await getAppSettingAsBoolean("editLockPresenceEnabled")
+    : false;
   const enforceEditLockFlag = allowLockedEditingFlag
     ? await shouldEnforceTemplateEditLock(id)
     : false;
@@ -46,6 +50,7 @@ export default async function Layout(props: {
       <EditLockClient
         formId={id}
         lockedEditingEnabled={enforceEditLockFlag}
+        editLockPresenceEnabled={editLockPresenceEnabled}
         restrictToEditPaths={false}
         reloadOnTakeover={true}
       >

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockBanner.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockBanner.tsx
@@ -43,7 +43,13 @@ const formatRelativeTime = (value: string, locale: string) => {
   return formatter.format(Math.round(diffMs / 86_400_000), "day");
 };
 
-export const EditLockBanner = ({ takeover }: { takeover: () => Promise<void> }) => {
+export const EditLockBanner = ({
+  takeover,
+  presenceEnabled = false,
+}: {
+  takeover: () => Promise<void>;
+  presenceEnabled?: boolean;
+}) => {
   const { t, i18n } = useTranslation("form-builder");
   const { isLockedByOther, editLock } = useTemplateStore((s) => ({
     isLockedByOther: s.isLockedByOther,
@@ -60,10 +66,10 @@ export const EditLockBanner = ({ takeover }: { takeover: () => Promise<void> }) 
     }
 
     bannerRef.current?.focus();
-  }, [isLockedByOther]);
+  }, [isLockedByOther, presenceEnabled]);
 
   useEffect(() => {
-    if (!EDIT_LOCK_DETECT_PRESENCE || !isLockedByOther) {
+    if (!presenceEnabled || !EDIT_LOCK_DETECT_PRESENCE || !isLockedByOther) {
       return;
     }
 
@@ -74,7 +80,7 @@ export const EditLockBanner = ({ takeover }: { takeover: () => Promise<void> }) 
     return () => {
       window.clearInterval(interval);
     };
-  }, [isLockedByOther]);
+  }, [isLockedByOther, presenceEnabled]);
 
   if (!isLockedByOther) return null;
 
@@ -84,11 +90,12 @@ export const EditLockBanner = ({ takeover }: { takeover: () => Promise<void> }) 
 
   // If the lock is nearing expiration, or if the presence status is explicitly marked as stale, treat the lock as stale.
   const isStale =
-    EDIT_LOCK_DETECT_PRESENCE && expiresAt
+    presenceEnabled && EDIT_LOCK_DETECT_PRESENCE && expiresAt
       ? expiresAt.getTime() - timeTick <= CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS
       : false;
 
-  const hasPresenceDetails = EDIT_LOCK_DETECT_PRESENCE && Boolean(editLock?.presenceStatus);
+  const hasPresenceDetails =
+    presenceEnabled && EDIT_LOCK_DETECT_PRESENCE && Boolean(editLock?.presenceStatus);
 
   // If the lock is stale, show "stale" status to encourage takeover. Otherwise, show the actual presence status reported by the server.
   const presenceKey = isStale ? "stale" : (editLock?.presenceStatus ?? "away");

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -24,12 +24,14 @@ const makeSessionId = () => {
 export const EditLockClient = ({
   formId,
   lockedEditingEnabled = true,
+  editLockPresenceEnabled = false,
   children,
   restrictToEditPaths = true,
   reloadOnTakeover = false,
 }: {
   formId: string;
   lockedEditingEnabled?: boolean;
+  editLockPresenceEnabled?: boolean;
   children?: React.ReactNode;
   restrictToEditPaths?: boolean;
   reloadOnTakeover?: boolean;
@@ -45,7 +47,12 @@ export const EditLockClient = ({
     activeFormId !== "0000";
   const [sessionId] = useState(() => makeSessionId());
 
-  const { takeover } = useEditLock({ formId: activeFormId, enabled, sessionId });
+  const { takeover } = useEditLock({
+    formId: activeFormId,
+    enabled,
+    presenceEnabled: editLockPresenceEnabled,
+    sessionId,
+  });
 
   const handleTakeover = useCallback(async () => {
     await takeover();
@@ -61,7 +68,7 @@ export const EditLockClient = ({
 
   return (
     <>
-      <EditLockBanner takeover={handleTakeover} />
+      <EditLockBanner takeover={handleTakeover} presenceEnabled={editLockPresenceEnabled} />
       {children}
     </>
   );

--- a/lib/appSettings.ts
+++ b/lib/appSettings.ts
@@ -55,6 +55,11 @@ export const getAppSetting = async (internalId: string) => {
   return uncachedSetting?.value ?? null;
 };
 
+export const getAppSettingAsBoolean = async (internalId: string) => {
+  const value = await getAppSetting(internalId);
+  return value === "true";
+};
+
 export const getFullAppSetting = async (internalId: string) => {
   const { user } = await authorization.canAccessSettings().catch((e) => {
     if (e instanceof AccessControlError) {

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -15,7 +15,6 @@ import {
 
 const SERVER_STATE_SYNC_MAX_ATTEMPTS = 10;
 const SERVER_STATE_SYNC_RETRY_MS = 500;
-const ENABLE_EDIT_LOCK_PRESENCE = false;
 
 const wait = async (timeMs: number) =>
   new Promise((resolve) => {
@@ -25,10 +24,12 @@ const wait = async (timeMs: number) =>
 export const useEditLock = ({
   formId,
   enabled,
+  presenceEnabled,
   sessionId,
 }: {
   formId: string;
   enabled: boolean;
+  presenceEnabled: boolean;
   sessionId: string;
 }) => {
   "use memo";
@@ -49,11 +50,7 @@ export const useEditLock = ({
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
   const suppressReleaseRef = useRef(false);
   const { getActivitySnapshot } = useEditLockPresence({
-    enabled:
-      ENABLE_EDIT_LOCK_PRESENCE &&
-      EDIT_LOCK_DETECT_PRESENCE &&
-      enabled &&
-      status === "authenticated",
+    enabled: presenceEnabled && EDIT_LOCK_DETECT_PRESENCE && enabled && status === "authenticated",
     coordinationKey: formId,
   });
 

--- a/prisma/seeds/fixtures/settings.ts
+++ b/prisma/seeds/fixtures/settings.ts
@@ -66,6 +66,16 @@ const responseDownloadLimit: Setting = {
   value: "20",
 };
 
+const editLockPresenceEnabled: Setting = {
+  internalId: "editLockPresenceEnabled",
+  nameEn: "Enable edit lock presence detection",
+  nameFr: "Activer la détection de présence pour le verrouillage d'édition",
+  descriptionEn: "Turn edit lock presence tracking on or off for the form builder experience.",
+  descriptionFr:
+    "Activez ou désactivez le suivi de présence du verrouillage d'édition dans l'expérience du générateur de formulaires.",
+  value: "false",
+};
+
 const allSettings = [
   brandingRequestFormSetting,
   nagwarePhaseEncouraged,
@@ -73,6 +83,7 @@ const allSettings = [
   nagwarePhaseWarned,
   nagwarePhaseEscalated,
   responseDownloadLimit,
+  editLockPresenceEnabled,
 ];
 
 export default {

--- a/tests/browser/form-builder/edit-lock/EditLockBanner.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/EditLockBanner.browser.vitest.tsx
@@ -22,10 +22,12 @@ function EditLockBannerHarness({
   editLock,
   isLockedByOther,
   takeover,
+  presenceEnabled = false,
 }: {
   editLock: EditLockState | null;
   isLockedByOther: boolean;
   takeover: () => Promise<void>;
+  presenceEnabled?: boolean;
 }) {
   const setEditLock = useTemplateStore((state) => state.setEditLock);
   const setIsLockedByOther = useTemplateStore((state) => state.setIsLockedByOther);
@@ -35,7 +37,7 @@ function EditLockBannerHarness({
     setIsLockedByOther(isLockedByOther);
   }, [editLock, isLockedByOther, setEditLock, setIsLockedByOther]);
 
-  return <EditLockBanner takeover={takeover} />;
+  return <EditLockBanner takeover={takeover} presenceEnabled={presenceEnabled} />;
 }
 
 describe("<EditLockBanner />", () => {
@@ -73,6 +75,7 @@ describe("<EditLockBanner />", () => {
         editLock={buildLock({ expiresAt: new Date(Date.now() + 5_000).toISOString() })}
         isLockedByOther={true}
         takeover={vi.fn().mockResolvedValue(undefined)}
+        presenceEnabled={true}
       />
     );
 
@@ -117,5 +120,20 @@ describe("<EditLockBanner />", () => {
     const loading = page.getByText("Syncing the latest saved version of this form...");
     await expect.element(loading).toBeVisible();
     await expect.element(page.getByRole("button", { name: "Taking over..." })).toBeDisabled();
+  });
+
+  it("hides presence details when presence detection is disabled", async () => {
+    await render(
+      <EditLockBannerHarness
+        editLock={buildLock()}
+        isLockedByOther={true}
+        takeover={vi.fn().mockResolvedValue(undefined)}
+        presenceEnabled={false}
+      />
+    );
+
+    await expect.element(page.getByText("This form is already being edited")).toBeVisible();
+    await expect.element(page.getByText("Status:", { exact: false })).not.toBeInTheDocument();
+    await expect.element(page.getByText("Last activity:", { exact: false })).not.toBeInTheDocument();
   });
 });

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -168,10 +168,12 @@ function EditLockHarness({
   onTakeoverReady,
   onChangeKey,
   onLockStateChange,
+  presenceEnabled = false,
 }: {
   onTakeoverReady?: (takeover: () => Promise<void>) => void;
   onChangeKey?: (changeKey: string) => void;
   onLockStateChange?: (state: { isLockedByOther: boolean; hasEditLock: boolean }) => void;
+  presenceEnabled?: boolean;
 }) {
   const changeKey = useTemplateStore((s) => s.changeKey);
   const isLockedByOther = useTemplateStore((s) => s.isLockedByOther);
@@ -179,6 +181,7 @@ function EditLockHarness({
   const { takeover } = useEditLock({
     formId: "test-form-id",
     enabled: true,
+    presenceEnabled,
     sessionId: "session-1",
   });
 


### PR DESCRIPTION
# Summary | Résumé

Adds setting for edit lock presence so we can toggle it on / off via app settings

<img width="500" height="611" alt="Screenshot 2026-04-23 at 12 07 04 PM" src="https://github.com/user-attachments/assets/b992667e-244a-4c73-adcc-237b68865f48" />

<hr>

<img width="536" height="313" alt="Screenshot 2026-04-23 at 12 07 44 PM" src="https://github.com/user-attachments/assets/7fe4d99d-83f5-416d-b341-03fbc8167b77" />

