### PR TITLE
chore: Add eslint rule to prevent external dependencies in packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,18 @@
 import { defineConfig, globalIgnores } from "eslint/config";
+import fs from "node:fs";
+import path from "node:path";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import importPlugin from "eslint-plugin-import";
 import reactHooks from "eslint-plugin-react-hooks";
+
+const packagesDir = path.resolve("packages");
+const packageDirList = fs.existsSync(packagesDir)
+  ? fs
+      .readdirSync(packagesDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(packagesDir, entry.name))
+  : [];
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -27,6 +38,29 @@ const eslintConfig = defineConfig([
     "coverage/**",
     ".lintstagedrc.mjs",
   ]),
+  {
+    files: ["packages/*/src/**/*.{js,jsx,ts,tsx,mts,cts}"],
+    plugins: {
+      import: importPlugin,
+    },
+    rules: {
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          packageDir: packageDirList,
+          devDependencies: [
+            "**/*.test.{js,jsx,ts,tsx,mts,cts}",
+            "**/*.spec.{js,jsx,ts,tsx,mts,cts}",
+            "**/*.vitest.{js,jsx,ts,tsx,mts,cts}",
+            "**/__tests__/**",
+          ],
+          includeTypes: true,
+          optionalDependencies: true,
+          peerDependencies: true,
+        },
+      ],
+    },
+  },
   {
     rules: {
       "no-console": "error",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "eslint": "^9.39.0",
     "eslint-config-next": "16.2.6",
     "eslint-config-prettier": "^9.1.2",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.0.10",
     "ioredis-mock": "^8.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12283,6 +12283,7 @@ __metadata:
     eslint: "npm:^9.39.0"
     eslint-config-next: "npm:16.2.6"
     eslint-config-prettier: "npm:^9.1.2"
+    eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-react-hooks: "npm:^7.0.1"
     formik: "npm:2.4.9"
     fuse.js: "npm:^7.1.0"


### PR DESCRIPTION
# Summary | Résumé

Adds an eslint rule that ensures our internal `packages` do not include dependencies from the main project (or otherwise not available dependencies).