### PR TITLE
chore: use new StatusCreatedAt_v2 index

### DIFF
--- a/lib/vault.ts
+++ b/lib/vault.ts
@@ -63,7 +63,7 @@ export const submissionTypeExists = async (formID: string, status: VaultStatus) 
 
   const queryCommand = new QueryCommand({
     TableName: "Vault",
-    IndexName: "StatusCreatedAt",
+    IndexName: "StatusCreatedAt_v2",
     // To optimize query since we only need to check whether one type of submission type exists
     ScanIndexForward: shouldNavigateThroughStatusCreatedAtIndexInAscendingOrder(status),
     // Limit the amount of responses to 1.
@@ -135,7 +135,7 @@ export async function listAllSubmissions(
     while (lastEvaluatedKey !== undefined) {
       const queryCommand: QueryCommand = new QueryCommand({
         TableName: "Vault",
-        IndexName: "StatusCreatedAt",
+        IndexName: "StatusCreatedAt_v2",
         ExclusiveStartKey: lastEvaluatedKey ?? undefined,
         // Limit the amount of response to responseRetrievalLimit
         Limit: responseRetrievalLimit - accumulatedResponses.length,


### PR DESCRIPTION
# Summary | Résumé

- Replaces old `StatusCreatedAt` with `StatusCreatedAt_v2` DynamoDB Vault table index

Note: we have to make sure we release infra to Production before this change is also released