### PR TITLE
chore: fix path for trace reports

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -100,5 +100,5 @@ jobs:
         if: failure()
         with:
           name: playwright-traces
-          path: playwright-report/
+          path: test-results/
           retention-days: 1


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where the wrong path was used for artifact upload.

> No files were found with the provided path: playwright-report/. No artifacts will be uploaded.