### PR TITLE
chore: add event for edit lock publish flow

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/EditWithGroups.tsx
@@ -74,7 +74,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
 
   useEffect(() => {
     if (isPublished) {
-      router.replace(`/${locale}/form-builder/${id}/settings/`);
+      router.replace(`/${locale}/form-builder/${id}/published`);
       return;
     }
   }, [router, isPublished, id, locale]);
@@ -135,7 +135,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
         <h2 id="editPagesHeading" className="whitespace-nowrap" tabIndex={-1}>
           {t("groups.editPagesHeading")}
         </h2>
-        <div className="ml-5 mt-2">
+        <div className="mt-2 ml-5">
           <SaveButton />
         </div>
       </div>
@@ -165,7 +165,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
                 <ExpandingInput
                   id="formTitle"
                   wrapperClassName="w-full laptop:w-3/4 mt-2 laptop:mt-0 font-bold laptop:text-3xl"
-                  className="font-bold placeholder:text-slate-500 laptop:text-3xl"
+                  className="laptop:text-3xl font-bold placeholder:text-slate-500"
                   ref={titleInput}
                   placeholder={t("placeHolderFormTitle")}
                   value={value}
@@ -235,7 +235,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
           summaryText={t("groups.confirmation.summary")}
           beforeContent={
             <div>
-              <h2 className="my-4 text-2xl laptop:mt-0">{t("richTextConfirmationTitle")}</h2>
+              <h2 className="laptop:mt-0 my-4 text-2xl">{t("richTextConfirmationTitle")}</h2>
               <p className="mb-4">{t("groups.confirmation.beforeText")}</p>
             </div>
           }
@@ -252,7 +252,7 @@ export const EditWithGroups = ({ id, locale }: { id: string; locale: string }) =
           className={"rounded-lg"}
         />
       )}
-      <div className="my-12 flex max-w-[800px] justify-center laptop:my-10">
+      <div className="laptop:my-10 my-12 flex max-w-[800px] justify-center">
         <AddPageButton className="mr-5" />
         <AddBranchingButton id={id} locale={locale} />
       </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/components/Publish.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/publish/components/Publish.tsx
