### PR TITLE
chore: update credentials check to allow for both archived and non-archived forms

### DIFF
--- a/app/api/forms/edit-locks/route.ts
+++ b/app/api/forms/edit-locks/route.ts
@@ -62,6 +62,7 @@ export const POST = middleware([sessionExists()], async (_req: NextRequest, prop
     }
 
     // Verify user has access to all requested templates using single batch DB query
+    // Note: allowDeleted=null explicitly allows checking both archived and non-archived templates
     try {
       logMessage.debug(
         `[edit-locks] Checking authorization for user ${session.user.id} on templates: ${templateIds.join(", ")}`
@@ -74,6 +75,7 @@ export const POST = middleware([sessionExists()], async (_req: NextRequest, prop
             type: "FormRecord",
             scope: { subjectIds: templateIds },
           },
+          allowDeleted: null,
         },
       ]);
     } catch (error) {

--- a/lib/privileges.ts
+++ b/lib/privileges.ts
@@ -312,16 +312,17 @@ export const getPrivilege = async (where: Prisma.PrivilegeWhereInput) => {
 const _getSubject = async (subject: {
   type: Extract<Subject, string>;
   id: string;
-  allowDeleted: boolean;
+  allowDeleted?: boolean | null;
 }) => {
-  if (subject.id === "all") {
+  const { id, allowDeleted } = subject;
+  if (id === "all") {
     return {};
   }
   switch (subject.type) {
     case "User":
       return prisma.user.findUniqueOrThrow({
         where: {
-          id: subject.id,
+          id,
         },
         select: {
           id: true,
@@ -334,8 +335,12 @@ const _getSubject = async (subject: {
     case "FormRecord":
       return prisma.template.findUniqueOrThrow({
         where: {
-          id: subject.id,
-          ttl: subject.allowDeleted ? { not: null } : null,
+          id,
+          // Handle TTL filter based on allowDeleted parameter:
+          // - null: no filter (allow both archived and non-archived)
+          // - false (default): only non-archived (ttl: null)
+          // - true: only archived (ttl: { not: null })
+          ...(allowDeleted !== null && { ttl: allowDeleted ? { not: null } : null }),
         },
         select: {
           id: true,
@@ -356,17 +361,17 @@ const _getSubject = async (subject: {
     case "Privilege":
       return prisma.privilege.findUniqueOrThrow({
         where: {
-          id: subject.id,
+          id,
         },
       });
     case "Setting":
       return prisma.setting.findUniqueOrThrow({
         where: {
-          internalId: subject.id,
+          internalId: id,
         },
       });
     case "Flag":
-      return { id: subject.id, value: await checkOne(subject.id) };
+      return { id, value: await checkOne(id) };
     default:
       throw new Error("Subject type not valid for privilege check");
   }
@@ -378,7 +383,7 @@ const _retrieveSubjects = async (
     type: Extract<Subject, string>;
     scope: "all" | { subjectId: string } | { subjectIds: string[] };
   },
-  allowDeleted: boolean
+  allowDeleted?: boolean | null
 ) => {
   if (subject.scope === "all") {
     return [{}];
@@ -421,7 +426,7 @@ const _authorizationCheck = async (
       scope: "all" | { subjectId: string } | { subjectIds: string[] };
     };
     fields?: string[];
-    allowDeleted?: boolean;
+    allowDeleted?: boolean | null;
   }[],
   logic: "all" | "one" = "all"
 ) => {
@@ -559,8 +564,9 @@ export const authorization = {
   /**
    * Can the user view this specific form
    * @param formId The ID of the form
+   * @param allowDeleted false (default) = non-archived only, true = archived only, null = both
    */
-  canViewForm: async (formId: string, allowDeleted?: boolean) => {
+  canViewForm: async (formId: string, allowDeleted?: boolean | null) => {
     return _authorizationCheck([
       {
         action: "view",
@@ -572,8 +578,9 @@ export const authorization = {
   /**
    * Can the user edit this specific form
    * @param formId The ID of the form
+   * @param allowDeleted false (default) = non-archived only, true = archived only, null = both
    */
-  canEditForm: async (formId: string, allowDeleted?: boolean) => {
+  canEditForm: async (formId: string, allowDeleted?: boolean | null) => {
     return _authorizationCheck([
       {
         action: "update",


### PR DESCRIPTION
# Summary | Résumé

The new edit-lock route used for polling was occasionally getting 403 errors. The reason became more obvious when comparing the initial template DB lookup on page load vs. the polling that has an authorization check. The difference is that the authorization check  was filtering templates by archive status (`ttl` field), but it was implicitly defaulting to "non-archived only". When users viewed archived templates, polling would fail with 403 errors because the authorization couldn't find those templates.

The fix modifies the authentication (`_getSubject()`) to keep the existing behaviour (backwards compatible)  but adds an additional state to check for both archived and non-archived (vs. one or the other):
- **`undefined/false` (default)**: non-archived only — preserves existing behaviour
- **`true`**: archived only — for restore operations  
- **`null`**: **no filter** — checks both archived and non-archived
