### PR TITLE
chore: update edit lock checks

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/layout.tsx
@@ -17,15 +17,16 @@ import { FormRecord } from "@lib/types";
 import { logMessage } from "@lib/logger";
 import { checkKeyExists } from "@lib/serviceAccount";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
-import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
 import { getAppSetting } from "@lib/appSettings";
 import { normalizeEditLockRedirectIdleMs } from "@lib/utils/form-builder/editLockRedirectIdleMs";
+import { shouldEnableTemplateEditLock } from "@lib/editLocks";
 import {
   FormBuilderConfigProvider,
   FormBuilderConfig,
   formBuilderConfigDefault,
 } from "@lib/hooks/useFormBuilderConfig";
 import { EditLockClient } from "@formBuilder/components/shared/edit-lock/EditLockClient";
+import { EditLockDebugMarker } from "@formBuilder/components/shared/edit-lock/EditLockDebugMarker";
 
 export default async function Layout(props: {
   children: React.ReactNode;
@@ -48,13 +49,10 @@ export default async function Layout(props: {
 
   const allowGroupsFlag = allowGrouping();
   const allowLockedEditingFlag = await allowLockedEditing();
-  const enforceEditLockFlag =
-    allowLockedEditingFlag && formID && formID !== "0000"
-      ? await shouldEnforceTemplateEditLock(formID)
-      : false;
   const ownerIdleTimeoutMs = normalizeEditLockRedirectIdleMs(
     await getAppSetting("editLockRedirectIdleMs")
   );
+  let assignedUserCount = 0;
 
   if (session && formID && formID !== "0000") {
     const templateWithUsers = await getTemplateWithAssociatedUsers(formID).catch((e) => {
@@ -66,11 +64,22 @@ export default async function Layout(props: {
     });
 
     initialForm = templateWithUsers?.formRecord ?? null;
+    assignedUserCount = templateWithUsers?.users.length ?? 0;
 
     if (initialForm === null) {
       redirect(`/${locale}/404`);
     }
   }
+
+  const enforceEditLockFlag =
+    initialForm !== null
+      ? shouldEnableTemplateEditLock({
+          allowLockedEditing: allowLockedEditingFlag,
+          templateId: formID,
+          isPublished: initialForm.isPublished,
+          assignedUserCount,
+        })
+      : false;
 
   let apiKeyId: string | undefined = undefined;
 
@@ -117,6 +126,11 @@ export default async function Layout(props: {
                   <div className="flex grow flex-row gap-7">
                     <div id="left-nav" className="z-10 border-r border-slate-200 bg-white">
                       <div className="sticky top-0">
+                        <EditLockDebugMarker
+                          testId="edit-page-lock-debug"
+                          editLockEnabled={enforceEditLockFlag}
+                          assignedUserCount={assignedUserCount}
+                        />
                         <LeftNavigation id={id} />
                       </div>
                     </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/layout.tsx
@@ -4,8 +4,8 @@ import { LoggedOutTab, LoggedOutTabName } from "@serverComponents/form-builder/L
 import { authCheckAndThrow } from "@lib/actions";
 import { Language } from "@lib/types/form-builder-types";
 import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
-import { shouldEnforceTemplateEditLock } from "@lib/editLocks";
 import { getAppSetting } from "@lib/appSettings";
+import { shouldEnforceTemplateEditLockWithVerifiedUserCount } from "@lib/editLocks";
 import { normalizeEditLockRedirectIdleMs } from "@lib/utils/form-builder/editLockRedirectIdleMs";
 import { SettingsNavigation } from "./components/SettingsNavigation";
 import { WaitForId } from "../components/WaitForId";
@@ -25,7 +25,7 @@ export default async function Layout(props: {
   const { t } = await serverTranslation("form-builder", { lang: locale });
   const allowLockedEditingFlag = await allowLockedEditing();
   const enforceEditLockFlag = allowLockedEditingFlag
-    ? await shouldEnforceTemplateEditLock(id)
+    ? await shouldEnforceTemplateEditLockWithVerifiedUserCount(id)
     : false;
   const ownerIdleTimeoutMs = normalizeEditLockRedirectIdleMs(
     await getAppSetting("editLockRedirectIdleMs")

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -36,13 +36,16 @@ import { BrandProperties, NotificationsInterval } from "@gcforms/types";
 import { redirect } from "next/navigation";
 import {
   assertTemplateEditLock,
-  shouldEnforceTemplateEditLock,
+  shouldEnforceTemplateEditLockWithVerifiedUserCount,
   TemplateEditLockedError,
 } from "@lib/editLocks";
 import { validateTemplate } from "@lib/utils/form-builder/validate";
 
 const assertTemplateEditLockIfEnabled = async (templateId: string, userId: string) => {
-  if (process.env.APP_ENV === "test" || !(await shouldEnforceTemplateEditLock(templateId))) {
+  if (
+    process.env.APP_ENV === "test" ||
+    !(await shouldEnforceTemplateEditLockWithVerifiedUserCount(templateId))
+  ) {
     return;
   }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockDebugMarker.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockDebugMarker.tsx
@@ -1,0 +1,19 @@
+export const EditLockDebugMarker = ({
+  testId,
+  editLockEnabled,
+  assignedUserCount,
+}: {
+  testId: string;
+  editLockEnabled: boolean;
+  assignedUserCount: number;
+}) => {
+  return (
+    <div
+      hidden
+      aria-hidden="true"
+      data-testid={testId}
+      data-edit-lock-enabled={String(editLockEnabled)}
+      data-assigned-user-count={String(assignedUserCount)}
+    />
+  );
+};

--- a/app/api/templates/[formID]/edit-lock/events/route.ts
+++ b/app/api/templates/[formID]/edit-lock/events/route.ts
@@ -2,13 +2,16 @@ import { NextResponse } from "next/server";
 import { middleware, sessionExists } from "@lib/middleware";
 import { MiddlewareProps, WithRequired } from "@lib/types";
 import { authorization } from "@lib/privileges";
-import { EditLockEvent, getEditLockStatus } from "@lib/editLocks";
+import {
+  EditLockEvent,
+  getEditLockStatus,
+  shouldEnforceTemplateEditLockWithVerifiedUserCount,
+} from "@lib/editLocks";
 import {
   registerActiveEditLockStream,
   subscribeToSharedEditLockEvents,
 } from "@lib/editLockEventStreams";
 import { logMessage } from "@lib/logger";
-import { allowLockedEditing } from "@lib/utils/form-builder/allowLockedEditing";
 
 export const dynamic = "force-dynamic";
 
@@ -30,7 +33,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
     return NextResponse.json({ error: "Invalid or missing formID" }, { status: 400 });
   }
 
-  if (!(await allowLockedEditing())) {
+  if (!(await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID))) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 

--- a/app/api/templates/[formID]/edit-lock/route.ts
+++ b/app/api/templates/[formID]/edit-lock/route.ts
@@ -14,7 +14,7 @@ import {
   heartbeatEditLock,
   requestEditLockTakeoverSave,
   releaseEditLock,
-  shouldEnforceTemplateEditLock,
+  shouldEnforceTemplateEditLockWithVerifiedUserCount,
   takeoverEditLock,
   TemplateEditLockedError,
   waitForEditLockTakeoverSaveAcknowledgement,
@@ -73,7 +73,7 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  if (!(await shouldEnforceTemplateEditLock(formID))) {
+  if (!(await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID))) {
     return NextResponse.json(getEditLockDisabledStatus());
   }
 
@@ -106,7 +106,7 @@ export const POST = middleware([sessionExists()], async (_req: NextRequest, prop
   };
   const presence = parsePresence(activity);
 
-  if (!(await shouldEnforceTemplateEditLock(formID))) {
+  if (!(await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID))) {
     if (action === "release") {
       return NextResponse.json({ released: false });
     }

--- a/app/api/templates/[formID]/edit-lock/route.ts
+++ b/app/api/templates/[formID]/edit-lock/route.ts
@@ -14,6 +14,7 @@ import {
   heartbeatEditLock,
   requestEditLockTakeoverSave,
   releaseEditLock,
+  shouldEnforceTemplateEditLock,
   shouldEnforceTemplateEditLockWithVerifiedUserCount,
   takeoverEditLock,
   TemplateEditLockedError,
@@ -59,10 +60,11 @@ const parsePresence = (value: unknown): EditLockPresenceInput | undefined => {
   };
 };
 
-export const GET = middleware([sessionExists()], async (_req, props) => {
+export const GET = middleware([sessionExists()], async (req, props) => {
   const { session } = props as WithRequired<MiddlewareProps, "session">;
   const params = props.params instanceof Promise ? await props.params : props.params;
   const formID = params?.formID;
+  const requestType = req.nextUrl.searchParams.get("requestType");
 
   if (!formID || typeof formID !== "string") {
     return NextResponse.json({ error: "Invalid or missing formID" }, { status: 400 });
@@ -73,7 +75,12 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  if (!(await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID))) {
+  const shouldEnforceEditLock =
+    requestType !== "lock-status-poll"
+      ? await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID)
+      : await shouldEnforceTemplateEditLock(formID);
+
+  if (!shouldEnforceEditLock) {
     return NextResponse.json(getEditLockDisabledStatus());
   }
 
@@ -104,15 +111,21 @@ export const POST = middleware([sessionExists()], async (_req: NextRequest, prop
       presenceStatus?: string;
     };
   };
-  const presence = parsePresence(activity);
 
-  if (!(await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID))) {
+  const shouldEnforceEditLock =
+    action !== "heartbeat"
+      ? await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID)
+      : await shouldEnforceTemplateEditLock(formID);
+
+  if (!shouldEnforceEditLock) {
     if (action === "release") {
       return NextResponse.json({ released: false });
     }
 
     return NextResponse.json(getEditLockDisabledStatus());
   }
+
+  const presence = parsePresence(activity);
 
   try {
     if (action === "acquire") {

--- a/app/api/templates/[formID]/route.ts
+++ b/app/api/templates/[formID]/route.ts
@@ -24,7 +24,7 @@ import { logMessage } from "@lib/logger";
 import { authCheckAndThrow } from "@lib/actions";
 import {
   assertTemplateEditLock,
-  shouldEnforceTemplateEditLock,
+  shouldEnforceTemplateEditLockWithVerifiedUserCount,
   TemplateEditLockedError,
 } from "@lib/editLocks";
 import { MiddlewareProps, WithRequired } from "@lib/types";
@@ -159,7 +159,7 @@ export const PUT = middleware(
       if (
         shouldCheckLock &&
         process.env.APP_ENV !== "test" &&
-        (await shouldEnforceTemplateEditLock(formID))
+        (await shouldEnforceTemplateEditLockWithVerifiedUserCount(formID))
       ) {
         const { session } = props as WithRequired<MiddlewareProps, "session">;
         await assertTemplateEditLock({ templateId: formID, userId: session.user.id });

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -457,6 +457,25 @@ export const getEditLockDisabledStatus = (): EditLockStatus => ({
   lock: null,
 });
 
+export const shouldEnableTemplateEditLock = ({
+  allowLockedEditing,
+  templateId,
+  isPublished,
+  assignedUserCount,
+}: {
+  allowLockedEditing: boolean;
+  templateId: string | null | undefined;
+  isPublished: boolean;
+  assignedUserCount: number;
+}): boolean =>
+  Boolean(
+    allowLockedEditing &&
+    templateId &&
+    templateId !== "0000" &&
+    !isPublished &&
+    assignedUserCount >= MIN_ASSIGNED_USERS_FOR_EDIT_LOCK
+  );
+
 export const invalidateTemplateEditLockUserCountCache = async (
   templateId: string
 ): Promise<void> => {
@@ -468,7 +487,14 @@ export const invalidateTemplateEditLockUserCountCache = async (
   await redis.del(getEditLockAssignedUsersCacheKey(templateId));
 };
 
-export const shouldEnforceTemplateEditLock = async (templateId: string): Promise<boolean> => {
+const shouldEnforceTemplateEditLockInternal = async (
+  templateId: string,
+  {
+    revalidateAssignedUserCount = false,
+  }: {
+    revalidateAssignedUserCount?: boolean;
+  } = {}
+): Promise<boolean> => {
   if (!(await allowLockedEditing())) {
     return false;
   }
@@ -492,7 +518,14 @@ export const shouldEnforceTemplateEditLock = async (templateId: string): Promise
   }
 
   // Both values are cached — skip the DB entirely.
-  if (cachedIsPublished !== null && cachedHasEnoughUsers !== null) {
+  if (
+    cachedIsPublished !== null &&
+    cachedHasEnoughUsers !== null &&
+    // A cached "single-user" or "published" result is safe to trust because it disables
+    // locking. When we are about to enforce locking, re-check the assigned-user count so a
+    // stale "multi-user" cache cannot keep single-user forms in a lockable state.
+    (!revalidateAssignedUserCount || cachedIsPublished || !cachedHasEnoughUsers)
+  ) {
     return !cachedIsPublished && cachedHasEnoughUsers;
   }
 
@@ -526,6 +559,18 @@ export const shouldEnforceTemplateEditLock = async (templateId: string): Promise
 
   return !template.isPublished && hasEnoughUsers;
 };
+
+export const shouldEnforceTemplateEditLock = async (templateId: string): Promise<boolean> =>
+  shouldEnforceTemplateEditLockInternal(templateId);
+
+// Use this on page-entry or mutation paths where a stale cached multi-user threshold would be
+// user-visible. It re-checks assigned-user count before enforcing edit locking.
+export const shouldEnforceTemplateEditLockWithVerifiedUserCount = async (
+  templateId: string
+): Promise<boolean> =>
+  shouldEnforceTemplateEditLockInternal(templateId, {
+    revalidateAssignedUserCount: true,
+  });
 
 export const getEditLockStatus = async (
   templateId: string,

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -37,6 +37,11 @@ const buildEditLockUrl = (formId: string, requestType: EditLockRequestType) =>
 const buildEditLockEventsUrl = (formId: string) =>
   `/api/templates/${formId}/edit-lock/events?requestType=event-stream`;
 
+const isEditLockDisabledStatus = (status: EditLockStatusPayload | null | undefined) =>
+  Boolean(
+    status && !status.locked && !status.lockedByOther && status.isOwner && status.lock === null
+  );
+
 export const useEditLock = ({
   formId,
   enabled,
@@ -50,6 +55,7 @@ export const useEditLock = ({
 }) => {
   "use memo";
   const [hasSessionExpired, setHasSessionExpired] = useState(false);
+  const [serverLockingEnabled, setServerLockingEnabled] = useState(enabled);
   const { status } = useSession();
   const setEditLock = useTemplateStore((s) => s.setEditLock);
   const setIsLockedByOther = useTemplateStore((s) => s.setIsLockedByOther);
@@ -71,6 +77,8 @@ export const useEditLock = ({
   const { getIsActiveTab, isActiveTab } = useActiveTab({
     coordinationKey: formId,
   });
+
+  const lockingEnabled = enabled && serverLockingEnabled;
 
   const clearTimers = useCallback(() => {
     lockLoopTokenRef.current += 1;
@@ -105,6 +113,15 @@ export const useEditLock = ({
     isOwnerRef.current = false;
     clearOwnerIdleTimer();
   }, [clearOwnerIdleTimer, setEditLock, setIsLockedByOther]);
+
+  const standDownForDisabledLocking = useCallback(() => {
+    setServerLockingEnabled(false);
+    setHasSessionExpired(false);
+    suppressReleaseRef.current = false;
+    clearTimers();
+    clearEvents();
+    clearLockState();
+  }, [clearEvents, clearLockState, clearTimers]);
 
   const setTakeoverFallbackState = useCallback(() => {
     setIsLockedByOther(true);
@@ -250,6 +267,16 @@ export const useEditLock = ({
   );
 
   useEffect(() => {
+    if (!enabled) {
+      setServerLockingEnabled(false);
+      setHasSessionExpired(false);
+      return;
+    }
+
+    setServerLockingEnabled(true);
+  }, [enabled, formId]);
+
+  useEffect(() => {
     updatedAtRef.current = updatedAt;
   }, [updatedAt]);
 
@@ -315,6 +342,11 @@ export const useEditLock = ({
         return;
       }
 
+      if (isEditLockDisabledStatus(heartbeatResult)) {
+        standDownForDisabledLocking();
+        return;
+      }
+
       if (!heartbeatResult.isOwner) {
         await autoSaveIfOwner(wasOwner);
       }
@@ -357,6 +389,11 @@ export const useEditLock = ({
       if (!pollResult) {
         clearTimers();
         clearLockState();
+        return;
+      }
+
+      if (isEditLockDisabledStatus(pollResult)) {
+        standDownForDisabledLocking();
         return;
       }
 
@@ -412,6 +449,10 @@ export const useEditLock = ({
   // When a non-owner tab's active status changes, update polling state accordingly.
   // Only the active tab should have the polling interval active to reduce network traffic.
   useEffect(() => {
+    if (!lockingEnabled) {
+      return;
+    }
+
     // Only applies to non-owners with active-tab coordination enabled
     if (isOwnerRef.current) {
       return;
@@ -424,6 +465,11 @@ export const useEditLock = ({
       } else {
         // Poll immediately to refresh state before next interval tick
         void getLockStatus().then((result) => {
+          if (isEditLockDisabledStatus(result)) {
+            cbRef.current.standDownForDisabledLocking();
+            return;
+          }
+
           if (result) {
             cbRef.current.updateStore(result);
           }
@@ -436,7 +482,7 @@ export const useEditLock = ({
         pollRef.current = null;
       }
     }
-  }, [getLockStatus, isActiveTab]);
+  }, [getLockStatus, isActiveTab, lockingEnabled]);
 
   // The main effect runs whenever "enabled" or "status" changes to start/stop
   // the lock logic. The ref "container" is necessary to hold the latest
@@ -453,6 +499,7 @@ export const useEditLock = ({
     flushDraftBeforeTakeover,
     startTimers,
     setTakeoverFallbackState,
+    standDownForDisabledLocking,
   };
   const cbRef = useRef(callbacks);
   cbRef.current = callbacks;
@@ -460,7 +507,7 @@ export const useEditLock = ({
   startHeartbeatRef.current = startHeartbeat;
 
   useEffect(() => {
-    if (!enabled || status !== "authenticated") {
+    if (!lockingEnabled || status !== "authenticated") {
       cbRef.current.clearTimers();
       cbRef.current.clearLockState();
       return;
@@ -474,6 +521,11 @@ export const useEditLock = ({
 
       if (!statusResult) {
         cbRef.current.clearLockState();
+        return;
+      }
+
+      if (isEditLockDisabledStatus(statusResult)) {
+        cbRef.current.standDownForDisabledLocking();
         return;
       }
 
@@ -501,13 +553,13 @@ export const useEditLock = ({
         }).catch(() => undefined);
       }
     };
-  }, [enabled, formId, sessionId, status]);
+  }, [formId, lockingEnabled, sessionId, status]);
 
   // Manage the shared SSE EventSource connection for edit-lock updates.
   // If an SSE event is missed, the next owner heartbeat or non-owner status poll
   // reconciles state from the server, and EventSource will retry on transient drops.
   useEffect(() => {
-    if (!enabled || status !== "authenticated") {
+    if (!lockingEnabled || status !== "authenticated") {
       cbRef.current.clearEvents();
       return;
     }
@@ -534,6 +586,11 @@ export const useEditLock = ({
           return;
         }
         const wasOwner = isOwnerRef.current;
+
+        if (isEditLockDisabledStatus(nextStatus)) {
+          cbRef.current.standDownForDisabledLocking();
+          return;
+        }
 
         if (!nextStatus.locked) {
           // Lock is free. Stop any non-owner polling and show the takeover fallback state (manual takeover required).
@@ -579,7 +636,7 @@ export const useEditLock = ({
         eventSourceRef.current = null;
       }
     };
-  }, [enabled, formId, status, setTakeoverFallbackState]);
+  }, [formId, lockingEnabled, status, setTakeoverFallbackState]);
 
   const takeover = useCallback(async () => {
     const previousUpdatedAt = updatedAt;
@@ -589,10 +646,14 @@ export const useEditLock = ({
     if (statusResult?.error) {
       throw new Error(statusResult.error);
     }
+    if (isEditLockDisabledStatus(statusResult)) {
+      standDownForDisabledLocking();
+      return;
+    }
     await refreshForm(previousUpdatedAt);
     updateStore(statusResult);
     startTimers(statusResult);
-  }, [postAction, refreshForm, startTimers, updateStore, updatedAt]);
+  }, [postAction, refreshForm, standDownForDisabledLocking, startTimers, updateStore, updatedAt]);
 
   return { takeover, getIsActiveTab, isOwnerIdleTimeExpired, hasSessionExpired };
 };

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -14,6 +14,7 @@ import {
   EDIT_LOCK_STATUS_POLL_INTERVAL_MS,
 } from "@root/constants";
 import { useEditLockInactiveUser } from "./useEditLockInactiveTimeout";
+import { normalizeEditLockRedirectIdleMs } from "@lib/utils/form-builder/editLockRedirectIdleMs";
 
 const SERVER_STATE_SYNC_MAX_ATTEMPTS = 10;
 const SERVER_STATE_SYNC_RETRY_MS = 500;
@@ -57,6 +58,7 @@ export const useEditLock = ({
   const [hasSessionExpired, setHasSessionExpired] = useState(false);
   const [serverLockingEnabled, setServerLockingEnabled] = useState(enabled);
   const { status } = useSession();
+  const normalizedOwnerIdleTimeoutMs = normalizeEditLockRedirectIdleMs(ownerIdleTimeoutMs);
   const setEditLock = useTemplateStore((s) => s.setEditLock);
   const setIsLockedByOther = useTemplateStore((s) => s.setIsLockedByOther);
   const setFromRecord = useTemplateStore((s) => s.setFromRecord);
@@ -64,6 +66,7 @@ export const useEditLock = ({
     useTemplateContext();
 
   const isOwnerRef = useRef(false);
+  const ownerLastActivityAtRef = useRef(Date.now());
   const heartbeatRef = useRef<number | null>(null);
   const pollRef = useRef<number | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -130,7 +133,33 @@ export const useEditLock = ({
     clearOwnerIdleTimer();
   }, [clearOwnerIdleTimer, setEditLock, setIsLockedByOther]);
 
+  const setSessionExpiredFallbackState = useCallback(() => {
+    setHasSessionExpired(true);
+    clearTimers();
+    setTakeoverFallbackState();
+    clearEvents();
+  }, [clearEvents, clearTimers, setTakeoverFallbackState]);
+
+  // Background tabs can miss the idle timeout callback, so preserve the
+  // session-expired owner path if the lock disappears after that threshold.
+  const shouldShowOwnerSessionExpiredFallback = useCallback(
+    (wasOwner: boolean) => {
+      if (!wasOwner) {
+        return false;
+      }
+
+      if (hasSessionExpired || isOwnerIdleTimeExpired) {
+        return true;
+      }
+
+      return Date.now() - ownerLastActivityAtRef.current >= normalizedOwnerIdleTimeoutMs;
+    },
+    [hasSessionExpired, isOwnerIdleTimeExpired, normalizedOwnerIdleTimeoutMs]
+  );
+
   const handleOwnerActivity = useCallback(() => {
+    ownerLastActivityAtRef.current = Date.now();
+
     if (isOwnerRef.current) {
       startOwnerIdleTimer();
     }
@@ -163,12 +192,9 @@ export const useEditLock = ({
 
   const handleOwnerIdleTimeout = useCallback(async () => {
     // Mark session as expired for this tab (previous owner)
-    setHasSessionExpired(true);
-    clearTimers();
-    setTakeoverFallbackState();
+    setSessionExpiredFallbackState();
     await postAction("release");
-    clearEvents();
-  }, [clearEvents, clearTimers, postAction, setTakeoverFallbackState]);
+  }, [postAction, setSessionExpiredFallbackState]);
 
   ownerIdleTimeoutHandlerRef.current = handleOwnerIdleTimeout;
 
@@ -198,6 +224,7 @@ export const useEditLock = ({
       if (status.isOwner) {
         suppressReleaseRef.current = false;
         if (!wasOwner) {
+          ownerLastActivityAtRef.current = Date.now();
           startOwnerIdleTimer(true);
         }
       } else if (wasOwner || isOwnerIdleTimeExpired) {
@@ -337,6 +364,11 @@ export const useEditLock = ({
       }
 
       if (!heartbeatResult) {
+        if (shouldShowOwnerSessionExpiredFallback(wasOwner)) {
+          setSessionExpiredFallbackState();
+          return;
+        }
+
         clearTimers();
         clearLockState();
         return;
@@ -360,6 +392,11 @@ export const useEditLock = ({
       }
 
       if (!heartbeatResult.locked) {
+        if (shouldShowOwnerSessionExpiredFallback(wasOwner)) {
+          setSessionExpiredFallbackState();
+          return;
+        }
+
         clearTimers();
         setTakeoverFallbackState();
       }
@@ -369,8 +406,11 @@ export const useEditLock = ({
     clearLockState,
     clearTimers,
     postAction,
+    setSessionExpiredFallbackState,
     setTakeoverFallbackState,
+    standDownForDisabledLocking,
     syncServerState,
+    shouldShowOwnerSessionExpiredFallback,
     updateStore,
   ]);
 
@@ -427,6 +467,7 @@ export const useEditLock = ({
     clearTimers,
     getLockStatus,
     setTakeoverFallbackState,
+    standDownForDisabledLocking,
     syncServerState,
     updateStore,
   ]);
@@ -593,6 +634,11 @@ export const useEditLock = ({
         }
 
         if (!nextStatus.locked) {
+          if (shouldShowOwnerSessionExpiredFallback(wasOwner)) {
+            setSessionExpiredFallbackState();
+            return;
+          }
+
           // Lock is free. Stop any non-owner polling and show the takeover fallback state (manual takeover required).
           if (!wasOwner) {
             cbRef.current.clearTimers();
@@ -636,7 +682,14 @@ export const useEditLock = ({
         eventSourceRef.current = null;
       }
     };
-  }, [formId, lockingEnabled, status, setTakeoverFallbackState]);
+  }, [
+    formId,
+    lockingEnabled,
+    setSessionExpiredFallbackState,
+    setTakeoverFallbackState,
+    shouldShowOwnerSessionExpiredFallback,
+    status,
+  ]);
 
   const takeover = useCallback(async () => {
     const previousUpdatedAt = updatedAt;

--- a/lib/tests/editLocks.test.ts
+++ b/lib/tests/editLocks.test.ts
@@ -26,6 +26,8 @@ import {
   invalidateTemplateEditLockUserCountCache,
   releaseEditLock,
   shouldEnforceTemplateEditLock,
+  shouldEnforceTemplateEditLockWithVerifiedUserCount,
+  shouldEnableTemplateEditLock,
   takeoverEditLock,
   waitForEditLockTakeoverSaveAcknowledgement,
 } from "@lib/editLocks";
@@ -224,4 +226,49 @@ describe("editLocks with redis", () => {
     expect(prisma.template.findUnique).toHaveBeenCalledTimes(2);
   });
 
+  it("disables edit locking for draft forms with fewer than two assigned users", () => {
+    expect(
+      shouldEnableTemplateEditLock({
+        allowLockedEditing: true,
+        templateId: "form-8",
+        isPublished: false,
+        assignedUserCount: 1,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldEnableTemplateEditLock({
+        allowLockedEditing: true,
+        templateId: "form-8",
+        isPublished: false,
+        assignedUserCount: 2,
+      })
+    ).toBe(true);
+  });
+
+  it("revalidates a cached multi-user threshold when fresh assigned-user enforcement is required", async () => {
+    const findUniqueMock = prisma.template.findUnique as unknown as ReturnType<typeof vi.fn>;
+
+    const cachedTemplate: PublicFormRecord = {
+      id: "form-7",
+      form: {} as FormProperties,
+      isPublished: false,
+      securityAttribute: "Unclassified",
+    };
+
+    vi.mocked(formCache.check).mockResolvedValue(cachedTemplate);
+
+    const redisInstance = await getRedisInstance();
+    await redisInstance.set("edit-lock:assigned-users:form-7", "1");
+
+    findUniqueMock.mockResolvedValue({
+      isPublished: false,
+      _count: {
+        users: 1,
+      },
+    });
+
+    await expect(shouldEnforceTemplateEditLockWithVerifiedUserCount("form-7")).resolves.toBe(false);
+    expect(prisma.template.findUnique).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/browser/form-builder/edit-lock/EditLockDebugMarker.browser.test.tsx
+++ b/tests/browser/form-builder/edit-lock/EditLockDebugMarker.browser.test.tsx
@@ -1,0 +1,27 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "../testUtils";
+import { setupFonts } from "../../helpers/setupFonts";
+import { EditLockDebugMarker } from "@root/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockDebugMarker";
+
+import "@root/styles/app.css";
+
+describe("<EditLockDebugMarker />", () => {
+  beforeAll(() => {
+    setupFonts();
+  });
+
+  it("renders hidden edit-lock debug attributes", async () => {
+    await render(
+      <EditLockDebugMarker
+        testId="edit-page-lock-debug"
+        editLockEnabled={false}
+        assignedUserCount={1}
+      />
+    );
+
+    const marker = page.getByTestId("edit-page-lock-debug");
+    await expect.element(marker).toHaveAttribute("data-edit-lock-enabled", "false");
+    await expect.element(marker).toHaveAttribute("data-assigned-user-count", "1");
+  });
+});

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.test.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.test.tsx
@@ -190,19 +190,24 @@ function EditLockHarness({
   onChangeKey,
   onLockStateChange,
   onActiveTabChange,
+  onSessionExpiredChange,
+  ownerIdleTimeoutMs,
 }: {
   onTakeoverReady?: (takeover: () => Promise<void>) => void;
   onChangeKey?: (changeKey: string) => void;
   onLockStateChange?: (state: { isLockedByOther: boolean; hasEditLock: boolean }) => void;
   onActiveTabChange?: (isActiveTab: boolean) => void;
+  onSessionExpiredChange?: (hasSessionExpired: boolean) => void;
+  ownerIdleTimeoutMs?: number;
 }) {
   const changeKey = useTemplateStore((s) => s.changeKey);
   const isLockedByOther = useTemplateStore((s) => s.isLockedByOther);
   const editLock = useTemplateStore((s) => s.editLock);
-  const { takeover, getIsActiveTab } = useEditLock({
+  const { takeover, getIsActiveTab, hasSessionExpired } = useEditLock({
     formId: "test-form-id",
     enabled: true,
     sessionId: "session-1",
+    ownerIdleTimeoutMs,
   });
 
   useEffect(() => {
@@ -223,6 +228,10 @@ function EditLockHarness({
   useEffect(() => {
     onActiveTabChange?.(getIsActiveTab());
   }, [getIsActiveTab, onActiveTabChange]);
+
+  useEffect(() => {
+    onSessionExpiredChange?.(hasSessionExpired);
+  }, [hasSessionExpired, onSessionExpiredChange]);
 
   useEffect(() => {
     return () => {
@@ -677,6 +686,75 @@ describe("useEditLock", () => {
     expect(lockStates.at(-1)).toEqual({ isLockedByOther: true, hasEditLock: false });
 
     // Always restore real timers so this test does not leak clock state.
+    vi.useRealTimers();
+  });
+
+  it("shows session expired when an idle owner learns the lock disappeared before the idle timer callback runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-31T12:00:00.000Z"));
+
+    const unlockedStatus = {
+      locked: false,
+      lockedByOther: false,
+      isOwner: false,
+      lock: null,
+    };
+
+    const sessionExpiredStates: boolean[] = [];
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+
+      if (isEditLockRequest(input) && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { action: string };
+
+        if (body.action === "acquire") {
+          return {
+            ok: true,
+            json: async () => ownerLockStatus,
+          } as Response;
+        }
+
+        if (body.action === "heartbeat") {
+          return {
+            ok: true,
+            json: async () => unlockedStatus,
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => ownerLockStatus,
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await render(
+      <EditLockHarness
+        ownerIdleTimeoutMs={15 * 60 * 1000}
+        onSessionExpiredChange={(value) => sessionExpiredStates.push(value)}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/templates/test-form-id/edit-lock?requestType=acquire",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    // Simulate a suspended tab: the wall clock moves past the idle threshold,
+    // but the client-side timeout callback has not fired yet.
+    vi.setSystemTime(new Date("2026-03-31T12:15:01.000Z"));
+
+    await vi.advanceTimersByTimeAsync(EDIT_LOCK_HEARTBEAT_INTERVAL_MS);
+
+    await vi.waitFor(() => {
+      expect(sessionExpiredStates.at(-1)).toBe(true);
+    });
+
     vi.useRealTimers();
   });
 

--- a/tests/browser/form-builder/edit-lock/useEditLock.browser.test.tsx
+++ b/tests/browser/form-builder/edit-lock/useEditLock.browser.test.tsx
@@ -747,4 +747,22 @@ describe("useEditLock", () => {
 
     vi.useRealTimers();
   });
+
+  it("does not start lock polling when edit locking is disabled", async () => {
+    function DisabledHarness() {
+      useEditLock({
+        formId: "test-form-id",
+        enabled: false,
+        sessionId: "session-1",
+      });
+
+      return null;
+    }
+
+    await render(<DisabledHarness />);
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

- Update edit lock checks to ensure min user count for all routes and hooks
- Adds stale user count check
- Fixes edit-lock idle handling so the previous owner still sees the session-expired overlay when a long idle period causes the lock to disappear, instead of incorrectly falling through to the generic "free to edit" state.

This covers the staging case where a 15-minute timeout could surface the wrong banner even though shorter timeouts behaved correctly.