@@ -32,14 +32,10 @@ export const Publish = ({ id }: { id: string }) => {
   const [errorCode, setErrorCode] = useState<null | number>(null);
   const {
     id: storeId,
-    setId,
-    setIsPublished,
     getSchema,
     getName,
   } = useTemplateStore((s) => ({
     id: s.id,
-    setId: s.setId,
-    setIsPublished: s.setIsPublished,
     getSchema: s.getSchema,
     getName: s.getName,
   }));
@@ -78,10 +74,6 @@ export const Publish = ({ id }: { id: string }) => {
     setPublishing(true);
 
     try {
-      // Optimistically set the form as published in the template store
-      setId(id);
-      setIsPublished(true);
-      // Note we don't reset setPublishing(false) here as we're navigating away
       ga("publish_form");
 
       const { formRecord, error } = await updateTemplatePublishedStatus({
@@ -97,9 +89,6 @@ export const Publish = ({ id }: { id: string }) => {
       }
     } catch (e) {
       if ((e as Error).message !== "NEXT_REDIRECT") {
-        // Revert optimistic update
-        setIsPublished(false);
-
         logMessage.error(e);
         setError(true);
         setErrorCode(500);
@@ -195,9 +184,7 @@ export const Publish = ({ id }: { id: string }) => {
           </Button>
           <div
             role="alert"
-            className={`ml-5 inline-block px-3 py-1 
-            ${error ? "bg-red-100 text-red-destructive" : ""}
-            ${!error ? "hidden" : ""}`}
+            className={`ml-5 inline-block px-3 py-1 ${error ? "text-red-destructive bg-red-100" : ""} ${!error ? "hidden" : ""}`}
           >
             <>{error && <p>{t("thereWasAnErrorPublishing")}</p>}</>
           </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -34,14 +34,23 @@ import { sendEmail } from "@lib/integration/notifyConnector";
 import { getOrigin } from "@lib/origin";
 import { BrandProperties, NotificationsInterval } from "@gcforms/types";
 import { redirect } from "next/navigation";
+import { logMessage } from "@lib/logger";
 import {
+  acquireEditLock,
   assertTemplateEditLock,
+  publishEditLockPublishedEvent,
   shouldEnforceTemplateEditLockWithVerifiedUserCount,
   TemplateEditLockedError,
 } from "@lib/editLocks";
 import { validateTemplate } from "@lib/utils/form-builder/validate";
 
-const assertTemplateEditLockIfEnabled = async (templateId: string, userId: string) => {
+const assertTemplateEditLockIfEnabled = async ({
+  templateId,
+  userId,
+}: {
+  templateId: string;
+  userId: string;
+}) => {
   if (
     process.env.APP_ENV === "test" ||
     !(await shouldEnforceTemplateEditLockWithVerifiedUserCount(templateId))
@@ -49,7 +58,25 @@ const assertTemplateEditLockIfEnabled = async (templateId: string, userId: strin
     return;
   }
 
-  await assertTemplateEditLock({ templateId, userId });
+  try {
+    await assertTemplateEditLock({ templateId, userId });
+  } catch (error) {
+    if (!(error instanceof TemplateEditLockedError)) {
+      throw error;
+    }
+
+    const reacquired = await acquireEditLock({
+      templateId,
+      userId,
+    });
+
+    if (!reacquired.isOwner) {
+      throw new TemplateEditLockedError(
+        "Form is locked for editing until you acquire the lock.",
+        reacquired.lock
+      );
+    }
+  }
 };
 
 export type CreateOrUpdateTemplateType = {
@@ -112,8 +139,7 @@ export const createOrUpdateTemplate = AuthenticatedAction(
       if (!formRecord) {
         throw new Error("Failed to create template");
       }
-      // revalidatePath must be at the end of a function.  It leverages the error object to trigger
-      // and internal refresh and can have awkward results if used before an error is thrown by a following fn.
+
       revalidatePath("/[locale]/forms", "page");
 
       return { formRecord };
@@ -146,7 +172,10 @@ export const updateTemplate = AuthenticatedAction(
     error?: string;
   }> => {
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       const formRecord = await updateDbTemplate({
         formID: formID,
         formConfig: formConfig,
@@ -196,7 +225,10 @@ export const updateTemplatePublishedStatus = AuthenticatedAction(
     let response: FormRecord | null = null;
 
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       response = await updateIsPublishedForTemplate(
         formID,
         isPublished,
@@ -210,7 +242,16 @@ export const updateTemplatePublishedStatus = AuthenticatedAction(
         );
       }
 
-      // Revalidate the form-builder layout and the specific published page
+      if (isPublished) {
+        try {
+          await publishEditLockPublishedEvent(formID);
+        } catch (error) {
+          logMessage.warn(
+            `Failed to publish edit-lock published event for ${formID}: ${(error as Error).message}`
+          );
+        }
+      }
+
       revalidatePath(`/form-builder/${formID}`, "layout");
       revalidatePath(`/form-builder/${formID}/published`, "page");
     } catch (error) {
@@ -243,7 +284,10 @@ export const updateTemplateFormPurpose = AuthenticatedAction(
     error?: string;
   }> => {
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       const response = await updateFormPurpose(formID, formPurpose);
       if (!response) {
         throw new Error(
@@ -276,7 +320,10 @@ export const updateTemplateFormSaveAndResume = AuthenticatedAction(
     error?: string;
   }> => {
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       const response = await updateFormSaveAndResume(formID, saveAndResume);
       if (!response) {
         throw new Error(
@@ -309,7 +356,10 @@ export const updateTemplateSecurityAttribute = AuthenticatedAction(
     error?: string;
   }> => {
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       const response = await updateSecurityAttribute(formID, securityAttribute);
       if (!response) {
         throw new Error(
@@ -345,10 +395,10 @@ export const closeForm = AuthenticatedAction(
     error?: string;
   }> => {
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
-      // closingDate: null means the form is open, or will be set to be open
-      // closingDate: a current or past date means the form is closed
-      // closingDate: a future date means the form is scheduled to close in the future
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
 
       if (closingDate && !isValidDateString(closingDate)) {
         throw new Error(`Invalid closing date. Request information: { ${formID}, ${closingDate} }`);
@@ -390,7 +440,10 @@ export const updateTemplateUsers = AuthenticatedAction(
     }
 
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       const response = await updateAssignedUsersForTemplate(formID, users);
       if (!response) {
         throw new Error(
@@ -421,7 +474,10 @@ export const sendResponsesToVault = AuthenticatedAction(
     error?: string;
   }> => {
     try {
-      await assertTemplateEditLockIfEnabled(formID, session.user.id);
+      await assertTemplateEditLockIfEnabled({
+        templateId: formID,
+        userId: session.user.id,
+      });
       await removeDeliveryOption(formID);
 
       return {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.test.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+
+import { EditLockClient } from "./EditLockClient";
+
+const mockState = vi.hoisted(() => ({
+  store: {
+    lang: "en",
+    isPublished: false,
+  },
+  editLockContext: {
+    takeover: vi.fn().mockResolvedValue(undefined),
+    getIsActiveTab: vi.fn(() => true),
+    hasSessionExpired: false,
+    isEnabled: true,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/form-builder/test-form-id/edit",
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("@lib/store/useTemplateStore", () => ({
+  useTemplateStore: (selector: (state: typeof mockState.store) => unknown) =>
+    selector(mockState.store),
+}));
+
+vi.mock(
+  "@formBuilder/components/shared/right-panel/headless-treeview/provider/TreeRefProvider",
+  () => ({
+    useTreeRef: () => ({ headlessTree: { current: { rebuildTree: vi.fn() } } }),
+  })
+);
+
+vi.mock("./EditLockContext", async () => {
+  const actual = await vi.importActual<typeof import("./EditLockContext")>("./EditLockContext");
+  return {
+    ...actual,
+    useEditLockContext: () => mockState.editLockContext,
+  };
+});
+
+vi.mock("./EditLockBanner", () => ({
+  EditLockBanner: () => <div>Take over editing</div>,
+}));
+
+vi.mock("./EditLockSessionExpiredOverlay", () => ({
+  EditLockSessionExpiredOverlay: () => <div>Session expired</div>,
+}));
+
+describe("EditLockClient", () => {
+  beforeEach(() => {
+    mockState.store.isPublished = false;
+    mockState.editLockContext.hasSessionExpired = false;
+    mockState.editLockContext.isEnabled = true;
+  });
+
+  it("renders the lock banner on edit paths while the form is unpublished", () => {
+    render(
+      <EditLockClient>
+        <div>Child content</div>
+      </EditLockClient>
+    );
+
+    expect(screen.getByText("Take over editing")).toBeInTheDocument();
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("hides the lock banner once the form is published", () => {
+    mockState.store.isPublished = true;
+
+    render(
+      <EditLockClient>
+        <div>Child content</div>
+      </EditLockClient>
+    );
+
+    expect(screen.queryByText("Take over editing")).not.toBeInTheDocument();
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+});

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -19,11 +19,15 @@ export const EditLockClient = ({
 }) => {
   const pathname = usePathname();
   const router = useRouter();
-  const { language } = useTemplateStore((s) => ({ language: s.lang }));
+  const { language, isPublished } = useTemplateStore((s) => ({
+    language: s.lang,
+    isPublished: s.isPublished,
+  }));
   const { takeover, getIsActiveTab, hasSessionExpired, isEnabled } = useEditLockContext();
   const { headlessTree } = useTreeRef();
 
-  const showLockedEdit = isEnabled && (!restrictToEditPaths || isEditPath(pathname));
+  const showLockedEdit =
+    isEnabled && !isPublished && (!restrictToEditPaths || isEditPath(pathname));
 
   const handleTakeover = async () => {
     await takeover();

--- a/app/api/templates/[formID]/edit-lock/events/route.ts
+++ b/app/api/templates/[formID]/edit-lock/events/route.ts
@@ -76,9 +76,22 @@ export const GET = middleware([sessionExists()], async (_req, props) => {
         controller.enqueue(encoder.encode("event: takeover-requested\ndata: {}\n\n"));
       };
 
+      const sendPublished = () => {
+        if (closed) {
+          return;
+        }
+
+        controller.enqueue(encoder.encode("event: form-published\ndata: {}\n\n"));
+      };
+
       const handleEvent = (event: EditLockEvent) => {
         if (event.type === "takeover-requested") {
           sendTakeoverRequested();
+          return;
+        }
+
+        if (event.type === "published") {
+          sendPublished();
           return;
         }
 

--- a/constants.ts
+++ b/constants.ts
@@ -46,4 +46,4 @@ export const CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS = 90_000;
 export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
 
 // Toggle verbose SSE lifecycle logging
-export const SHOULD_DEBUG_EDIT_LOCK_SSE = false;
+export const SHOULD_DEBUG_EDIT_LOCK_SSE = true;

--- a/constants.ts
+++ b/constants.ts
@@ -46,4 +46,4 @@ export const CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS = 90_000;
 export const EDIT_LOCK_PRE_TAKEOVER_SAVE_WAIT_MS = 5_000;
 
 // Toggle verbose SSE lifecycle logging
-export const SHOULD_DEBUG_EDIT_LOCK_SSE = true;
+export const SHOULD_DEBUG_EDIT_LOCK_SSE = false;

--- a/lib/editLockEventStreams.ts
+++ b/lib/editLockEventStreams.ts
@@ -86,7 +86,11 @@ const runReaderLoop = async (templateId: string, state: TemplateReaderState): Pr
           }
 
           const eventType = fieldMap["type"];
-          if (eventType === "updated" || eventType === "takeover-requested") {
+          if (
+            eventType === "updated" ||
+            eventType === "takeover-requested" ||
+            eventType === "published"
+          ) {
             const event: EditLockEvent = { type: eventType };
             state.subscribers.forEach((subscriber) => subscriber(event));
           }

--- a/lib/editLocks.ts
+++ b/lib/editLocks.ts
@@ -54,7 +54,7 @@ export type EditLockStatus = {
 };
 
 export type EditLockEvent = {
-  type: "updated" | "takeover-requested";
+  type: "updated" | "takeover-requested" | "published";
 };
 
 export class TemplateEditLockedError extends Error {
@@ -265,6 +265,10 @@ const publishEditLockEvent = async (templateId: string, event: EditLockEvent = u
   await redis.expire(streamKey, editLockTtlSeconds * 2);
 };
 
+export const publishEditLockPublishedEvent = async (templateId: string) => {
+  await publishEditLockEvent(templateId, { type: "published" });
+};
+
 const storeRedisLock = async (lock: EditLockInfo) => {
   const redis = await getRedisInstance();
   await redis.set(
@@ -470,10 +474,10 @@ export const shouldEnableTemplateEditLock = ({
 }): boolean =>
   Boolean(
     allowLockedEditing &&
-    templateId &&
-    templateId !== "0000" &&
-    !isPublished &&
-    assignedUserCount >= MIN_ASSIGNED_USERS_FOR_EDIT_LOCK
+      templateId &&
+      templateId !== "0000" &&
+      !isPublished &&
+      assignedUserCount >= MIN_ASSIGNED_USERS_FOR_EDIT_LOCK
   );
 
 export const invalidateTemplateEditLockUserCountCache = async (

--- a/lib/hooks/form-builder/useEditLock.tsx
+++ b/lib/hooks/form-builder/useEditLock.tsx
@@ -666,8 +666,17 @@ export const useEditLock = ({
       void cbRef.current.flushDraftBeforeTakeover();
     };
 
+    const handleFormPublished: EventListener = () => {
+      if (isOwnerRef.current) {
+        return;
+      }
+
+      void cbRef.current.syncServerState();
+    };
+
     eventSource.addEventListener("lock-status", handleLockStatus);
     eventSource.addEventListener("takeover-requested", handleTakeoverRequested);
+    eventSource.addEventListener("form-published", handleFormPublished);
     eventSource.onerror = () => {
       if (eventSource.readyState === EventSource.CLOSED && eventSourceRef.current === eventSource) {
         eventSourceRef.current = null;
@@ -677,6 +686,7 @@ export const useEditLock = ({
     return () => {
       eventSource.removeEventListener("lock-status", handleLockStatus);
       eventSource.removeEventListener("takeover-requested", handleTakeoverRequested);
+      eventSource.removeEventListener("form-published", handleFormPublished);
       eventSource.close();
       if (eventSourceRef.current === eventSource) {
         eventSourceRef.current = null;

--- a/lib/tests/editLockEventStreams.test.ts
+++ b/lib/tests/editLockEventStreams.test.ts
@@ -105,7 +105,7 @@ vi.mock("@lib/integration/redisConnector", () => ({
   })),
 }));
 
-import { requestEditLockTakeoverSave } from "@lib/editLocks";
+import { publishEditLockPublishedEvent, requestEditLockTakeoverSave } from "@lib/editLocks";
 import { subscribeToSharedEditLockEvents } from "@lib/editLockEventStreams";
 
 describe("editLockEventStreams", () => {
@@ -190,6 +190,23 @@ describe("editLockEventStreams", () => {
 
     // Removing the last subscriber should stop the reader.
     await unsubB();
+    expect(mockReaderConnections[0].disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes published events to subscribers on the matching template", async () => {
+    const events: string[] = [];
+
+    const unsubscribe = await subscribeToSharedEditLockEvents("form-4", (event) => {
+      events.push(event.type);
+    });
+
+    await publishEditLockPublishedEvent("form-4");
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(["published"]);
+    });
+
+    await unsubscribe();
     expect(mockReaderConnections[0].disconnect).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Summary | Résumé

Adds code for edit lock publish flow to redirect to published page when a non lock owner gets a published event.