### PR TITLE
chore: Playwright isolated runs for local dev

### DIFF
--- a/.env.yarn.example
+++ b/.env.yarn.example
@@ -40,3 +40,6 @@ ZITADEL_ADMINISTRATION_KEY=
 # This will be used by the Prisma seed script to automatically create a developer account when running in development mode
 DEVELOPER_NAME=craigzour
 DEVELOPER_EMAIL=clement.janin@cds-snc.ca
+
+# For local dev run playwright:isolated and playwright:run:isolated on a custom port # 
+PLAYWRIGHT_PORT=3006

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ yarn playwright:run:isolated
 
 Those commands set `PLAYWRIGHT_ISOLATE_DB=true`, which keeps the same PostgreSQL server but rewrites the Prisma connection to use a separate schema named `playwright` by default. Your normal development schema is left alone.
 
+Reference:
+Prisma PostgreSQL connection string arguments: https://www.prisma.io/docs/orm/overview/databases/postgresql
+Prisma multi-schema support: https://www.prisma.io/docs/orm/prisma-schema/data-model/multi-schema
+
 If you want a different schema name, set `PLAYWRIGHT_DB_SCHEMA`:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -99,3 +99,47 @@ Once the change is made, you will need to 'Log Out' and log back in. Alternative
 See package.json scripts for vitest and playwright
 
 Playwight is configured to run "yarn build:test && yarn start:test" for the web server
+
+### Running Playwright without resetting your dev schema
+
+Local Playwright runs currently execute `yarn db:test`, which resets the Prisma target before seeding test data. If your normal development workflow depends on a long-lived local schema with users, templates, and feature flags, use the isolated Playwright scripts instead:
+
+```sh
+yarn playwright:isolated
+```
+
+or headless:
+
+```sh
+yarn playwright:run:isolated
+```
+
+Those commands set `PLAYWRIGHT_ISOLATE_DB=true`, which keeps the same PostgreSQL server but rewrites the Prisma connection to use a separate schema named `playwright` by default. Your normal development schema is left alone.
+
+If you want a different schema name, set `PLAYWRIGHT_DB_SCHEMA`:
+
+```sh
+PLAYWRIGHT_DB_SCHEMA=your_schema yarn playwright:run:isolated
+```
+
+To run a single Playwright test file:
+
+```sh
+yarn playwright:run:isolated tests/e2e/smoke.spec.ts
+```
+
+To run a single test by name:
+
+```sh
+yarn playwright:run:isolated --grep "should load the homepage and display expected content"
+```
+
+### Updating Browserslist data
+
+If you see a Browserslist warning about stale `caniuse-lite` data, update it with:
+
+```sh
+npx update-browserslist-db@latest
+```
+
+This updates the dependency data in `yarn.lock`, so include the lockfile change in your commit.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "test:watch:vitest": "vitest --watch",
     "test:watch": "DEBUG_PRINT_LIMIT=10000  vitest --watch",
     "playwright": "playwright test --ui",
+    "playwright:isolated": "PLAYWRIGHT_ISOLATE_DB=true playwright test --ui",
     "playwright:run:headless": "CI=true playwright test",
+    "playwright:run:isolated": "PLAYWRIGHT_ISOLATE_DB=true playwright test",
     "playwright:run": "playwright test",
     "postinstall": "yarn node -e \"process.env.NODE_ENV != 'production' && process.exit(1)\" || husky install && yarn db:generate",
     "upgrade": "yarn next upgrade"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,37 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const isolatedSchemaName = process.env.PLAYWRIGHT_DB_SCHEMA ?? "playwright";
+
+function getPlaywrightDatabaseUrl() {
+  if (process.env.PLAYWRIGHT_DATABASE_URL) {
+    return process.env.PLAYWRIGHT_DATABASE_URL;
+  }
+
+  if (process.env.PLAYWRIGHT_ISOLATE_DB !== "true") {
+    return process.env.DATABASE_URL;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return undefined;
+  }
+
+  const databaseUrl = new URL(process.env.DATABASE_URL);
+  databaseUrl.searchParams.set("schema", isolatedSchemaName);
+  return databaseUrl.toString();
+}
+
+const playwrightDatabaseUrl = getPlaywrightDatabaseUrl();
+
+const webServerEnv = Object.fromEntries(
+  Object.entries({
+    ...process.env,
+    APP_ENV: "test",
+    DATABASE_URL: playwrightDatabaseUrl,
+    NEXT_PUBLIC_APP_ENV: "test",
+    PLAYWRIGHT_TEST: "true",
+  }).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+);
+
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -64,12 +96,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "yarn db:test && yarn build:test && yarn start:test",
-    env: {
-      ...process.env,
-      APP_ENV: "test",
-      NEXT_PUBLIC_APP_ENV: "test",
-      PLAYWRIGHT_TEST: "true",
-    },
+    env: webServerEnv,
     url: "http://localhost:3000",
     reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === "true",
     timeout: 120 * 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const isolatedSchemaName = process.env.PLAYWRIGHT_DB_SCHEMA ?? "playwright";
+const playwrightPort = process.env.PLAYWRIGHT_PORT ?? process.env.PORT ?? "3000";
+const playwrightBaseUrl = `http://localhost:${playwrightPort}`;
 
 function getPlaywrightDatabaseUrl() {
   if (process.env.PLAYWRIGHT_DATABASE_URL) {
@@ -29,6 +31,7 @@ const webServerEnv = Object.fromEntries(
     DATABASE_URL: playwrightDatabaseUrl,
     NEXT_PUBLIC_APP_ENV: "test",
     PLAYWRIGHT_TEST: "true",
+    PORT: playwrightPort,
   }).filter((entry): entry is [string, string] => typeof entry[1] === "string")
 );
 
