### PR TITLE
chore: Add Standards Council of Canada to allowed email domains

### DIFF
--- a/lib/tests/validation/validation.test.js
+++ b/lib/tests/validation/validation.test.js
@@ -452,6 +452,8 @@ describe("Gov Email domain validator", () => {
     ["test.hi+example-1@cds-snc.ca", true],
     ["test.with'apostrophe@cds-snc.ca", true],
     ["test@invcanada.ca", true],
+    ["test.test@scc-ccn.ca", true],
+    ["test.test@scc.ca", true],
   ])(`Should return true if email is valid (testing "%s")`, async (email, isValid) => {
     expect(isValidGovEmail(email)).toBe(isValid);
   });

--- a/lib/validation/validation.tsx
+++ b/lib/validation/validation.tsx
@@ -128,7 +128,7 @@ export const setFocusOnErrorMessage = (props: FormikProps<Responses>, errorId: s
  */
 export const isValidGovEmail = (email: string): boolean => {
   const regex =
-    /^([a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+(\+[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]*)?)@((?:[a-zA-Z0-9-.]+\.gc\.ca|cds-snc\.freshdesk\.com)|(canada|cds-snc|elections|rcafinnovation|canadacouncil|nfb|debates-debats|invcanada|gg)\.ca)$/;
+    /^([a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+(\+[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]*)?)@((?:[a-zA-Z0-9-.]+\.gc\.ca|cds-snc\.freshdesk\.com)|(canada|cds-snc|scc-ccn|scc|elections|rcafinnovation|canadacouncil|nfb|debates-debats|invcanada|gg)\.ca)$/;
   return regex.test(email);
 };
 


### PR DESCRIPTION
# Summary | Résumé

Adds Standards Council of Canada to allowed email comains:
- scc-ccn.ca
- scc.ca