### PR TITLE
fix: validate email server side when processing support/contact form submissions

### DIFF
--- a/app/(gcforms)/[locale]/(support)/contact/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/contact/actions.ts
@@ -3,7 +3,18 @@
 import { serverTranslation } from "@i18n";
 import { createTicket } from "@lib/integration/freshdesk";
 import { logMessage } from "@lib/logger";
-import { email, minLength, object, safeParse, string, toLowerCase, trim, pipe } from "valibot";
+import { isValidGovEmail } from "@lib/validation/validation";
+import {
+  email,
+  minLength,
+  object,
+  safeParse,
+  string,
+  toLowerCase,
+  trim,
+  pipe,
+  check,
+} from "valibot";
 
 export interface ErrorStates {
   validationErrors: {
@@ -126,7 +137,11 @@ const validate = async (
       toLowerCase(),
       trim(),
       minLength(1, t("input-validation.required", { ns: "common" })),
-      email(t("input-validation.email", { ns: "common" }))
+      email(t("input-validation.email", { ns: "common" })),
+      check(
+        (email) => isValidGovEmail(email),
+        t("input-validation.validGovEmail", { ns: "common" })
+      )
     ),
     department: pipe(string(), minLength(1, t("input-validation.required", { ns: "common" }))),
     // Note: branch and jobTitle are not required/validated

--- a/app/(gcforms)/[locale]/(support)/support/actions.ts
+++ b/app/(gcforms)/[locale]/(support)/support/actions.ts
@@ -3,7 +3,18 @@
 import { serverTranslation } from "@i18n";
 import { createTicket } from "@lib/integration/freshdesk";
 import { logMessage } from "@lib/logger";
-import { email, minLength, object, safeParse, string, toLowerCase, trim, pipe } from "valibot";
+import { isValidGovEmail } from "@lib/validation/validation";
+import {
+  email,
+  minLength,
+  object,
+  safeParse,
+  string,
+  toLowerCase,
+  trim,
+  pipe,
+  check,
+} from "valibot";
 
 export interface ErrorStates {
   validationErrors: {
@@ -102,7 +113,8 @@ const validate = async (
       toLowerCase(),
       trim(),
       minLength(1, t("input-validation.required")),
-      email(t("input-validation.email"))
+      email(t("input-validation.email")),
+      check((email) => isValidGovEmail(email), t("input-validation.validGovEmail"))
     ),
     // radio input can send a non-string value when empty
     request: pipe(


### PR DESCRIPTION
# Summary | Résumé

- Adds missing email validation check server side when processing support/contact form submissions