### PR TITLE
chore: Refactor general update action

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -113,14 +113,13 @@ export const createOrUpdateTemplate = AuthenticatedAction(
             templateId: id,
             userId: session.user.id,
           });
-          // Note: we only update formConfig and name in the update flow since other
-          // properties (deliveryOption, securityAttribute, formPurpose) have their
-          // own dedicated update functions called from the settings page.
+          // Note: we only update formConfig in the update flow since other
+          // properties (name, deliveryOption, securityAttribute, formPurpose)
+          // have their own dedicated update functions called from the settings page.
           const formRecord = await updateDbTemplate({
-            action: UpdateTemplateAction.General,
+            action: UpdateTemplateAction.FormConfig,
             formId: id,
             formConfig: formConfig,
-            name: name,
           });
 
           return { formRecord };

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -182,7 +182,20 @@ export const updateTemplate = AuthenticatedAction(
           });
           if (!response) {
             throw new Error(
-              `Template response was null. Request information: { ${command.formId}, ${command.name} }`
+              `Template update failed for Name. Request information: { ${command.formId}, ${command.name} }`
+            );
+          }
+
+          return { formRecord: response };
+        case UpdateTemplateAction.FormConfig:
+          response = await updateDbTemplate({
+            action: UpdateTemplateAction.FormConfig,
+            formId: command.formId,
+            formConfig: command.formConfig,
+          });
+          if (!response) {
+            throw new Error(
+              `Template update failed for FormConfig. Request information: { ${command.formId} }`
             );
           }
 
@@ -199,7 +212,7 @@ export const updateTemplate = AuthenticatedAction(
 
           if (!response) {
             throw new Error(
-              `Template response was null. Request information: { ${command.formId}, ${command.isPublished} }`
+              `Template update failed for IsPublished. Request information: { ${command.formId}, ${command.isPublished} }`
             );
           }
 
@@ -224,7 +237,7 @@ export const updateTemplate = AuthenticatedAction(
           });
           if (!response) {
             throw new Error(
-              `Template response was null. Request information: { ${command.formId}, ${command.formPurpose} }`
+              `Template update failed for FormPurpose. Request information: { ${command.formId}, ${command.formPurpose} }`
             );
           }
 
@@ -237,7 +250,7 @@ export const updateTemplate = AuthenticatedAction(
           });
           if (!response) {
             throw new Error(
-              `Template response was null. Request information: { ${command.formId}, ${command.saveAndResume} }`
+              `Template update failed for FormSaveAndResume. Request information: { ${command.formId}, ${command.saveAndResume} }`
             );
           }
 
@@ -250,7 +263,7 @@ export const updateTemplate = AuthenticatedAction(
           });
           if (!response) {
             throw new Error(
-              `Template response was null. Request information: { ${command.formId}, ${command.securityAttribute} }`
+              `Template update failed for SecurityAttribute. Request information: { ${command.formId}, ${command.securityAttribute} }`
             );
           }
 
