### PR TITLE
chore: allow template query fallback

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -277,6 +277,8 @@ export const ResponsesProvider = ({
             `Loaded form template successfully version ${activeSelectedVersion || 1}`
           );
         } catch (err) {
+          // Note: this code can be removed once the backend is updated to support versioned templates for all forms. The fallback logic is only needed for forms that do not yet have versioned templates.
+
           // Only fallback to non-versioned template when requesting version 1.
           if (requestedVersionNumber === 1) {
             responseLogger.warn(

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -267,37 +267,12 @@ export const ResponsesProvider = ({
       }
 
       try {
-        const requestedVersionNumber = activeSelectedVersion
-          ? parseInt(activeSelectedVersion, 10)
-          : 1;
-
-        try {
-          formTemplate = await apiClient.getFormTemplate(requestedVersionNumber);
-          responseLogger.info(
-            `Loaded form template successfully version ${activeSelectedVersion || 1}`
-          );
-        } catch (err) {
-          // Note: this code can be removed once the backend is updated to support versioned templates for all forms. The fallback logic is only needed for forms that do not yet have versioned templates.
-
-          // Only fallback to non-versioned template when requesting version 1.
-          if (requestedVersionNumber === 1) {
-            responseLogger.warn(
-              `Failed to load requested template version ${requestedVersionNumber} for form ${apiClient.getFormId()}, attempting fallback to non-versioned template.`
-            );
-            try {
-              formTemplate = await apiClient.getFormTemplate(1);
-              responseLogger.info(
-                `Loaded fallback non-versioned form template for form ${apiClient.getFormId()}`
-              );
-            } catch (err2) {
-              throw err2;
-            }
-          } else {
-            // For other versions, rethrow to surface the error
-            throw err;
-          }
-        }
-
+        formTemplate = await apiClient.getFormTemplate(
+          activeSelectedVersion ? parseInt(activeSelectedVersion, 10) : 1
+        );
+        responseLogger.info(
+          `Loaded form template successfully version ${activeSelectedVersion || 1}`
+        );
         formId = apiClient.getFormId();
       } catch (error) {
         responseLogger.error("Error loading form template: ", error);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/context/ResponsesContext.tsx
@@ -267,12 +267,35 @@ export const ResponsesProvider = ({
       }
 
       try {
-        formTemplate = await apiClient.getFormTemplate(
-          activeSelectedVersion ? parseInt(activeSelectedVersion, 10) : 1
-        );
-        responseLogger.info(
-          `Loaded form template successfully version ${activeSelectedVersion || 1}`
-        );
+        const requestedVersionNumber = activeSelectedVersion
+          ? parseInt(activeSelectedVersion, 10)
+          : 1;
+
+        try {
+          formTemplate = await apiClient.getFormTemplate(requestedVersionNumber);
+          responseLogger.info(
+            `Loaded form template successfully version ${activeSelectedVersion || 1}`
+          );
+        } catch (err) {
+          // Only fallback to non-versioned template when requesting version 1.
+          if (requestedVersionNumber === 1) {
+            responseLogger.warn(
+              `Failed to load requested template version ${requestedVersionNumber} for form ${apiClient.getFormId()}, attempting fallback to non-versioned template.`
+            );
+            try {
+              formTemplate = await apiClient.getFormTemplate(1);
+              responseLogger.info(
+                `Loaded fallback non-versioned form template for form ${apiClient.getFormId()}`
+              );
+            } catch (err2) {
+              throw err2;
+            }
+          } else {
+            // For other versions, rethrow to surface the error
+            throw err;
+          }
+        }
+
         formId = apiClient.getFormId();
       } catch (error) {
         responseLogger.error("Error loading form template: ", error);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -173,11 +173,17 @@ export const getSubmissionsByFormat = AuthenticatedAction(
           );
         }
 
-        const fullFormTemplate = await getFullTemplateByID(
-          formID,
-          undefined,
-          templateVersionNumber
-        );
+        let fullFormTemplate = await getFullTemplateByID(formID, undefined, templateVersionNumber);
+
+        // Fallback: only allow fallback to non-versioned template when version 1
+        // was requested. This covers the case where responses were collected
+        // before any versions were created and the UI requests version 1.
+        if (fullFormTemplate === null && templateVersioningEnabled && templateVersionNumber === 1) {
+          logMessage.warn(
+            `Requested template version ${templateVersionNumber} not found for form ${formID}, attempting non-versioned fallback to version 1`
+          );
+          fullFormTemplate = await getFullTemplateByID(formID);
+        }
 
         if (fullFormTemplate === null) {
           logMessage.warn(`getSubmissionsByFormat form not found: ${formID}`);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -175,6 +175,8 @@ export const getSubmissionsByFormat = AuthenticatedAction(
 
         let fullFormTemplate = await getFullTemplateByID(formID, undefined, templateVersionNumber);
 
+        // Note: this code can be removed once the backend is updated to support versioned templates for all forms. The fallback logic is only needed for forms that do not yet have versioned templates.
+
         // Fallback: only allow fallback to non-versioned template when version 1
         // was requested. This covers the case where responses were collected
         // before any versions were created and the UI requests version 1.


### PR DESCRIPTION
# Summary | Résumé

Update to allow a template query to fallback to the templates table for version 1 templates if a versioned template doesn't exist yet --- this can happen if a form is created, has responses ... the user later is granted access to the versioned template feature.

## Notes

This code can be removed if / once we backfill existing templates to the versioned table.