### PR TITLE
chore: remove unused `RELIABILITY_FILE_STORAGE` environment variable from `.env.yarn.example`

### DIFF
--- a/.env.yarn.example
+++ b/.env.yarn.example
@@ -13,11 +13,10 @@ TEMPLATE_ID=
 TOKEN_SECRET=
 
 # This is required for local development
-# When working with AWS Scratch accounts the <DATABASE_URL>, <REDIS_URL> and <RELIABILITY_FILE_STORAGE> will be provided by the deployment script once it has completed
+# When working with AWS Scratch accounts the <DATABASE_URL> and <REDIS_URL> will be provided by the deployment script once it has completed
 AWS_PROFILE=development
 DATABASE_URL=postgres://<DATABASE_URL>
 REDIS_URL=<REDIS_URL>
-RELIABILITY_FILE_STORAGE=<RELIABILITY_FILE_STORAGE>
 
 # This is required for the authentication to work in local development. Ask a team member for the values. 
 COGNITO_APP_CLIENT_ID=


### PR DESCRIPTION
# Summary | Résumé

- Removes unused `RELIABILITY_FILE_STORAGE` environment variable