### PR TITLE
chore: rework SSL implementation in @gcforms/database package

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,19 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.7] - 2025-05-04
+## [1.0.8] - 2026-05-05
+
+### Changed
+
+- Reworked SSL implementation
+
+## [1.0.7] - 2026-05-04
 
 ### Fixed
 
 - Added missing `global-bundle.pem` file to `dist` output folder
 
-## [1.0.6] - 2025-05-04
+## [1.0.6] - 2026-05-04
 
 ### Fixed
 
 - Fixed Prisma Studio connection URL
 
-## [1.0.5] - 2025-04-30
+## [1.0.5] - 2026-04-30
 
 ### Changed
 
@@ -35,19 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added edit lock idle timeout setting
 
-## [1.0.2] - 2025-04-28
+## [1.0.2] - 2026-04-28
 
 ### Changed
 
 - Specify connection URL when launching Prisma Studio
 
-## [1.0.1] - 2025-04-27
+## [1.0.1] - 2026-04-27
 
 ### Changed
 
 - Tweaked scripts in package.json
 
-## [1.0.0] - 2025-04-17
+## [1.0.0] - 2026-04-17
 
 ### Changed
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -1,10 +1,24 @@
 import { PrismaClient, Prisma } from "./generated/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { getConnectionUrl } from "./connection";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const certPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "global-bundle.pem");
+const connectionUrl = getConnectionUrl();
 
 const adapter = new PrismaPg({
-  connectionString: getConnectionUrl(),
+  connectionString: connectionUrl,
+  // Test environment does not support SSL
+  ...(/\.ca-central-1\.rds\.amazonaws\.com:5432/i.test(connectionUrl) && {
+    ssl: {
+      rejectUnauthorized: true,
+      ca: fs.readFileSync(certPath),
+    },
+  }),
 });
+
 // Instantiate the extended Prisma client to infer its type
 const extendedPrisma = new PrismaClient({ adapter }).$extends({
   model: {
@@ -28,6 +42,7 @@ const extendedPrisma = new PrismaClient({ adapter }).$extends({
     },
   },
 });
+
 type ExtendedPrismaClient = typeof extendedPrisma;
 
 // Use globalThis for broader environment compatibility

--- a/packages/database/src/connection.ts
+++ b/packages/database/src/connection.ts
@@ -1,6 +1,3 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
 
 let connectionUrl = "";
@@ -19,35 +16,27 @@ const connectionString = async () => {
       `Missing Database Url Environment Variable, current node env is ${process.env.NODE_ENV}`
     );
   }
+
   let envConnectionString: string = envDatabaseUrl;
 
   // If the passed in variable is a secret ARN retrieve the secret
   if (/^arn\:aws\:secretsmanager\:/i.test(envDatabaseUrl)) {
     const secret = await getAwsSecret(envDatabaseUrl);
+
     if (!secret) {
       throw new Error(
         `Could not retrieve Database Url Secret, current node env is ${process.env.NODE_ENV}`
       );
     }
+
     envConnectionString = secret;
   }
-  connectionUrl = addSSLParameters(envConnectionString);
+
+  connectionUrl = envConnectionString;
 };
 
-const addSSLParameters = (envConnectionString: string) => {
-  if (/\.ca-central-1\.rds\.amazonaws\.com:5432/i.test(envConnectionString)) {
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const certPath = path.join(__dirname, "global-bundle.pem");
-
-    if (/:5432\/forms$/i.test(envConnectionString)) {
-      return envConnectionString + `?sslmode=verify-full&sslrootcert=${certPath}`;
-    } else {
-      return envConnectionString + `&sslmode=verify-full&sslrootcert=${certPath}`;
-    }
-  }
-  return envConnectionString;
-};
 await connectionString();
+
 export const getConnectionUrl = () => {
   return connectionUrl;
 };


### PR DESCRIPTION
# Summary | Résumé

- Reworks SSL implementation in `@gcforms/database` package due to path resolution issue in GC Forms API product (related to PNPM symlink paths).