### PR TITLE
chore: leader tab polling for non lock owner

### DIFF
--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -8,6 +8,10 @@ export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
 // Wrap presence detection behind a single switch so the lock can fall back to the simpler editing-only UX.
 export const EDIT_LOCK_DETECT_PRESENCE = true;
 
+// Use leader tab coordination so only the foreground tab sends edit-lock heartbeats,
+// reducing redundant requests when multiple tabs have the same form open.
+export const EDIT_LOCK_LEADER_TAB_ENABLED = true;
+
 // Refresh the owner's lock heartbeat once per minute to reduce network noise; the longer TTL above
 // provides enough slack that missing a single heartbeat should not immediately drop the lock.
 export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 60_000;

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -7,9 +7,11 @@ import { FormRecord } from "@lib/types";
 import { clearTemplateStore } from "@lib/store/utils";
 import { useTemplateContext } from "@lib/hooks/form-builder/useTemplateContext";
 import { useEditLockPresence } from "@lib/hooks/form-builder/useEditLockPresence";
+import { useLeaderTab } from "@lib/hooks/form-builder/useLeaderTab";
 import { isEditLockStatus, type EditLockStatusPayload } from "@lib/editLockStatus";
 import {
   EDIT_LOCK_DETECT_PRESENCE,
+  EDIT_LOCK_LEADER_TAB_ENABLED,
   EDIT_LOCK_HEARTBEAT_INTERVAL_MS,
   EDIT_LOCK_STATUS_POLL_INTERVAL_MS,
 } from "@lib/formBuilderEditLockPresence";
