### PR TITLE
chore: lock-owner presence handling

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -7,6 +7,7 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { EditLockBanner } from "@formBuilder/components/shared/edit-lock/EditLockBanner";
 import { useTreeRef } from "@formBuilder/components/shared/right-panel/headless-treeview/provider/TreeRefProvider";
 import { EditLockSessionExpiredOverlay } from "./EditLockSessionExpiredOverlay";
+import { useRouter } from "next/navigation";
 
 const isEditPath = (pathname: string | null) => {
   if (!pathname) return false;
@@ -38,9 +39,11 @@ export const EditLockClient = ({
 }) => {
   "use memo";
   const pathname = usePathname();
-  const { currentFormId, isLockedByOther } = useTemplateStore((s) => ({
+  const router = useRouter();
+  const { currentFormId, isLockedByOther, language } = useTemplateStore((s) => ({
     currentFormId: s.id,
     isLockedByOther: s.isLockedByOther,
+    language: s.lang,
   }));
   const activeFormId = currentFormId || formId;
   const enabled =
@@ -73,10 +76,14 @@ export const EditLockClient = ({
 
   const showSessionExpiredOverlay = isOwnerIdleTimeExpired && !isLockedByOther;
 
+  const returnToForms = () => {
+    router.push(`/${language}/forms`);
+  };
+
   return (
     <>
       {showSessionExpiredOverlay && (
-        <EditLockSessionExpiredOverlay onReturnToForms={() => "HELLO TEMP"} />
+        <EditLockSessionExpiredOverlay onReturnToForms={returnToForms} />
       )}
       <EditLockBanner takeover={handleTakeover} getIsActiveTab={getIsActiveTab} />
       {children}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -38,7 +38,10 @@ export const EditLockClient = ({
 }) => {
   "use memo";
   const pathname = usePathname();
-  const currentFormId = useTemplateStore((s) => s.id);
+  const { currentFormId, isLockedByOther } = useTemplateStore((s) => ({
+    currentFormId: s.id,
+    isLockedByOther: s.isLockedByOther,
+  }));
   const activeFormId = currentFormId || formId;
   const enabled =
     lockedEditingEnabled &&
@@ -68,9 +71,11 @@ export const EditLockClient = ({
     return children ? <>{children}</> : null;
   }
 
+  const showSessionExpiredOverlay = isOwnerIdleTimeExpired && !isLockedByOther;
+
   return (
     <>
-      {isOwnerIdleTimeExpired && (
+      {showSessionExpiredOverlay && (
         <EditLockSessionExpiredOverlay onReturnToForms={() => "HELLO TEMP"} />
       )}
       <EditLockBanner takeover={handleTakeover} getIsActiveTab={getIsActiveTab} />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -6,6 +6,7 @@ import { useEditLock } from "@lib/hooks/form-builder/useEditLock";
 import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { EditLockBanner } from "@formBuilder/components/shared/edit-lock/EditLockBanner";
 import { useTreeRef } from "@formBuilder/components/shared/right-panel/headless-treeview/provider/TreeRefProvider";
+import { EditLockSessionExpiredOverlay } from "./EditLockSessionExpiredOverlay";
 
 const isEditPath = (pathname: string | null) => {
   if (!pathname) return false;
@@ -46,7 +47,7 @@ export const EditLockClient = ({
     activeFormId !== "0000";
   const [sessionId] = useState(() => makeSessionId());
 
-  const { takeover, getIsActiveTab } = useEditLock({
+  const { takeover, getIsActiveTab, isOwnerIdleTimeExpired } = useEditLock({
     formId: activeFormId,
     enabled,
     sessionId,
@@ -69,6 +70,9 @@ export const EditLockClient = ({
 
   return (
     <>
+      {isOwnerIdleTimeExpired && (
+        <EditLockSessionExpiredOverlay onReturnToForms={() => "HELLO TEMP"} />
+      )}
       <EditLockBanner takeover={handleTakeover} getIsActiveTab={getIsActiveTab} />
       {children}
     </>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -76,6 +76,8 @@ export const EditLockClient = ({
 
   const showSessionExpiredOverlay = isOwnerIdleTimeExpired && !isLockedByOther;
 
+console.log("isOwnerIdleTimeExpired", isOwnerIdleTimeExpired, "isLockedByOther", isLockedByOther, "showSessionExpiredOverlay", showSessionExpiredOverlay);
+
   const returnToForms = () => {
     router.push(`/${language}/forms`);
   };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -76,8 +76,6 @@ export const EditLockClient = ({
 
   const showSessionExpiredOverlay = isOwnerIdleTimeExpired && !isLockedByOther;
 
-console.log("isOwnerIdleTimeExpired", isOwnerIdleTimeExpired, "isLockedByOther", isLockedByOther, "showSessionExpiredOverlay", showSessionExpiredOverlay);
-
   const returnToForms = () => {
     router.push(`/${language}/forms`);
   };

--- a/app/api/templates/[formID]/edit-lock/events/route.ts
+++ b/app/api/templates/[formID]/edit-lock/events/route.ts
@@ -7,9 +7,20 @@ import {
   registerActiveEditLockStream,
   subscribeToSharedEditLockEvents,
 } from "@lib/editLockEventStreams";
+import { logMessage } from "@lib/logger";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 
 export const dynamic = "force-dynamic";
+
+const shouldDebugEditLockSse = true;
+
+const debugEditLockSse = (message: string, metadata: Record<string, unknown>) => {
+  if (!shouldDebugEditLockSse) {
+    return;
+  }
+
+  logMessage.debug({ message, ...metadata });
+};
 
 export const GET = middleware([sessionExists()], async (_req, props) => {
   const { session } = props as WithRequired<MiddlewareProps, "session">;
@@ -30,12 +41,19 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
   }
 
   const encoder = new TextEncoder();
+  const streamDebugContext = {
+    formID,
+    userId: session.user.id,
+  };
+  let closeStream: ((reason: string) => Promise<void>) | null = null;
 
   const stream = new ReadableStream({
     start(controller) {
       let closed = false;
       let unsubscribe: (() => void | Promise<void>) | null = null;
       let unregisterStream: (() => void) | null = null;
+
+      debugEditLockSse("edit-lock-sse-open", streamDebugContext);
 
       const sendStatus = async () => {
         if (closed) {
@@ -73,12 +91,16 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
         }
       }, 25000);
 
-      const close = async () => {
+      const close = async (reason: string) => {
         if (closed) {
           return;
         }
 
         closed = true;
+        debugEditLockSse("edit-lock-sse-close", {
+          ...streamDebugContext,
+          reason,
+        });
         clearInterval(keepAlive);
         unregisterStream?.();
 
@@ -93,7 +115,11 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
         }
       };
 
-      unregisterStream = registerActiveEditLockStream(session.user.id, formID, close);
+      closeStream = close;
+
+      unregisterStream = registerActiveEditLockStream(session.user.id, formID, () =>
+        close("replaced-by-newer-stream")
+      );
 
       void (async () => {
         try {
@@ -106,7 +132,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
 
           unsubscribe = unsubscribeEvents;
         } catch {
-          void close();
+          void close("subscribe-failed");
         }
       })();
 
@@ -115,8 +141,11 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
       });
 
       _req.signal.addEventListener("abort", () => {
-        void close();
+        void close("request-aborted");
       });
+    },
+    cancel() {
+      return closeStream?.("stream-cancelled");
     },
   });
 

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -7,7 +7,7 @@ export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
 
 // Refresh the owner's lock heartbeat once per minute to reduce network noise; the longer TTL above
 // provides enough slack that missing a single heartbeat should not immediately drop the lock.
-export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 30_000; // TEMP 60_000;
+export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 60_000;
 
 // Non-owners check lock status on the same cadence so they can notice ownership changes without
 // spamming the server. This can diverge from the owner heartbeat interval later if needed.
@@ -36,4 +36,4 @@ export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
 
 // Kick the current editor out of edit mode and release their lock after this long without activity.
 // This is intentionally much longer than the "away" threshold so brief distractions don't eject users.
-export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 2 * 60_000; // TEMP  was 1_800_000; // 30 minutes
+export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 1_800_000; // 30 minutes

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -7,7 +7,7 @@ export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
 
 // Refresh the owner's lock heartbeat once per minute to reduce network noise; the longer TTL above
 // provides enough slack that missing a single heartbeat should not immediately drop the lock.
-export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 60_000;
+export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 5_000; // TEMP 60_000;
 
 // Non-owners check lock status on the same cadence so they can notice ownership changes without
 // spamming the server. This can diverge from the owner heartbeat interval later if needed.
@@ -36,4 +36,4 @@ export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
 
 // Kick the current editor out of edit mode and release their lock after this long without activity.
 // This is intentionally much longer than the "away" threshold so brief distractions don't eject users.
-export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 30_000; // TEMP  was 1_800_000; // 30 minutes
+export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 10_000; // TEMP  was 1_800_000; // 30 minutes

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -7,7 +7,7 @@ export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
 
 // Refresh the owner's lock heartbeat once per minute to reduce network noise; the longer TTL above
 // provides enough slack that missing a single heartbeat should not immediately drop the lock.
-export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 60_000; // TEMP 60_000;
+export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 30_000; // TEMP 60_000;
 
 // Non-owners check lock status on the same cadence so they can notice ownership changes without
 // spamming the server. This can diverge from the owner heartbeat interval later if needed.
@@ -36,4 +36,4 @@ export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
 
 // Kick the current editor out of edit mode and release their lock after this long without activity.
 // This is intentionally much longer than the "away" threshold so brief distractions don't eject users.
-export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 10_000; // TEMP  was 1_800_000; // 30 minutes
+export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 2 * 60_000; // TEMP  was 1_800_000; // 30 minutes

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -33,3 +33,7 @@ export const CLIENT_SIDE_EDIT_LOCK_TIME_TICK_MS = 5_000;
 // This must be generous enough for Lambda / cold-start environments where the full
 // SSE → saveDraft → ack round-trip can take several seconds.
 export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
+
+// Kick the current editor out of edit mode and release their lock after this long without activity.
+// This is intentionally much longer than the "away" threshold so brief distractions don't eject users.
+export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 5_000; // TEMP  was 1_800_000; // 30 minutes

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -36,4 +36,4 @@ export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
 
 // Kick the current editor out of edit mode and release their lock after this long without activity.
 // This is intentionally much longer than the "away" threshold so brief distractions don't eject users.
-export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 5_000; // TEMP  was 1_800_000; // 30 minutes
+export const CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS = 30_000; // TEMP  was 1_800_000; // 30 minutes

--- a/lib/formBuilderEditLockPresence.ts
+++ b/lib/formBuilderEditLockPresence.ts
@@ -7,7 +7,7 @@ export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
 
 // Refresh the owner's lock heartbeat once per minute to reduce network noise; the longer TTL above
 // provides enough slack that missing a single heartbeat should not immediately drop the lock.
-export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 5_000; // TEMP 60_000;
+export const EDIT_LOCK_HEARTBEAT_INTERVAL_MS = 60_000; // TEMP 60_000;
 
 // Non-owners check lock status on the same cadence so they can notice ownership changes without
 // spamming the server. This can diverge from the owner heartbeat interval later if needed.

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -68,8 +68,6 @@ export const useEditLock = ({
     coordinationKey: formId,
   });
 
-  const { getActivitySnapshot } = useEditLockPresence({ getIsActiveTab });
-
   // const cleanupHeartbeat = useCallback(() => {
   //   console.log("User identified as inactive due to inactivity timeout. This is where you'd trigger any additional handling needed for inactive users, such as showing a warning or releasing the lock.");
   //   if (heartbeatRef.current) {
@@ -78,9 +76,6 @@ export const useEditLock = ({
   //   }
   //   clearEvents();
   // }, []);
-
-  const { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired } =
-    useEditLockInactiveUser();
 
   const clearLockState = useCallback(() => {
     setIsLockedByOther(false);
@@ -93,6 +88,44 @@ export const useEditLock = ({
     setEditLock(null);
     isOwnerRef.current = false;
   }, [setEditLock, setIsLockedByOther]);
+
+  const clearTimers = useCallback(() => {
+    lockLoopTokenRef.current += 1;
+    if (heartbeatRef.current) {
+      window.clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+    if (pollRef.current) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const clearEvents = useCallback(() => {
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+  }, []);
+
+  const handleOwnerIdleTimeout = useCallback(() => {
+    clearTimers();
+    clearEvents();
+  }, [clearEvents, clearTimers]);
+
+  const { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired } =
+    useEditLockInactiveUser({
+      onOwnerIdleTimeout: handleOwnerIdleTimeout,
+    });
+
+  const handleOwnerActivity = useCallback(() => {
+    if (isOwnerRef.current) {
+      startOwnerIdleTimer();
+    }
+  }, [startOwnerIdleTimer]);
+
+  const { getActivitySnapshot } = useEditLockPresence({
+    getIsActiveTab,
+    onActivity: handleOwnerActivity,
+  });
 
   const updateStore = useCallback(
     (status: EditLockStatusPayload) => {
@@ -124,23 +157,6 @@ export const useEditLock = ({
     },
     [setEditLock, setIsLockedByOther, startOwnerIdleTimer, clearOwnerIdleTimer]
   );
-
-  const clearTimers = useCallback(() => {
-    lockLoopTokenRef.current += 1;
-    if (heartbeatRef.current) {
-      window.clearInterval(heartbeatRef.current);
-      heartbeatRef.current = null;
-    }
-    if (pollRef.current) {
-      window.clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  }, []);
-
-  const clearEvents = useCallback(() => {
-    eventSourceRef.current?.close();
-    eventSourceRef.current = null;
-  }, []);
 
   const postAction = useCallback(
     async (action: "acquire" | "heartbeat" | "release" | "takeover" | "takeover-save-complete") => {

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -68,15 +68,6 @@ export const useEditLock = ({
     coordinationKey: formId,
   });
 
-  // const cleanupHeartbeat = useCallback(() => {
-  //   console.log("User identified as inactive due to inactivity timeout. This is where you'd trigger any additional handling needed for inactive users, such as showing a warning or releasing the lock.");
-  //   if (heartbeatRef.current) {
-  //     window.clearInterval(heartbeatRef.current);
-  //     heartbeatRef.current = null;
-  //   }
-  //   clearEvents();
-  // }, []);
-
   const clearTimers = useCallback(() => {
     lockLoopTokenRef.current += 1;
     if (heartbeatRef.current) {

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -13,6 +13,7 @@ import {
   EDIT_LOCK_HEARTBEAT_INTERVAL_MS,
   EDIT_LOCK_STATUS_POLL_INTERVAL_MS,
 } from "@lib/formBuilderEditLockPresence";
+import { useEditLockInactiveUser } from "./useEditLockInactiveTimeout";
 
 const SERVER_STATE_SYNC_MAX_ATTEMPTS = 10;
 const SERVER_STATE_SYNC_RETRY_MS = 500;
@@ -69,6 +70,18 @@ export const useEditLock = ({
 
   const { getActivitySnapshot } = useEditLockPresence({ getIsActiveTab });
 
+  // const cleanupHeartbeat = useCallback(() => {
+  //   console.log("User identified as inactive due to inactivity timeout. This is where you'd trigger any additional handling needed for inactive users, such as showing a warning or releasing the lock.");
+  //   if (heartbeatRef.current) {
+  //     window.clearInterval(heartbeatRef.current);
+  //     heartbeatRef.current = null;
+  //   }
+  //   clearEvents();
+  // }, []);
+
+  const { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired } =
+    useEditLockInactiveUser();
+
   const clearLockState = useCallback(() => {
     setIsLockedByOther(false);
     setEditLock(null);
@@ -104,9 +117,12 @@ export const useEditLock = ({
       isOwnerRef.current = status.isOwner;
       if (status.isOwner) {
         suppressReleaseRef.current = false;
+        startOwnerIdleTimer();
+      } else {
+        clearOwnerIdleTimer();
       }
     },
-    [setEditLock, setIsLockedByOther]
+    [setEditLock, setIsLockedByOther, startOwnerIdleTimer, clearOwnerIdleTimer]
   );
 
   const clearTimers = useCallback(() => {
@@ -509,5 +525,5 @@ export const useEditLock = ({
     startTimers(statusResult);
   }, [postAction, refreshForm, startTimers, updateStore, updatedAt]);
 
-  return { takeover, getIsActiveTab };
+  return { takeover, getIsActiveTab, isOwnerIdleTimeExpired };
 };

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -68,6 +68,31 @@ export const useEditLock = ({
     coordinationKey: formId,
   });
 
+  const { getActivitySnapshot } = useEditLockPresence({
+    getIsActiveTab,
+    onActivity: () => console.log("onActivity called") 
+  });
+
+  const postAction = useCallback(
+    async (action: "acquire" | "heartbeat" | "release" | "takeover" | "takeover-save-complete") => {
+      const activity = getActivitySnapshot();
+
+      const res = await fetch(buildEditLockUrl(formId, action), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action,
+          sessionId,
+          ...(activity ? { activity } : {}),
+        }),
+      });
+
+      const payload = (await res.json().catch(() => null)) as unknown;
+      return isEditLockStatus(payload) ? payload : null;
+    },
+    [formId, getActivitySnapshot, sessionId]
+  );
+
   // const cleanupHeartbeat = useCallback(() => {
   //   console.log("User identified as inactive due to inactivity timeout. This is where you'd trigger any additional handling needed for inactive users, such as showing a warning or releasing the lock.");
   //   if (heartbeatRef.current) {
@@ -102,16 +127,15 @@ export const useEditLock = ({
   }, []);
 
   const clearEvents = useCallback(() => {
-    console.log("CLEAR EVENTS");
     eventSourceRef.current?.close();
     eventSourceRef.current = null;
   }, []);
 
-  const handleOwnerIdleTimeout = useCallback(() => {
-    console.log("CLEAR TIMERS AND EVENTS");
+  const handleOwnerIdleTimeout = useCallback(async () => {
     clearTimers();
+    await postAction("release");
     clearEvents();
-  }, [clearEvents, clearTimers]);
+  }, [clearEvents, clearTimers, postAction]);
 
   const { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired } =
     useEditLockInactiveUser({
@@ -124,10 +148,7 @@ export const useEditLock = ({
     }
   }, [startOwnerIdleTimer]);
 
-  const { getActivitySnapshot } = useEditLockPresence({
-    getIsActiveTab,
-    onActivity: () => console.log("onActivity called") //handleOwnerActivity,
-  });
+  
 
   const updateStore = useCallback(
     (status: EditLockStatusPayload) => {
@@ -160,26 +181,6 @@ export const useEditLock = ({
       }
     },
     [setEditLock, setIsLockedByOther, startOwnerIdleTimer, clearOwnerIdleTimer]
-  );
-
-  const postAction = useCallback(
-    async (action: "acquire" | "heartbeat" | "release" | "takeover" | "takeover-save-complete") => {
-      const activity = getActivitySnapshot();
-
-      const res = await fetch(buildEditLockUrl(formId, action), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          action,
-          sessionId,
-          ...(activity ? { activity } : {}),
-        }),
-      });
-
-      const payload = (await res.json().catch(() => null)) as unknown;
-      return isEditLockStatus(payload) ? payload : null;
-    },
-    [formId, getActivitySnapshot, sessionId]
   );
 
   // When this tab does not own the lock, it polls lock status until ownership changes.

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -102,11 +102,13 @@ export const useEditLock = ({
   }, []);
 
   const clearEvents = useCallback(() => {
+    console.log("CLEAR EVENTS");
     eventSourceRef.current?.close();
     eventSourceRef.current = null;
   }, []);
 
   const handleOwnerIdleTimeout = useCallback(() => {
+    console.log("CLEAR TIMERS AND EVENTS");
     clearTimers();
     clearEvents();
   }, [clearEvents, clearTimers]);
@@ -124,7 +126,7 @@ export const useEditLock = ({
 
   const { getActivitySnapshot } = useEditLockPresence({
     getIsActiveTab,
-    onActivity: handleOwnerActivity,
+    onActivity: () => console.log("onActivity called") //handleOwnerActivity,
   });
 
   const updateStore = useCallback(
@@ -149,9 +151,11 @@ export const useEditLock = ({
       );
       isOwnerRef.current = status.isOwner;
       if (status.isOwner) {
+        console.log("STORE startOwnerIdleTimer heatbeat");
         suppressReleaseRef.current = false;
         startOwnerIdleTimer();
       } else {
+        console.log("STORE clearOwnerIdleTimer heatbeat");
         clearOwnerIdleTimer();
       }
     },

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -68,9 +68,64 @@ export const useEditLock = ({
     coordinationKey: formId,
   });
 
+  // const cleanupHeartbeat = useCallback(() => {
+  //   console.log("User identified as inactive due to inactivity timeout. This is where you'd trigger any additional handling needed for inactive users, such as showing a warning or releasing the lock.");
+  //   if (heartbeatRef.current) {
+  //     window.clearInterval(heartbeatRef.current);
+  //     heartbeatRef.current = null;
+  //   }
+  //   clearEvents();
+  // }, []);
+
+  const clearTimers = useCallback(() => {
+    lockLoopTokenRef.current += 1;
+    if (heartbeatRef.current) {
+      window.clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+    if (pollRef.current) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const clearEvents = useCallback(() => {
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+  }, []);
+
+  const ownerIdleTimeoutHandlerRef = useRef<() => Promise<void>>(async () => undefined);
+
+  const { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired } =
+    useEditLockInactiveUser({
+      onOwnerIdleTimeout: () => {
+        void ownerIdleTimeoutHandlerRef.current();
+      },
+    });
+
+  const clearLockState = useCallback(() => {
+    setIsLockedByOther(false);
+    setEditLock(null);
+    isOwnerRef.current = false;
+    clearOwnerIdleTimer();
+  }, [clearOwnerIdleTimer, setEditLock, setIsLockedByOther]);
+
+  const setTakeoverFallbackState = useCallback(() => {
+    setIsLockedByOther(true);
+    setEditLock(null);
+    isOwnerRef.current = false;
+    clearOwnerIdleTimer();
+  }, [clearOwnerIdleTimer, setEditLock, setIsLockedByOther]);
+
+  const handleOwnerActivity = useCallback(() => {
+    if (isOwnerRef.current) {
+      startOwnerIdleTimer();
+    }
+  }, [startOwnerIdleTimer]);
+
   const { getActivitySnapshot } = useEditLockPresence({
     getIsActiveTab,
-    onActivity: () => console.log("onActivity called") 
+    onActivity: handleOwnerActivity,
   });
 
   const postAction = useCallback(
@@ -93,65 +148,18 @@ export const useEditLock = ({
     [formId, getActivitySnapshot, sessionId]
   );
 
-  // const cleanupHeartbeat = useCallback(() => {
-  //   console.log("User identified as inactive due to inactivity timeout. This is where you'd trigger any additional handling needed for inactive users, such as showing a warning or releasing the lock.");
-  //   if (heartbeatRef.current) {
-  //     window.clearInterval(heartbeatRef.current);
-  //     heartbeatRef.current = null;
-  //   }
-  //   clearEvents();
-  // }, []);
-
-  const clearLockState = useCallback(() => {
-    setIsLockedByOther(false);
-    setEditLock(null);
-    isOwnerRef.current = false;
-  }, [setEditLock, setIsLockedByOther]);
-
-  const setTakeoverFallbackState = useCallback(() => {
-    setIsLockedByOther(true);
-    setEditLock(null);
-    isOwnerRef.current = false;
-  }, [setEditLock, setIsLockedByOther]);
-
-  const clearTimers = useCallback(() => {
-    lockLoopTokenRef.current += 1;
-    if (heartbeatRef.current) {
-      window.clearInterval(heartbeatRef.current);
-      heartbeatRef.current = null;
-    }
-    if (pollRef.current) {
-      window.clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  }, []);
-
-  const clearEvents = useCallback(() => {
-    eventSourceRef.current?.close();
-    eventSourceRef.current = null;
-  }, []);
-
   const handleOwnerIdleTimeout = useCallback(async () => {
     clearTimers();
     await postAction("release");
     clearEvents();
   }, [clearEvents, clearTimers, postAction]);
 
-  const { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired } =
-    useEditLockInactiveUser({
-      onOwnerIdleTimeout: handleOwnerIdleTimeout,
-    });
-
-  const handleOwnerActivity = useCallback(() => {
-    if (isOwnerRef.current) {
-      startOwnerIdleTimer();
-    }
-  }, [startOwnerIdleTimer]);
-
-  
+  ownerIdleTimeoutHandlerRef.current = handleOwnerIdleTimeout;
 
   const updateStore = useCallback(
     (status: EditLockStatusPayload) => {
+      const wasOwner = isOwnerRef.current;
+
       setIsLockedByOther(status.lockedByOther);
       setEditLock(
         status.lock
@@ -172,15 +180,21 @@ export const useEditLock = ({
       );
       isOwnerRef.current = status.isOwner;
       if (status.isOwner) {
-        console.log("STORE startOwnerIdleTimer heatbeat");
         suppressReleaseRef.current = false;
-        startOwnerIdleTimer();
-      } else {
-        console.log("STORE clearOwnerIdleTimer heatbeat");
+        if (!wasOwner) {
+          startOwnerIdleTimer(true);
+        }
+      } else if (wasOwner || isOwnerIdleTimeExpired) {
         clearOwnerIdleTimer();
       }
     },
-    [setEditLock, setIsLockedByOther, startOwnerIdleTimer, clearOwnerIdleTimer]
+    [
+      clearOwnerIdleTimer,
+      isOwnerIdleTimeExpired,
+      setEditLock,
+      setIsLockedByOther,
+      startOwnerIdleTimer,
+    ]
   );
 
   // When this tab does not own the lock, it polls lock status until ownership changes.

--- a/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
+++ b/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRef } from "react";
+import {
+  CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS, // TODO update to use app setting
+} from "@lib/formBuilderEditLockPresence";
+
+/**
+ * Keeps track of whether a user is identified as inactive and if so
+ * fires a callback.
+ */
+export const useEditLockInactiveUser = () => {
+  const timeoutRef = useRef<number | null>(null);
+  const isOwnerIdleTimeExpired = useRef<boolean>(false);
+
+  const startOwnerIdleTimer = () => {
+    isOwnerIdleTimeExpired.current = false;
+    timeoutRef.current = window.setInterval(() => {
+      // console.log("~~~~~JAVASCRIPT TIMER");
+      isOwnerIdleTimeExpired.current = true;
+    }, CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS);
+  };
+
+  const clearOwnerIdleTimer = () => {
+    if (timeoutRef.current) {
+      // console.log("~~~~~CLEARING TIMER");
+      window.clearInterval(timeoutRef.current);
+      timeoutRef.current = null;
+      isOwnerIdleTimeExpired.current = false;
+    }
+  };
+
+  return { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired };
+};

--- a/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
+++ b/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
@@ -18,6 +18,8 @@ export const useEditLockInactiveUser = ({
   const [isOwnerIdleTimeExpired, setIsOwnerIdleTimeExpired] = useState(false);
 
   const startOwnerIdleTimer = () => {
+      console.log("Start Timer heatbeat");
+
     setIsOwnerIdleTimeExpired(false);
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
@@ -26,10 +28,14 @@ export const useEditLockInactiveUser = ({
       setIsOwnerIdleTimeExpired(true);
       timeoutRef.current = null;
       onOwnerIdleTimeout?.();
+
+      console.log("Owner idle timeout expired");
     }, CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS);
   };
 
   const clearOwnerIdleTimer = () => {
+        console.log("Clear Timer heatbeat");
+
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
       timeoutRef.current = null;

--- a/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
+++ b/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
@@ -5,6 +5,11 @@ import {
   CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS, // TODO update to use app setting
 } from "@lib/formBuilderEditLockPresence";
 
+const OWNER_IDLE_TIMER_RESET_THROTTLE_MS = Math.min(
+  CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS / 2,
+  5_000
+);
+
 /**
  * Keeps track of whether a user is identified as inactive and if so
  * fires a callback.
@@ -15,31 +20,38 @@ export const useEditLockInactiveUser = ({
   onOwnerIdleTimeout?: () => void;
 } = {}) => {
   const timeoutRef = useRef<number | null>(null);
+  const lastTimerResetAtRef = useRef(0);
   const [isOwnerIdleTimeExpired, setIsOwnerIdleTimeExpired] = useState(false);
 
-  const startOwnerIdleTimer = () => {
-      console.log("Start Timer heatbeat");
+  const startOwnerIdleTimer = (force = false) => {
+    const now = Date.now();
+
+    if (
+      !force &&
+      timeoutRef.current &&
+      now - lastTimerResetAtRef.current < OWNER_IDLE_TIMER_RESET_THROTTLE_MS
+    ) {
+      return;
+    }
 
     setIsOwnerIdleTimeExpired(false);
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
     }
+    lastTimerResetAtRef.current = now;
     timeoutRef.current = window.setTimeout(() => {
       setIsOwnerIdleTimeExpired(true);
       timeoutRef.current = null;
       onOwnerIdleTimeout?.();
-
-      console.log("Owner idle timeout expired");
     }, CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS);
   };
 
   const clearOwnerIdleTimer = () => {
-        console.log("Clear Timer heatbeat");
-
     if (timeoutRef.current) {
       window.clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
+    lastTimerResetAtRef.current = 0;
     setIsOwnerIdleTimeExpired(false);
   };
 

--- a/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
+++ b/lib/hooks/form-builder/useEditLockInactiveTimeout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import {
   CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS, // TODO update to use app setting
 } from "@lib/formBuilderEditLockPresence";
@@ -9,25 +9,32 @@ import {
  * Keeps track of whether a user is identified as inactive and if so
  * fires a callback.
  */
-export const useEditLockInactiveUser = () => {
+export const useEditLockInactiveUser = ({
+  onOwnerIdleTimeout,
+}: {
+  onOwnerIdleTimeout?: () => void;
+} = {}) => {
   const timeoutRef = useRef<number | null>(null);
-  const isOwnerIdleTimeExpired = useRef<boolean>(false);
+  const [isOwnerIdleTimeExpired, setIsOwnerIdleTimeExpired] = useState(false);
 
   const startOwnerIdleTimer = () => {
-    isOwnerIdleTimeExpired.current = false;
-    timeoutRef.current = window.setInterval(() => {
-      // console.log("~~~~~JAVASCRIPT TIMER");
-      isOwnerIdleTimeExpired.current = true;
+    setIsOwnerIdleTimeExpired(false);
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = window.setTimeout(() => {
+      setIsOwnerIdleTimeExpired(true);
+      timeoutRef.current = null;
+      onOwnerIdleTimeout?.();
     }, CLIENT_SIDE_EDIT_LOCK_INACTIVE_TIMEOUT_MS);
   };
 
   const clearOwnerIdleTimer = () => {
     if (timeoutRef.current) {
-      // console.log("~~~~~CLEARING TIMER");
-      window.clearInterval(timeoutRef.current);
+      window.clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
-      isOwnerIdleTimeExpired.current = false;
     }
+    setIsOwnerIdleTimeExpired(false);
   };
 
   return { startOwnerIdleTimer, clearOwnerIdleTimer, isOwnerIdleTimeExpired };

--- a/lib/hooks/form-builder/useEditLockPresence.tsx
+++ b/lib/hooks/form-builder/useEditLockPresence.tsx
@@ -32,28 +32,38 @@ const getPresenceStatus = (
   return "active";
 };
 
-export const useEditLockPresence = ({ getIsActiveTab }: { getIsActiveTab: () => boolean }) => {
+export const useEditLockPresence = ({
+  getIsActiveTab,
+  onActivity,
+}: {
+  getIsActiveTab: () => boolean;
+  onActivity?: (lastActivityAt: number) => void;
+}) => {
   "use memo";
   const lastActivityAtRef = useRef(0);
   const visibilityStateRef = useRef<EditLockVisibilityState>("visible");
 
   const isTrackingPresence = getIsActiveTab();
 
-  const markActivity = useCallback((force = false) => {
-    const nextVisibilityState = getVisibilityState();
-    const now = Date.now();
+  const markActivity = useCallback(
+    (force = false) => {
+      const nextVisibilityState = getVisibilityState();
+      const now = Date.now();
 
-    if (
-      !force &&
-      nextVisibilityState === visibilityStateRef.current &&
-      now - lastActivityAtRef.current < CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS
-    ) {
-      return;
-    }
+      if (
+        !force &&
+        nextVisibilityState === visibilityStateRef.current &&
+        now - lastActivityAtRef.current < CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS
+      ) {
+        return;
+      }
 
-    lastActivityAtRef.current = now;
-    visibilityStateRef.current = nextVisibilityState;
-  }, []);
+      lastActivityAtRef.current = now;
+      visibilityStateRef.current = nextVisibilityState;
+      onActivity?.(now);
+    },
+    [onActivity]
+  );
 
   const getActivitySnapshot = useCallback((): EditLockActivitySnapshot | undefined => {
     if (!isTrackingPresence) {

--- a/lib/hooks/form-builder/useEditLockPresence.tsx
+++ b/lib/hooks/form-builder/useEditLockPresence.tsx
@@ -88,8 +88,10 @@ export const useEditLockPresence = ({
     }
 
     const handleVisibilityChange = () => {
+      console.log("Visibility change detected");
       visibilityStateRef.current = getVisibilityState();
       if (visibilityStateRef.current === "visible") {
+        console.log("Visibility change detected - visible");
         markActivity(true);
       }
     };

--- a/lib/hooks/form-builder/useEditLockPresence.tsx
+++ b/lib/hooks/form-builder/useEditLockPresence.tsx
@@ -88,10 +88,8 @@ export const useEditLockPresence = ({
     }
 
     const handleVisibilityChange = () => {
-      console.log("Visibility change detected");
       visibilityStateRef.current = getVisibilityState();
       if (visibilityStateRef.current === "visible") {
-        console.log("Visibility change detected - visible");
         markActivity(true);
       }
     };


### PR DESCRIPTION
# Summary | Résumé

Continuing to iterate on the timers for heartbeat. In particular the idle timeout. This gets the locked edit work into a working start for checking inactivity on a lock owner.