### PR TITLE
chore: add edit lock ms setting

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-<!-- markdownlint-disable MD024 -->
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,19 +1,27 @@
 # Changelog
 
+<!-- markdownlint-disable MD024 -->
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-04-29
+
+### Added
+
+- Added edit lock idle timeout setting
+
 ## [1.0.2] - 2025-04-28
 
-### Changed
+### Changed
 
 - Specify connection URL when launching Prisma Studio
 
 ## [1.0.1] - 2025-04-27
 
-### Changed
+### Changed
 
 - Tweaked scripts in package.json
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "type": "module",

--- a/packages/database/src/fixtures/settings.ts
+++ b/packages/database/src/fixtures/settings.ts
@@ -80,10 +80,9 @@ const editLockRedirectIdleMs: Setting = {
   internalId: "editLockRedirectIdleMs",
   nameEn: "Edit lock idle redirect timeout (ms)",
   nameFr: "Délai de redirection d'inactivité du verrou d'édition (ms)",
-  descriptionEn:
-    "How long the form builder can stay idle before the tab releases the edit lock and returns to the forms list.",
+  descriptionEn: "How long the form builder can stay idle before becoming inactive.",
   descriptionFr:
-    "Durée pendant laquelle le générateur de formulaires peut rester inactif avant que l'onglet libère le verrou d'édition et retourne à la liste des formulaires.",
+    "Durée pendant laquelle le générateur de formulaires peut rester inactif avant de devenir inactif.",
   value: "1800000",
 };
 

--- a/packages/database/src/fixtures/settings.ts
+++ b/packages/database/src/fixtures/settings.ts
@@ -76,6 +76,17 @@ const editLockPresenceEnabled: Setting = {
   value: "false",
 };
 
+const editLockRedirectIdleMs: Setting = {
+  internalId: "editLockRedirectIdleMs",
+  nameEn: "Edit lock idle redirect timeout (ms)",
+  nameFr: "Délai de redirection d'inactivité du verrou d'édition (ms)",
+  descriptionEn:
+    "How long the form builder can stay idle before the tab releases the edit lock and returns to the forms list.",
+  descriptionFr:
+    "Durée pendant laquelle le générateur de formulaires peut rester inactif avant que l'onglet libère le verrou d'édition et retourne à la liste des formulaires.",
+  value: "1800000",
+};
+
 const allSettings = [
   brandingRequestFormSetting,
   nagwarePhaseEncouraged,
@@ -84,6 +95,7 @@ const allSettings = [
   nagwarePhaseEscalated,
   responseDownloadLimit,
   editLockPresenceEnabled,
+  editLockRedirectIdleMs,
 ];
 
 export default {


### PR DESCRIPTION
# Summary | Résumé

Adds a timeout in `ms` for the edit lock setting