### PR TITLE
chore: update edit lock timing

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -11,9 +11,10 @@ export const MAX_CHOICE_AMOUNT = 400;
 /*--------------------------------------------*
  * Edit lock and timing constants
  *--------------------------------------------*/
-// Keep the edit lock alive for 5 minutes after the last successful heartbeat so brief stalls
+// Keep the edit lock alive for 6 minutes after the last successful heartbeat so brief stalls
 // or delayed requests do not drop ownership while we prefer a quieter, more stable lock.
-export const EDIT_LOCK_TTL_MS = 300_000;
+// This extends the original 5 min to 6 min to provide buffer before 10-min session expires.
+export const EDIT_LOCK_TTL_MS = 360_000;
 
 // Only enforce edit locking when more than one assigned person could plausibly edit the form.
 export const MIN_ASSIGNED_USERS_FOR_EDIT_LOCK = 2;
@@ -32,13 +33,16 @@ export const EDIT_LOCK_STATUS_POLL_INTERVAL_MS = 60_000;
 export const CLIENT_SIDE_EDIT_LOCK_ACTIVITY_THROTTLE_MS = 1_000;
 
 // After 30 seconds without local interaction, we stop calling the editor actively engaged.
+// Status: "Active now" (0-30s) → "Open, no recent activity" (30s-4min)
 export const CLIENT_SIDE_EDIT_LOCK_IDLE_MS = 30_000;
 
-// After 2 minutes without interaction, or as soon as the tab is hidden, we treat the editor as away.
-export const CLIENT_SIDE_EDIT_LOCK_AWAY_MS = 120_000;
+// After 4 minutes without interaction, or as soon as the tab is hidden, we treat the editor as away.
+// Status changes to: "Away" (4-5min). Provides 1-minute buffer before stale warning appears.
+export const CLIENT_SIDE_EDIT_LOCK_AWAY_MS = 240_000;
 
-// Surface a stale connection warning during the last 90 seconds of the longer lock TTL.
-export const CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS = 90_000;
+// Surface a stale connection warning during the last 1 minute of the lock TTL (5-6min).
+// Status changes to: "Inactive" + warning banner. Lock expires after 6 minutes total.
+export const CLIENT_SIDE_EDIT_LOCK_STALE_THRESHOLD_MS = 60_000;
 
 // Give the current editor a window to flush any dirty draft state before a takeover completes.
 // This must be generous enough for Lambda / cold-start environments where the full


### PR DESCRIPTION
# Summary | Résumé

Based on a 10min session idle timeout

Update the timing thresholds for various statuses

```
"statuses": {
"active": "Active now" // 0-30 seconds
"idle": "Open, no recent activity" // 30 seconds to 4 minutes
"away": "Away" // 4 minutes to 5 minutes
"stale": "Inactive" // 5 minutes to 6 minutes (lock expires)
},
```