### PR TITLE
chore: Display the error when an audit log fails.

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/AuditForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/AuditForm.tsx
@@ -106,7 +106,7 @@ export const AuditForm = ({ formId }: { formId: string }) => {
         retrieveFileBlob(events);
       }
     } else {
-      alert(t("auditDownload.errorFetchingEvents"));
+      alert(events.error);
     }
   };
 


### PR DESCRIPTION
Need to debug why audit logs are failing, need the message.