### PR TITLE
fix: Add missing message for deleting draft responses.

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -594,7 +594,7 @@
       "InvitationAccepted": "Invitation accepted",
       "UpdateFormJsonConfig": "Downloaded copy of the form",
       "UpdatedNotificationSettings": "Updated notification settings",
-      "DeletedDraftResponses": "Deleted draft responses"
+      "DeletedDraftResponses": "Deleted draft form responses"
     },
     "eventDetails": {
       "CreatedForm": "Created form",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -593,7 +593,8 @@
       "PublishForm": "Form published",
       "InvitationAccepted": "Invitation accepted",
       "UpdateFormJsonConfig": "Downloaded copy of the form",
-      "UpdatedNotificationSettings": "Updated notification settings"
+      "UpdatedNotificationSettings": "Updated notification settings",
+      "DeletedDraftResponses": "Deleted draft responses"
     },
     "eventDetails": {
       "CreatedForm": "Created form",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -613,7 +613,6 @@
       "UpdateClosingDate": "Date de fermeture modifiée à : {{closingDate}}",
       "RemoveClosingDate": "Date de fermeture supprimée.",
       "UpdatedNotificationSettings": "Paramètre de notification {{enabled}} pour {{userEmail}}",
-
       "GrantAccess": "Accès accordé à {{userEmail}}",
       "RevokeAccess": "Accès révoqué pour {{userEmail}}",
       "UserInvited": "{{userEmail}} a invité {{invitationEmail}}",
@@ -622,7 +621,8 @@
       "CancelInvitation": "Invitation annulée pour {{invitationEmail}}",
       "ReceivedFormResponses": "Réponse {{submissionId}} reçue",
       "DownloadedFormResponses": "Réponse {{submissionId}} téléchargée en format {{format}}",
-      "ConfirmedResponsesForForm": "Réponse {{submissionId}} confirmée"
+      "ConfirmedResponsesForForm": "Réponse {{submissionId}} confirmée",
+      "DeletedDraftResponses": "Réponses brouillon supprimées"
     },
     "eventParams": {
       "Unclassified": "Non classifié",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -622,7 +622,7 @@
       "ReceivedFormResponses": "Réponse {{submissionId}} reçue",
       "DownloadedFormResponses": "Réponse {{submissionId}} téléchargée en format {{format}}",
       "ConfirmedResponsesForForm": "Réponse {{submissionId}} confirmée",
-      "DeletedDraftResponses": "Réponses brouillon supprimées"
+      "DeletedDraftResponses": "Réponses de l'ébauche de formulaire supprimées"
     },
     "eventParams": {
       "Unclassified": "Non classifié",

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -139,7 +139,7 @@ export const AuditLogDetails = {
   CognitoUserIdentifier: "Cognito user unique identifier (sub): ${userId}",
   UpdatedNotificationSettings: "UpdatedNotificationSettings",
   ConfirmedResponsesForForm: "ConfirmedResponsesForForm",
-  DeletedDraftResponsesForForm: "Deleted draft responses for form ${formId}",
+  DeletedDraftResponsesForForm: "DeletedDraftResponses",
   RetreiveSelectedFormResponses:
     "Retrieve selected responses for form ${formID} with ID ${submissionID}",
   ListAllResponsesForForm: "List all responses ${status} for form ${formID}",


### PR DESCRIPTION
Part of #7195

Added missing message, it removes the formId param as the formId is already available in the first column.