### PR TITLE
Fix bug when resuming a form that has fileUpload in repeating set

### DIFF
--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -177,6 +177,22 @@ export const GCFormsProvider = ({
         cleanedValue = { name: null, size: null, content: null } as FileInputResponse;
       }
 
+      // For repeating sets (dynamicRow), reset any file inputs within rows
+      if (Array.isArray(value)) {
+        cleanedValue = value.map((row) => {
+          if (row && typeof row === "object" && !Array.isArray(row)) {
+            const cleanedRow = { ...(row as Record<string, unknown>) };
+            for (const [rowKey, rowValue] of Object.entries(cleanedRow)) {
+              if (rowValue && typeof rowValue === "object" && "size" in rowValue) {
+                cleanedRow[rowKey] = { name: null, size: null, content: null };
+              }
+            }
+            return cleanedRow;
+          }
+          return row;
+        });
+      }
+
       // For all other inputs just return the value
       cleanedValues[key] = cleanedValue as string | string[];
     });


### PR DESCRIPTION
# Summary | Résumé

When saving a form to continue later, the form values are stripped of any fileUpload inputs since attached files can't be embedded. The code was handling regular fileInputs fine, but if the fileInput was in a repeating set, it was missing them. This PR adds a loop to handle fileInputs within a repeatingSet.

Fixes #7203 