### PR TITLE
fix: rework ResponseValidationValues to isolate actual responses from the rest of the type attributes

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.test.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.test.ts
@@ -59,11 +59,13 @@ describe("submitForm", () => {
   const mockFormId = "test-form-id";
   const mockLanguage = "en";
   const mockValues: ResponseValidationValues = {
-    "1": "test value",
-    "2": "another value",
     currentGroup: null,
     groupHistory: [],
     matchedIds: [],
+    responses: {
+      "1": "test value",
+      "2": "another value",
+    },
   };
 
   const mockTemplate: PublicFormRecord = {
@@ -140,7 +142,7 @@ describe("submitForm", () => {
       formRecord: mockTemplate,
       t: expect.any(Function),
     });
-    expect(normalizeFormResponses).toHaveBeenCalledWith(mockTemplate, mockValues);
+    expect(normalizeFormResponses).toHaveBeenCalledWith(mockTemplate, mockValues.responses);
     expect(processFormData).toHaveBeenCalledWith({
       responses: mockValues,
       securityAttribute: mockTemplate.securityAttribute,
@@ -186,14 +188,16 @@ describe("submitForm", () => {
 
     // Mock form values with a .exe file (which should be invalid based on fileType restriction)
     const valuesWithExeFile: ResponseValidationValues = {
-      "1": {
-        name: "malware.exe", // This .exe extension should be rejected by real validation
-        size: 5000,
-        id: "test-file-id",
-      },
       currentGroup: null,
       groupHistory: [],
       matchedIds: [],
+      responses: {
+        "1": {
+          name: "malware.exe", // This .exe extension should be rejected by real validation
+          size: 5000,
+          id: "test-file-id",
+        },
+      },
     };
 
     // Override template mock for this test

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
@@ -112,7 +112,7 @@ export async function submitForm(
         }
       }
 
-      const formData = normalizeFormResponses(template, values as Responses);
+      const formData = normalizeFormResponses(template, values.responses as Responses);
 
       const { submissionId, fileURLMap } = await processFormData({
         responses: formData,

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -4,7 +4,7 @@ import { withFormik } from "formik";
 import { getFormInitialValues } from "@lib/formBuilder";
 import { getErrorList, setFocusOnErrorMessage } from "@lib/validation/validation";
 import { Alert, RichText } from "@clientComponents/forms";
-import { validateVisibleElements } from "@gcforms/core";
+import { ResponseValidationValues, validateVisibleElements } from "@gcforms/core";
 
 import { type FormProps, type InnerFormProps } from "./types";
 import { type Language } from "@lib/types/form-builder-types";
@@ -277,11 +277,11 @@ export const Form = withFormik<FormProps, Responses>({
   },
 
   validate: (values, props) => {
-    const validationPrepValues = {
-      ...values,
+    const validationPrepValues: ResponseValidationValues = {
       currentGroup: props.currentGroup,
       groupHistory: props.getGroupHistory(),
       matchedIds: props.matchedIds.current,
+      responses: values,
     };
     const { errors } = validateVisibleElements(validationPrepValues, props);
     return errors;
@@ -334,12 +334,13 @@ export const Form = withFormik<FormProps, Responses>({
         }, 500);
       }
 
-      const validationPrepValues = {
-        ...formValuesWithoutFileContent,
+      const validationPrepValues: ResponseValidationValues = {
         currentGroup: formikBag.props.currentGroup,
         groupHistory: formikBag.props.getGroupHistory(),
         matchedIds: formikBag.props.matchedIds.current,
+        responses: formValuesWithoutFileContent,
       };
+
       const result = await submitForm(
         validationPrepValues,
         formikBag.props.language,

--- a/lib/tests/validation/validation.test.ts
+++ b/lib/tests/validation/validation.test.ts
@@ -49,7 +49,7 @@ type TestCase = {
 };
 
 const toValidationValues = (value: Record<number, unknown>): ValidationValues => {
-  return value as unknown as ValidationValues;
+  return { responses: value } as unknown as ValidationValues;
 };
 
 const toValidationProps = (value: unknown): ValidationProps => {
@@ -429,13 +429,15 @@ describe("Test input validation", () => {
     test("validates required dynamicRow fields row correctly", () => {
       const { errors } = validateVisibleElements(
         {
-          0: [
-            { 1: "", 3: "" },
-            { 1: "", 3: "" },
-          ],
           currentGroup: null,
           groupHistory: [],
           matchedIds: [],
+          responses: {
+            0: [
+              { 1: "", 3: "" },
+              { 1: "", 3: "" },
+            ],
+          },
         },
         toValidationProps({ formRecord, t: (key: string) => key })
       );
@@ -453,13 +455,15 @@ describe("Test input validation", () => {
     test("validates dynamic row correctly", () => {
       const { errors } = validateVisibleElements(
         {
-          0: [
-            { 1: "test", 3: "" },
-            { 1: "test", 3: "" },
-          ],
           currentGroup: null,
           groupHistory: [],
           matchedIds: [],
+          responses: {
+            0: [
+              { 1: "test", 3: "" },
+              { 1: "test", 3: "" },
+            ],
+          },
         },
         toValidationProps({ formRecord, t: (key: string) => key })
       );
@@ -468,7 +472,7 @@ describe("Test input validation", () => {
   });
   test("Value not in elements", () => {
     const props = getFormMetaData("textField", "");
-    const values = { 4: "test value" };
+    const values = { responses: { 4: "test value" } };
     const { errors } = validateVisibleElements(toValidationValues(values), props);
     expect(errors).not.toHaveProperty("4");
   });

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.16] - 2026-06-30
+
+- Update validation type for form responses
+
 ## [2.2.15] - 2026-06-25
 
 - Update validation type for form responses

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/core",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -13,7 +13,9 @@ export type ResponseValidationValues = {
   currentGroup: string | null;
   groupHistory: string[];
   matchedIds: string[];
-  [key: string]: Response | null;
+  responses: {
+    [key: string]: Response | null;
+  };
 };
 
 /*
@@ -56,7 +58,7 @@ export const validateVisibleElements = (
   const valueMatchErrors: ValueMatchErrors = {};
 
   for (const formElement of props.formRecord.form.elements) {
-    const responseValue = values[formElement.id];
+    const responseValue = values.responses[formElement.id];
 
     const currentGroup = values.currentGroup as string;
     const groups = props.formRecord.form.groups as GroupsType;
@@ -71,7 +73,11 @@ export const validateVisibleElements = (
       continue;
     }
 
-    const isVisible = checkVisibilityRecursive(props.formRecord, formElement, values as FormValues);
+    const isVisible = checkVisibilityRecursive(
+      props.formRecord,
+      formElement,
+      values.responses as FormValues
+    );
 
     // If the form element is not visible, skip validation
     if (!isVisible) {


### PR DESCRIPTION
# Summary | Résumé

Context: https://gcdigital.slack.com/archives/C01GFD150MC/p1782826094382269

closes https://github.com/cds-snc/platform-forms-client/issues/7441

- Reworks `ResponseValidationValues` to isolate actual responses from the rest of the type attributes