### PR TITLE
fix: fix toast background

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -8,7 +8,6 @@
 @import "./form-builder.css";
 @import "../packages/core/styles/header.css";
 @import "../packages/core/styles/gc-header.css";
-@import "../packages/core/styles/toast.css";
 @import "./animations.css";
 
 /* ===== Custom max-width breakpoint variants (inherited from legacy config) ===== */
@@ -382,6 +381,9 @@
   /* ----- Outline ----- */
   --outline-color-default: #ffbf47;
 }
+
+/* ===== Toast styles (after @theme to use defined variables) ===== */
+@import "../packages/core/styles/toast.css";
 
 /* ===== Tailwind source detection ===== */
 @source "../app/**/*.{js,ts,jsx,tsx,mdx}";


### PR DESCRIPTION
# Summary | Résumé

Toast background have reverted to dropping the background colour

<img width="535" height="226" alt="Screenshot 2026-05-14 at 12 46 22 PM" src="https://github.com/user-attachments/assets/5b5b035c-492f-4ca5-9b79-2f3bea3c4866" />


Fixed:


<img width="676" height="296" alt="Screenshot 2026-05-14 at 12 45 49 PM" src="https://github.com/user-attachments/assets/f373b4d0-ad17-45d6-b68d-3d269ef8fc2a" />
