### PR TITLE
chore: Rename canAccessBetaComponents privilege check

### DIFF
--- a/lib/privileges.ts
+++ b/lib/privileges.ts
@@ -772,7 +772,7 @@ export const authorization = {
       },
     ]);
   },
-  canAccessBetaComponents: async (flag: string) => {
+  checkUserFlag: async (flag: string) => {
     const session = await auth();
     const userFeatureFlags = session?.user.featureFlags;
     if (!userFeatureFlags || userFeatureFlags.length < 1) {

--- a/lib/templates/internal/index.ts
+++ b/lib/templates/internal/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@gcforms/types";
 
 export const checkFlag = async (flag: string) => {
-  return (await Promise.all([checkOne(flag), authorization.canAccessBetaComponents(flag)])).reduce(
+  return (await Promise.all([checkOne(flag), authorization.checkUserFlag(flag)])).reduce(
     (prev, curr) => prev || curr
   );
 };


### PR DESCRIPTION
Renamed canAccessBetaComponents to checkUserFlag for clarity of purpose