### PR TITLE
chore: add a Redis Stream cap

### DIFF
--- a/lib/editLockEventStreams.ts
+++ b/lib/editLockEventStreams.ts
@@ -54,7 +54,7 @@ const runReaderLoop = async (templateId: string, state: TemplateReaderState): Pr
   while (!state.stopped) {
     try {
       // eslint-disable-next-line no-await-in-loop
-      const results = (await state.redis.xread(
+      const results = await state.redis.xread(
         "COUNT",
         100,
         "BLOCK",
@@ -62,7 +62,7 @@ const runReaderLoop = async (templateId: string, state: TemplateReaderState): Pr
         "STREAMS",
         streamKey,
         state.lastId
-      )) as Array<[string, Array<[string, string[]]>]> | null;
+      );
 
       if (state.stopped) {
         break;

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -250,11 +250,19 @@ const publishEditLockEvent = async (templateId: string, event: EditLockEvent = u
   const streamKey = getEditLockStreamKey(templateId);
   // Append the event to the per-template stream.  The stream TTL is reset on
   // every write so it stays alive as long as the lock itself is active.
-  await redis
-    .multi()
-    .xadd(streamKey, "MAXLEN", "~", 100, "*", "type", event.type, "templateId", templateId)
-    .expire(streamKey, editLockTtlSeconds * 2)
-    .exec();
+  // Note: XADD API params: key, MAXLEN ~ count (cap stream to ~100 entries lazily), * (auto-generate entry ID), ...field-value pairs
+  await redis.xadd(
+    streamKey,
+    "MAXLEN",
+    "~",
+    100,
+    "*",
+    "type",
+    event.type,
+    "templateId",
+    templateId
+  );
+  await redis.expire(streamKey, editLockTtlSeconds * 2);
 };
 
 const storeRedisLock = async (lock: EditLockInfo) => {

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -250,8 +250,11 @@ const publishEditLockEvent = async (templateId: string, event: EditLockEvent = u
   const streamKey = getEditLockStreamKey(templateId);
   // Append the event to the per-template stream.  The stream TTL is reset on
   // every write so it stays alive as long as the lock itself is active.
-  await redis.xadd(streamKey, "*", "type", event.type, "templateId", templateId);
-  await redis.expire(streamKey, editLockTtlSeconds * 2);
+  await redis
+    .multi()
+    .xadd(streamKey, "MAXLEN", "~", 100, "*", "type", event.type, "templateId", templateId)
+    .expire(streamKey, editLockTtlSeconds * 2)
+    .exec();
 };
 
 const storeRedisLock = async (lock: EditLockInfo) => {


### PR DESCRIPTION
# Summary | Résumé

Adds a Redis Stream cap on Add events. Previously this was unbounded and could have a potential vunlerability.
Also cleans up a type.