### PR TITLE
fix: broken GC Forms API documentation links

### DIFF
--- a/i18n/translations/en/form-builder-responses.json
+++ b/i18n/translations/en/form-builder-responses.json
@@ -150,11 +150,11 @@
       "noProblemResponses": "No responses reported with problems",
       "noProblemResponsesMessage": "Problem responses will appear here until signed off for removal from GC Forms.",
       "noNewResponsesApiTitle": "No responses awaiting retrieval",
-      "noNewResponsesApiMessage": "<p className='mb-2'>Once retrieved from the API endpoint, the form submissions will appear here and be available in GC Forms for 30 days.</p><p>Read more about setting up the integration in our <a href='https://cds-snc.github.io/forms-api/home/' target='_blank'>API documentation</a>.</p>",
+      "noNewResponsesApiMessage": "<p className='mb-2'>Once retrieved from the API endpoint, the form submissions will appear here and be available in GC Forms for 30 days.</p><p>Read more about setting up the integration in our <a href='https://cds-snc.github.io/forms-api' target='_blank'>API documentation</a>.</p>",
       "apiResponsesAvailableTitle": "Responses waiting for retrieval",
-      "apiResponsesAvailableMessage": "<p className='mb-2'>Retrieve new form submissions via the API.</p><p>Read more about making API requests in our <a href='https://cds-snc.github.io/forms-api/making-requests/' target='_blank'>API documentation</a>.</p>",
+      "apiResponsesAvailableMessage": "<p className='mb-2'>Retrieve new form submissions via the API.</p><p>Read more about making API requests in our <a href='https://cds-snc.github.io/forms-api/making-requests' target='_blank'>API documentation</a>.</p>",
       "apiResponsesAwaitingConfirmTitle": "Responses waiting on confirmation",
