### PR TITLE
fix: my page polling update

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
@@ -9,7 +9,7 @@ import { DraftEditLink } from "../client/DraftEditLink";
 import { useTranslation } from "@i18n/client";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { FormsTemplateWithLockInfo } from "../types";
+import { FormsTemplateWithLockInfo, FormTabStatus } from "../types";
 import {
   getCardState,
   formatDateToYYYYMMDD,
@@ -247,7 +247,13 @@ const CardFooterPublished = memo(({ cardId }: { cardId: string }) => {
 });
 CardFooterPublished.displayName = "CardFooterPublished";
 
-const CardComponent = ({ card, status }: { card: FormsTemplateWithLockInfo; status?: string }) => {
+const CardComponent = ({
+  card,
+  status,
+}: {
+  card: FormsTemplateWithLockInfo;
+  status?: FormTabStatus;
+}) => {
   const params = useParams();
   const language = params?.locale as string;
 

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
@@ -45,11 +45,13 @@ export const Cards = ({
     onLoadMore: handleLoadMore,
   });
 
-  // Setup edit lock polling
+  // Setup edit lock polling - only poll for recentlyEdited and draft tabs
+  const shouldPoll = !filter || filter === "recentlyEdited" || filter === "draft";
   useEditLockPolling({
     templates,
     displayedCount,
     pollIntervalMs,
+    enabled: shouldPoll,
     onUpdate: (nextTemplates) => {
       startTransition(() => {
         setTemplates(nextTemplates);

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, startTransition, ViewTransition } from "react";
 import { Card } from "./Card";
-import { FormsTemplateWithLockInfo } from "../types";
+import { FormsTemplateWithLockInfo, FormTabStatus, TAB_STATUS } from "../types";
 import { useTranslation } from "@i18n/client";
 import { CARDS_PER_BATCH } from "../constants";
 import { useEditLockPolling } from "../hooks/useEditLockPolling";
@@ -16,10 +16,10 @@ export const Cards = ({
   status,
   pollIntervalMs,
 }: {
-  filter?: string;
+  filter?: FormTabStatus;
   initialTemplates: FormsTemplateWithLockInfo[];
   overdueTemplateIds: string[];
-  status?: string;
+  status?: FormTabStatus;
   pollIntervalMs: number;
 }) => {
   const { t } = useTranslation("my-forms");
@@ -46,7 +46,8 @@ export const Cards = ({
   });
 
   // Setup edit lock polling - only poll for recentlyEdited and draft tabs
-  const shouldPoll = !filter || filter === "recentlyEdited" || filter === "draft";
+  const shouldPoll =
+    !filter || filter === TAB_STATUS.RECENTLY_EDITED || filter === TAB_STATUS.DRAFT;
   useEditLockPolling({
     templates,
     displayedCount,
@@ -61,10 +62,10 @@ export const Cards = ({
 
   // Get the appropriate message when there are no forms to display
   const emptyStateMessage = useMemo(() => {
-    if (filter === "recentlyEdited" || !filter) return t("cards.noRecentlyEditedForms");
-    if (filter === "draft") return t("cards.noDraftsForms");
-    if (filter === "published") return t("cards.noPublishedForms");
-    if (filter === "archived") return t("cards.noArchivedForms");
+    if (filter === TAB_STATUS.RECENTLY_EDITED || !filter) return t("cards.noRecentlyEditedForms");
+    if (filter === TAB_STATUS.DRAFT) return t("cards.noDraftsForms");
+    if (filter === TAB_STATUS.PUBLISHED) return t("cards.noPublishedForms");
+    if (filter === TAB_STATUS.ARCHIVED) return t("cards.noArchivedForms");
     return t("cards.noForms");
   }, [filter, t]);
 
@@ -87,7 +88,7 @@ export const Cards = ({
         {templates.length > 0 ? (
           <>
             <ol className="grid grid-cols-[repeat(auto-fit,16em)] items-start gap-4 p-0">
-              {(status === "draft" || status === "published" || !status) && (
+              {(status === TAB_STATUS.DRAFT || status === TAB_STATUS.PUBLISHED || !status) && (
                 <li className="flex h-full w-full max-w-[16em]" key={-1}>
                   <NewFormButton />
                 </li>

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
@@ -12,6 +12,7 @@ import {
   MenuDropdownItemCallback,
   MenuDropdownItemI,
 } from "./MenuDropdown/MenuDropdown";
+import { FormTabStatus, TAB_STATUS } from "../types";
 
 export const Menu = ({
   id,
@@ -24,7 +25,7 @@ export const Menu = ({
   name: string;
   isPublished: boolean;
   ttl?: Date;
-  status?: string;
+  status?: FormTabStatus;
 }) => {
   const {
     t,
@@ -110,7 +111,7 @@ export const Menu = ({
           // Start async clone but return immediate callback value to satisfy MenuDropdown
           (async () => {
             try {
-              const res = await cloneForm(id, status === "archived", language);
+              const res = await cloneForm(id, status === TAB_STATUS.ARCHIVED, language);
               if (res && res.formRecord && !res.error) {
                 toast.success(t("card.menu.cloneSuccess"));
                 window.location.href = `/${language}/form-builder/${res.formRecord.id}/edit`;

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/hooks/useEditLockPolling.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/hooks/useEditLockPolling.ts
@@ -24,11 +24,13 @@ export function useEditLockPolling({
   displayedCount,
   pollIntervalMs,
   onUpdate,
+  enabled = true,
 }: {
   templates: FormsTemplateWithLockInfo[];
   displayedCount: number;
   pollIntervalMs: number;
   onUpdate: (updater: (prev: FormsTemplateWithLockInfo[]) => FormsTemplateWithLockInfo[]) => void;
+  enabled?: boolean;
 }) {
   const templatesRef = useRef(templates);
   const displayedCountRef = useRef(displayedCount);
@@ -199,7 +201,7 @@ export function useEditLockPolling({
   // Also pause/resume polling based on tab visibility.
   useEffect(() => {
     const startPolling = () => {
-      if (document.hidden) {
+      if (document.hidden || !enabled) {
         return;
       }
 
@@ -213,7 +215,7 @@ export function useEditLockPolling({
     };
 
     const handleVisibilityChange = () => {
-      if (document.hidden) {
+      if (document.hidden || !enabled) {
         // Tab became inactive - pause polling.
         stopPolling();
       } else {
@@ -227,8 +229,10 @@ export function useEditLockPolling({
       markActivity();
     };
 
-    // Start polling on mount.
-    startPolling();
+    // Start polling on mount if enabled
+    if (enabled) {
+      startPolling();
+    }
 
     // Presence detection for progressive backoff
     document.addEventListener("visibilitychange", handleVisibilityChange); // TODO probably not needed since we won't be polling when hidden, could leave just in case
@@ -250,5 +254,5 @@ export function useEditLockPolling({
         abortControllerRef.current.abort();
       }
     };
-  }, [clearScheduledPoll, fetchEditLockUpdates, markActivity, scheduleNextPoll]);
+  }, [clearScheduledPoll, fetchEditLockUpdates, markActivity, scheduleNextPoll, enabled]);
 }

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/server/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/server/Card.tsx
@@ -7,6 +7,7 @@ import { serverTranslation } from "@i18n";
 import Link from "next/link";
 import { DeliveryOption } from "@lib/types";
 import Skeleton from "react-loading-skeleton";
+import { FormTabStatus } from "../types";
 
 const CardBanner = async ({ isPublished, ttl }: { isPublished: boolean; ttl: Date | null }) => {
   const { t } = await serverTranslation("my-forms");
@@ -168,10 +169,10 @@ export interface CardI {
   date: string;
   url: string;
   overdue: boolean;
-  status?: string;
+  status?: FormTabStatus;
 }
 
-export const Card = async ({ card, status }: { card: CardI; status?: string }) => {
+export const Card = async ({ card, status }: { card: CardI; status?: FormTabStatus }) => {
   const { t } = await serverTranslation("my-forms");
   return (
     <div

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/server/Navigation.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/server/Navigation.tsx
@@ -2,8 +2,14 @@ import { serverTranslation } from "@i18n";
 import { ArchiveIcon, FolderIcon, GlobeIcon, PageIcon } from "@serverComponents/icons";
 import { NavLink } from "./NavLink";
 import { cn } from "@lib/utils";
+import { FormTabStatus, TAB_STATUS } from "../types";
 
-export const Navigation = async ({ filter }: { filter?: string; templateCount?: number }) => {
+export const Navigation = async ({
+  filter,
+}: {
+  filter?: FormTabStatus;
+  templateCount?: number;
+}) => {
   const {
     t,
     i18n: { language },
@@ -17,14 +23,18 @@ export const Navigation = async ({ filter }: { filter?: string; templateCount?: 
       <NavLink
         href={`/${language}/forms`}
         id="tab-all"
-        active={filter === "recentlyEdited" || !filter}
+        active={filter === TAB_STATUS.RECENTLY_EDITED || !filter}
       >
         <>
           <FolderIcon className={cn(iconClassname, "h-5 w-5")} />
           {t("nav.recentlyEdited")}
         </>
       </NavLink>
-      <NavLink href={`/${language}/forms?status=draft`} id="tab-drafts" active={filter === "draft"}>
+      <NavLink
+        href={`/${language}/forms?status=draft`}
+        id="tab-drafts"
+        active={filter === TAB_STATUS.DRAFT}
+      >
         <>
           <PageIcon className={cn(iconClassname, "h-5 w-5")} />
           {t("nav.drafts")}
@@ -33,7 +43,7 @@ export const Navigation = async ({ filter }: { filter?: string; templateCount?: 
       <NavLink
         href={`/${language}/forms?status=published`}
         id="tab-published"
-        active={filter === "published"}
+        active={filter === TAB_STATUS.PUBLISHED}
       >
         <>
           <GlobeIcon className={cn(iconClassname, "h-5 w-5")} />
@@ -43,7 +53,7 @@ export const Navigation = async ({ filter }: { filter?: string; templateCount?: 
       <NavLink
         href={`/${language}/forms?status=archived`}
         id="tab-archived"
-        active={filter === "archived"}
+        active={filter === TAB_STATUS.ARCHIVED}
       >
         <>
           <ArchiveIcon className={cn(iconClassname)} />

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/types.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/types.ts
@@ -72,3 +72,18 @@ export type FormsTemplateWithLockInfo = FormsTemplate & {
   editLockInfo?: EditLockInfoClient | null;
   lastEditedBy?: string | null;
 };
+
+/**
+ * Possible tab statuses for filtering forms
+ */
+export type FormTabStatus = "recentlyEdited" | "draft" | "published" | "archived";
+
+/**
+ * Constants for form tab status values
+ */
+export const TAB_STATUS = {
+  RECENTLY_EDITED: "recentlyEdited",
+  DRAFT: "draft",
+  PUBLISHED: "published",
+  ARCHIVED: "archived",
+} as const;

--- a/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
@@ -16,22 +16,23 @@ import { prisma } from "@gcforms/database";
 import { getTemplateIdsWithEditLocks, getEditLockInfoWithCollaborators } from "@lib/editLockUtils";
 import { EDIT_LOCK_POLL_INTERVAL_MS } from "./components/constants";
 import { CoEditingHelp } from "./components/server/CoEditingHelp";
-import type { FormsTemplate, FormsTemplateWithLockInfo } from "./components/types";
+import type { FormsTemplate, FormsTemplateWithLockInfo, FormTabStatus } from "./components/types";
+import { TAB_STATUS } from "./components/types";
 
-const getStatusTitle = (status: string | undefined, t: (key: string) => string): string => {
+const getStatusTitle = (status: FormTabStatus | undefined, t: (key: string) => string): string => {
   const defaultStatus = t("nav.recentlyEdited");
   const statusTitleMap: Record<string, string> = {
-    draft: t("nav.drafts"),
-    published: t("nav.published"),
-    archived: t("nav.archived"),
-    recentlyEdited: t("nav.recentlyEdited"),
+    [TAB_STATUS.DRAFT]: t("nav.drafts"),
+    [TAB_STATUS.PUBLISHED]: t("nav.published"),
+    [TAB_STATUS.ARCHIVED]: t("nav.archived"),
+    [TAB_STATUS.RECENTLY_EDITED]: t("nav.recentlyEdited"),
   };
   return status ? statusTitleMap[status] : defaultStatus;
 };
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{ status?: FormTabStatus }>;
 }): Promise<Metadata> {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
   const { locale } = params;
@@ -91,7 +92,7 @@ const FALLBACK_DATE = Date.now().toString();
 
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{ status?: FormTabStatus }>;
 }) {
   const searchParams = await props.searchParams;
 
@@ -117,8 +118,9 @@ export default async function Page(props: {
   // Moved from Cards to Page to avoid component being cached when navigating back to this page
   const options: TemplateOptions = {
     requestedWhere: {
-      isPublished: status === "published" ? true : status === "draft" ? false : undefined,
-      ttl: status === "archived" ? { not: null } : null,
+      isPublished:
+        status === TAB_STATUS.PUBLISHED ? true : status === TAB_STATUS.DRAFT ? false : undefined,
+      ttl: status === TAB_STATUS.ARCHIVED ? { not: null } : null,
     },
     sortByDateUpdated: "desc",
   };
@@ -178,7 +180,7 @@ export default async function Page(props: {
   // Filter templates based on status
   // For "recentlyEdited", show the 4 most recently updated templates
   const filteredTemplates =
-    status === "recentlyEdited" || !status
+    status === TAB_STATUS.RECENTLY_EDITED || !status
       ? templatesWithEditLocks.slice(0, 4)
       : templatesWithEditLocks;
 
@@ -223,14 +225,14 @@ export default async function Page(props: {
           <Navigation filter={status} />
         </div>
         <div className="mt-6 ml-2">
-          {status == "draft" && <ResumeEditingForm />}
+          {status == TAB_STATUS.DRAFT && <ResumeEditingForm />}
           <CoEditingHelp />
         </div>
       </div>
       <div className="flex h-full min-h-0 flex-col">
         <div className="">
           <Invitations invitations={invitations} />
-          {status == "archived" && (
+          {status == TAB_STATUS.ARCHIVED && (
             <div className="mb-4">
               <div>
                 {t("archivedNotice")}&nbsp;


### PR DESCRIPTION
# Summary | Résumé

Update the my page polling to only run when the Draft or Recently Edited tabs are active. Also add some types for form status to improve the developer experience.