### PR TITLE
fix: handle non draft templates and archive action in polling

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
@@ -253,9 +253,11 @@ CardFooterPublished.displayName = "CardFooterPublished";
 const CardComponent = ({
   card,
   status,
+  onRemove,
 }: {
   card: FormsTemplateWithLockInfo;
-  status?: FormTabStatus;
+  status: FormTabStatus;
+  onRemove?: (templateId: string) => void;
 }) => {
   const params = useParams();
   const language = params?.locale as string;
@@ -323,6 +325,7 @@ const CardComponent = ({
           isPublished={card.isPublished}
           ttl={card.ttl ? card.ttl : undefined}
           status={status}
+          onRemove={onRemove}
         />
       </div>
     </div>

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
@@ -10,16 +10,14 @@ import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
 import { NewFormButton } from "./NewFormButton";
 
 export const Cards = ({
-  filter,
+  tabStatus,
   initialTemplates,
   overdueTemplateIds,
-  status,
   pollIntervalMs,
 }: {
-  filter?: FormTabStatus;
+  tabStatus: FormTabStatus;
   initialTemplates: FormsTemplateWithLockInfo[];
   overdueTemplateIds: string[];
-  status?: FormTabStatus;
   pollIntervalMs: number;
 }) => {
   const { t } = useTranslation("my-forms");
@@ -45,11 +43,24 @@ export const Cards = ({
     onLoadMore: handleLoadMore,
   });
 
-  // Setup edit lock polling - only poll for recentlyEdited and draft tabs
+  // Handle template removal (e.g., when archived)
+  const handleTemplateRemoved = useCallback((templateId: string) => {
+    startTransition(() => {
+      setTemplates((prev) => prev.filter((t) => t.id !== templateId));
+    });
+  }, []);
+
+  // Setup edit lock polling - only poll for draft forms in the recentlyEdited and draft tabs
   const shouldPoll =
-    !filter || filter === TAB_STATUS.RECENTLY_EDITED || filter === TAB_STATUS.DRAFT;
+    !tabStatus || tabStatus === TAB_STATUS.RECENTLY_EDITED || tabStatus === TAB_STATUS.DRAFT;
+
+  const draftTemplates = useMemo(
+    () => templates.filter((t) => t.isPublished === false && t.ttl === null),
+    [templates]
+  );
+
   useEditLockPolling({
-    templates,
+    templates: draftTemplates,
     displayedCount,
     pollIntervalMs,
     enabled: shouldPoll,
@@ -62,18 +73,18 @@ export const Cards = ({
 
   // Get the appropriate message when there are no forms to display
   const emptyStateMessage = useMemo(() => {
-    if (filter === TAB_STATUS.RECENTLY_EDITED || !filter) return t("cards.noRecentlyEditedForms");
-    if (filter === TAB_STATUS.DRAFT) return t("cards.noDraftsForms");
-    if (filter === TAB_STATUS.PUBLISHED) return t("cards.noPublishedForms");
-    if (filter === TAB_STATUS.ARCHIVED) return t("cards.noArchivedForms");
+    if (tabStatus === TAB_STATUS.RECENTLY_EDITED || !tabStatus)
+      return t("cards.noRecentlyEditedForms");
+    if (tabStatus === TAB_STATUS.DRAFT) return t("cards.noDraftsForms");
+    if (tabStatus === TAB_STATUS.PUBLISHED) return t("cards.noPublishedForms");
+    if (tabStatus === TAB_STATUS.ARCHIVED) return t("cards.noArchivedForms");
     return t("cards.noForms");
-  }, [filter, t]);
+  }, [tabStatus, t]);
 
   // Prepare cards for display with overdue status
   // Memoized to prevent recalculation on every render (e.g. every 5s during polling)
   const displayedCards = useMemo(() => {
     return templates.slice(0, displayedCount).map((card) => {
-      // Add overdue flag without mutating the original card
       if (overdueTemplateIds.includes(card.id)) {
         return { ...card, overdue: true };
       }
@@ -84,18 +95,20 @@ export const Cards = ({
 
   return (
     <ViewTransition name="forms-tab-switch">
-      <div id={`tabpanel-${filter}`} role="tabpanel" aria-labelledby={`tab-${filter}`}>
+      <div id={`tabpanel-${tabStatus}`} role="tabpanel" aria-labelledby={`tab-${tabStatus}`}>
         {templates.length > 0 ? (
           <>
             <ol className="grid grid-cols-[repeat(auto-fit,16em)] items-start gap-4 p-0">
-              {(status === TAB_STATUS.DRAFT || status === TAB_STATUS.PUBLISHED || !status) && (
+              {(tabStatus === TAB_STATUS.DRAFT ||
+                tabStatus === TAB_STATUS.PUBLISHED ||
+                !tabStatus) && (
                 <li className="flex h-full w-full max-w-[16em]" key={-1}>
                   <NewFormButton />
                 </li>
               )}
               {displayedCards.map((card) => (
                 <li className="flex h-full w-full max-w-[16em]" key={card.id}>
-                  <Card card={card} status={status} />
+                  <Card card={card} status={tabStatus} onRemove={handleTemplateRemoved} />
                 </li>
               ))}
             </ol>

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
@@ -20,12 +20,14 @@ export const Menu = ({
   isPublished,
   ttl,
   status,
+  onRemove,
 }: {
   id: string;
   name: string;
   isPublished: boolean;
   ttl?: Date;
-  status?: FormTabStatus;
+  status: FormTabStatus;
+  onRemove?: (templateId: string) => void;
 }) => {
   const {
     t,
@@ -167,8 +169,10 @@ export const Menu = ({
         {/* {t("card.menu.more")} */}
       </MenuDropdown>
       <ConfirmDelete
-        onDeleted={() => {
+        onDeleted={(deletedId) => {
           setShowConfirm(false);
+          // Remove from polling list to avoid 403 on next poll
+          onRemove?.(deletedId);
         }}
         show={showConfirm}
         id={id}

--- a/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
   const { locale } = params;
-  const { status } = searchParams;
+  const { status = TAB_STATUS.RECENTLY_EDITED } = searchParams;
   const { t } = await serverTranslation("my-forms", { lang: locale });
   const subtitle = getStatusTitle(status, t);
   return {
@@ -96,7 +96,7 @@ export default async function Page(props: {
 }) {
   const searchParams = await props.searchParams;
 
-  const { status } = searchParams;
+  const { status = TAB_STATUS.RECENTLY_EDITED } = searchParams;
 
   const params = await props.params;
 
@@ -244,10 +244,9 @@ export default async function Page(props: {
         <Cards
           // tell react the state resets when tabs change
           key={status || "default"}
-          filter={status}
+          tabStatus={status}
           initialTemplates={filteredTemplates}
           overdueTemplateIds={overdueTemplateIds}
-          status={status}
           pollIntervalMs={EDIT_LOCK_POLL_INTERVAL_MS}
         />
       </div>


### PR DESCRIPTION
# Summary | Résumé

Proactively removes any potential published or archived forms from polling. Also handles the case of a user archiving a form and it becoming unaccessible.