### PR TITLE
chore: tweak error message punctuation

### DIFF
--- a/i18n/translations/en/common.json
+++ b/i18n/translations/en/common.json
@@ -35,47 +35,47 @@
   "lang-toggle": "Language selection",
   "submitButton": "Submit",
   "input-validation": {
-    "heading": "Please correct the errors on the page.",
+    "heading": "Please correct the errors on the page",
     "required": "Complete the required field to continue.",
-    "alphanumeric": "Enter letters and numbers only.",
-    "duplicateEmail": "This email address was already added.",
+    "alphanumeric": "Enter letters and numbers only",
+    "duplicateEmail": "This email address was already added",
     "text": "",
-    "number": "Enter a number.",
-    "email": "Enter a valid email address.",
-    "date": "Enter a valid date in mm/dd/yyyy format.",
-    "date-invalid": "Enter a valid date.",
-    "phone": "Enter a valid telephone number.",
-    "regex": "Enter the correct format.",
-    "invalidRegex": "There was a problem processing the form.",
-    "combobox-strict": "Select a value from the list.",
-    "too-few-digits": "The number entered does not have enough digits.",
-    "too-many-digits": "The number entered has too many digits.",
-    "too-small": "The number entered must be at least {{min}}.",
-    "too-large": "The number entered must be at most {{max}}.",
+    "number": "Enter a number",
+    "email": "Enter a valid email address",
+    "date": "Enter a valid date in mm/dd/yyyy format",
+    "date-invalid": "Enter a valid date",
+    "phone": "Enter a valid telephone number",
+    "regex": "Enter the correct format",
+    "invalidRegex": "There was a problem processing the form",
+    "combobox-strict": "Select a value from the list",
+    "too-few-digits": "The number entered does not have enough digits",
+    "too-many-digits": "The number entered has too many digits",
+    "too-small": "The number entered must be at least {{min}}",
+    "too-large": "The number entered must be at most {{max}}",
     "file-upload": {
       "default": {
         "heading": "There was a problem submitting your form",
-        "message": "The file {{fileName}} could not be uploaded."
+        "message": "The file {{fileName}} could not be uploaded"
       },
       "file-size-too-large": {
-        "message": "'{{fileName}}' is too big. Choose a file size that is less than {{maxSizeInMb}} MB."
+        "message": "'{{fileName}}' is too big. Choose a file size that is less than {{maxSizeInMb}} MB"
       },
       "mime": {
         "heading": "There was a problem submitting your form",
-        "message": "{{fileName}} could not be uploaded. Try saving the file in a different format and uploading it again."
+        "message": "{{fileName}} could not be uploaded. Try saving the file in a different format and uploading it again"
       },
       "network-error": {
         "heading": "There was a problem submitting your form",
-        "message": "Check your network connection and try to submit again later."
+        "message": "Check your network connection and try to submit again later"
       }
     },
-    "file-type-invalid": "Select a different file type.",
-    "too-many-characters": "Shorten the response.",
-    "all-checkboxes-required": "Read and check all boxes to confirm the items in this section.",
-    "validGovEmail": "Enter a valid government email address.",
-    "notSameAsUserEmail": "This cannot be your email address. Enter the email of the person in charge of your team. If that's you, add a colleague.",
-    "min-length-4-characters": "Must be at least 4 characters.",
-    "mismatched-type": "The answer does not match the required type.",
+    "file-type-invalid": "Select a different file type",
+    "too-many-characters": "Shorten the response",
+    "all-checkboxes-required": "Read and check all boxes to confirm the items in this section",
+    "validGovEmail": "Enter a valid government email address",
+    "notSameAsUserEmail": "This cannot be your email address. Enter the email of the person in charge of your team. If that's you, add a colleague",
+    "min-length-4-characters": "Must be at least 4 characters",
+    "mismatched-type": "The answer does not match the required type",
     "MB": "MB",
     "KB": "KB",
     "bytes": "bytes",

--- a/i18n/translations/fr/common.json
+++ b/i18n/translations/fr/common.json
@@ -35,38 +35,38 @@
   "lang-toggle": "Sélection de la langue",
   "submitButton": "Soumettre",
   "input-validation": {
-    "heading": "Veuillez corriger les erreurs sur la page.",
-    "required": "Compléter le champ obligatoire afin de continuer.",
-    "alphanumeric": "Entrer uniquement des lettres et des chiffres.",
-    "duplicateEmail": "Cette adresse courriel a déjà été ajoutée.",
+    "heading": "Veuillez corriger les erreurs sur la page",
+    "required": "Compléter le champ obligatoire afin de continuer",
+    "alphanumeric": "Entrer uniquement des lettres et des chiffres",
+    "duplicateEmail": "Cette adresse courriel a déjà été ajoutée",
     "text": "",
-    "number": "Entrer un numéro.",
-    "email": "Entrer une adresse courriel valide.",
-    "date": "Entrer une date valide au format mm/jj/aaaa.",
-    "date-invalid": "Entrer une date valide.",
-    "phone": "Entrer un numéro de téléphone valide.",
-    "regex": "Veuillez utiliser le bon format.",
-    "invalidRegex": "Il y a eu un problème lors du traitement du formulaire.",
-    "combobox-strict": "Sélectionnez une valeur dans la liste.",
-    "too-few-digits": "Le chiffre saisi ne contient pas assez de chiffres.",
-    "too-many-digits": "Le chiffre saisi contient trop de chiffres.",
-    "too-small": "Le chiffre saisi doit être au moins {{min}}.",
-    "too-large": "Le chiffre saisi doit être au plus {{max}}.",
+    "number": "Entrer un numéro",
+    "email": "Entrer une adresse courriel valide",
+    "date": "Entrer une date valide au format mm/jj/aaaa",
+    "date-invalid": "Entrer une date valide",
+    "phone": "Entrer un numéro de téléphone valide",
+    "regex": "Veuillez utiliser le bon format",
+    "invalidRegex": "Il y a eu un problème lors du traitement du formulaire",
+    "combobox-strict": "Sélectionnez une valeur dans la liste",
+    "too-few-digits": "Le chiffre saisi ne contient pas assez de chiffres",
+    "too-many-digits": "Le chiffre saisi contient trop de chiffres",
+    "too-small": "Le chiffre saisi doit être au moins {{min}}",
+    "too-large": "Le chiffre saisi doit être au plus {{max}}",
     "file-upload": {
       "default": {
-        "heading": "Il y a eu un problème lors de la soumission de votre formulaire.",
-        "message": "Le fichier « {{fileName}} » n'a pas pu être envoyé."
+        "heading": "Il y a eu un problème lors de la soumission de votre formulaire",
+        "message": "Le fichier « {{fileName}} » n'a pas pu être envoyé"
       },
       "file-size-too-large": {
-        "message": "Le fichier « {{fileName}} » est trop volumineux. Choisissez un fichier dont la taille est inférieure à {{maxSizeInMb}} Mo."
+        "message": "Le fichier « {{fileName}} » est trop volumineux. Choisissez un fichier dont la taille est inférieure à {{maxSizeInMb}} Mo"
       },
       "mime": {
-        "heading": "Il y a eu un problème lors de la soumission de votre formulaire.",
-        "message": "{{fileName}} n'a pas pu être envoyé. Essayez d'enregistrer le fichier dans un autre format et de le téléverser à nouveau."
+        "heading": "Il y a eu un problème lors de la soumission de votre formulaire",
+        "message": "{{fileName}} n'a pas pu être envoyé. Essayez d'enregistrer le fichier dans un autre format et de le téléverser à nouveau"
       },
       "network-error": {
-        "heading": "Il y a eu un problème lors de la soumission de votre formulaire.",
-        "message": "Vérifiez votre connexion réseau et réessayez plus tard."
+        "heading": "Il y a eu un problème lors de la soumission de votre formulaire",
+        "message": "Vérifiez votre connexion réseau et réessayez plus tard"
       }
     },
     "file-type-invalid": "Sélectionner un autre type de fichier.",


### PR DESCRIPTION
Fixes #6940

Avoids multiple punctuations:

<img width="1508" height="1126" alt="image" src="https://github.com/user-attachments/assets/9d68bed7-2b7f-45e4-9e4b-4246ea377db7" />