-      "apiResponsesAwaitingConfirmMessage": "<p className='mb-2'>Confirm that form submissions were successfully retrieved via the API.</p><p>Read more about making API requests in our <a href='https://cds-snc.github.io/forms-api/making-requests/' target='_blank'>API documentation</a>.</p>"
+      "apiResponsesAwaitingConfirmMessage": "<p className='mb-2'>Confirm that form submissions were successfully retrieved via the API.</p><p>Read more about making API requests in our <a href='https://cds-snc.github.io/forms-api/making-requests' target='_blank'>API documentation</a>.</p>"
     },
     "notifications": {
       "downloadComplete": "Responses moved to the “Downloaded” tab",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -876,7 +876,7 @@
         "text1": "This section is for developers who want to use the API to pull form submission data to a target system with a custom integration. Once set-up, responses can be retrieved from the API endpoint programmatically. Visit our documentation site for more information.",
         "docsButton": {
           "text": "Go to API documentation",
-          "link": "https://cds-snc.github.io/forms-api/home"
+          "link": "https://cds-snc.github.io/forms-api"
         },
         "apiKey": {
           "title": "Retrieve submissions via API",
@@ -913,7 +913,7 @@
         "title": "API key generated",
         "message": "New responses are available through the API. Find out more about integration set-up in ",
         "docsLinkText": "API documentation",
-        "docsLink": "https://cds-snc.github.io/forms-api/home/"
+        "docsLink": "https://cds-snc.github.io/forms-api"
       },
       "keyExists": "API key already exists",
       "keyIdToolTip": {
@@ -1268,7 +1268,7 @@
     },
     "apiDocNotes": {
       "title": "Set up your API integration",
-      "text1": "To connect to our API endpoint and retrieve responses, follow the <a href='https://cds-snc.github.io/forms-api/home' target='_blank'>API documentation</a> for developers."
+      "text1": "To connect to our API endpoint and retrieve responses, follow the <a href='https://cds-snc.github.io/forms-api' target='_blank'>API documentation</a> for developers."
     },
     "vaultNote": {
       "text1": "PROTECTED B form responses must be downloaded from GC Forms.",

--- a/i18n/translations/fr/form-builder-responses.json
+++ b/i18n/translations/fr/form-builder-responses.json
@@ -150,11 +150,11 @@
       "noProblemResponses": "Aucune réponse signalée avec problème",
       "noProblemResponsesMessage": "Les réponses signalées avec problèmes apparaîtront ici jusqu'à ce qu'elles soient approuvées pour leur suppression de Formulaires GC.",
       "noNewResponsesApiTitle": "Aucune réponse en attente de récupération",
-      "noNewResponsesApiMessage": "<p className='mb-2'>Une fois récupérées du point de terminaison API, les soumissions de formulaires apparaîtront ici et seront disponibles dans Formulaires GC pendant 30 jours.</p><p>Pour en savoir plus sur la configuration de l'intégration consultez notre <a href='https://cds-snc.github.io/forms-api/accueil' target='_blank'>documentation API</a>)</p>",
+      "noNewResponsesApiMessage": "<p className='mb-2'>Une fois récupérées du point de terminaison API, les soumissions de formulaires apparaîtront ici et seront disponibles dans Formulaires GC pendant 30 jours.</p><p>Pour en savoir plus sur la configuration de l'intégration consultez notre <a href='https://cds-snc.github.io/forms-api/fr' target='_blank'>documentation API</a>)</p>",
       "apiResponsesAvailableTitle": "Réponses en attente de récupération",
-      "apiResponsesAvailableMessage": "<p className='mb-2'>Récupérez les nouvelles soumissions via l'API.</p><p>Pour en savoir plus sur les demandes API, consultez notre <a href='https://cds-snc.github.io/forms-api/effectuer-des-demandes/' target='_blank'>documentation API</a></p>",
+      "apiResponsesAvailableMessage": "<p className='mb-2'>Récupérez les nouvelles soumissions via l'API.</p><p>Pour en savoir plus sur les demandes API, consultez notre <a href='https://cds-snc.github.io/forms-api/fr/making-requests' target='_blank'>documentation API</a></p>",
       "apiResponsesAwaitingConfirmTitle": "Réponses en attente de confirmation",
-      "apiResponsesAwaitingConfirmMessage": "<p className='mb-2'>Confirmez que les soumissions de formulaire ont bien été récupérées via l'API.</p><p>Pour en savoir plus sur les demandes API, consultez notre  <a href='https://cds-snc.github.io/forms-api/effectuer-des-demandes/' target='_blank'>Documentation API</a>.</p>"
+      "apiResponsesAwaitingConfirmMessage": "<p className='mb-2'>Confirmez que les soumissions de formulaire ont bien été récupérées via l'API.</p><p>Pour en savoir plus sur les demandes API, consultez notre  <a href='https://cds-snc.github.io/forms-api/fr/making-requests' target='_blank'>Documentation API</a>.</p>"
     },
     "notifications": {
       "downloadComplete": "Réponses déplacées vers l'onglet « Téléchargements »",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -878,7 +878,7 @@
 
         "docsButton": {
           "text": "Accéder à la documentation API",
-          "link": "https://cds-snc.github.io/forms-api/accueil"
+          "link": "https://cds-snc.github.io/forms-api/fr"
         },
         "apiKey": {
           "title": "Récupérer les soumissions via l'API",
@@ -919,7 +919,7 @@
         "title": "La clé API a été générée",
         "message": "Les nouvelles réponses seront disponibles par l'API. Trouvez des instructions pour la configuration de l'intégration dans ",
         "docsLinkText": "la documentation API",
-        "docsLink": "https://cds-snc.github.io/forms-api/accueil/"
+        "docsLink": "https://cds-snc.github.io/forms-api/fr"
       },
       "keyExists": "La clé existe déjà",
       "keyIdToolTip": {
@@ -1277,7 +1277,7 @@
     },
     "apiDocNotes": {
       "title": "Configurez votre intégration API",
-      "text1": "Pour vous connecter à notre point de terminaison afin de récupérer des réponses, suivez la <a href='https://cds-snc.github.io/forms-api/accueil' target='_blank'>Documentation API</a> pour développeurs."
+      "text1": "Pour vous connecter à notre point de terminaison afin de récupérer des réponses, suivez la <a href='https://cds-snc.github.io/forms-api/fr' target='_blank'>Documentation API</a> pour développeurs."
     },
     "vaultNote": {
       "text1": "Les réponses aux formulaires PROTÉGÉ B doivent être téléchargées de Formulaires GC",


### PR DESCRIPTION
# Summary | Résumé

closes https://github.com/cds-snc/forms-api/issues/356

- Fixes broken GC Forms API documentation links