### PR TITLE
chore: Edit lock session timeout

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -18,7 +18,11 @@ import { logMessage } from "@lib/logger";
 import { checkKeyExists } from "@lib/serviceAccount";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
-import { getAppSettingAsBoolean } from "@lib/appSettings";
+import { getAppSettingAsBoolean, getAppSettingAsNumber } from "@lib/appSettings";
+import {
+  EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
+  EDIT_LOCK_REDIRECT_IDLE_SETTING_ID,
+} from "@lib/formBuilderEditLockPresence";
 import {
   FormBuilderConfigProvider,
   FormBuilderConfig,
@@ -50,6 +54,12 @@ export default async function Layout(props: {
   const editLockPresenceEnabled = allowLockedEditingFlag
     ? await getAppSettingAsBoolean("editLockPresenceEnabled")
     : false;
+  const editLockRedirectIdleMs = allowLockedEditingFlag
+    ? await getAppSettingAsNumber(
+        EDIT_LOCK_REDIRECT_IDLE_SETTING_ID,
+        EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS
+      )
+    : EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS;
   const enforceEditLockFlag =
     allowLockedEditingFlag && formID && formID !== "0000"
       ? await shouldEnforceTemplateEditLock(formID)
@@ -125,6 +135,9 @@ export default async function Layout(props: {
                           formId={id}
                           lockedEditingEnabled={enforceEditLockFlag}
                           editLockPresenceEnabled={editLockPresenceEnabled}
+                          idleTimeoutMs={
+                            editLockRedirectIdleMs ?? EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS
+                          }
                         >
                           <main
                             id="content"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -5,7 +5,11 @@ import { authCheckAndThrow } from "@lib/actions";
 import { Language } from "@lib/types/form-builder-types";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
-import { getAppSettingAsBoolean } from "@lib/appSettings";
+import { getAppSettingAsBoolean, getAppSettingAsNumber } from "@lib/appSettings";
+import {
+  EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
+  EDIT_LOCK_REDIRECT_IDLE_SETTING_ID,
+} from "@lib/formBuilderEditLockPresence";
 import { SettingsNavigation } from "./components/SettingsNavigation";
 import { WaitForId } from "../components/WaitForId";
 import { EditLockClient } from "@formBuilder/components/shared/edit-lock/EditLockClient";
@@ -26,6 +30,12 @@ export default async function Layout(props: {
   const editLockPresenceEnabled = allowLockedEditingFlag
     ? await getAppSettingAsBoolean("editLockPresenceEnabled")
     : false;
+  const editLockRedirectIdleMs = allowLockedEditingFlag
+    ? await getAppSettingAsNumber(
+        EDIT_LOCK_REDIRECT_IDLE_SETTING_ID,
+        EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS
+      )
+    : EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS;
   const enforceEditLockFlag = allowLockedEditingFlag
     ? await shouldEnforceTemplateEditLock(id)
     : false;
@@ -51,6 +61,7 @@ export default async function Layout(props: {
         formId={id}
         lockedEditingEnabled={enforceEditLockFlag}
         editLockPresenceEnabled={editLockPresenceEnabled}
+        idleTimeoutMs={editLockRedirectIdleMs ?? EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS}
         restrictToEditPaths={false}
         reloadOnTakeover={true}
       >

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useEditLock } from "@lib/hooks/form-builder/useEditLock";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { EditLockBanner } from "@formBuilder/components/shared/edit-lock/EditLockBanner";
+import { EditLockSessionExpiredOverlay } from "@formBuilder/components/shared/edit-lock/EditLockSessionExpiredOverlay";
 import { useTreeRef } from "@formBuilder/components/shared/right-panel/headless-treeview/provider/TreeRefProvider";
 
 const isEditPath = (pathname: string | null) => {
@@ -26,6 +27,7 @@ export const EditLockClient = ({
   formId,
   lockedEditingEnabled = true,
   editLockPresenceEnabled = false,
+  idleTimeoutMs,
   children,
   restrictToEditPaths = true,
   reloadOnTakeover = false,
@@ -33,6 +35,7 @@ export const EditLockClient = ({
   formId: string;
   lockedEditingEnabled?: boolean;
   editLockPresenceEnabled?: boolean;
+  idleTimeoutMs: number;
   children?: React.ReactNode;
   restrictToEditPaths?: boolean;
   reloadOnTakeover?: boolean;
@@ -48,11 +51,12 @@ export const EditLockClient = ({
     activeFormId !== "0000";
   const [sessionId] = useState(() => makeSessionId());
 
-  const { takeover } = useEditLock({
+  const { takeover, hasEditExpired, returnToForms } = useEditLock({
     formId: activeFormId,
     enabled,
     presenceEnabled: editLockPresenceEnabled,
     sessionId,
+    idleTimeoutMs,
   });
 
   const { headlessTree } = useTreeRef();
@@ -72,6 +76,7 @@ export const EditLockClient = ({
 
   return (
     <>
+      {hasEditExpired && <EditLockSessionExpiredOverlay onReturnToForms={returnToForms} />}
       <EditLockBanner takeover={handleTakeover} presenceEnabled={editLockPresenceEnabled} />
       {children}
     </>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockSessionExpiredOverlay.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockSessionExpiredOverlay.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTranslation } from "@i18n/client";
+import { Button } from "@clientComponents/globals";
+import { PilotBadge } from "@clientComponents/globals/PilotBadge";
+import { WarningIcon } from "@serverComponents/icons";
+
+export const EditLockSessionExpiredOverlay = ({
+  onReturnToForms,
+}: {
+  onReturnToForms: () => void;
+}) => {
+  const { t } = useTranslation("form-builder");
+
+  return (
+    <div
+      className="fixed inset-0 z-140 bg-slate-900/20"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("editLock.sessionExpiredTitle")}
+      aria-live="assertive"
+    >
+      <div className="flex min-h-screen items-start justify-center px-6 pt-24">
+        <div className="pointer-events-auto w-full max-w-2xl rounded-lg border border-slate-300 bg-white px-6 py-5 text-sm text-slate-700 shadow-xl">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex max-w-xl items-start gap-3 text-left">
+              <WarningIcon className="mt-0.5 size-8 shrink-0 fill-amber-500" />
+              <div>
+                <PilotBadge className="mb-3" />
+                <p className="mb-2 text-xl font-semibold text-slate-900">
+                  {t("editLock.sessionExpiredTitle")}
+                </p>
+                <p className="text-base text-slate-900">{t("editLock.sessionExpiredMessage")}</p>
+              </div>
+            </div>
+            <Button
+              theme="primary"
+              onClick={onReturnToForms}
+              className="self-center whitespace-nowrap hover:cursor-pointer sm:self-start"
+            >
+              {t("editLock.returnToForms")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/api/templates/[formID]/edit-lock/events/route.ts
+++ b/app/api/templates/[formID]/edit-lock/events/route.ts
@@ -12,7 +12,7 @@ import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 
 export const dynamic = "force-dynamic";
 
-const shouldDebugEditLockSse = false;
+const shouldDebugEditLockSse = true;
 
 const debugEditLockSse = (message: string, metadata: Record<string, unknown>) => {
   if (!shouldDebugEditLockSse) {
@@ -45,6 +45,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
     formID,
     userId: session.user.id,
   };
+  let closeStream: ((reason: string) => Promise<void>) | null = null;
 
   const stream = new ReadableStream({
     start(controller) {
@@ -113,6 +114,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
           // no-op: controller may already be closed
         }
       };
+      closeStream = close;
 
       unregisterStream = registerActiveEditLockStream(session.user.id, formID, () =>
         close("replaced-by-newer-stream")
@@ -140,6 +142,9 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
       _req.signal.addEventListener("abort", () => {
         void close("request-aborted");
       });
+    },
+    cancel() {
+      return closeStream?.("stream-cancelled");
     },
   });
 

--- a/app/api/templates/[formID]/edit-lock/events/route.ts
+++ b/app/api/templates/[formID]/edit-lock/events/route.ts
@@ -7,9 +7,20 @@ import {
   registerActiveEditLockStream,
   subscribeToSharedEditLockEvents,
 } from "@lib/editLockEventStreams";
+import { logMessage } from "@lib/logger";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 
 export const dynamic = "force-dynamic";
+
+const shouldDebugEditLockSse = false;
+
+const debugEditLockSse = (message: string, metadata: Record<string, unknown>) => {
+  if (!shouldDebugEditLockSse) {
+    return;
+  }
+
+  logMessage.debug({ message, ...metadata });
+};
 
 export const GET = middleware([sessionExists()], async (_req, props) => {
   const { session } = props as WithRequired<MiddlewareProps, "session">;
@@ -30,12 +41,18 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
   }
 
   const encoder = new TextEncoder();
+  const streamDebugContext = {
+    formID,
+    userId: session.user.id,
+  };
 
   const stream = new ReadableStream({
     start(controller) {
       let closed = false;
       let unsubscribe: (() => void | Promise<void>) | null = null;
       let unregisterStream: (() => void) | null = null;
+
+      debugEditLockSse("edit-lock-sse-open", streamDebugContext);
 
       const sendStatus = async () => {
         if (closed) {
@@ -73,12 +90,16 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
         }
       }, 25000);
 
-      const close = async () => {
+      const close = async (reason: string) => {
         if (closed) {
           return;
         }
 
         closed = true;
+        debugEditLockSse("edit-lock-sse-close", {
+          ...streamDebugContext,
+          reason,
+        });
         clearInterval(keepAlive);
         unregisterStream?.();
 
@@ -93,7 +114,9 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
         }
       };
 
-      unregisterStream = registerActiveEditLockStream(session.user.id, formID, close);
+      unregisterStream = registerActiveEditLockStream(session.user.id, formID, () =>
+        close("replaced-by-newer-stream")
+      );
 
       void (async () => {
         try {
@@ -106,7 +129,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
 
           unsubscribe = unsubscribeEvents;
         } catch {
-          void close();
+          void close("subscribe-failed");
         }
       })();
 
@@ -115,7 +138,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
       });
 
       _req.signal.addEventListener("abort", () => {
-        void close();
+        void close("request-aborted");
       });
     },
   });

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -626,7 +626,10 @@
     "takingOver": "Taking over...",
     "syncingLatest": "Syncing the latest saved version of this form...",
     "syncedLatest": "You now have the edit lock and the latest saved form has been loaded.",
-    "takeoverError": "Unable to take over. Please try again."
+    "takeoverError": "Unable to take over. Please try again.",
+    "sessionExpiredTitle": "Your editing session expired",
+    "sessionExpiredMessage": "Editing was stopped because this form was idle for too long. Return to forms to reopen it if you still need to make changes.",
+    "returnToForms": "Return to forms"
   },
   "gcFormsApi": "API",
   "gcFormsPublish": "Publish",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -626,7 +626,10 @@
     "takingOver": "Prise de contrôle...",
     "syncingLatest": "Synchronisation de la plus récente version enregistrée du formulaire...",
     "syncedLatest": "Vous avez maintenant le verrou de modification et la plus récente version enregistrée du formulaire a été chargée.",
-    "takeoverError": "Impossible de prendre le contrôle. Veuillez réessayer."
+    "takeoverError": "Impossible de prendre le contrôle. Veuillez réessayer.",
+    "sessionExpiredTitle": "Votre session de modification a expiré",
+    "sessionExpiredMessage": "La modification a été arrêtée parce que ce formulaire est resté inactif trop longtemps. Retournez à la liste des formulaires pour le rouvrir si vous devez encore apporter des changements.",
+    "returnToForms": "Retourner aux formulaires"
   },
   "gcFormsApi": "API",
   "gcFormsPublish": "Publier",

--- a/lib/appSettings.ts
+++ b/lib/appSettings.ts
@@ -60,6 +60,17 @@ export const getAppSettingAsBoolean = async (internalId: string) => {
   return value === "true";
 };
 
+export const getAppSettingAsNumber = async (internalId: string, fallbackValue?: number) => {
+  const value = await getAppSetting(internalId);
+
+  if (value === null) {
+    return fallbackValue ?? null;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? parsedValue : (fallbackValue ?? null);
+};
+
 export const getFullAppSetting = async (internalId: string) => {
   const { user } = await authorization.canAccessSettings().catch((e) => {
     if (e instanceof AccessControlError) {

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -3,7 +3,10 @@ import { getRedisInstance } from "@lib/integration/redisConnector";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 import { logMessage } from "@lib/logger";
 import { formCache } from "./cache/formCache";
+import { getAppSettingAsNumber } from "./appSettings";
 import {
+  EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
+  EDIT_LOCK_REDIRECT_IDLE_SETTING_ID,
   EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS,
   EDIT_LOCK_TTL_MS,
   MIN_ASSIGNED_USERS_FOR_EDIT_LOCK,
@@ -207,7 +210,22 @@ const buildStatus = (lock: EditLockInfo | null, userId?: string): EditLockStatus
   };
 };
 
-const readMemoryLock = (templateId: string) => {
+const getEditLockIdleTimeoutMs = async () => {
+  return getAppSettingAsNumber(
+    EDIT_LOCK_REDIRECT_IDLE_SETTING_ID,
+    EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS
+  );
+};
+
+const isEditLockIdleExpired = (lock: EditLockInfo, now: Date, idleTimeoutMs: number | null) => {
+  if (idleTimeoutMs === null || !lock.lastActivityAt) {
+    return false;
+  }
+
+  return now.getTime() - lock.lastActivityAt.getTime() >= idleTimeoutMs;
+};
+
+const readMemoryLock = async (templateId: string) => {
   const now = new Date();
   const store = getEditLockStore();
   const lock = store.get(templateId);
@@ -217,7 +235,11 @@ const readMemoryLock = (templateId: string) => {
   }
 
   const normalized = toEditLockInfo(lock);
-  if (isExpired(normalized, now)) {
+  const idleTimeoutMs = await getEditLockIdleTimeoutMs();
+  if (
+    isEditLockHeartbeatExpired(normalized, now) ||
+    isEditLockIdleExpired(normalized, now, idleTimeoutMs)
+  ) {
     store.delete(templateId);
     return null;
   }
@@ -233,8 +255,11 @@ const readRedisLock = async (templateId: string) => {
     return null;
   }
 
-  if (isExpired(lock, new Date())) {
+  const now = new Date();
+  const idleTimeoutMs = await getEditLockIdleTimeoutMs();
+  if (isEditLockHeartbeatExpired(lock, now) || isEditLockIdleExpired(lock, now, idleTimeoutMs)) {
     await redis.del(getEditLockKey(templateId));
+    await publishEditLockEvent(templateId);
     return null;
   }
 
@@ -345,7 +370,9 @@ export const acknowledgeEditLockTakeoverSave = async ({
     return false;
   }
 
-  const currentLock = redisEnabled() ? await readRedisLock(templateId) : readMemoryLock(templateId);
+  const currentLock = redisEnabled()
+    ? await readRedisLock(templateId)
+    : await readMemoryLock(templateId);
   if (
     !currentLock ||
     currentLock.lockedByUserId !== userId ||
@@ -430,7 +457,8 @@ export const waitForEditLockTakeoverSaveAcknowledgement = async ({
   return poll();
 };
 
-const isExpired = (lock: EditLockInfo, now: Date) => lock.expiresAt.getTime() <= now.getTime();
+const isEditLockHeartbeatExpired = (lock: EditLockInfo, now: Date) =>
+  lock.expiresAt.getTime() <= now.getTime();
 
 const toEditLockInfo = (lock: EditLockInfo): Required<EditLockInfo> => ({
   ...lock,
@@ -531,7 +559,7 @@ export const getEditLockStatus = async (
   templateId: string,
   userId?: string
 ): Promise<EditLockStatus> => {
-  const lock = redisEnabled() ? await readRedisLock(templateId) : readMemoryLock(templateId);
+  const lock = redisEnabled() ? await readRedisLock(templateId) : await readMemoryLock(templateId);
   return buildStatus(lock, userId);
 };
 
@@ -629,7 +657,7 @@ export const acquireEditLock = async ({
 
   if (existing) {
     const normalized = toEditLockInfo(existing);
-    if (!isExpired(normalized, now) && normalized.lockedByUserId !== userId) {
+    if (!isEditLockHeartbeatExpired(normalized, now) && normalized.lockedByUserId !== userId) {
       logEditLockAction({
         action: "acquire",
         templateId,
@@ -672,7 +700,9 @@ export const takeoverEditLock = async ({
   const expiresAt = new Date(now.getTime() + EDIT_LOCK_TTL_MS);
   const presenceSnapshot = getPresenceSnapshot(presence);
   const actor = describeActionActor({ userId, userEmail });
-  const existing = redisEnabled() ? await readRedisLock(templateId) : readMemoryLock(templateId);
+  const existing = redisEnabled()
+    ? await readRedisLock(templateId)
+    : await readMemoryLock(templateId);
   const updated: EditLockInfo = {
     templateId,
     lockedByUserId: userId,
@@ -727,6 +757,7 @@ export const heartbeatEditLock = async ({
   const now = new Date();
   const expiresAt = new Date(now.getTime() + EDIT_LOCK_TTL_MS);
   const presenceSnapshot = getPresenceSnapshot(presence);
+  const idleTimeoutMs = await getEditLockIdleTimeoutMs();
 
   if (redisEnabled()) {
     return withRedisWatch(templateId, async (current, redis) => {
@@ -734,6 +765,19 @@ export const heartbeatEditLock = async ({
         const unlocked = buildStatus(null, userId);
         const execResult = await redis.multi().exec();
         return execResult ? unlocked : null;
+      }
+
+      if (
+        isEditLockHeartbeatExpired(current, now) ||
+        isEditLockIdleExpired(current, now, idleTimeoutMs)
+      ) {
+        const execResult = await redis.multi().del(getEditLockKey(templateId)).exec();
+        if (!execResult) {
+          return null;
+        }
+
+        await publishEditLockEvent(templateId);
+        return buildStatus(null, userId);
       }
 
       if (current.lockedByUserId !== userId || (sessionId && current.sessionId !== sessionId)) {
@@ -772,6 +816,14 @@ export const heartbeatEditLock = async ({
   }
 
   const normalized = toEditLockInfo(existing);
+  if (
+    isEditLockHeartbeatExpired(normalized, now) ||
+    isEditLockIdleExpired(normalized, now, idleTimeoutMs)
+  ) {
+    store.delete(templateId);
+    return buildStatus(null, userId);
+  }
+
   if (normalized.lockedByUserId !== userId || (sessionId && normalized.sessionId !== sessionId)) {
     return buildStatus(normalized, userId);
   }

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -12,6 +12,10 @@ export const EDIT_LOCK_DETECT_PRESENCE = true;
 // reducing redundant requests when multiple tabs have the same form open.
 export const EDIT_LOCK_ACTIVE_TAB_ENABLED = true;
 
+export const EDIT_LOCK_REDIRECT_IDLE_SETTING_ID = "editLockRedirectIdleMs";
+// Fall back to 30 minutes when the admin setting is missing so idle edit cleanup stays on by default.
+export const EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS = 1_800_000;
+
 // Refresh the owner's lock heartbeat once per minute to reduce network noise; the longer TTL above
 // provides enough slack that missing a single heartbeat should not immediately drop the lock.
 export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 60_000;

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { FormRecord } from "@lib/types";
@@ -13,6 +14,7 @@ import {
   EDIT_LOCK_DETECT_PRESENCE,
   EDIT_LOCK_ACTIVE_TAB_ENABLED,
   EDIT_LOCK_HEARTBEAT_INTERVAL_MS,
+  EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
   EDIT_LOCK_STATUS_POLL_INTERVAL_MS,
 } from "@lib/formBuilderEditLockPresence";
 
@@ -43,13 +45,17 @@ export const useEditLock = ({
   enabled,
   presenceEnabled,
   sessionId,
+  idleTimeoutMs = EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
 }: {
   formId: string;
   enabled: boolean;
   presenceEnabled: boolean;
   sessionId: string;
+  idleTimeoutMs?: number;
 }) => {
   "use memo";
+  const router = useRouter();
+  const pathname = usePathname();
   const { status } = useSession();
   const setEditLock = useTemplateStore((s) => s.setEditLock);
   const setIsLockedByOther = useTemplateStore((s) => s.setIsLockedByOther);
@@ -66,28 +72,69 @@ export const useEditLock = ({
   const updatedAtRef = useRef(updatedAt);
   const takeoverSaveRef = useRef<Promise<void> | null>(null);
   const suppressReleaseRef = useRef(false);
+  const idleExpiryHandledRef = useRef(false);
+  const [hasEditExpired, setHasEditExpired] = useState(false);
+  const [isOwner, setIsOwner] = useState(false);
+  const language = pathname?.startsWith("/fr") ? "fr" : "en";
+  const formsPath = `/${language}/forms`;
 
   const { isActiveTab } = useActiveTab({
     enabled: enabled && EDIT_LOCK_ACTIVE_TAB_ENABLED && status === "authenticated",
     coordinationKey: formId,
   });
 
+  const handleIdleTimeout = useCallback(async () => {
+    if (idleExpiryHandledRef.current) {
+      return;
+    }
+
+    idleExpiryHandledRef.current = true;
+    cbRef.current.clearTimers();
+    cbRef.current.clearEvents();
+
+    try {
+      await saveDraftIfNeeded();
+    } catch {
+      // no-op: the expired-session fallback should still be shown even if autosave fails
+    }
+
+    if (isOwnerRef.current && !suppressReleaseRef.current) {
+      suppressReleaseRef.current = true;
+
+      try {
+        await cbRef.current.postAction("release");
+      } catch {
+        suppressReleaseRef.current = false;
+      }
+    }
+
+    setHasEditExpired(true);
+  }, [saveDraftIfNeeded]);
+
+  const returnToForms = useCallback(() => {
+    router.push(formsPath);
+  }, [formsPath, router]);
+
   const { getActivitySnapshot } = useEditLockPresence({
     enabled: presenceEnabled && EDIT_LOCK_DETECT_PRESENCE && enabled && status === "authenticated",
     coordinationKey: formId,
     activeTabEnabled: EDIT_LOCK_ACTIVE_TAB_ENABLED,
+    idleTimeoutMs,
+    onIdleTimeout: isOwner ? handleIdleTimeout : undefined,
   });
 
   const clearLockState = useCallback(() => {
     setIsLockedByOther(false);
     setEditLock(null);
     isOwnerRef.current = false;
+    setIsOwner(false);
   }, [setEditLock, setIsLockedByOther]);
 
   const setTakeoverFallbackState = useCallback(() => {
     setIsLockedByOther(true);
     setEditLock(null);
     isOwnerRef.current = false;
+    setIsOwner(false);
   }, [setEditLock, setIsLockedByOther]);
 
   const updateStore = useCallback(
@@ -111,6 +158,7 @@ export const useEditLock = ({
           : null
       );
       isOwnerRef.current = status.isOwner;
+      setIsOwner(status.isOwner);
       if (status.isOwner) {
         suppressReleaseRef.current = false;
       }
@@ -430,6 +478,7 @@ export const useEditLock = ({
 
     return () => {
       cancelled = true;
+      idleExpiryHandledRef.current = false;
       cbRef.current.clearTimers();
       if (isOwnerRef.current && !suppressReleaseRef.current) {
         cbRef.current.postAction("release");
@@ -518,5 +567,5 @@ export const useEditLock = ({
     startTimers(statusResult);
   }, [postAction, refreshForm, startTimers, updateStore, updatedAt]);
 
-  return { takeover };
+  return { hasEditExpired, returnToForms, takeover };
 };

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -82,6 +82,10 @@ export const useEditLock = ({
     enabled: enabled && EDIT_LOCK_ACTIVE_TAB_ENABLED && status === "authenticated",
     coordinationKey: formId,
   });
+  // With active-tab coordination on, background tabs should release the SSE stream.
+  const isEventStreamAllowedInCurrentTab = EDIT_LOCK_ACTIVE_TAB_ENABLED ? isActiveTab : true;
+  const shouldKeepEventStreamOpen =
+    enabled && status === "authenticated" && !hasEditExpired && isEventStreamAllowedInCurrentTab;
 
   const handleIdleTimeout = useCallback(async () => {
     if (idleExpiryHandledRef.current) {
@@ -487,16 +491,14 @@ export const useEditLock = ({
   }, [enabled, status]);
 
   // Manage the shared SSE EventSource connection for edit-lock updates.
-  // If an SSE event is missed, the next owner heartbeat or non-owner status poll
-  // reconciles state from the server, and EventSource will retry on transient drops.
+  // If active-tab coordination is enabled, only the active tab keeps the SSE
+  // stream open. Owners still reconcile via heartbeat and non-owners via polling.
   useEffect(() => {
-    if (!enabled || status !== "authenticated") {
+    if (!shouldKeepEventStreamOpen) {
       cbRef.current.clearEvents();
       return;
     }
 
-    // Owners and non-owners both keep the SSE stream open so either side can react
-    // immediately to lock changes without waiting for the next interval tick.
     const eventSource = new EventSource(buildEditLockEventsUrl(formId));
     eventSourceRef.current = eventSource;
 
@@ -552,7 +554,7 @@ export const useEditLock = ({
         eventSourceRef.current = null;
       }
     };
-  }, [enabled, formId, status]);
+  }, [formId, shouldKeepEventStreamOpen]);
 
   const takeover = useCallback(async () => {
     const previousUpdatedAt = updatedAt;

--- a/lib/hooks/form-builder/useEditLockPresence.tsx
+++ b/lib/hooks/form-builder/useEditLockPresence.tsx
@@ -6,6 +6,7 @@ import {
   CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS,
   CLIENT_SIDE_EDIT_LOCK_AWAY_MS,
   CLIENT_SIDE_EDIT_LOCK_IDLE_MS,
+  EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
 } from "@lib/formBuilderEditLockPresence";
 import { type EditLockPresenceStatus, type EditLockVisibilityState } from "@lib/editLockStatus";
 
@@ -37,10 +38,14 @@ export const useEditLockPresence = ({
   enabled,
   coordinationKey,
   activeTabEnabled = false,
+  idleTimeoutMs = EDIT_LOCK_REDIRECT_IDLE_FALLBACK_MS,
+  onIdleTimeout,
 }: {
   enabled: boolean;
   coordinationKey: string;
   activeTabEnabled?: boolean;
+  idleTimeoutMs?: number;
+  onIdleTimeout?: () => void;
 }) => {
   "use memo";
   const { isActiveTab } = useActiveTab({
@@ -48,9 +53,75 @@ export const useEditLockPresence = ({
     coordinationKey,
   });
   const lastActivityAtRef = useRef(0);
+  const idleTimeoutRef = useRef<number | null>(null);
+  const idleTimeoutTriggeredRef = useRef(false);
   const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
 
   const isTrackingPresence = enabled && (!activeTabEnabled || isActiveTab);
+
+  const clearIdleTimeout = useCallback(() => {
+    if (idleTimeoutRef.current) {
+      window.clearTimeout(idleTimeoutRef.current);
+      idleTimeoutRef.current = null;
+    }
+  }, []);
+
+  const getIdleMs = useCallback(() => {
+    const lastActivityAt = lastActivityAtRef.current || Date.now();
+    return Date.now() - lastActivityAt;
+  }, []);
+
+  const checkIdleTimeout = useCallback(() => {
+    if (!onIdleTimeout || idleTimeoutTriggeredRef.current || getIdleMs() < idleTimeoutMs) {
+      return false;
+    }
+
+    idleTimeoutTriggeredRef.current = true;
+    clearIdleTimeout();
+    onIdleTimeout();
+    return true;
+  }, [clearIdleTimeout, getIdleMs, idleTimeoutMs, onIdleTimeout]);
+
+  const scheduleIdleTimeout = useCallback(
+    function scheduleIdleTimeout() {
+      clearIdleTimeout();
+
+      if (!enabled || !onIdleTimeout || idleTimeoutTriggeredRef.current) {
+        return;
+      }
+
+      const remainingMs = Math.max(idleTimeoutMs - getIdleMs(), 0);
+      idleTimeoutRef.current = window.setTimeout(() => {
+        if (!checkIdleTimeout()) {
+          scheduleIdleTimeout();
+        }
+      }, remainingMs);
+    },
+    [checkIdleTimeout, clearIdleTimeout, enabled, getIdleMs, idleTimeoutMs, onIdleTimeout]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      clearIdleTimeout();
+      return;
+    }
+
+    if (!lastActivityAtRef.current) {
+      lastActivityAtRef.current = Date.now();
+    }
+
+    if (checkIdleTimeout()) {
+      return () => {
+        clearIdleTimeout();
+      };
+    }
+
+    scheduleIdleTimeout();
+
+    return () => {
+      clearIdleTimeout();
+    };
+  }, [checkIdleTimeout, clearIdleTimeout, enabled, scheduleIdleTimeout]);
 
   const markActivity = useCallback((force = false) => {
     const nextVisibilityState = getVisibilityState();
@@ -66,6 +137,7 @@ export const useEditLockPresence = ({
 
     lastActivityAtRef.current = now;
     visibilityStateRef.current = nextVisibilityState;
+    idleTimeoutTriggeredRef.current = false;
   }, []);
 
   const getActivitySnapshot = useCallback((): EditLockActivitySnapshot | undefined => {
@@ -92,16 +164,36 @@ export const useEditLockPresence = ({
 
     const handleVisibilityChange = () => {
       visibilityStateRef.current = getVisibilityState();
+
       if (visibilityStateRef.current === "visible") {
+        if (checkIdleTimeout()) {
+          return;
+        }
+
         markActivity(true);
       }
+
+      scheduleIdleTimeout();
     };
 
     const handleActivity = () => {
+      if (checkIdleTimeout()) {
+        return;
+      }
+
       markActivity();
+      scheduleIdleTimeout();
     };
 
-    markActivity(true);
+    if (!lastActivityAtRef.current) {
+      markActivity(true);
+    } else if (checkIdleTimeout()) {
+      return () => {
+        clearIdleTimeout();
+      };
+    }
+
+    scheduleIdleTimeout();
 
     window.addEventListener("pointerdown", handleActivity, { passive: true });
     window.addEventListener("keydown", handleActivity);
@@ -115,8 +207,9 @@ export const useEditLockPresence = ({
       window.removeEventListener("focus", handleActivity);
       window.removeEventListener("input", handleActivity);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearIdleTimeout();
     };
-  }, [isTrackingPresence, markActivity]);
+  }, [checkIdleTimeout, clearIdleTimeout, isTrackingPresence, markActivity, scheduleIdleTimeout]);
 
-  return { getActivitySnapshot, isActiveTab };
+  return { getActivitySnapshot };
 };

--- a/lib/tests/appSettings.test.ts
+++ b/lib/tests/appSettings.test.ts
@@ -2,6 +2,7 @@ import { prismaMock } from "@jestUtils";
 import {
   getAppSetting,
   getAllAppSettings,
+  getAppSettingAsNumber,
   createAppSetting,
   updateAppSetting,
   deleteAppSetting,
@@ -36,6 +37,14 @@ jest.mock("@lib/cache/settingCache", () => ({
 }));
 
 const userId = "1";
+const numericSettingRecord = {
+  internalId: "editLockRedirectIdleMs",
+  nameEn: "Edit lock idle redirect timeout (ms)",
+  nameFr: "Délai de redirection d'inactivité du verrou d'édition (ms)",
+  descriptionEn: "setting description",
+  descriptionFr: "description du paramètre",
+  value: "1800000",
+};
 
 describe("Application Settings", () => {
   beforeEach(() => {
@@ -59,6 +68,23 @@ describe("Application Settings", () => {
 
     expect(mockedLogEvent).not.toHaveBeenCalled();
     expect(setting).toEqual("123");
+  });
+  test("Get an application setting as number", async () => {
+    prismaMock.setting.findUnique.mockResolvedValue(numericSettingRecord);
+
+    const setting = await getAppSettingAsNumber("editLockRedirectIdleMs");
+
+    expect(setting).toEqual(1800000);
+  });
+  test("Get an application setting as number falls back when invalid", async () => {
+    prismaMock.setting.findUnique.mockResolvedValue({
+      ...numericSettingRecord,
+      value: "not-a-number",
+    });
+
+    const setting = await getAppSettingAsNumber("editLockRedirectIdleMs", 1800000);
+
+    expect(setting).toEqual(1800000);
   });
   test("Get all application settings", async () => {
     prismaMock.setting.findMany.mockResolvedValue([

--- a/lib/tests/appSettings.test.ts
+++ b/lib/tests/appSettings.test.ts
@@ -22,7 +22,7 @@ jest.mock("@lib/auditLogs", () => ({
   },
   get AuditLogAccessDeniedDetails() {
     return jest.requireActual("@lib/auditLogs").AuditLogAccessDeniedDetails;
-  }
+  },
 }));
 
 import { mockAuthorizationFail, mockAuthorizationPass } from "__utils__/authorization";
@@ -154,8 +154,11 @@ describe("Application Settings", () => {
         userId,
         { id: "testSetting", type: "Setting" },
         "CreateSetting",
-        'Created setting with ${settingData}',
-        { settingData: '{"internalId":"testSetting","nameEn":"Test Setting","nameFr":"[FR] Test Setting","value":"123"}' }
+        "Created setting with ${settingData}",
+        {
+          settingData:
+            '{"internalId":"testSetting","nameEn":"Test Setting","nameFr":"[FR] Test Setting","value":"123"}',
+        }
       );
       expect(newSetting).toMatchObject({
         internalId: "testSetting",
@@ -214,8 +217,11 @@ describe("Application Settings", () => {
         userId,
         { id: "testSetting", type: "Setting" },
         "ChangeSetting",
-        'Updated setting with ${settingData}',
-        { settingData: '{"internalId":"testSetting","nameEn":"Test Setting","nameFr":"[FR] Test Setting","value":"123"}' }
+        "Updated setting with ${settingData}",
+        {
+          settingData:
+            '{"internalId":"testSetting","nameEn":"Test Setting","nameFr":"[FR] Test Setting","value":"123"}',
+        }
       );
       expect(newSetting).toMatchObject({
         internalId: "testSetting",
@@ -273,7 +279,7 @@ describe("Application Settings", () => {
         userId,
         { id: "testSetting", type: "Setting" },
         "DeleteSetting",
-        'Deleted setting with internalId: ${internalId}',
+        "Deleted setting with internalId: ${internalId}",
         { internalId: "testSetting" }
       );
     });

--- a/lib/tests/editLocks.vitest.ts
+++ b/lib/tests/editLocks.vitest.ts
@@ -17,6 +17,12 @@ vi.mock("@lib/cache/formCache", () => ({
   },
 }));
 
+vi.mock("@lib/appSettings", () => ({
+  getAppSettingAsNumber: vi.fn(async (_internalId: string, fallbackValue?: number) => {
+    return fallbackValue ?? null;
+  }),
+}));
+
 import {
   acknowledgeEditLockTakeoverSave,
   acquireEditLock,
@@ -30,6 +36,7 @@ import {
   waitForEditLockTakeoverSaveAcknowledgement,
 } from "@lib/editLocks";
 import { formCache } from "@lib/cache/formCache";
+import { getAppSettingAsNumber } from "@lib/appSettings";
 import { prisma } from "@gcforms/database";
 import { getRedisInstance } from "@lib/integration/redisConnector";
 import type { FormProperties, PublicFormRecord } from "@lib/types";
@@ -158,6 +165,79 @@ describe("editLocks with redis", () => {
     expect(heartbeatStatus.lock?.lastActivityAt).toEqual(activityAt);
     expect(heartbeatStatus.lock?.visibilityState).toBe("hidden");
     expect(heartbeatStatus.lock?.presenceStatus).toBe("away");
+  });
+
+  it("clears a stale lock from status reads when last activity exceeds the configured idle timeout", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:00.000Z"));
+    vi.mocked(getAppSettingAsNumber).mockResolvedValueOnce(10_000);
+
+    await acquireEditLock({
+      templateId: "form-stale-status",
+      userId: "user-1",
+      userName: "User One",
+      sessionId: "session-1",
+      presence: {
+        lastActivityAt: new Date("2026-03-17T12:00:00.000Z"),
+        visibilityState: "visible",
+        presenceStatus: "active",
+      },
+    });
+
+    vi.setSystemTime(new Date("2026-03-17T12:00:11.000Z"));
+    vi.mocked(getAppSettingAsNumber).mockResolvedValueOnce(10_000);
+
+    const status = await getEditLockStatus("form-stale-status", "user-2");
+
+    expect(status).toEqual({
+      locked: false,
+      lockedByOther: false,
+      isOwner: false,
+      lock: null,
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("clears a stale owner lock on heartbeat when the client resumes after the idle deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:00.000Z"));
+    vi.mocked(getAppSettingAsNumber).mockResolvedValueOnce(10_000);
+
+    await acquireEditLock({
+      templateId: "form-stale-heartbeat",
+      userId: "user-1",
+      userName: "User One",
+      sessionId: "session-1",
+      presence: {
+        lastActivityAt: new Date("2026-03-17T12:00:00.000Z"),
+        visibilityState: "visible",
+        presenceStatus: "active",
+      },
+    });
+
+    vi.setSystemTime(new Date("2026-03-17T12:00:11.000Z"));
+    vi.mocked(getAppSettingAsNumber).mockResolvedValueOnce(10_000);
+
+    const heartbeatStatus = await heartbeatEditLock({
+      templateId: "form-stale-heartbeat",
+      userId: "user-1",
+      sessionId: "session-1",
+      presence: {
+        lastActivityAt: new Date("2026-03-17T12:00:00.000Z"),
+        visibilityState: "hidden",
+        presenceStatus: "away",
+      },
+    });
+
+    expect(heartbeatStatus).toEqual({
+      locked: false,
+      lockedByOther: false,
+      isOwner: false,
+      lock: null,
+    });
+
+    vi.useRealTimers();
   });
 
   it("waits for the current editor to acknowledge takeover save completion", async () => {

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-04-29
+
+### Changed
+
+- Added edit lock idle timeout setting
+
 ## [1.0.2] - 2025-04-28
 
 ### Changed

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "type": "module",

--- a/packages/database/src/fixtures/settings.ts
+++ b/packages/database/src/fixtures/settings.ts
@@ -76,6 +76,17 @@ const editLockPresenceEnabled: Setting = {
   value: "false",
 };
 
+const editLockRedirectIdleMs: Setting = {
+  internalId: "editLockRedirectIdleMs",
+  nameEn: "Edit lock idle redirect timeout (ms)",
+  nameFr: "Délai de redirection d'inactivité du verrou d'édition (ms)",
+  descriptionEn:
+    "How long the form builder can stay idle before the tab releases the edit lock and returns to the forms list.",
+  descriptionFr:
+    "Durée pendant laquelle le générateur de formulaires peut rester inactif avant que l'onglet libère le verrou d'édition et retourne à la liste des formulaires.",
+  value: "1800000",
+};
+
 const allSettings = [
   brandingRequestFormSetting,
   nagwarePhaseEncouraged,
@@ -84,6 +95,7 @@ const allSettings = [
   nagwarePhaseEscalated,
   responseDownloadLimit,
   editLockPresenceEnabled,
+  editLockRedirectIdleMs,
 ];
 
 export default {

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -36,6 +36,7 @@ vi.mock("next-auth/react", () => ({
 
 vi.mock("next/navigation", () => ({
   usePathname: () => pathname,
+  useParams: () => ({ locale: "en" }),
   useRouter: () => ({
     push: pushMock,
   }),

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -3,7 +3,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "../testUtils";
 import { setupFonts } from "../../helpers/setupFonts";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
-import { EDIT_LOCK_HEARTBEAT_INTERVAL_MS, EDIT_LOCK_STATUS_POLL_INTERVAL_MS } from "@lib/formBuilderEditLockPresence";
+import {
+  EDIT_LOCK_HEARTBEAT_INTERVAL_MS,
+  EDIT_LOCK_STATUS_POLL_INTERVAL_MS,
+} from "@lib/formBuilderEditLockPresence";
 
 const pushMock = vi.fn();
 let pathname = "/en/form-builder/test-form-id";

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.vitest.tsx
@@ -3,10 +3,11 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "../testUtils";
 import { setupFonts } from "../../helpers/setupFonts";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
-import {
-  EDIT_LOCK_HEARTBEAT_INTERVAL_MS,
-  EDIT_LOCK_STATUS_POLL_INTERVAL_MS,
-} from "@lib/formBuilderEditLockPresence";
+import { EDIT_LOCK_HEARTBEAT_INTERVAL_MS, EDIT_LOCK_STATUS_POLL_INTERVAL_MS } from "@lib/formBuilderEditLockPresence";
+
+const pushMock = vi.fn();
+let pathname = "/en/form-builder/test-form-id";
+const idleTimeoutMs = 1_800_000;
 
 const saveDraft = vi.fn(async () => ({ status: "saved" as const }));
 const saveDraftIfNeeded = vi.fn(async () => ({ status: "skipped" as const }));
@@ -28,6 +29,13 @@ vi.mock("next-auth/react", () => ({
   getCsrfToken: vi.fn(),
   getProviders: vi.fn(),
   getSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({
+    push: pushMock,
+  }),
 }));
 
 // Expose the template-context side effects so tests can assert save and refresh behavior.
@@ -192,21 +200,24 @@ function EditLockHarness({
   onTakeoverReady,
   onChangeKey,
   onLockStateChange,
+  onEditExpiredChange,
   presenceEnabled = false,
 }: {
   onTakeoverReady?: (takeover: () => Promise<void>) => void;
   onChangeKey?: (changeKey: string) => void;
   onLockStateChange?: (state: { isLockedByOther: boolean; hasEditLock: boolean }) => void;
+  onEditExpiredChange?: (hasEditExpired: boolean) => void;
   presenceEnabled?: boolean;
 }) {
   const changeKey = useTemplateStore((s) => s.changeKey);
   const isLockedByOther = useTemplateStore((s) => s.isLockedByOther);
   const editLock = useTemplateStore((s) => s.editLock);
-  const { takeover } = useEditLock({
+  const { takeover, hasEditExpired } = useEditLock({
     formId: "test-form-id",
     enabled: true,
     presenceEnabled,
     sessionId: "session-1",
+    idleTimeoutMs,
   });
 
   useEffect(() => {
@@ -223,6 +234,10 @@ function EditLockHarness({
       hasEditLock: editLock !== null,
     });
   }, [editLock, isLockedByOther, onLockStateChange]);
+
+  useEffect(() => {
+    onEditExpiredChange?.(hasEditExpired);
+  }, [hasEditExpired, onEditExpiredChange]);
 
   useEffect(() => {
     return () => {
@@ -242,6 +257,8 @@ describe("useEditLock", () => {
     vi.clearAllMocks();
     MockEventSource.reset();
     MockBroadcastChannel.reset();
+    pushMock.mockReset();
+    pathname = "/en/form-builder/test-form-id";
     templateIsDirty.current = false;
     templateUpdatedAt = Date.parse("2026-03-31T12:00:00.000Z");
     vi.stubGlobal("EventSource", MockEventSource);
@@ -532,6 +549,164 @@ describe("useEditLock", () => {
     // With active-tab coordination enabled, a BroadcastChannel is created
     // for coordination even in background tabs
     expect(MockBroadcastChannel.channels.size).toBe(1);
+  });
+
+  it("marks the editing session expired after the configured idle timeout", async () => {
+    vi.useFakeTimers();
+    const expiredStates: boolean[] = [];
+
+    await render(
+      <EditLockHarness
+        presenceEnabled
+        onEditExpiredChange={(hasEditExpired) => expiredStates.push(hasEditExpired)}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock?requestType=acquire",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    await vi.advanceTimersByTimeAsync(idleTimeoutMs);
+
+    await vi.waitFor(() => {
+      expect(expiredStates.at(-1)).toBe(true);
+    });
+
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(saveDraftIfNeeded).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it("marks an inactive tab session expired after the configured idle timeout so it does not keep idle edit-lock connections open", async () => {
+    vi.useFakeTimers();
+    setDocumentVisibility("hidden");
+    setDocumentFocus(false);
+    const expiredStates: boolean[] = [];
+
+    await render(
+      <EditLockHarness
+        presenceEnabled
+        onEditExpiredChange={(hasEditExpired) => expiredStates.push(hasEditExpired)}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock?requestType=acquire",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    await vi.advanceTimersByTimeAsync(idleTimeoutMs);
+
+    await vi.waitFor(() => {
+      expect(expiredStates.at(-1)).toBe(true);
+    });
+
+    expect(pushMock).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("does not mark a non-owner session expired after the idle timeout", async () => {
+    vi.useFakeTimers();
+    const expiredStates: boolean[] = [];
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      const lockedByOtherStatus = {
+        locked: true,
+        lockedByOther: true,
+        isOwner: false,
+        lock: {
+          ...ownerLockStatus.lock,
+          lockedByUserId: "user-2",
+          lockedByName: "User Two",
+          lockedByEmail: "user.two@example.com",
+          sessionId: "session-2",
+        },
+      };
+
+      if (isEditLockRequest(input) && init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => lockedByOtherStatus,
+        } as Response;
+      }
+
+      if (isEditLockRequest(input) && init?.method === "GET") {
+        return {
+          ok: true,
+          json: async () => lockedByOtherStatus,
+        } as Response;
+      }
+
+      if (isTemplateRequest(input)) {
+        return {
+          ok: true,
+          json: async () => ({ form: { elements: [] }, updatedAt: new Date().toISOString() }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(
+      <EditLockHarness
+        presenceEnabled
+        onEditExpiredChange={(hasEditExpired) => expiredStates.push(hasEditExpired)}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock?requestType=acquire",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    await vi.advanceTimersByTimeAsync(idleTimeoutMs);
+
+    expect(expiredStates.at(-1)).not.toBe(true);
+    expect(pushMock).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("marks the session expired on focus return when the browser delayed the background idle timer", async () => {
+    vi.useFakeTimers();
+    const expiredStates: boolean[] = [];
+
+    await render(
+      <EditLockHarness
+        presenceEnabled
+        onEditExpiredChange={(hasEditExpired) => expiredStates.push(hasEditExpired)}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock?requestType=acquire",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    setDocumentFocus(false);
+    vi.setSystemTime(Date.now() + idleTimeoutMs + 1_000);
+    setDocumentFocus(true);
+    window.dispatchEvent(new Event("focus"));
+
+    await vi.waitFor(() => {
+      expect(expiredStates.at(-1)).toBe(true);
+    });
+
+    expect(pushMock).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 
   it("does not include presence activity in edit-lock requests", async () => {


### PR DESCRIPTION
# Summary | Résumé


<img width="986" height="460" alt="Screenshot 2026-04-29 at 8 24 00 AM" src="https://github.com/user-attachments/assets/b555ff92-4aad-496f-ac1f-664ff094214f" />

<hr>



This PR adds an adjustable idle timeout for edit-lock sessions

After the configured idle period:

- the tab stops polling,
- the owner tab closes its edit-lock SSE connection,
- the current owner attempts a final autosave,
- the lock is released,
- the editor is blocked with an expired-session message and a button to return to `/<lang>/forms`.

## Why

The main goal is to stop idle edit tabs from keeping edit-lock resources open when the user is no longer meaningfully editing.