### PR TITLE
chore: Audit Log Events String Cleanup

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -2,7 +2,7 @@
 
 import { Language, FormServerErrorCodes, ServerActionError } from "@lib/types/form-builder-types";
 import { getAppSetting } from "@lib/appSettings";
-import { AuditLogDetails, logEvent } from "@lib/auditLogs";
+import { AuditLogEvent, AuditLogDetails, logEvent } from "@lib/auditLogs";
 import { ucfirst } from "@lib/client/clientHelpers";
 import {
   Answer,
@@ -518,7 +518,7 @@ const logDownload = async (
     logEvent(
       userId,
       { type: "Response", id: item.id },
-      "DownloadResponse",
+      AuditLogEvent.DownloadResponse,
       AuditLogDetails.DownloadedFormResponses,
       { format: format, "item.id": item.id }
     );

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api-integration/components/throttlingRate/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/api-integration/components/throttlingRate/actions.ts
@@ -8,7 +8,7 @@ import {
 } from "@lib/cache/throttlingCache";
 import { AuthenticatedAction } from "@lib/actions";
 import { ServerActionError } from "@lib/types/form-builder-types";
-import { AuditLogDetails, logEvent } from "@lib/auditLogs";
+import { AuditLogEvent, AuditLogDetails, logEvent } from "@lib/auditLogs";
 
 // Public facing functions - they can be used by anyone who finds the associated server action identifer
 
@@ -26,7 +26,7 @@ export const temporarilyIncreaseThrottlingRate = AuthenticatedAction(
       logEvent(
         session.user.id,
         { type: "ServiceAccount" },
-        "IncreaseThrottlingRate",
+        AuditLogEvent.IncreaseThrottlingRate,
         AuditLogDetails.IncreasedThrottling,
         { formId: formId, weeks: weeks.toString(), userId: session.user.id }
       );
@@ -44,7 +44,7 @@ export const permanentlyIncreaseThrottlingRate = AuthenticatedAction(
       logEvent(
         session.user.id,
         { type: "ServiceAccount" },
-        "IncreaseThrottlingRate",
+        AuditLogEvent.IncreaseThrottlingRate,
         AuditLogDetails.PermanentIncreasedThrottling,
         { formId: formId, userId: session.user.id }
       );
@@ -61,7 +61,7 @@ export const resetThrottlingRate = AuthenticatedAction(async (session, formId: s
     logEvent(
       session.user.id,
       { type: "ServiceAccount" },
-      "ResetThrottlingRate",
+      AuditLogEvent.ResetThrottlingRate,
       AuditLogDetails.ResetThrottling,
       { formId: formId, userId: session.user.id }
     );

--- a/lib/templates/mutations/updateFormPurpose.ts
+++ b/lib/templates/mutations/updateFormPurpose.ts
@@ -1,7 +1,12 @@
 import { prisma, prismaErrors, Prisma } from "@gcforms/database";
 import { FormRecord } from "@lib/types";
 import { authorization } from "@lib/privileges";
-import { AuditLogAccessDeniedDetails, AuditLogDetails, logEvent } from "@lib/auditLogs";
+import {
+  AuditLogAccessDeniedDetails,
+  AuditLogEvent,
+  AuditLogDetails,
+  logEvent,
+} from "@lib/auditLogs";
 import { TemplateAlreadyPublishedError } from "../internal/errors";
 import { parseTemplate } from "../internal";
 
@@ -59,7 +64,7 @@ export async function updateFormPurpose(
   logEvent(
     user.id,
     { type: "Form", id: formID },
-    "ChangeFormPurpose",
+    AuditLogEvent.ChangeFormPurpose,
     AuditLogDetails.SetFormPurpose,
     { formPurpose: formPurpose }
   );


### PR DESCRIPTION
Just swaps strings to their appropriate property.