### PR TITLE
chore: add published version number to card view

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
@@ -38,24 +38,24 @@ const calculateCollaboratorCount = (userCount: number, pendingUserCount: number)
   return userCount - 1 + pendingUserCount;
 };
 
-const VersionNumberText = memo(
+const DraftVersionNumber = memo(
   ({
     language,
     cardId,
     hasDraft,
-    versionNumber,
+    draftVersionNumber,
     isPublished,
   }: {
     language: string;
     cardId: string;
     hasDraft: boolean;
-    versionNumber?: number;
+    draftVersionNumber?: number;
     isPublished: boolean;
   }) => {
     const { t } = useTranslation("my-forms");
     const link = `/${language}/form-builder/${cardId}/edit`;
 
-    if (isPublished && hasDraft && versionNumber) {
+    if (isPublished && hasDraft && draftVersionNumber) {
       return (
         <div className="mt-2 flex items-center text-sm">
           <span
@@ -63,7 +63,7 @@ const VersionNumberText = memo(
             aria-hidden="true"
           ></span>
           <Link href={link} prefetch={false}>
-            {t("card.draftVersion", { versionNumber: versionNumber })}
+            {t("card.draftVersion", { draftVersionNumber: draftVersionNumber })}
           </Link>
         </div>
       );
@@ -73,21 +73,23 @@ const VersionNumberText = memo(
   }
 );
 
-VersionNumberText.displayName = "VersionNumberText";
+DraftVersionNumber.displayName = "DraftVersionNumber";
 
 const CardBanner = memo(
   ({
     language,
     cardId,
     hasDraft,
-    versionNumber,
+    publishedVersionNumber,
+    draftVersionNumber,
     isPublished,
     isClosed,
   }: {
     language: string;
     cardId: string;
     hasDraft: boolean;
-    versionNumber?: number;
+    publishedVersionNumber?: number;
+    draftVersionNumber?: number;
     isPublished: boolean;
     isClosed: boolean;
   }) => {
@@ -98,6 +100,11 @@ const CardBanner = memo(
         ? "bg-emerald-500"
         : "bg-yellow-400";
 
+    const publishedVersionText =
+      isPublished && publishedVersionNumber
+        ? t("card.versionNumber", { publishedVersionNumber: publishedVersionNumber })
+        : "";
+
     return (
       <>
         <div className="mt-4 flex items-center gap-1 self-start text-sm" aria-hidden="true">
@@ -107,15 +114,17 @@ const CardBanner = memo(
           {isClosed
             ? t("card.states.closed")
             : isPublished
-              ? t("card.states.published")
+              ? t("card.states.published") +
+                t(publishedVersionText ? `${publishedVersionText}` : "")
               : t("card.states.draft")}
         </div>
-        <VersionNumberText
+
+        <DraftVersionNumber
           language={language}
           cardId={cardId}
           isPublished={isPublished}
           hasDraft={hasDraft}
-          versionNumber={versionNumber}
+          draftVersionNumber={draftVersionNumber}
         />
       </>
     );
@@ -470,7 +479,8 @@ const CardComponent = ({
             language={language}
             cardId={card.id}
             hasDraft={card.hasDraft}
-            versionNumber={card.versionNumber ?? undefined}
+            publishedVersionNumber={card.currentPublishedVersion ?? undefined}
+            draftVersionNumber={card.currentDraftVersion ?? undefined}
             isPublished={card.isPublished}
             isClosed={cardState === CARD_STATE.CLOSED}
           />

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/types.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/types.ts
@@ -55,6 +55,7 @@ export type FormsTemplate = {
   isPublished: boolean;
   hasDraft: boolean;
   currentDraftVersion?: number | null;
+  currentPublishedVersion?: number | null;
   versionNumber?: number | null;
   ttl: Date | null;
   date: string;

--- a/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
@@ -183,7 +183,8 @@ export default async function Page(props: {
       url: `/${locale}/id/${id}`,
       isShared: userCount + pendingUserCount >= 2,
       hasDraft: !!template.currentDraftVersionId,
-      versionNumber: template.versionNumber ?? null,
+      currentPublishedVersion: Number(template.currentPublishedVersion) ?? null,
+      currentDraftVersion: Number(template.currentDraftVersion) ?? null,
       collaboratorCount: {
         userCount,
         pendingUserCount,

--- a/i18n/translations/en/my-forms.json
+++ b/i18n/translations/en/my-forms.json
@@ -52,7 +52,8 @@
       "email": "Responses get sent to:",
       "vault": "Responses page"
     },
-    "draftVersion": "Draft - version {{versionNumber}}",
+    "draftVersion": "Draft - version {{draftVersionNumber}}",
+    "versionNumber": "- version {{publishedVersionNumber}}",
     "menu": {
       "more": "More",
       "save": "Download copy",

--- a/i18n/translations/fr/my-forms.json
+++ b/i18n/translations/fr/my-forms.json
@@ -52,7 +52,8 @@
       "email": "Réponses envoyées à :",
       "vault": "Page Réponses"
     },
-    "draftVersion": "Ébauche - version {{versionNumber}}",
+    "draftVersion": "Ébauche - version {{draftVersionNumber}}",
+    "versionNumber": "- version {{publishedVersionNumber}}",
     "menu": {
       "more": "Plus",
       "save": "Télécharger une copie",

--- a/lib/templates/versioning/internal/index.ts
+++ b/lib/templates/versioning/internal/index.ts
@@ -66,6 +66,8 @@ export const parseTemplate = (
     currentPublishedVersionId: template.currentPublishedVersionId ?? null,
     currentDraftVersionId: template.currentDraftVersionId ?? null,
     versionNumber: version?.versionNumber ?? null,
+    currentPublishedVersion: template.currentPublishedVersion?.versionNumber ?? null,
+    currentDraftVersion: template.currentDraftVersion?.versionNumber ?? null,
     ...(template.deliveryOption && {
       deliveryOption: {
         emailAddress: template.deliveryOption.emailAddress,

--- a/lib/templates/versioning/internal/types.ts
+++ b/lib/templates/versioning/internal/types.ts
@@ -11,6 +11,8 @@ type TemplateVersionStatus = (typeof TEMPLATE_VERSION_STATUS)[keyof typeof TEMPL
 export type TemplateVersionSnapshot = {
   id: string;
   versionNumber: number;
+  currentDraftVersion?: number | null;
+  currentPublishedVersion?: number | null;
   status: TemplateVersionStatus;
   jsonConfig: Prisma.JsonValue;
 };

--- a/packages/types/src/form-types.ts
+++ b/packages/types/src/form-types.ts
@@ -235,6 +235,7 @@ export type FormRecord = {
   currentPublishedVersionId?: string | null;
   currentDraftVersionId?: string | null;
   versionNumber?: number | null;
+  currentPublishedVersion?: number | null;
   deliveryOption?: DeliveryOption;
   securityAttribute: SecurityAttribute;
   closingDate?: string;

--- a/packages/types/src/form-types.ts
+++ b/packages/types/src/form-types.ts
@@ -235,7 +235,6 @@ export type FormRecord = {
   currentPublishedVersionId?: string | null;
   currentDraftVersionId?: string | null;
   versionNumber?: number | null;
-  currentPublishedVersion?: number | null;
   deliveryOption?: DeliveryOption;
   securityAttribute: SecurityAttribute;
   closingDate?: string;


### PR DESCRIPTION
# Summary | Résumé

Adds visual indicator to show what version the published form is on.

<img width="421" height="398" alt="Screenshot 2026-07-06 at 2 34 09 PM" src="https://github.com/user-attachments/assets/9d8f3a69-d374-4e4f-98eb-a102960e64a4" />


