### PR TITLE
chore: added missing global-bundle.pem file output folder in @gcforms/database package

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2025-05-04
+
+### Fixed
+
+- Added missing `global-bundle.pem` file to `dist` output folder
+
 ## [1.0.6] - 2025-05-04
 
-### Fixed
+### Fixed
 
 - Fixed Prisma Studio connection URL
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/database/tsdown.config.ts
+++ b/packages/database/tsdown.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: "src/index.ts",
+  copy: "src/global-bundle.pem",
   format: "esm",
   dts: true,
   target: "es2023",


### PR DESCRIPTION
# Summary | Résumé

- Copies `global-bundle.pem` file to output folder (`dist`) in `@gcforms/database` package

Note: this is a requirement for when the package is used outside of the web app project (Lambda/API).