### PR TITLE
fix: use local type for translation function

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## [2.2.8] - 2026-05-11
 
-- BREAKING: Remove i18next as a dependency from validation types. Introduced a local TranslateFn type for translation function signatures in validation. This keeps the core package framework-agnostic and avoids unnecessary dependencies.
+- Remove i18next as a dependency from validation types. Introduced a local TranslateFn type for translation function signatures in validation. This keeps the core package framework-agnostic and avoids unnecessary dependencies.
 
 ## [2.2.7] - 2026-05-04
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## [2.2.8] - 2026-05-11
+
+- BREAKING: Remove i18next as a dependency from validation types. Introduced a local TranslateFn type for translation function signatures in validation. This keeps the core package framework-agnostic and avoids unnecessary dependencies.
+
 ## [2.2.7] - 2026-05-04
 
 - Support for new Advanced number input validation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/core",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/validation/validation.ts
+++ b/packages/core/src/validation/validation.ts
@@ -13,7 +13,9 @@ import { getRegexByType } from "./regex";
 import { isFileExtensionValid, isIndividualFileSizeValid } from "./file";
 import { isSafeRegex } from "./regex";
 import { isNumberInput } from "../utils/isNumberInput";
-import { TFunction } from "i18next";
+
+// Minimal translation function type to avoid i18next dependency
+export type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
 
 export const isFieldResponseValid = (
   value: unknown,
@@ -21,7 +23,7 @@ export const isFieldResponseValid = (
   componentType: string,
   formElement: FormElement,
   validator: ValidationProperties,
-  t: TFunction<"common">
+  t: TranslateFn
 ): string | null | Record<string, unknown>[] => {
   // Note that this will ignore a file upload since the value is an object. We could check the
   // file's file name length but this is probably not necessary since OS's have a filename limit.


### PR DESCRIPTION
# Summary | Résumé

Removes 'i18next' dep for type

6.745 node_modules/@gcforms/core/dist/index.d.ts(1,27): error TS2307: Cannot find module 'i18next' or its corresponding type declarations.