### PR TITLE
chore: add Playwright trace to local + ci upload

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -95,3 +95,10 @@ jobs:
         with:
           name: playwright-screenshots
           path: test-results/
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: playwright-traces
+          path: playwright-report/
+          retention-days: 1

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:vitest:browser:watch": "VITEST_BROWSER=true vitest --watch",
     "test:watch:vitest": "vitest --watch",
     "test:watch": "DEBUG_PRINT_LIMIT=10000  vitest --watch",
-    "playwright:ui:local": "playwright install chromium --with-deps && PLAYWRIGHT_ISOLATE_DB=true playwright test --ui",
+    "playwright:ui:local": "playwright install chromium --with-deps && PLAYWRIGHT_ISOLATE_DB=true playwright test --ui --trace on",
     "playwright:headless:local": "playwright install chromium --with-deps && PLAYWRIGHT_ISOLATE_DB=true playwright test",
     "playwright:headless:ci": "CI=true playwright test",
     "postinstall": "yarn node -e \"process.env.NODE_ENV != 'production' && process.exit(1)\" || husky install && yarn db:generate",


### PR DESCRIPTION
# Summary | Résumé

Adds trace mode see: https://playwright.dev/docs/trace-viewer to help debug flaky tests

Adds trace option for local dev
Adds upload action for CI so we can download the trace zip.


