### PR TITLE
chore: add reload for edit session time-out

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockClient.tsx
@@ -5,7 +5,6 @@ import { useTemplateStore } from "@lib/store/useTemplateStore";
 import { EditLockBanner } from "@formBuilder/components/shared/edit-lock/EditLockBanner";
 import { useTreeRef } from "@formBuilder/components/shared/right-panel/headless-treeview/provider/TreeRefProvider";
 import { EditLockSessionExpiredOverlay } from "./EditLockSessionExpiredOverlay";
-import { useRouter } from "next/navigation";
 import { useEditLockContext, isEditPath } from "./EditLockContext";
 
 export const EditLockClient = ({
@@ -20,9 +19,7 @@ export const EditLockClient = ({
   formId: string;
 }) => {
   const pathname = usePathname();
-  const router = useRouter();
-  const { language, isPublished } = useTemplateStore((s) => ({
-    language: s.lang,
+  const { isPublished } = useTemplateStore((s) => ({
     isPublished: s.isPublished,
   }));
   const { takeover, getIsActiveTab, hasSessionExpired, isEnabled } = useEditLockContext();
@@ -47,14 +44,14 @@ export const EditLockClient = ({
   // Show the session expired overlay only for the previous owner
   const showSessionExpiredOverlay = hasSessionExpired;
 
-  const returnToForms = () => {
-    router.push(`/${language}/forms`);
+  const reloadPage = () => {
+    window.location.reload();
   };
 
   return (
     <>
       {showSessionExpiredOverlay ? (
-        <EditLockSessionExpiredOverlay onReturnToForms={returnToForms} formId={formId} />
+        <EditLockSessionExpiredOverlay onReloadPage={reloadPage} formId={formId} />
       ) : (
         <EditLockBanner takeover={handleTakeover} getIsActiveTab={getIsActiveTab} formId={formId} />
       )}

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockSessionExpiredOverlay.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/edit-lock/EditLockSessionExpiredOverlay.tsx
@@ -11,10 +11,10 @@ import { usePathname } from "next/navigation";
 
 export const EditLockSessionExpiredOverlay = ({
   formId,
-  onReturnToForms,
+  onReloadPage,
 }: {
   formId: string;
-  onReturnToForms: () => void;
+  onReloadPage: () => void;
 }) => {
   const { t } = useTranslation("form-builder");
   const pathname = usePathname();
@@ -50,10 +50,10 @@ export const EditLockSessionExpiredOverlay = ({
             </div>
             <Button
               theme="primary"
-              onClick={onReturnToForms}
+              onClick={onReloadPage}
               className="self-center whitespace-nowrap hover:cursor-pointer sm:self-start"
             >
-              {t("editLock.returnToForms")}
+              {t("editLock.reloadPage")}
             </Button>
           </div>
         </div>

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -666,7 +666,8 @@
     "takeoverAvailableTitle": "Form available for editing",
     "sessionExpiredTitle": "Your session expired",
     "sessionExpiredMessage": "Editing was stopped because the form was idle. Re-open the form to make changes.",
-    "returnToForms": "Return to forms"
+    "returnToForms": "Return to forms",
+    "reloadPage": "Reload"
   },
   "gcFormsApi": "API",
   "gcFormsPublish": "Publish",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -664,7 +664,8 @@
     "takeoverError": "Impossible de prendre le contrôle. Veuillez réessayer.",
     "sessionExpiredTitle": "Votre session a expiré",
     "sessionExpiredMessage": "La modification a été arrêtée parce que ce formulaire était inactif. Veuillez rouvrir le formulaire pour y apporter des changements.",
-    "returnToForms": "Retourner aux formulaires"
+    "returnToForms": "Retourner aux formulaires",
+    "reloadPage": "Recharger"
   },
   "gcFormsApi": "API",
   "gcFormsPublish": "Publier",


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/7161

Updates session time-out dialog to reload current page vs redirecting to forms

<img width="735" height="347" alt="Screenshot 2026-05-19 at 9 05 29 AM" src="https://github.com/user-attachments/assets/2529a272-8e09-4e0d-967e-4c441e1ef848" />