@@ -54,7 +57,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: playwrightBaseUrl,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
     /* Take screenshot only on failures */
@@ -97,7 +100,7 @@ export default defineConfig({
   webServer: {
     command: "yarn db:test && yarn build:test && yarn start:test",
     env: webServerEnv,
-    url: "http://localhost:3000",
+    url: playwrightBaseUrl,
     reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === "true",
     timeout: 120 * 1000,
   },

--- a/tests/e2e/form-builder/names-and-titles.spec.ts
+++ b/tests/e2e/form-builder/names-and-titles.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from "@playwright/test";
 
 test.describe("Form builder names and titles", () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    await page.goto("http://localhost:3000/en/form-builder/0000/edit");
+    await page.goto("/en/form-builder/0000/edit");
   });
 
   test("Autocompletes name with title on focus", async ({ page }) => {

--- a/tests/helpers/user-session.ts
+++ b/tests/helpers/user-session.ts
@@ -9,7 +9,7 @@ export async function userSession(
   const { admin = false, acceptableUse = true } = options;
 
   // Navigate to login page
-  await page.goto("http://localhost:3000/en/auth/login");
+  await page.goto("/en/auth/login");
 
   // Wait for login inputs
   await page.locator("input[id='username']").waitFor({ state: "visible" });
@@ -64,7 +64,7 @@ export async function userSession(
 
   if (acceptableUse) {
     // Visit policy page and accept
-    await page.goto("http://localhost:3000/en/auth/policy", { waitUntil: "networkidle" });
+    await page.goto("/en/auth/policy", { waitUntil: "networkidle" });
 
     // Wait for the accept button to be ready (visible and enabled)
     const acceptButton = page.locator("#acceptableUse");

--- a/yarn.lock
+++ b/yarn.lock
@@ -11559,21 +11559,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.10.12, baseline-browser-mapping@npm:^2.9.19":
-  version: 2.10.16
-  resolution: "baseline-browser-mapping@npm:2.10.16"
+"baseline-browser-mapping@npm:^2.10.12, baseline-browser-mapping@npm:^2.8.25, baseline-browser-mapping@npm:^2.9.19":
+  version: 2.10.27
+  resolution: "baseline-browser-mapping@npm:2.10.27"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/9947243bb8f16db3f8e05397c5c3e7a91243dcf2d1ec6a681ad5ffabeadee36c1061cd18e5f0432088df6798fa0689890ba26db173b9ad23c5650709b7b2e7cf
-  languageName: node
-  linkType: hard
-
-"baseline-browser-mapping@npm:^2.8.25":
-  version: 2.10.12
-  resolution: "baseline-browser-mapping@npm:2.10.12"
-  bin:
-    baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/391d354240160546c8248317698b61f21f287cc6444766414c2d299a8880045e605ed97e8d8cd198a0b9dfaa4e73c2fa765bbef089474533a904733b1dc9a363
+  checksum: 10c0/8ebadaeeddc99367a1522661476d6c895b452a96023c6cef0576aecf8f5f6d37c91e6bde8fa8904cc11a32c5c6bc9df2030481504e50a5aed17e6c7f8bac3b5a
   languageName: node
   linkType: hard
 
@@ -11828,17 +11819,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001579":
-  version: 1.0.30001787
-  resolution: "caniuse-lite@npm:1.0.30001787"
-  checksum: 10c0/93a6975afbf07f49c9077b348948bbc25b6a82596ccd07b4b6503e48f6f968e1a1e057cc25004db8a2d1d4f35f0c792739e33634edfcefc88ff184c9a2f7a036
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001754":
-  version: 1.0.30001755
-  resolution: "caniuse-lite@npm:1.0.30001755"
-  checksum: 10c0/7b8e32a4ec307b50f557d30176651cf69f20a0ea4de6f5f34149ea65a1f0cfcc0677b403484aea3661c7469ab11f2df6528027b9ec2d0265635ede9d5b517380
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001754":
+  version: 1.0.30001792
+  resolution: "caniuse-lite@npm:1.0.30001792"
+  checksum: 10c0/03bab64b123453e18e7c6747c32bb820be6d82ac78536c5c3704988aaeec411715a2045069fb569f872d73acf1ea64bf83508c9fdfa87b6d012236cde738e1be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary | Résumé

This change adds an opt-in isolated Playwright workflow for local development so running end-to-end tests does not tear down the database setup used by the normal `yarn dev` session.

Previously, Playwright always started its own app server and ran `yarn db:test`, which resets and reseeds whatever Prisma target `DATABASE_URL` points to. That is destructive when the local development database contains users, templates, feature flags, or other state that should persist between sessions.

With this change, the new `yarn playwright:isolated` and `yarn playwright:run:isolated` commands rewrite the Playwright web server's `DATABASE_URL` to use a separate Postgres schema. Playwright still resets and seeds a test database target, but it does so in that isolated schema instead of the normal dev schema. The regular local database setup remains intact, and when returning to `yarn dev` the existing local state is still there.

See: Prisma multi-schema support: https://www.prisma.io/docs/orm/prisma-schema/data-model/multi-schema
