### PR TITLE
chore: upgrade database package version

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-12
+
+- No change. Reason: previous version did not get push to NPM
+
 ## [1.1.0] - 2026-05-29
 
 ### Added

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
# Summary | Résumé

- No change. Previous version did not get push to NPM (there was an error in the Github workflow and the fix has been pushed after so we can't just re-run it)