### PR TITLE
chore: fix rendering perf issue for large forms

### DIFF
--- a/components/clientComponents/forms/SaveAndResume/ConfirmDownloadDialog.tsx
+++ b/components/clientComponents/forms/SaveAndResume/ConfirmDownloadDialog.tsx
@@ -14,7 +14,6 @@ import { toast } from "@formBuilder/components/shared/Toast";
 
 import { generateResponseProgressHtml } from "@lib/saveAndResume/generateResponseProgressHtml";
 import { downloadDataAsBlob } from "@lib/downloadDataAsBlob";
-import { logMessage } from "@lib/logger";
 
 import { SaveFileWarning } from "./FileWarning/SaveFileWarning";
 
@@ -62,7 +61,6 @@ export const ConfirmDownloadDialog = ({
       await downloadDataAsBlob(html.data, fileName, { "text/html": [".html"] });
       return true;
     } catch (error) {
-      logMessage.error(error);
       toast.error(generateHtmlError, "public-facing-form");
       return false;
     } finally {

--- a/components/clientComponents/forms/SaveAndResume/SaveAndResume.tsx
+++ b/components/clientComponents/forms/SaveAndResume/SaveAndResume.tsx
@@ -53,12 +53,14 @@ export const SaveAndResume = ({ formId, language }: { formId: string; language: 
         </Button>
       </span>
 
-      <ConfirmDownloadDialog
-        type="progress"
-        language={language}
-        open={confirm}
-        handleClose={() => setConfirm(false)}
-      />
+      {confirm && (
+        <ConfirmDownloadDialog
+          type="progress"
+          language={language}
+          open={confirm}
+          handleClose={() => setConfirm(false)}
+        />
+      )}
 
       {drawerOpen && (
         <MobileDrawer

--- a/components/clientComponents/forms/SaveAndResume/SaveAndResumeButton.tsx
+++ b/components/clientComponents/forms/SaveAndResume/SaveAndResumeButton.tsx
@@ -25,12 +25,14 @@ export const SaveAndResumeButton = ({ language }: { language: Language }) => {
         </>
       </DownloadProgress>
 
-      <ConfirmDownloadDialog
-        type="progress"
-        language={language}
-        open={confirm}
-        handleClose={() => setConfirm(false)}
-      />
+      {confirm && (
+        <ConfirmDownloadDialog
+          type="progress"
+          language={language}
+          open={confirm}
+          handleClose={() => setConfirm(false)}
+        />
+      )}
     </div>
   );
 };

--- a/components/clientComponents/forms/SaveAndResume/SaveResponse.tsx
+++ b/components/clientComponents/forms/SaveAndResume/SaveResponse.tsx
@@ -31,12 +31,14 @@ export const SaveResponse = ({ language }: { language: Language }) => {
           <DownloadSubmissionIcon className="fill-white" />
         </>
       </DownloadConfirm>
-      <ConfirmDownloadDialog
-        type="confirm"
-        language={language}
-        open={confirm}
-        handleClose={() => setConfirm(false)}
-      />
+      {confirm && (
+        <ConfirmDownloadDialog
+          type="confirm"
+          language={language}
+          open={confirm}
+          handleClose={() => setConfirm(false)}
+        />
+      )}
     </div>
   );
 };

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -143,7 +143,6 @@ export const GCFormsProvider = ({
 
   const getValues = useCallback(() => {
     return values.current;
-    return {};
   }, []);
 
   const getNonce = () => {

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { createContext, useContext, ReactNode } from "react";
+import React, { createContext, useContext, ReactNode, useCallback } from "react";
 
 import { type FormValues, type GroupsType, type PublicFormRecord } from "@gcforms/types";
 import { type Language } from "@lib/types/form-builder-types";
@@ -34,7 +34,6 @@ interface GCFormsContextValueType {
   updateValues: ({ formValues }: { formValues: FormValues }) => void;
   getValues: () => FormValues;
   matchedIds: string[];
-  filteredMatchedIds: string[];
   groups?: GroupsType;
   currentGroup: string | null;
   getPreviousGroup: (currentGroup: string) => string;
@@ -85,15 +84,6 @@ export const GCFormsProvider = ({
   const [submissionId, setSubmissionId] = React.useState<string | undefined>(undefined);
   const [submissionDate, setSubmissionDate] = React.useState<string | undefined>(undefined);
 
-  // eslint-disable-next-line react-hooks/refs
-  const filteredResponses = filterValuesByVisibleElements(formRecord, values.current);
-  const filteredMatchedIds = matchedIds.filter((id) => {
-    const parentId = id.split(".")[0];
-    if (filteredResponses[parentId]) {
-      return id;
-    }
-  });
-
   const hasNextAction = (group: string) => {
     return groups[group]?.nextAction ? true : false;
   };
@@ -115,6 +105,14 @@ export const GCFormsProvider = ({
 
   const handleNextAction = () => {
     if (!currentGroup) return;
+
+    const filteredResponses = filterValuesByVisibleElements(formRecord, values.current);
+    const filteredMatchedIds = matchedIds.filter((id) => {
+      const parentId = id.split(".")[0];
+      if (filteredResponses[parentId]) {
+        return id;
+      }
+    });
 
     if (hasNextAction(currentGroup)) {
       const nextAction = getNextAction(groups, currentGroup, filteredMatchedIds);
@@ -143,9 +141,10 @@ export const GCFormsProvider = ({
     setCurrentGroup(group);
   };
 
-  const getValues = () => {
-    return values.current as FormValues;
-  };
+  const getValues = useCallback(() => {
+    return values.current;
+    return {};
+  }, []);
 
   const getNonce = () => {
     return nonce || "";
@@ -253,7 +252,6 @@ export const GCFormsProvider = ({
         updateValues,
         getValues,
         matchedIds,
-        filteredMatchedIds,
         groups,
         currentGroup,
         getPreviousGroup,
@@ -293,7 +291,6 @@ export const useGCFormsContext = () => {
       submissionDate: undefined,
       setSubmissionDate: () => void 0,
       matchedIds: [""],
-      filteredMatchedIds: [""],
       groups: {},
       currentGroup: "",
       getPreviousGroup: () => "",


### PR DESCRIPTION
# Summary | Résumé

- Updates code to not render the confirm dialog when it's in a hidden state 
- Moves filteredResponses to function where it's being called.

We previously had the dialog in a hidden state until it was open but caused a regression in  #7255
https://github.com/cds-snc/platform-forms-client/pull/7255/changes#diff-ae3622ef706fe8743654bb5e451edd6bf332bd839329ff873fcb6ab63528faf7L56


**Current main:**


https://github.com/user-attachments/assets/f79fccfa-cf0e-4cf0-8b47-2607836f6d0b


**Branch**


https://github.com/user-attachments/assets/c7d19e67-f624-4964-a2fe-448ef9da1fa7



