### PR TITLE
chore: remove next env from tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ packages/database/src/generated
 
 tests/.auth/*.json
 eslint_report.html
+
+next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Summary | Résumé

Update to add .env.next to the ignore list as per the docs

<img width="1310" height="496" alt="Screenshot 2026-06-08 at 9 08 04 AM" src="https://github.com/user-attachments/assets/5d6cde3a-21ed-46d2-bd10-3564b241f22a" />

