### PR TITLE
bug: ensure correct template gets pulled for versioned response 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -53,8 +53,22 @@ import {
 } from "@clientComponents/forms/AddressComplete/utils";
 import { serverTranslation } from "@i18n";
 import { traceFunction } from "@lib/otel";
+import { isTemplateVersioningEnabled } from "@lib/templates/versioning/internal";
 
 const IGNORED_KEYS = ["formID", "securityAttribute"];
+
+type ResponseVersion = string | number | null;
+
+const parseTemplateVersionNumber = (version?: ResponseVersion) => {
+  if (version === undefined || version === null || version === "") return undefined;
+
+  if (typeof version === "number") {
+    return Number.isInteger(version) && version > 0 ? version : undefined;
+  }
+
+  const match = version.trim().match(/^v?(\d+)$/i);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+};
 
 // Public facing functions - they can be used by anyone who finds the associated server action identifer
 
@@ -124,11 +138,13 @@ export const getSubmissionsByFormat = AuthenticatedAction(
       ids,
       format = DownloadFormat.HTML,
       lang,
+      version,
     }: {
       formID: string;
       ids: string[];
       format: DownloadFormat;
       lang: Language;
+      version?: ResponseVersion;
     }
   ): Promise<
     | HtmlResponse
@@ -145,7 +161,23 @@ export const getSubmissionsByFormat = AuthenticatedAction(
 
         const responseConfirmLimit = Number(await getAppSetting("responseDownloadLimit"));
 
-        const fullFormTemplate = await getFullTemplateByID(formID);
+        const templateVersioningEnabled = await isTemplateVersioningEnabled();
+        const templateVersionNumber = templateVersioningEnabled
+          ? parseTemplateVersionNumber(version)
+          : undefined;
+
+        if (templateVersioningEnabled && version && templateVersionNumber === undefined) {
+          throw new FormBuilderError(
+            `Invalid response version: ${version}`,
+            FormServerErrorCodes.DOWNLOAD_INVALID_FORMAT
+          );
+        }
+
+        const fullFormTemplate = await getFullTemplateByID(
+          formID,
+          undefined,
+          templateVersionNumber
+        );
 
         if (fullFormTemplate === null) {
           logMessage.warn(`getSubmissionsByFormat form not found: ${formID}`);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/DownloadDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/DownloadDialog.tsx
@@ -39,7 +39,7 @@ export const DownloadDialog = ({
   formName: string;
   onSuccessfulDownload: (filteredIds: string[]) => void;
   responseDownloadLimit: number;
-  checkedMeta?: { id?: string; name?: string; version?: string | null }[];
+  checkedMeta?: { id?: string; name?: string; version?: string | number | null }[];
 }) => {
   const dialogRef = useDialogRef();
   const { t, i18n } = useTranslation("form-builder-responses");
@@ -143,6 +143,8 @@ export const DownloadDialog = ({
       filteredIds = filteredIdsWithVersion;
     }
 
+    const selectedVersion = selectedVersionForDialog ?? dialogVersions[0] ?? null;
+
     try {
       if (selectedFormat === DownloadFormat.HTML_ZIPPED) {
         const response = (await getSubmissionsByFormat({
@@ -150,6 +152,7 @@ export const DownloadDialog = ({
           ids: filteredIds,
           format: DownloadFormat.HTML_ZIPPED,
           lang: i18n.language as Language,
+          version: selectedVersion,
         })) as HtmlZippedResponse | ServerActionError;
 
         if ("error" in response) {
@@ -179,6 +182,7 @@ export const DownloadDialog = ({
           ids: filteredIds,
           format: DownloadFormat.CSV,
           lang: i18n.language as Language,
+          version: selectedVersion,
         })) as CSVResponse | ServerActionError;
 
         if ("error" in response) {
@@ -216,6 +220,7 @@ export const DownloadDialog = ({
           ids: filteredIds,
           format: DownloadFormat.JSON,
           lang: i18n.language as Language,
+          version: selectedVersion,
         })) as JSONResponse | ServerActionError;
 
         if ("error" in response) {

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/useTemplateVersioning.test.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/useTemplateVersioning.test.tsx
@@ -66,4 +66,24 @@ describe("useTemplateVersioning", () => {
     expect(result.current.getFilteredIds("v2")).toEqual(["response-2"]);
     expect(result.current.getFilteredIds("missing-version")).toEqual([]);
   });
+
+  it("normalizes numeric versions for dialog filtering", () => {
+    const checkedItems = new Map<string, boolean>([
+      ["response-1", true],
+      ["response-2", true],
+      ["response-3", true],
+    ]);
+
+    const checkedMeta = [
+      { name: "response-1", version: 1 },
+      { name: "response-2", version: 2 },
+      { name: "response-3", version: 1 },
+    ];
+
+    const { result } = renderHook(() => useTemplateVersioning(checkedItems, checkedMeta));
+
+    expect(result.current.dialogVersions).toEqual(["1", "2"]);
+    expect(result.current.getFilteredIds("1")).toEqual(["response-1", "response-3"]);
+    expect(result.current.getFilteredIds("2")).toEqual(["response-2"]);
+  });
 });

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/useTemplateVersioning.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/useTemplateVersioning.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 
-type CheckedMeta = { id?: string; name?: string; version?: string | null }[];
+type CheckedMeta = { id?: string; name?: string; version?: string | number | null }[];
 
 export const useTemplateVersioning = (
   checkedItems: Map<string, boolean>,
@@ -10,7 +10,7 @@ export const useTemplateVersioning = (
   const ids = React.useMemo(() => Array.from(checkedItems.keys()), [checkedItems]);
 
   const metaMap = React.useMemo(() => {
-    const map = new Map<string, { version?: string | null }>();
+    const map = new Map<string, { version?: string | number | null }>();
     if (checkedMeta && checkedMeta.length > 0) {
       checkedMeta.forEach((m) => {
         if (m && m.name) map.set(m.name, { version: m.version });
@@ -25,8 +25,7 @@ export const useTemplateVersioning = (
   );
 
   const dialogVersions = React.useMemo(
-    () =>
-      Array.from(new Set(filteredIdsWithVersion.map((id) => metaMap.get(id)!.version as string))),
+    () => Array.from(new Set(filteredIdsWithVersion.map((id) => String(metaMap.get(id)!.version)))),
     [filteredIdsWithVersion, metaMap]
   );
 

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/DownloadSingleButton.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/DownloadSingleButton.tsx
@@ -12,6 +12,7 @@ export const DownloadSingleButton = ({
   id,
   formId,
   responseId,
+  version,
   setDownloadError,
   onDownloadSuccess,
   ariaLabelledBy,
@@ -19,6 +20,7 @@ export const DownloadSingleButton = ({
   id: string;
   formId: string;
   responseId: string;
+  version?: string | number | null;
   setDownloadError: React.Dispatch<React.SetStateAction<boolean | string>>;
   onDownloadSuccess: () => void;
   ariaLabelledBy: string;
@@ -32,6 +34,7 @@ export const DownloadSingleButton = ({
         ids: [responseId],
         format: DownloadFormat.HTML,
         lang: i18n.language as Language,
+        version,
       })) as HtmlResponse | ServerActionError;
 
       if ("error" in response) {
@@ -63,7 +66,7 @@ export const DownloadSingleButton = ({
     <button
       id={id}
       onClick={handleDownload}
-      className="rounded border-2 border-white active:border-blue-focus"
+      className="active:border-blue-focus rounded border-2 border-white"
       aria-labelledby={`${id} ${ariaLabelledBy}`}
     >
       <DownloadIcon className="inline-block scale-50" />

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/DownloadTable.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/DownloadTable.tsx
@@ -280,6 +280,7 @@ export const DownloadTable = ({
                       id={`button-${submission.name}`}
                       formId={submission.formID}
                       responseId={submission.name}
+                      version={submission.version}
                       onDownloadSuccess={() => {
                         setDownloadError(false);
                         setRemovedRows([...removedRows, submission.name]);

--- a/lib/templates/queries/getFullTemplateByID.ts
+++ b/lib/templates/queries/getFullTemplateByID.ts
@@ -13,10 +13,11 @@ import { getFullTemplateByID as getFullTemplateByIDVersioningEnabled } from "@li
  */
 export async function getFullTemplateByID(
   formID: string,
-  allowDeleted?: boolean
+  allowDeleted?: boolean,
+  versionNumber?: number
 ): Promise<FormRecord | null> {
   if (await isTemplateVersioningEnabled()) {
-    return getFullTemplateByIDVersioningEnabled(formID, allowDeleted);
+    return getFullTemplateByIDVersioningEnabled(formID, allowDeleted, versionNumber);
   }
 
   try {

--- a/lib/templates/versioning/queries/getFullTemplateByID.ts
+++ b/lib/templates/versioning/queries/getFullTemplateByID.ts
@@ -6,7 +6,8 @@ import { getBuilderVersion, parseTemplate, templateRecordInclude } from "../inte
 
 export async function getFullTemplateByID(
   formID: string,
-  allowDeleted?: boolean
+  allowDeleted?: boolean,
+  versionNumber?: number
 ): Promise<FormRecord | null> {
   try {
     const { user } = await authorization.canViewForm(formID, allowDeleted).catch((e) => {
@@ -31,10 +32,29 @@ export async function getFullTemplateByID(
 
     if (!template) return null;
 
+    const requestedVersion = versionNumber
+      ? await prisma.templateVersion
+          .findFirst({
+            where: {
+              templateId: formID,
+              versionNumber,
+            },
+            select: {
+              id: true,
+              versionNumber: true,
+              status: true,
+              jsonConfig: true,
+            },
+          })
+          .catch((e) => prismaErrors(e, null))
+      : null;
+
+    if (versionNumber && !requestedVersion) return null;
+
     logEvent(user.id, { type: "Form", id: formID }, "ReadForm");
 
     return parseTemplate(template, {
-      version: getBuilderVersion(template),
+      version: requestedVersion ?? getBuilderVersion(template),
     });
   } catch {
     return null;

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -351,6 +351,81 @@ describe("Template CRUD functions", () => {
       );
     });
 
+    it("Get a full template for a specific version when versioning is enabled", async () => {
+      vi.spyOn(versioningInternal, "isTemplateVersioningEnabled").mockResolvedValue(true);
+
+      const currentFormConfiguration = structuredClone(formConfiguration as FormProperties);
+      currentFormConfiguration.elements = [
+        ...currentFormConfiguration.elements,
+        {
+          id: 999,
+          type: "textField",
+          properties: {
+            titleEn: "Current question",
+            titleFr: "Question courante",
+            validation: { required: false },
+            descriptionEn: "",
+            descriptionFr: "",
+          },
+        },
+      ];
+
+      (prismaMock.template.findUnique as MockedFunction<any>).mockResolvedValue({
+        ...buildPrismaResponse("formtestID", currentFormConfiguration, true),
+        currentPublishedVersion: {
+          id: "published-version-3",
+          versionNumber: 3,
+          status: "PUBLISHED",
+          jsonConfig: currentFormConfiguration,
+        },
+        currentDraftVersion: null,
+      });
+      (prismaMock.templateVersion.findFirst as MockedFunction<any>).mockResolvedValue({
+        id: "published-version-2",
+        versionNumber: 2,
+        status: "SUPERSEDED",
+        jsonConfig: formConfiguration,
+      });
+
+      const template = await getFullTemplateByID("formTestID", false, 2);
+
+      expect(prismaMock.templateVersion.findFirst).toHaveBeenCalledWith({
+        where: {
+          templateId: "formTestID",
+          versionNumber: 2,
+        },
+        select: {
+          id: true,
+          versionNumber: true,
+          status: true,
+          jsonConfig: true,
+        },
+      });
+      expect(template).toEqual(
+        expect.objectContaining({
+          id: "formtestID",
+          form: formConfiguration,
+          versionNumber: 2,
+        })
+      );
+    });
+
+    it("Ignores requested template version when versioning is disabled", async () => {
+      (prismaMock.template.findUnique as MockedFunction<any>).mockResolvedValue(
+        buildPrismaResponse("formtestID", formConfiguration)
+      );
+
+      const template = await getFullTemplateByID("formTestID", false, 2);
+
+      expect(prismaMock.templateVersion.findFirst).not.toHaveBeenCalled();
+      expect(template).toEqual(
+        expect.objectContaining({
+          id: "formtestID",
+          form: formConfiguration,
+        })
+      );
+    });
+
     it("Null returned when Template does not Exist", async () => {
       (prismaMock.template.findUnique as MockedFunction<any>).mockResolvedValue(null);
 


### PR DESCRIPTION
# Summary | Résumé

When downloading via the responses ui we need to ensure the proper versioned template gets pulled not the latest.

The template should match the template that the response was submitted with.

## Testing

- Create and publish a form
- Submit responses for that form (don't download)
- Republish the form with a new form field or something where you can identify a difference in the template
 - Submit responses for that form
 - Download the first set of versioned responses --- validate the template is correct
 - Download the second set of versioned responses --- validate the template is correct