### PR TITLE
chore: ensure new form button

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
@@ -120,7 +120,7 @@ export const Cards = ({
         ) : (
           <div>
             {emptyStateMessage}
-            {(tabStatus === TAB_STATUS.DRAFT || tabStatus === TAB_STATUS.RECENTLY_EDITED) && (
+            {tabStatus !== TAB_STATUS.ARCHIVED && (
               <ol className="mt-4 grid grid-cols-[repeat(auto-fit,16em)] items-start gap-4 p-0">
                 <li className="mt-4 flex h-full w-full max-w-[16em]" key={-1}>
                   <NewFormButton />

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
@@ -118,7 +118,16 @@ export const Cards = ({
             )}
           </>
         ) : (
-          emptyStateMessage
+          <div>
+            {emptyStateMessage}
+            {(tabStatus === TAB_STATUS.DRAFT || tabStatus === TAB_STATUS.RECENTLY_EDITED) && (
+              <ol className="mt-4 grid grid-cols-[repeat(auto-fit,16em)] items-start gap-4 p-0">
+                <li className="mt-4 flex h-full w-full max-w-[16em]" key={-1}>
+                  <NewFormButton />
+                </li>
+              </ol>
+            )}
+          </div>
         )}
       </div>
     </ViewTransition>


### PR DESCRIPTION
# Summary | Résumé


When signing up for a new account or when a user just doesn't have any forms the current app kind of traps the user with no  link to reach the editor. 

https://github.com/user-attachments/assets/2bc46150-618c-4643-b023-fd9467712223


This PR adds the new form button for recent and draft tabs when showing the empty message to allow users to reach the forms start page.

https://github.com/user-attachments/assets/7116dbfc-8043-4d9b-9c89-33e7f33401bf


