### PR TITLE
bug: unset selected version

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/DownloadDialog.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/components/Dialogs/DownloadDialog.tsx
@@ -65,6 +65,7 @@ export const DownloadDialog = ({
   const handleClose = () => {
     setSelectedFormat(defaultSelectedFormat);
     setZipAllFiles(true);
+    setSelectedVersionForDialog(null);
     setIsDialogVisible(false);
     dialogRef.current?.close();
   };


### PR DESCRIPTION
# Summary | Résumé

When multiple versions are selected -- after choosing a version to download we uncheck the downloaded items.

Trying to download the remaining item from another version was throwing an error.

This update ensure the selected version gets reset

<img width="724" height="480" alt="Screenshot 2026-07-09 at 7 35 19 AM" src="https://github.com/user-attachments/assets/603ee2a7-28a6-44f3-b1a0-97196608c130" />