@@ -271,7 +284,7 @@ export const updateTemplate = AuthenticatedAction(
 
           if (!response) {
             throw new Error(
-              `Template response was null. Request information: { ${command.formId}, ${command.closingDate} }`
+              `Template update failed for ClosedData. Request information: { ${command.formId}, ${command.closingDate} }`
             );
           }
 
@@ -281,7 +294,7 @@ export const updateTemplate = AuthenticatedAction(
 
           if (!formConfig) {
             throw new Error(
-              `Failed to get template for branding update with formId ${command.formId}`
+              `Template update failed for FormBranding. Request information: { ${command.formId} }`
             );
           }
 
@@ -298,7 +311,7 @@ export const updateTemplate = AuthenticatedAction(
 
           if (!response) {
             throw new Error(
-              `Failed to update template for branding update with formId ${command.formId}`
+              `Template update failed for FormBranding. Request information: { ${command.formId} }`
             );
           }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/actions.ts
@@ -157,7 +157,7 @@ export const createOrUpdateTemplate = AuthenticatedAction(
 export const updateTemplate = AuthenticatedAction(
   async (
     session,
-    command: Exclude<UpdateTemplateCommand, { action: typeof UpdateTemplateAction.General }> & {
+    command: UpdateTemplateCommand & {
       redirectAfter?: string;
     }
   ): Promise<{

--- a/lib/templates/mutations/updateTemplate.ts
+++ b/lib/templates/mutations/updateTemplate.ts
@@ -404,6 +404,7 @@ export async function updateTemplate(command: UpdateTemplateCommand): Promise<Fo
     },
     select: {
       name: true,
+      jsonConfig: true,
     },
   });
 
@@ -436,6 +437,7 @@ export async function updateTemplate(command: UpdateTemplateCommand): Promise<Fo
     user,
     beforeContext: {
       name: currentTemplate?.name,
+      jsonConfig: currentTemplate?.jsonConfig as FormProperties,
     },
   });
 

--- a/lib/templates/mutations/updateTemplate.ts
+++ b/lib/templates/mutations/updateTemplate.ts
@@ -29,7 +29,9 @@ import {
   UpdateSecurityAttributeCommand,
   UpdateFormSaveAndResumeCommand,
   UpdateNameCommand,
+  UpdateFormConfigCommand,
 } from "../types";
+import isEqual from "lodash.isequal";
 
 /**
  * Validate the form config for a template update command
@@ -79,6 +81,16 @@ const authorizeForCommand = async (
           { type: "Form", id: command.formId },
           "AccessDenied",
           AuditLogAccessDeniedDetails.AccessDenied_AttemptToUpdateForm
+        );
+        throw e;
+      });
+    case UpdateTemplateAction.FormConfig:
+      return authorization.canEditForm(command.formId).catch((e) => {
+        logEvent(
+          e.user.id,
+          { type: "Form", id: command.formId },
+          "AccessDenied",
+          AuditLogAccessDeniedDetails.AccessDenied_AttemptToUpdateFormJson
         );
         throw e;
       });
@@ -177,6 +189,17 @@ const buildUpdateQuery = (command: UpdateTemplateCommand): UpdatePlan => {
         ...basePlan,
         data: {
           name: command.name,
+        },
+      };
+    case UpdateTemplateAction.FormConfig:
+      return {
+        ...basePlan,
+        where: {
+          id: command.formId,
+          isPublished: false,
+        },
+        data: {
+          jsonConfig: command.formConfig as Prisma.JsonObject,
         },
       };
     case UpdateTemplateAction.ClosedData:
@@ -285,6 +308,7 @@ type UpdateAuditEvent = {
   user: { id: string; email: string };
   beforeContext?: {
     name?: string;
+    jsonConfig?: FormProperties;
   };
 };
 
@@ -323,6 +347,16 @@ const logTemplateUpdateEvent = async (event: UpdateAuditEvent) => {
           AuditLogEvent.ChangeFormName,
           AuditLogDetails.UpdatedFormName,
           { newFormName: nameCommand.name ?? "" }
+        );
+      break;
+    case UpdateTemplateAction.FormConfig:
+      const formConfigCommand = event.command as UpdateFormConfigCommand;
+      !isEqual(beforeContext?.jsonConfig ?? {}, formConfigCommand.formConfig) &&
+        logEvent(
+          event.user.id,
+          { type: "Form", id: formConfigCommand.formId },
+          "UpdateForm",
+          AuditLogDetails.FormContentUpdated
         );
       break;
     case UpdateTemplateAction.ClosedData:

--- a/lib/templates/mutations/updateTemplate.ts
+++ b/lib/templates/mutations/updateTemplate.ts
@@ -23,7 +23,6 @@ import {
   UpdateFormPurposeCommand,
   UpdateIsPublishedCommand,
   UpdateTemplateAction,
-  GeneralUpdateTemplateCommand,
   UpdateClosedDataCommand,
   UpdateFormBrandingCommand,
   UpdateSecurityAttributeCommand,
@@ -73,7 +72,6 @@ const authorizeForCommand = async (
   command: UpdateTemplateCommand
 ): Promise<AuthorizationResult> => {
   switch (command.action) {
-    case UpdateTemplateAction.General:
     case UpdateTemplateAction.Name:
       return authorization.canEditForm(command.formId).catch((e) => {
         logEvent(
@@ -172,18 +170,6 @@ const buildUpdateQuery = (command: UpdateTemplateCommand): UpdatePlan => {
   };
 
   switch (command.action) {
-    case UpdateTemplateAction.General:
-      return {
-        ...basePlan,
-        where: {
-          id: command.formId,
-          isPublished: false,
-        },
-        data: {
-          jsonConfig: command.formConfig as Prisma.JsonObject,
-          name: command.name,
-        },
-      };
     case UpdateTemplateAction.Name:
       return {
         ...basePlan,
@@ -314,35 +300,12 @@ type UpdateAuditEvent = {
 
 const logTemplateUpdateEvent = async (event: UpdateAuditEvent) => {
   switch (event.action) {
-    case UpdateTemplateAction.General:
-      const command = event.command as GeneralUpdateTemplateCommand;
-      const { user, beforeContext } = event;
-
-      command.name !== undefined &&
-        (beforeContext?.name ?? "") !== command.name &&
-        logEvent(
-          user.id,
-          { type: "Form", id: command.formId },
-          AuditLogEvent.ChangeFormName,
-          AuditLogDetails.UpdatedFormName,
-          { newFormName: command.name ?? "" }
-        );
-
-      logEvent(
-        user.id,
-        { type: "Form", id: command.formId },
-        "UpdateForm",
-        AuditLogDetails.FormContentUpdated
-      );
-      break;
     case UpdateTemplateAction.Name:
       const nameCommand = event.command as UpdateNameCommand;
-      const { user: nameUser, beforeContext: nameBeforeContext } = event;
-
       nameCommand.name !== undefined &&
-        (nameBeforeContext?.name ?? "") !== nameCommand.name &&
+        (event.beforeContext?.name ?? "") !== nameCommand.name &&
         logEvent(
-          nameUser.id,
+          event.user.id,
           { type: "Form", id: nameCommand.formId },
           AuditLogEvent.ChangeFormName,
           AuditLogDetails.UpdatedFormName,
@@ -351,7 +314,7 @@ const logTemplateUpdateEvent = async (event: UpdateAuditEvent) => {
       break;
     case UpdateTemplateAction.FormConfig:
       const formConfigCommand = event.command as UpdateFormConfigCommand;
-      !isEqual(beforeContext?.jsonConfig ?? {}, formConfigCommand.formConfig) &&
+      !isEqual(event.beforeContext?.jsonConfig ?? {}, formConfigCommand.formConfig) &&
         logEvent(
           event.user.id,
           { type: "Form", id: formConfigCommand.formId },
@@ -464,10 +427,6 @@ export async function updateTemplate(command: UpdateTemplateCommand): Promise<Fo
 
   const updateQuery = buildUpdateQuery(command);
   const updatedTemplate = await executeTemplateUpdate(updateQuery, user.id);
-
-  if (updatedTemplate === null && command.action === UpdateTemplateAction.General) {
-    throw new TemplateAlreadyPublishedError();
-  }
 
   if (formCache.cacheAvailable) formCache.invalidate(command.formId);
 

--- a/lib/templates/mutations/updateTemplate.ts
+++ b/lib/templates/mutations/updateTemplate.ts
@@ -429,6 +429,10 @@ export async function updateTemplate(command: UpdateTemplateCommand): Promise<Fo
   const updateQuery = buildUpdateQuery(command);
   const updatedTemplate = await executeTemplateUpdate(updateQuery, user.id);
 
+  if (updatedTemplate === null && command.action === UpdateTemplateAction.FormConfig) {
+    throw new TemplateAlreadyPublishedError();
+  }
+
   if (formCache.cacheAvailable) formCache.invalidate(command.formId);
 
   await logTemplateUpdateEvent({

--- a/lib/templates/types.ts
+++ b/lib/templates/types.ts
@@ -3,6 +3,7 @@ import { ClosedDetails, FormProperties, SecurityAttribute } from "../types";
 export const UpdateTemplateAction = {
   General: "general",
   Name: "name",
+  FormConfig: "formConfig",
   ClosedData: "closedData",
   FormBranding: "formBranding",
   FormPurpose: "formPurpose",
@@ -15,6 +16,7 @@ export type UpdateTemplateAction = (typeof UpdateTemplateAction)[keyof typeof Up
 
 export type UpdateTemplateCommand =
   | GeneralUpdateTemplateCommand
+  | UpdateFormConfigCommand
   | UpdateNameCommand
   | UpdateClosedDataCommand
   | UpdateFormBrandingCommand
@@ -71,4 +73,9 @@ export type UpdateSecurityAttributeCommand = BaseUpdateCommand & {
 export type UpdateNameCommand = BaseUpdateCommand & {
   action: typeof UpdateTemplateAction.Name;
   name: string;
+};
+
+export type UpdateFormConfigCommand = BaseUpdateCommand & {
+  action: typeof UpdateTemplateAction.FormConfig;
+  formConfig: FormProperties;
 };

--- a/lib/templates/types.ts
+++ b/lib/templates/types.ts
@@ -1,7 +1,6 @@
 import { ClosedDetails, FormProperties, SecurityAttribute } from "../types";
 
 export const UpdateTemplateAction = {
-  General: "general",
   Name: "name",
   FormConfig: "formConfig",
   ClosedData: "closedData",
@@ -15,7 +14,6 @@ export const UpdateTemplateAction = {
 export type UpdateTemplateAction = (typeof UpdateTemplateAction)[keyof typeof UpdateTemplateAction];
 
 export type UpdateTemplateCommand =
-  | GeneralUpdateTemplateCommand
   | UpdateFormConfigCommand
   | UpdateNameCommand
   | UpdateClosedDataCommand
@@ -30,10 +28,14 @@ type BaseUpdateCommand = {
   action: UpdateTemplateAction;
 };
 
-export type GeneralUpdateTemplateCommand = BaseUpdateCommand & {
-  action: typeof UpdateTemplateAction.General;
+export type UpdateNameCommand = BaseUpdateCommand & {
+  action: typeof UpdateTemplateAction.Name;
+  name: string;
+};
+
+export type UpdateFormConfigCommand = BaseUpdateCommand & {
+  action: typeof UpdateTemplateAction.FormConfig;
   formConfig: FormProperties;
-  name?: string;
 };
 
 export type UpdateClosedDataCommand = BaseUpdateCommand & {
@@ -68,14 +70,4 @@ export type UpdateIsPublishedCommand = BaseUpdateCommand & {
 export type UpdateSecurityAttributeCommand = BaseUpdateCommand & {
   action: typeof UpdateTemplateAction.SecurityAttribute;
   securityAttribute: SecurityAttribute;
-};
-
-export type UpdateNameCommand = BaseUpdateCommand & {
-  action: typeof UpdateTemplateAction.Name;
-  name: string;
-};
-
-export type UpdateFormConfigCommand = BaseUpdateCommand & {
-  action: typeof UpdateTemplateAction.FormConfig;
-  formConfig: FormProperties;
 };

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -348,7 +348,7 @@ describe("Template CRUD functions", () => {
       );
 
       const updatedTemplate = await updateTemplate({
-        action: UpdateTemplateAction.General,
+        action: UpdateTemplateAction.FormConfig,
         formId: "test1",
         formConfig: updatedFormConfig,
       });
@@ -580,7 +580,7 @@ describe("Template CRUD functions", () => {
 
       await expect(async () => {
         await updateTemplate({
-          action: UpdateTemplateAction.General,
+          action: UpdateTemplateAction.FormConfig,
           formId: "test1",
           formConfig: updatedFormConfig,
         });
@@ -902,7 +902,7 @@ describe("Template CRUD functions", () => {
     it("Update a template", async () => {
       await expect(
         updateTemplate({
-          action: UpdateTemplateAction.General,
+          action: UpdateTemplateAction.FormConfig,
           formId: "test1",
           formConfig: structuredClone(formConfiguration as FormProperties),
         })
@@ -912,7 +912,7 @@ describe("Template CRUD functions", () => {
         userID,
         { id: "test1", type: "Form" },
         "AccessDenied",
-        "Attempted to update Form"
+        "Attempted to update form jsonConfig"
       );
     });
     it("Update `isPublished` on a specific form", async () => {


### PR DESCRIPTION
# Summary | Résumé

Removes the "General" template update in favour of two new actions for Name and FormConfig.
