### PR TITLE
chore: fix db studio connection URL

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2025-05-04
+
+### Fixed
+
+- Fixed Prisma Studio connection URL
+
 ## [1.0.5] - 2025-04-30
 
-### Changed
+### Changed
 
 - Only use SSL connection for connecting to AWS RDS
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {
@@ -23,7 +23,7 @@
   "scripts": {
     "reset": "prisma migrate reset -f --skip-seed",
     "db:generate": "DATABASE_URL=dummy_url_for_build prisma generate && tsx fixGeneratedPrisma.ts",
-    "db:studio": "prisma studio --url=\"${DATABASE_URL}?sslmode=prefer\"",
+    "db:studio": "prisma studio --url=\"${DATABASE_URL}&sslmode=prefer\"",
     "db:prod": "prisma migrate deploy && prisma db seed -- --environment production",
     "db:dev": "prisma migrate dev && prisma db seed -- --environment development",
     "db:test": "prisma migrate reset --force && prisma db seed -- --environment test",


### PR DESCRIPTION
# Summary | Résumé

- Fixes Prisma Studio connection URL (replace `?` with `&` to work with existing parameters)