### PR TITLE
fix: DateModified sometimes appears to be in the future

### DIFF
--- a/components/clientComponents/globals/DateModified.tsx
+++ b/components/clientComponents/globals/DateModified.tsx
@@ -75,7 +75,7 @@ export const DateModified = ({
   if (isSubmitting) return null;
 
   const date = new Date(String(updatedAt));
-  const formattedDate = date.toISOString().slice(0, 10);
+  const formattedDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 
   return (
     <div className="gc-date-modified mt-10" id="date-modified">

--- a/tests/e2e/auth/login.spec.ts
+++ b/tests/e2e/auth/login.spec.ts
@@ -42,7 +42,7 @@ test.describe("Login Page", () => {
       await page.locator("button[type='submit']").click();
       await expect(page.locator("[id='errorMessageusername']")).toBeVisible();
       await expect(page.locator("[id='errorMessageusername']")).toContainText(
-        "Enter a valid government email address."
+        "Enter a valid government email address"
       );
     });
 

--- a/tests/e2e/auth/register.spec.ts
+++ b/tests/e2e/auth/register.spec.ts
@@ -11,7 +11,7 @@ test.describe("Register Page", () => {
   test("Error on submitting a form with an empty name field", async ({ page }) => {
     await page.locator("button[type='submit']").click();
     await expect(page.locator("#errorMessagename")).toContainText(
-      "Complete the required field to continue."
+      "Complete the required field to continue"
     );
   });
 
@@ -24,7 +24,7 @@ test.describe("Register Page", () => {
   test("Error on submitting a form with an empty email field", async ({ page }) => {
     await page.locator("button[type='submit']").click();
     await expect(page.locator("#errorMessageusername")).toContainText(
-      "Complete the required field to continue."
+      "Complete the required field to continue"
     );
   });
 
@@ -32,7 +32,7 @@ test.describe("Register Page", () => {
     await page.fill("input[id='username']", "myemail@email");
     await page.locator("button[type='submit']").click();
     await expect(page.locator("#errorMessageusername")).toContainText(
-      "Enter a valid government email address."
+      "Enter a valid government email address"
     );
   });
 
@@ -40,7 +40,7 @@ test.describe("Register Page", () => {
     await page.fill("input[id='username']", "myemail@email.com");
     await page.locator("button[type='submit']").click();
     await expect(page.locator("#errorMessageusername")).toContainText(
-      "Enter a valid government email address."
+      "Enter a valid government email address"
     );
   });
 
@@ -53,7 +53,7 @@ test.describe("Register Page", () => {
   test("Error on submitting a form with an empty password field", async ({ page }) => {
     await page.locator("button[type='submit']").click();
     await expect(page.locator("#errorMessagepassword")).toContainText(
-      "Complete the required field to continue."
+      "Complete the required field to continue"
     );
   });
 
@@ -129,7 +129,7 @@ test.describe("Register Page", () => {
     await page.fill("input[id='passwordConfirmation']", "Password1!!!!!!!");
     await page.locator("button[type='submit']").click();
     await expect(page.locator("#errorMessagepasswordConfirmation")).toContainText(
-      "The entries for password must match."
+      "The entries for password must match"
     );
   });
 

--- a/tests/e2e/forms/attestation.spec.ts
+++ b/tests/e2e/forms/attestation.spec.ts
@@ -67,7 +67,7 @@ test.describe("Testing attestation fields", { tag: "@published-form" }, () => {
 
       // Verify error messages
       await expect(errorMessage).toContainText(
-        "Read and check all boxes to confirm the items in this section."
+        "Read and check all boxes to confirm the items in this section"
       );
 
       await setCheckboxValue(condition1Checkbox, true);
@@ -78,7 +78,7 @@ test.describe("Testing attestation fields", { tag: "@published-form" }, () => {
 
       // Verify error messages
       await expect(errorMessage).toContainText(
-        "Read and check all boxes to confirm the items in this section."
+        "Read and check all boxes to confirm the items in this section"
       );
     });
 

--- a/tests/e2e/forms/required-attributes.spec.ts
+++ b/tests/e2e/forms/required-attributes.spec.ts
@@ -44,7 +44,7 @@ test.describe("Testing a basic frontend form", { tag: "@published-form" }, () =>
       await page.waitForTimeout(2000);
 
       await expect(
-        page.getByRole("heading", { name: "Please correct the errors on the page." })
+        page.getByRole("heading", { name: "Please correct the errors on the page" })
       ).toBeVisible();
       await expect(shortAnswerErrorLink).toBeVisible();
       await expect(


### PR DESCRIPTION
# Summary | Résumé

When parsing the updated_at date from the Template to display as "DateModified" on frontend forms, the previous code parsed the date to local time using `Date(updatedAt)`, but then used `.toISOString()` which would convert it back to UTC before splitting the date off for display. So if the updatedAt was close to midnight, the date could cross the date boundary depending on the user's timezone.

This PR addresses the issue by parsing the date portion directly from the Date object.

Fixes #7228 