@@ -64,9 +66,16 @@ export const useEditLock = ({
   const updatedAtRef = useRef(updatedAt);
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
   const suppressReleaseRef = useRef(false);
+
+  const { isLeaderTab } = useLeaderTab({
+    enabled: enabled && EDIT_LOCK_LEADER_TAB_ENABLED && status === "authenticated",
+    coordinationKey: formId,
+  });
+
   const { getActivitySnapshot } = useEditLockPresence({
     enabled: presenceEnabled && EDIT_LOCK_DETECT_PRESENCE && enabled && status === "authenticated",
     coordinationKey: formId,
+    leaderTabEnabled: EDIT_LOCK_LEADER_TAB_ENABLED,
   });
 
   const clearLockState = useCallback(() => {
@@ -293,6 +302,7 @@ export const useEditLock = ({
   ]);
 
   // Non-owners poll on this interval while waiting for the lock state to change.
+  // If leader-tab coordination is enabled, only the leader tab polls to reduce requests.
   const startPolling = useCallback((): void => {
     clearTimers();
     const loopToken = lockLoopTokenRef.current;
@@ -333,11 +343,43 @@ export const useEditLock = ({
       if (statusResult.isOwner) {
         startHeartbeat();
       } else {
-        startPolling();
+        // For non-owners with leader-tab coordination, only start polling if this is the leader tab
+        if (!EDIT_LOCK_LEADER_TAB_ENABLED || isLeaderTab) {
+          startPolling();
+        }
       }
     },
-    [startHeartbeat, startPolling]
+    [startHeartbeat, startPolling, isLeaderTab]
   );
+
+  // When a non-owner tab's leader status changes, update polling state accordingly.
+  // Only the leader tab should have the polling interval active to reduce network traffic.
+  useEffect(() => {
+    // Only applies to non-owners with leader-tab coordination enabled
+    if (isOwnerRef.current || !EDIT_LOCK_LEADER_TAB_ENABLED) {
+      return;
+    }
+
+    if (isLeaderTab) {
+      // Tab just became the leader - start polling if not already running
+      if (!pollRef.current) {
+        startPollingRef.current();
+      } else {
+        // Poll immediately to refresh state before next interval tick
+        void getLockStatus().then((result) => {
+          if (result) {
+            cbRef.current.updateStore(result);
+          }
+        });
+      }
+    } else {
+      // Tab stopped being the leader - stop polling
+      if (pollRef.current) {
+        window.clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    }
+  }, [isLeaderTab, getLockStatus]);
 
   // The main effect runs whenever "enabled" or "status" changes to start/stop
   // the lock logic. The ref "container" is necessary to hold the latest

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -146,11 +146,7 @@ const setDocumentFocus = (isFocused: boolean) => {
 
 const getRequestUrl = (input: RequestInfo | URL) => new URL(String(input), "https://example.test");
 
-const isEditLockRequest = (
-  input: RequestInfo | URL,
-  method?: string,
-  requestType?: string
-) => {
+const isEditLockRequest = (input: RequestInfo | URL, method?: string, requestType?: string) => {
   const url = getRequestUrl(input);
 
   if (url.pathname !== "/api/templates/test-form-id/edit-lock") {
@@ -258,14 +254,20 @@ describe("useEditLock", () => {
     fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = getRequestUrl(input);
 
-      if (isEditLockRequest(input, init?.method, url.searchParams.get("requestType") ?? undefined) && init?.method === "POST") {
+      if (
+        isEditLockRequest(input, init?.method, url.searchParams.get("requestType") ?? undefined) &&
+        init?.method === "POST"
+      ) {
         return {
           ok: true,
           json: async () => ownerLockStatus,
         } as Response;
       }
 
-      if (isEditLockRequest(input, init?.method, url.searchParams.get("requestType") ?? undefined) && init?.method === "GET") {
+      if (
+        isEditLockRequest(input, init?.method, url.searchParams.get("requestType") ?? undefined) &&
+        init?.method === "GET"
+      ) {
         return {
           ok: true,
           json: async () => ownerLockStatus,
@@ -400,9 +402,7 @@ describe("useEditLock", () => {
       expect(setUpdatedAt).toHaveBeenCalledWith(Date.parse(freshUpdatedAt));
     });
 
-    const formFetchCalls = fetchMock.mock.calls.filter(([input]) =>
-      isTemplateRequest(input)
-    );
+    const formFetchCalls = fetchMock.mock.calls.filter(([input]) => isTemplateRequest(input));
 
     expect(formFetchCalls).toHaveLength(3);
     formFetchCalls.forEach(([, init]) => {
@@ -794,9 +794,7 @@ describe("useEditLock", () => {
       expect(heartbeatCallCount).toBe(1);
     });
 
-    const formFetchCalls = fetchMock.mock.calls.filter(([input]) =>
-      isTemplateRequest(input)
-    );
+    const formFetchCalls = fetchMock.mock.calls.filter(([input]) => isTemplateRequest(input));
     const lockPostBodies = fetchMock.mock.calls
       .filter(([input, init]) => {
         return isEditLockRequest(input) && init?.method === "POST";
@@ -883,9 +881,7 @@ describe("useEditLock", () => {
       expect(lockStates.at(-1)).toEqual({ isLockedByOther: true, hasEditLock: false });
     });
 
-    const formFetchCalls = fetchMock.mock.calls.filter(([input]) =>
-      isTemplateRequest(input)
-    );
+    const formFetchCalls = fetchMock.mock.calls.filter(([input]) => isTemplateRequest(input));
     const lockPostBodies = fetchMock.mock.calls
       .filter(([input, init]) => {
         return isEditLockRequest(input) && init?.method === "POST";

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -516,7 +516,7 @@ describe("useEditLock", () => {
     expect(lockStates.at(-1)).toEqual({ isLockedByOther: false, hasEditLock: false });
   });
 
-  it("opens an EventSource even when the tab is not active if leader-tab coordination is disabled", async () => {
+  it("opens an EventSource and initializes leader-tab coordination even when the tab is not active", async () => {
     setDocumentVisibility("hidden");
     setDocumentFocus(false);
 
@@ -529,7 +529,9 @@ describe("useEditLock", () => {
     expect(MockEventSource.instances[0].url).toBe(
       "/api/templates/test-form-id/edit-lock/events?requestType=event-stream"
     );
-    expect(MockBroadcastChannel.channels.size).toBe(0);
+    // With leader-tab coordination enabled, a BroadcastChannel is created
+    // for leader tab coordination even in background tabs
+    expect(MockBroadcastChannel.channels.size).toBe(1);
   });
 
   it("does not include presence activity in edit-lock requests", async () => {


### PR DESCRIPTION
# Summary | Résumé

Adds check for active tab to start and stop polling for non lock owners.