### PR TITLE
chore: versioned response pilot

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/Responses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/Responses.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from "@i18n/client";
 
 import Skeleton from "react-loading-skeleton";
 import { FocusHeader } from "@root/app/(gcforms)/[locale]/(support)/components/client/FocusHeader";
+import { VersionSelector } from "./components/VersionSelector";
 
 export const Responses = ({ actions }: { actions?: React.ReactNode }) => {
-  const { newFormSubmissions } = useResponsesContext();
+  const { newFormSubmissions, responseVersions, selectedVersion, setSelectedVersion } =
+    useResponsesContext();
   const { t } = useTranslation("response-api");
 
   if (newFormSubmissions === null) {
@@ -33,6 +35,12 @@ export const Responses = ({ actions }: { actions?: React.ReactNode }) => {
         <FocusHeader headingTag="h2" dataTestId="new-responses-heading">
           {t("loadKeyPage.newResponsesAvailable")}
         </FocusHeader>
+        <VersionSelector
+          responseVersions={responseVersions}
+          selectedVersion={selectedVersion}
+          setSelectedVersion={setSelectedVersion}
+          t={t}
+        />
         {actions}
       </div>
       <div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/Responses.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/Responses.tsx
@@ -7,7 +7,7 @@ import { FocusHeader } from "@root/app/(gcforms)/[locale]/(support)/components/c
 import { VersionSelector } from "./components/VersionSelector";
 
 export const Responses = ({ actions }: { actions?: React.ReactNode }) => {
-  const { newFormSubmissions, responseVersions, selectedVersion, setSelectedVersion } =
+  const { newFormSubmissions, responseVersions, activeSelectedVersion, setSelectedVersion } =
     useResponsesContext();
   const { t } = useTranslation("response-api");
 
@@ -37,7 +37,7 @@ export const Responses = ({ actions }: { actions?: React.ReactNode }) => {
         </FocusHeader>
         <VersionSelector
           responseVersions={responseVersions}
-          selectedVersion={selectedVersion}
+          selectedVersion={activeSelectedVersion}
           setSelectedVersion={setSelectedVersion}
           t={t}
         />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/components/VersionSelector.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/components/VersionSelector.tsx
@@ -1,6 +1,8 @@
 "use client";
 import React from "react";
 
+import { Tooltip } from "@formBuilder/components/shared/Tooltip";
+
 type Props = {
   responseVersions: string[];
   selectedVersion: string | null;
@@ -14,20 +16,38 @@ export const VersionSelector = ({
   setSelectedVersion,
   t,
 }: Props) => {
-  if (!responseVersions || responseVersions.length <= 1) return null;
+  if (!responseVersions || responseVersions.length === 0) return null;
+
+  const isDisabled = responseVersions.length === 1;
+  const base =
+    "gc-select w-auto min-w-55 appearance-none rounded-md border-2 border-slate-800 py-2 pr-10 pl-4";
+  const disabledStyles = "bg-slate-100 text-slate-500 cursor-not-allowed";
 
   return (
     <div className="mb-4">
-      <label htmlFor="downloadVersion" className="mb-1 block font-medium">
-        {t("loadKeyPage.versionSelector.label")}
-      </label>
+      <div>
+        <label htmlFor="downloadVersion" className="mb-1 inline-block font-medium">
+          {t("loadKeyPage.versionSelector.label")}
+        </label>
+
+        <Tooltip.Info
+          side="top"
+          triggerClassName="align-middle ml-1"
+          tooltipClassName="font-normal"
+        >
+          <strong>{t(`tooltips.version.title`)}</strong>
+          <p>{t(`tooltips.version.body`)}</p>
+        </Tooltip.Info>
+      </div>
+
       <div className="relative inline-block">
         <select
           id="downloadVersion"
-          value={selectedVersion ?? ""}
+          value={selectedVersion ?? (responseVersions.length === 1 ? responseVersions[0] : "")}
           onChange={(e) => setSelectedVersion(e.target.value || null)}
-          className="gc-select w-auto min-w-55 appearance-none rounded-md border-2 border-slate-800 py-2 pr-10 pl-4"
+          className={`${base} ${isDisabled ? disabledStyles : "bg-white"}`}
           data-testid="download-dialog-version-filter"
+          disabled={isDisabled}
         >
           <option value="">{t("loadKeyPage.versionSelector.placeholder")}</option>
           {responseVersions.map((v) => (

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/components/VersionSelector.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/components/VersionSelector.tsx
@@ -1,0 +1,60 @@
+"use client";
+import React from "react";
+
+type Props = {
+  responseVersions: string[];
+  selectedVersion: string | null;
+  setSelectedVersion: (v: string | null) => void;
+  t: (key: string) => string | React.ReactNode;
+};
+
+export const VersionSelector = ({
+  responseVersions,
+  selectedVersion,
+  setSelectedVersion,
+  t,
+}: Props) => {
+  if (!responseVersions || responseVersions.length <= 1) return null;
+
+  return (
+    <div className="mb-4">
+      <label htmlFor="downloadVersion" className="mb-1 block font-medium">
+        {t("loadKeyPage.versionSelector.label")}
+      </label>
+      <div className="relative inline-block">
+        <select
+          id="downloadVersion"
+          value={selectedVersion ?? ""}
+          onChange={(e) => setSelectedVersion(e.target.value || null)}
+          className="gc-select w-auto min-w-55 appearance-none rounded-md border-2 border-slate-800 py-2 pr-10 pl-4"
+          data-testid="download-dialog-version-filter"
+        >
+          <option value="">{t("loadKeyPage.versionSelector.placeholder")}</option>
+          {responseVersions.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+        <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path
+              d="M6 9l6 6 6-6"
+              stroke="#0f172a"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -63,6 +63,7 @@ interface ResponsesContextType {
   setSelectedFormat: Dispatch<SetStateAction<string>>;
   selectedVersion: string | null;
   setSelectedVersion: Dispatch<SetStateAction<string | null>>;
+  activeSelectedVersion: string | null;
   interrupt: boolean;
   setInterrupt: Dispatch<SetStateAction<boolean>>;
   currentSubmissionId: string | null;
@@ -213,6 +214,16 @@ export const ResponsesProvider = ({
     return Array.from(versionsSet).sort();
   }, [newFormSubmissions]);
 
+  // Derive the effective/active selected version without synchronously
+  // mutating state inside an effect. If exactly one version exists, treat
+  // that as the active selection; otherwise use the user-selected value.
+  const activeSelectedVersion = useMemo(() => {
+    if (!responseVersions || responseVersions.length === 0) return null;
+    if (responseVersions.length === 1) return responseVersions[0];
+    if (selectedVersion && responseVersions.includes(selectedVersion)) return selectedVersion;
+    return null;
+  }, [responseVersions, selectedVersion]);
+
   const resetProcessingCompleted = useCallback(() => {
     setProcessingCompleted(false);
   }, []);
@@ -236,12 +247,14 @@ export const ResponsesProvider = ({
       let formResponses = [...(initialSubmissions || newFormSubmissions || [])];
 
       responseLogger.info(
-        `Processing ${formResponses.length} submissions for form ID ${formId} and version ${selectedVersion || 1}`
+        `Processing ${formResponses.length} submissions for form ID ${formId} and version ${
+          activeSelectedVersion || 1
+        }`
       );
 
-      // If a specific version is selected, only process submissions for that version
-      if (selectedVersion) {
-        formResponses = formResponses.filter((s) => String(s.version) === selectedVersion);
+      // If a specific version is selected (or implied), only process submissions for that version
+      if (activeSelectedVersion) {
+        formResponses = formResponses.filter((s) => String(s.version) === activeSelectedVersion);
       }
 
       responseLogger.info(
@@ -255,9 +268,11 @@ export const ResponsesProvider = ({
 
       try {
         formTemplate = await apiClient.getFormTemplate(
-          selectedVersion ? parseInt(selectedVersion, 10) : 1
+          activeSelectedVersion ? parseInt(activeSelectedVersion, 10) : 1
         );
-        responseLogger.info(`Loaded form template successfully version ${selectedVersion || 1}`);
+        responseLogger.info(
+          `Loaded form template successfully version ${activeSelectedVersion || 1}`
+        );
         formId = apiClient.getFormId();
       } catch (error) {
         responseLogger.error("Error loading form template: ", error);
@@ -356,8 +371,8 @@ export const ResponsesProvider = ({
         // Get subsequent submissions (always fetch full set, then filter)
         // eslint-disable-next-line no-await-in-loop
         formResponses = await retrieveResponses();
-        if (selectedVersion) {
-          formResponses = formResponses.filter((s) => String(s.version) === selectedVersion);
+        if (activeSelectedVersion) {
+          formResponses = formResponses.filter((s) => String(s.version) === activeSelectedVersion);
         }
       }
 
@@ -392,7 +407,7 @@ export const ResponsesProvider = ({
       privateApiKey,
       retrieveResponses,
       selectedFormat,
-      selectedVersion,
+      activeSelectedVersion,
       setInterrupt,
       t,
     ]
@@ -439,6 +454,7 @@ export const ResponsesProvider = ({
       setSelectedFormat,
       selectedVersion,
       setSelectedVersion,
+      activeSelectedVersion,
       interrupt: isProcessingInterrupted,
       setInterrupt,
       currentSubmissionId,
@@ -475,6 +491,7 @@ export const ResponsesProvider = ({
       hasMaliciousAttachments,
       selectedVersion,
       setSelectedVersion,
+      activeSelectedVersion,
       setCurrentSubmissionId,
       resetState,
       resetNewSubmissions,

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -61,6 +61,8 @@ interface ResponsesContextType {
   setHasError: Dispatch<SetStateAction<boolean>>;
   selectedFormat: string;
   setSelectedFormat: Dispatch<SetStateAction<string>>;
+  selectedVersion: string | null;
+  setSelectedVersion: Dispatch<SetStateAction<string | null>>;
   interrupt: boolean;
   setInterrupt: Dispatch<SetStateAction<boolean>>;
   currentSubmissionId: string | null;
@@ -70,6 +72,7 @@ interface ResponsesContextType {
   resetState: () => void;
   resetNewSubmissions: () => void;
   logger: ResponseDownloadLogger;
+  responseVersions: string[];
 }
 
 const ResponsesContext = createContext<ResponsesContextType | undefined>(undefined);
@@ -78,7 +81,7 @@ const CsvDetected = () => {
   const { t } = useTranslation("response-api");
   return (
     <div className="w-full">
-      <h3 className="!mb-0 pb-0 text-xl font-semibold">{t("locationPage.csvDetected.title")}</h3>
+      <h3 className="mb-0! pb-0 text-xl font-semibold">{t("locationPage.csvDetected.title")}</h3>
       <p className="mb-2 text-black">{t("locationPage.csvDetected.message")}</p>
     </div>
   );
@@ -103,6 +106,7 @@ export const ResponsesProvider = ({
   const [processingCompleted, setProcessingCompleted] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [selectedFormat, setSelectedFormat] = useState<string>("");
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const [currentSubmissionId, setCurrentSubmissionId] = useState<string | null>(null);
   const [hasMaliciousAttachments, setHasMaliciousAttachments] = useState<boolean>(false);
   const [processedSubmissionsCount, setProcessedSubmissionsCountState] = useState<number>(0);
@@ -193,6 +197,21 @@ export const ResponsesProvider = ({
   const resetNewSubmissions = useCallback(() => {
     setNewFormSubmissions([]);
   }, []);
+
+  const responseVersions = useMemo(() => {
+    if (!newFormSubmissions || newFormSubmissions.length === 0) {
+      return [];
+    }
+
+    const versionsSet = new Set<string>();
+    newFormSubmissions.forEach((submission) => {
+      if (submission.version) {
+        versionsSet.add(String(submission.version));
+      }
+    });
+
+    return Array.from(versionsSet).sort();
+  }, [newFormSubmissions]);
 
   const resetProcessingCompleted = useCallback(() => {
     setProcessingCompleted(false);
@@ -368,6 +387,7 @@ export const ResponsesProvider = ({
     resetProcessedSubmissionsCount();
     setHasMaliciousAttachments(false);
     setSelectedFormat("csv");
+    setSelectedVersion(null);
     setHasError(false);
     setInterrupt(false);
     interruptRef.current = false;
@@ -397,6 +417,8 @@ export const ResponsesProvider = ({
       setHasError,
       selectedFormat,
       setSelectedFormat,
+      selectedVersion,
+      setSelectedVersion,
       interrupt: isProcessingInterrupted,
       setInterrupt,
       currentSubmissionId,
@@ -406,6 +428,7 @@ export const ResponsesProvider = ({
       resetState,
       resetNewSubmissions,
       logger: responseLogger,
+      responseVersions,
     }),
     [
       locale,
@@ -430,9 +453,12 @@ export const ResponsesProvider = ({
       setInterrupt,
       currentSubmissionId,
       hasMaliciousAttachments,
+      selectedVersion,
+      setSelectedVersion,
       setCurrentSubmissionId,
       resetState,
       resetNewSubmissions,
+      responseVersions,
     ]
   );
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -235,10 +235,18 @@ export const ResponsesProvider = ({
       let htmlDirectoryHandle: FileSystemDirectoryHandle | null = null;
       let formResponses = [...(initialSubmissions || newFormSubmissions || [])];
 
+      responseLogger.info(
+        `Processing ${formResponses.length} submissions for form ID ${formId} and version ${selectedVersion || 1}`
+      );
+
       // If a specific version is selected, only process submissions for that version
       if (selectedVersion) {
         formResponses = formResponses.filter((s) => String(s.version) === selectedVersion);
       }
+
+      responseLogger.info(
+        `After filtering by version, ${formResponses.length} submissions remain for processing`
+      );
 
       if (!directoryHandle || !privateApiKey || !apiClient) {
         responseLogger.error("Missing required context values, aborting processing");
@@ -249,6 +257,7 @@ export const ResponsesProvider = ({
         formTemplate = await apiClient.getFormTemplate(
           selectedVersion ? parseInt(selectedVersion, 10) : 1
         );
+        responseLogger.info(`Loaded form template successfully version ${selectedVersion || 1}`);
         formId = apiClient.getFormId();
       } catch (error) {
         responseLogger.error("Error loading form template: ", error);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -235,13 +235,20 @@ export const ResponsesProvider = ({
       let htmlDirectoryHandle: FileSystemDirectoryHandle | null = null;
       let formResponses = [...(initialSubmissions || newFormSubmissions || [])];
 
+      // If a specific version is selected, only process submissions for that version
+      if (selectedVersion) {
+        formResponses = formResponses.filter((s) => String(s.version) === selectedVersion);
+      }
+
       if (!directoryHandle || !privateApiKey || !apiClient) {
         responseLogger.error("Missing required context values, aborting processing");
         return;
       }
 
       try {
-        formTemplate = await apiClient.getFormTemplate();
+        formTemplate = await apiClient.getFormTemplate(
+          selectedVersion ? parseInt(selectedVersion, 10) : 1
+        );
         formId = apiClient.getFormId();
       } catch (error) {
         responseLogger.error("Error loading form template: ", error);
@@ -337,9 +344,12 @@ export const ResponsesProvider = ({
           break;
         }
 
-        // Get subsequent submissions
+        // Get subsequent submissions (always fetch full set, then filter)
         // eslint-disable-next-line no-await-in-loop
         formResponses = await retrieveResponses();
+        if (selectedVersion) {
+          formResponses = formResponses.filter((s) => String(s.version) === selectedVersion);
+        }
       }
 
       // Timer end
@@ -373,6 +383,7 @@ export const ResponsesProvider = ({
       privateApiKey,
       retrieveResponses,
       selectedFormat,
+      selectedVersion,
       setInterrupt,
       t,
     ]

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/apiClient.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/apiClient.ts
@@ -89,12 +89,7 @@ export class GCFormsApiClient {
       return Promise.resolve(this.cachedFormTemplate);
     }
 
-    let endpoint = `/forms/${this.formId}/template`;
-
-    // Once this feature is fully rolled out, we can remove this check and always use the versioned endpoint.
-    if (process.env.NODE_ENV !== "production") {
-      endpoint = `/forms/${this.formId}/template?version=${selectedVersion}`;
-    }
+    const endpoint = `/forms/${this.formId}/template?version=${selectedVersion}`;
     return this.httpClient
       .get<FormProperties>(endpoint)
       .then((response) => {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/apiClient.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/apiClient.ts
@@ -83,14 +83,20 @@ export class GCFormsApiClient {
     return this.formId;
   }
 
-  public getFormTemplate(): Promise<FormProperties> {
+  public getFormTemplate(selectedVersion: number = 1): Promise<FormProperties> {
     // Return cached template if available
     if (this.cachedFormTemplate) {
       return Promise.resolve(this.cachedFormTemplate);
     }
 
+    let endpoint = `/forms/${this.formId}/template`;
+
+    // Once this feature is fully rolled out, we can remove this check and always use the versioned endpoint.
+    if (process.env.NODE_ENV !== "production") {
+      endpoint = `/forms/${this.formId}/template?version=${selectedVersion}`;
+    }
     return this.httpClient
-      .get<FormProperties>(`/forms/${this.formId}/template`)
+      .get<FormProperties>(endpoint)
       .then((response) => {
         // Cache the template for future calls
         this.cachedFormTemplate = response.data;

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/types.d.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/types.d.ts
@@ -8,6 +8,7 @@ export type PrivateApiKey = {
 export type NewFormSubmission = {
   name: string;
   createdAt: number;
+  version: number;
 };
 
 export type EncryptedFormSubmission = {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/utils.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/utils.ts
@@ -56,7 +56,7 @@ export async function getAccessTokenFromApiKey(
 ): Promise<string> {
   const zitadelURL = process.env.NEXT_PUBLIC_ZITADEL_URL;
 
-  https: if (!zitadelURL) {
+  if (!zitadelURL) {
     return Promise.reject(new Error("Zitadel URL is not set."));
   }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/utils.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/utils.ts
@@ -54,8 +54,7 @@ export async function getAccessTokenFromApiKey(
   apiKey: PrivateApiKey,
   productId: string
 ): Promise<string> {
-  // const zitadelURL = process.env.NEXT_PUBLIC_ZITADEL_URL;
-  const zitadelURL = "https://auth.forms-staging.cdssandbox.xyz";
+  const zitadelURL = process.env.NEXT_PUBLIC_ZITADEL_URL;
 
   https: if (!zitadelURL) {
     return Promise.reject(new Error("Zitadel URL is not set."));

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/utils.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/utils.ts
@@ -54,8 +54,10 @@ export async function getAccessTokenFromApiKey(
   apiKey: PrivateApiKey,
   productId: string
 ): Promise<string> {
-  const zitadelURL = process.env.NEXT_PUBLIC_ZITADEL_URL;
-  if (!zitadelURL) {
+  // const zitadelURL = process.env.NEXT_PUBLIC_ZITADEL_URL;
+  const zitadelURL = "https://auth.forms-staging.cdssandbox.xyz";
+
+  https: if (!zitadelURL) {
     return Promise.reject(new Error("Zitadel URL is not set."));
   }
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/load-key/ResponseActionButtons.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/load-key/ResponseActionButtons.tsx
@@ -12,7 +12,7 @@ export const ResponseActionButtons = () => {
     locale,
     formId,
     responseVersions,
-    selectedVersion,
+    activeSelectedVersion,
   } = useResponsesContext();
 
   const handleBack = () => {
@@ -39,7 +39,7 @@ export const ResponseActionButtons = () => {
           disabled={Boolean(
             !apiClient ||
             (newFormSubmissions && newFormSubmissions.length === 0) ||
-            (responseVersions && responseVersions.length > 1 && !selectedVersion)
+            (responseVersions && responseVersions.length > 1 && !activeSelectedVersion)
           )}
           onClick={handleNext}
           data-testid="continue-button"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/load-key/ResponseActionButtons.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/load-key/ResponseActionButtons.tsx
@@ -5,7 +5,15 @@ import { CheckForResponsesButton } from "../components/CheckForResponsesButton";
 
 export const ResponseActionButtons = () => {
   const { t, router } = useResponsesApp();
-  const { apiClient, newFormSubmissions, resetState, locale, formId } = useResponsesContext();
+  const {
+    apiClient,
+    newFormSubmissions,
+    resetState,
+    locale,
+    formId,
+    responseVersions,
+    selectedVersion,
+  } = useResponsesContext();
 
   const handleBack = () => {
     resetState();
@@ -28,7 +36,11 @@ export const ResponseActionButtons = () => {
       ) : (
         <Button
           theme="primary"
-          disabled={Boolean(!apiClient || (newFormSubmissions && newFormSubmissions.length === 0))}
+          disabled={Boolean(
+            !apiClient ||
+            (newFormSubmissions && newFormSubmissions.length === 0) ||
+            (responseVersions && responseVersions.length > 1 && !selectedVersion)
+          )}
           onClick={handleNext}
           data-testid="continue-button"
         >

--- a/i18n/translations/en/response-api.json
+++ b/i18n/translations/en/response-api.json
@@ -154,5 +154,11 @@
       "title": "Unable to modify folder contents",
       "message": "Please grant your browser “edit” or “write” access to transfer responses to the selected folder. You can find this in the browser's menu. Your department may have blocked this functionality."
     }
+  },
+  "tooltips": {
+    "version": {
+      "title": "Form version",
+      "body": "Indicates the version of the form used to submit the response."
+    }
   }
 }

--- a/i18n/translations/en/response-api.json
+++ b/i18n/translations/en/response-api.json
@@ -55,6 +55,10 @@
         "link": " Settings > API integration"
       },
       "close": "Close"
+    },
+    "versionSelector": {
+      "label": "Download responses for version",
+      "placeholder": "Choose a version"
     }
   },
   "locationPage": {

--- a/i18n/translations/fr/response-api.json
+++ b/i18n/translations/fr/response-api.json
@@ -56,6 +56,10 @@
         "link": " Paramètres > Intégration API"
       },
       "close": "Fermer"
+    },
+    "versionSelector": {
+      "label": "Download responses for version",
+      "placeholder": "Choose a version"
     }
   },
   "locationPage": {

--- a/i18n/translations/fr/response-api.json
+++ b/i18n/translations/fr/response-api.json
@@ -155,5 +155,11 @@
       "title": "Impossible de modifier le contenu du dossier",
       "message": "Veuillez accorder à votre navigateur l'accès de « modification » ou accès « en écriture » au dossier sélectionné. Vous trouverez cette option dans le menu du navigateur. Il est possible que votre ministère ait bloqué cette fonctionnalité."
     }
+  },
+  "tooltips": {
+    "version": {
+      "title": "Version du formulaire",
+      "body": "Indique la version du formulaire utilisée pour soumettre la réponse."
+    }
   }
 }

--- a/tests/browser/responses-pilot/NoVersion.browser.test.tsx
+++ b/tests/browser/responses-pilot/NoVersion.browser.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { page } from "vitest/browser";
+import { SelectApiKey } from "@responses-pilot/load-key/SelectApiKey";
+import { GCFormsApiClient } from "@responses-pilot/lib/apiClient";
+import { render } from "./testUtils";
+import { setupFonts } from "./testHelpers";
+
+import "@root/styles/app.css";
+
+describe("Responses pilot - missing version handling (browser)", () => {
+  beforeAll(() => {
+    setupFonts();
+  });
+
+  it("hides version selector and enables Continue when submissions have no version", async () => {
+    const mockApiClient = {
+      getNewFormSubmissions: async () => [
+        {
+          confirmationCode: "NOVERSION-1",
+          createdAt: new Date().toISOString(),
+          name: "Submission No Version",
+        },
+      ],
+      formId: "test-form",
+    } as unknown as GCFormsApiClient;
+
+    await render(<SelectApiKey locale="en" id="test-form" />, { mockApiClient });
+
+    // Version selector should not be rendered because no submissions provide a version
+    const selector = document.querySelector('[data-testid="download-dialog-version-filter"]');
+    expect(selector).toBeNull();
+
+    // Continue button should be enabled since there are submissions and no multi-version blocking
+    await expect.element(page.getByTestId("continue-button")).toBeEnabled();
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

Update response pilot to handle versioned responses

Adds a version selector for the responses pilot

**With multiple versions available**
 
<img width="925" height="353" alt="Screenshot 2026-07-07 at 8 55 52 AM" src="https://github.com/user-attachments/assets/5a19b93c-19b9-4898-933c-619ddb4574ba" />


**With versioned responses available all with the same version**

Keeping the dropdown in place but disabled so the user still knows what form version they are downloading for.

<img width="980" height="516" alt="Screenshot 2026-07-07 at 8 53 48 AM" src="https://github.com/user-attachments/assets/46b40c02-75b9-4753-9e24-3f4893a94043" />

<hr>

⚠️  Note: If no versioned responses exist the dropdown will not show
