### PR TITLE
chore: Add audit logs for versioned templates

### DIFF
--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -614,7 +614,7 @@
       "DeleteAPIKey": "Deleted API Key",
       "RefreshAPIKey": "Re-generated API Key",
       "PublishForm": "Form published",
-      "RepublishForm": "Updated form published",
+      "RepublishForm": "Re-published form",
       "InvitationAccepted": "Invitation accepted",
       "UpdateFormBranding": "Updated form branding",
       "UpdatedNotificationSettings": "Updated notification settings",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -593,6 +593,7 @@
     },
     "events": {
       "CreateForm": "Form created",
+      "CreateDraftFromPublishedForm": "Draft created from published form",
       "DeleteForm": "Form archived",
       "UnarchiveForm": "Form restored",
       "ChangeDeliveryOption": "Delivery option changed",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -623,8 +623,6 @@
       "InvitationCancelled": "Cancelled a collaboration invitation"
     },
     "eventDetails": {
-      "PublishForm": "Published form",
-      "RepublishForm": "Published updated form",
       "CreateDraftFromPublishedForm": "Draft version {{versionNumber}}",
       "CreatedForm": "Created form",
       "UpdatedFormName": "Renamed form to: {{newFormName}}",

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -614,6 +614,7 @@
       "DeleteAPIKey": "Deleted API Key",
       "RefreshAPIKey": "Re-generated API Key",
       "PublishForm": "Form published",
+      "RepublishForm": "Updated form published",
       "InvitationAccepted": "Invitation accepted",
       "UpdateFormBranding": "Updated form branding",
       "UpdatedNotificationSettings": "Updated notification settings",
@@ -622,6 +623,9 @@
       "InvitationCancelled": "Cancelled a collaboration invitation"
     },
     "eventDetails": {
+      "PublishForm": "Published form",
+      "RepublishForm": "Published updated form",
+      "CreateDraftFromPublishedForm": "Draft version {{versionNumber}}",
       "CreatedForm": "Created form",
       "UpdatedFormName": "Renamed form to: {{newFormName}}",
       "UpdatedFormContent": "Updated form content",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -622,8 +622,6 @@
       "InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
     },
     "eventDetails": {
-      "PublishForm": "Formulaire publié",
-      "RepublishForm": "Mise à jour du formulaire publié",
       "CreateDraftFromPublishedForm": "Ébauche - version : {{versionNumber}}",
       "CreatedForm": "Formulaire créé",
       "UpdatedFormName": "Formulaire renommé à :{{newFormName}}",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -614,17 +614,17 @@
       "DeleteAPIKey": "Clé API supprimée",
       "RefreshAPIKey": "Clé API re-générée",
       "PublishForm": "Formulaire publié",
-      "RepublishForm": "Re-published form [FR]",
-      "InvitationAccepted": "Invitation acceptée",
-      "UpdateFormBranding": "Mise à jour de l'image de marque du formulaire",
-      "UpdatedNotificationSettings": "Mise à jour des paramètres de notification",
-      "InvitationCreated": "Invitation pour collaborer sur le formulaire envoyée",
-      "InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
-    },
-    "eventDetails": {
-      "PublishForm": "Published form [FR]",
-      "RepublishForm": "Published updated form [FR]",
-      "CreateDraftFromPublishedForm": "Draft version {{versionNumber}} [FR]",
+      "RepublishForm": "Formulaire re-publié",
+"InvitationAccepted": "Invitation acceptée",
+"UpdateFormBranding": "Mise à jour de l'image de marque du formulaire",
+"UpdatedNotificationSettings": "Mise à jour des paramètres de notification",
+"InvitationCreated": "Invitation pour collaborer sur le formulaire envoyée",
+"InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
+},
+"eventDetails": {
+      "PublishForm": "Formulaire publié",
+      "RepublishForm": "Mise à jour du formulaire publié",
+      "CreateDraftFromPublishedForm": "Ébauche - version : {{versionNumber}}",
       "CreatedForm": "Formulaire créé",
       "UpdatedFormName": "Formulaire renommé à :{{newFormName}}",
       "UpdatedFormContent": "Contenu du formulaire mis à jour",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -615,13 +615,13 @@
       "RefreshAPIKey": "Clé API re-générée",
       "PublishForm": "Formulaire publié",
       "RepublishForm": "Formulaire re-publié",
-"InvitationAccepted": "Invitation acceptée",
-"UpdateFormBranding": "Mise à jour de l'image de marque du formulaire",
-"UpdatedNotificationSettings": "Mise à jour des paramètres de notification",
-"InvitationCreated": "Invitation pour collaborer sur le formulaire envoyée",
-"InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
-},
-"eventDetails": {
+      "InvitationAccepted": "Invitation acceptée",
+      "UpdateFormBranding": "Mise à jour de l'image de marque du formulaire",
+      "UpdatedNotificationSettings": "Mise à jour des paramètres de notification",
+      "InvitationCreated": "Invitation pour collaborer sur le formulaire envoyée",
+      "InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
+    },
+    "eventDetails": {
       "PublishForm": "Formulaire publié",
       "RepublishForm": "Mise à jour du formulaire publié",
       "CreateDraftFromPublishedForm": "Ébauche - version : {{versionNumber}}",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -593,7 +593,7 @@
     },
     "events": {
       "CreateForm": "Formulaire créé",
-      "CreateDraftFromPublishedForm": "Brouillon créé à partir du formulaire publié",
+      "CreateDraftFromPublishedForm": "Ébauche créée à partir du formulaire publié",
       "DeleteForm": "Formulaire archivé",
       "UnarchiveForm": "Formulaire désarchivé",
       "ChangeDeliveryOption": "Option de livraison modifiée",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -614,7 +614,7 @@
       "DeleteAPIKey": "Clé API supprimée",
       "RefreshAPIKey": "Clé API re-générée",
       "PublishForm": "Formulaire publié",
-      "RepublishForm": "Formulaire mis à jour publié",
+      "RepublishForm": "Re-published form [FR]",
       "InvitationAccepted": "Invitation acceptée",
       "UpdateFormBranding": "Mise à jour de l'image de marque du formulaire",
       "UpdatedNotificationSettings": "Mise à jour des paramètres de notification",
@@ -622,9 +622,9 @@
       "InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
     },
     "eventDetails": {
-      "PublishForm": "Formulaire publié",
-      "RepublishForm": "Formulaire mis à jour publié",
-      "CreateDraftFromPublishedForm": "Version brouillon {{versionNumber}}",
+      "PublishForm": "Published form [FR]",
+      "RepublishForm": "Published updated form [FR]",
+      "CreateDraftFromPublishedForm": "Draft version {{versionNumber}} [FR]",
       "CreatedForm": "Formulaire créé",
       "UpdatedFormName": "Formulaire renommé à :{{newFormName}}",
       "UpdatedFormContent": "Contenu du formulaire mis à jour",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -593,6 +593,7 @@
     },
     "events": {
       "CreateForm": "Formulaire créé",
+      "CreateDraftFromPublishedForm": "Brouillon créé à partir du formulaire publié",
       "DeleteForm": "Formulaire archivé",
       "UnarchiveForm": "Formulaire désarchivé",
       "ChangeDeliveryOption": "Option de livraison modifiée",

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -614,6 +614,7 @@
       "DeleteAPIKey": "Clé API supprimée",
       "RefreshAPIKey": "Clé API re-générée",
       "PublishForm": "Formulaire publié",
+      "RepublishForm": "Formulaire mis à jour publié",
       "InvitationAccepted": "Invitation acceptée",
       "UpdateFormBranding": "Mise à jour de l'image de marque du formulaire",
       "UpdatedNotificationSettings": "Mise à jour des paramètres de notification",
@@ -621,6 +622,9 @@
       "InvitationCancelled": "Invitation pour collaborer sur le formulaire annulée"
     },
     "eventDetails": {
+      "PublishForm": "Formulaire publié",
+      "RepublishForm": "Formulaire mis à jour publié",
+      "CreateDraftFromPublishedForm": "Version brouillon {{versionNumber}}",
       "CreatedForm": "Formulaire créé",
       "UpdatedFormName": "Formulaire renommé à :{{newFormName}}",
       "UpdatedFormContent": "Contenu du formulaire mis à jour",

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -17,6 +17,7 @@ import { getClientIp } from "./ip";
 export const AuditLogEvent = {
   // Form Events
   CreateForm: "CreateForm",
+  CreateDraftFromPublishedForm: "CreateDraftFromPublishedForm",
   ReadForm: "ReadForm",
   UpdateForm: "UpdateForm",
   DeleteForm: "DeleteForm",
@@ -78,6 +79,7 @@ export const AuditLogEvent = {
 
 const FormBuildingEvents = [
   AuditLogEvent.CreateForm,
+  AuditLogEvent.CreateDraftFromPublishedForm,
   AuditLogEvent.UpdateForm,
   AuditLogEvent.DeleteForm,
   AuditLogEvent.UnarchiveForm,
@@ -175,6 +177,8 @@ export const AuditLogDetails = {
     "Granted privilege ${privilege} to user ${email} (userID: ${userId}) by ${userEmail} (userID: ${abilityUserId})",
   RevokedPrivilege:
     "Revoked privilege ${privilege} from user ${email} (userID: ${userId}) by ${userEmail} (userID: ${abilityUserId})",
+  CreateDraftFromPublishedForm:
+    "User ${userId} created a draft version ${versionNumber} from published form ${formId} with versioned form ID ${versionedFormID}",
 } as const;
 
 export type AuditLogDetails = (typeof AuditLogDetails)[keyof typeof AuditLogDetails];
@@ -277,6 +281,12 @@ type AuditDetailsParams = {
     abilityUserId: string;
   };
   [AuditLogDetails.UpdateFormBranding]: { brand: string };
+  [AuditLogDetails.CreateDraftFromPublishedForm]: {
+    userId: string;
+    versionNumber: string;
+    formId: string;
+    versionedFormID: string;
+  };
 };
 
 export const AuditLogAccessDeniedDetails = {

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -23,6 +23,7 @@ export const AuditLogEvent = {
   DeleteForm: "DeleteForm",
   UnarchiveForm: "UnarchiveForm",
   PublishForm: "PublishForm",
+  RepublishForm: "RepublishForm",
   ChangeFormName: "ChangeFormName",
   ChangeDeliveryOption: "ChangeDeliveryOption",
   ChangeFormPurpose: "ChangeFormPurpose",
@@ -84,6 +85,7 @@ const FormBuildingEvents = [
   AuditLogEvent.DeleteForm,
   AuditLogEvent.UnarchiveForm,
   AuditLogEvent.PublishForm,
+  AuditLogEvent.RepublishForm,
   AuditLogEvent.ChangeFormName,
   AuditLogEvent.ChangeDeliveryOption,
   AuditLogEvent.ChangeFormPurpose,
@@ -177,8 +179,9 @@ export const AuditLogDetails = {
     "Granted privilege ${privilege} to user ${email} (userID: ${userId}) by ${userEmail} (userID: ${abilityUserId})",
   RevokedPrivilege:
     "Revoked privilege ${privilege} from user ${email} (userID: ${userId}) by ${userEmail} (userID: ${abilityUserId})",
-  CreateDraftFromPublishedForm:
-    "User ${userId} created a draft version ${versionNumber} from published form ${formId} with versioned form ID ${versionedFormID}",
+  CreateDraftFromPublishedForm: "CreateDraftFromPublishedForm",
+  PublishForm: "PublishForm",
+  RepublishForm: "RepublishForm",
 } as const;
 
 export type AuditLogDetails = (typeof AuditLogDetails)[keyof typeof AuditLogDetails];
@@ -282,11 +285,10 @@ type AuditDetailsParams = {
   };
   [AuditLogDetails.UpdateFormBranding]: { brand: string };
   [AuditLogDetails.CreateDraftFromPublishedForm]: {
-    userId: string;
     versionNumber: string;
-    formId: string;
-    versionedFormID: string;
   };
+  [AuditLogDetails.PublishForm]: never;
+  [AuditLogDetails.RepublishForm]: never;
 };
 
 export const AuditLogAccessDeniedDetails = {

--- a/lib/auditLogs.ts
+++ b/lib/auditLogs.ts
@@ -287,8 +287,6 @@ type AuditDetailsParams = {
   [AuditLogDetails.CreateDraftFromPublishedForm]: {
     versionNumber: string;
   };
-  [AuditLogDetails.PublishForm]: never;
-  [AuditLogDetails.RepublishForm]: never;
 };
 
 export const AuditLogAccessDeniedDetails = {

--- a/lib/templates/mutations/shared/logTemplateUpdateEvent.ts
+++ b/lib/templates/mutations/shared/logTemplateUpdateEvent.ts
@@ -107,8 +107,7 @@ export const logTemplateUpdateEvent = async (event: UpdateAuditEvent) => {
       logEvent(
         event.user.id,
         { type: "Form", id: publishCommand.formId },
-        event.isRepublish ? AuditLogEvent.RepublishForm : AuditLogEvent.PublishForm,
-        event.isRepublish ? AuditLogDetails.RepublishForm : AuditLogDetails.PublishForm
+        event.isRepublish ? AuditLogEvent.RepublishForm : AuditLogEvent.PublishForm
       );
       break;
     case UpdateTemplateAction.SecurityAttribute:

--- a/lib/templates/mutations/shared/logTemplateUpdateEvent.ts
+++ b/lib/templates/mutations/shared/logTemplateUpdateEvent.ts
@@ -19,6 +19,7 @@ export type UpdateAuditEvent = {
   action: UpdateTemplateAction;
   command: UpdateTemplateCommand;
   user: { id: string; email: string };
+  isRepublish?: boolean;
   beforeContext?: {
     name?: string;
     jsonConfig?: FormProperties;
@@ -103,7 +104,12 @@ export const logTemplateUpdateEvent = async (event: UpdateAuditEvent) => {
       break;
     case UpdateTemplateAction.IsPublished:
       const publishCommand = event.command as UpdateIsPublishedCommand;
-      logEvent(event.user.id, { type: "Form", id: publishCommand.formId }, "PublishForm");
+      logEvent(
+        event.user.id,
+        { type: "Form", id: publishCommand.formId },
+        event.isRepublish ? AuditLogEvent.RepublishForm : AuditLogEvent.PublishForm,
+        event.isRepublish ? AuditLogDetails.RepublishForm : AuditLogDetails.PublishForm
+      );
       break;
     case UpdateTemplateAction.SecurityAttribute:
       const securityCommand = event.command as UpdateSecurityAttributeCommand;

--- a/lib/templates/versioning/mutations/createDraftForTemplate.ts
+++ b/lib/templates/versioning/mutations/createDraftForTemplate.ts
@@ -5,7 +5,12 @@ import {
   templateVersionSelect,
 } from "../internal/index";
 import { authorization } from "@lib/privileges";
-import { AuditLogAccessDeniedDetails, AuditLogDetails, logEvent } from "@lib/auditLogs";
+import {
+  AuditLogAccessDeniedDetails,
+  AuditLogDetails,
+  AuditLogEvent,
+  logEvent,
+} from "@lib/auditLogs";
 import { prisma, prismaErrors, Prisma } from "@gcforms/database";
 import { TEMPLATE_VERSION_STATUS } from "../internal/types";
 import { parseTemplate } from "../internal/index";
@@ -163,13 +168,10 @@ export async function createDraftVersionForTemplate(formID: string): Promise<For
   logEvent(
     user.id,
     { type: "Form", id: formID },
-    "CreateDraftFromPublishedForm",
+    AuditLogEvent.CreateDraftFromPublishedForm,
     AuditLogDetails.CreateDraftFromPublishedForm,
     {
-      userId: user.id,
-      formId: updatedTemplate.id,
       versionNumber: String(updatedTemplate.currentDraftVersion?.versionNumber ?? 0),
-      versionedFormID: updatedTemplate.currentDraftVersionId ?? "",
     }
   );
 

--- a/lib/templates/versioning/mutations/createDraftForTemplate.ts
+++ b/lib/templates/versioning/mutations/createDraftForTemplate.ts
@@ -5,7 +5,7 @@ import {
   templateVersionSelect,
 } from "../internal/index";
 import { authorization } from "@lib/privileges";
-import { AuditLogAccessDeniedDetails, logEvent } from "@lib/auditLogs";
+import { AuditLogAccessDeniedDetails, AuditLogDetails, logEvent } from "@lib/auditLogs";
 import { prisma, prismaErrors, Prisma } from "@gcforms/database";
 import { TEMPLATE_VERSION_STATUS } from "../internal/types";
 import { parseTemplate } from "../internal/index";
@@ -159,6 +159,19 @@ export async function createDraftVersionForTemplate(formID: string): Promise<For
     .catch((e) => prismaErrors(e, null));
 
   if (!updatedTemplate) return null;
+
+  logEvent(
+    user.id,
+    { type: "Form", id: formID },
+    "CreateDraftFromPublishedForm",
+    AuditLogDetails.CreateDraftFromPublishedForm,
+    {
+      userId: user.id,
+      formId: updatedTemplate.id,
+      versionNumber: String(updatedTemplate.currentDraftVersion?.versionNumber ?? 0),
+      versionedFormID: updatedTemplate.currentDraftVersionId ?? "",
+    }
+  );
 
   return parseTemplate(updatedTemplate, {
     version: updatedTemplate.currentDraftVersion,

--- a/lib/templates/versioning/mutations/publishTemplate.ts
+++ b/lib/templates/versioning/mutations/publishTemplate.ts
@@ -137,6 +137,7 @@ export async function publishTemplate(
     action: command.action,
     command,
     user,
+    isRepublish: Boolean(templateVersionState?.currentPublishedVersionId),
   });
 
   return parseTemplate(updatedTemplate, {

--- a/lib/tests/templates.test.ts
+++ b/lib/tests/templates.test.ts
@@ -24,7 +24,7 @@ import formConfiguration from "@testFixtures/cdsIntakeTestForm.json";
 import v8 from "v8";
 import { Prisma } from "@gcforms/database";
 
-import { AuditLogAccessDeniedDetails, logEvent } from "@lib/auditLogs";
+import { AuditLogAccessDeniedDetails, AuditLogEvent, logEvent } from "@lib/auditLogs";
 import { unprocessedSubmissions } from "@lib/vault";
 import { deleteKey } from "@lib/serviceAccount";
 import { AccessControlError } from "@lib/auth/errors";
@@ -577,7 +577,7 @@ describe("Template CRUD functions", () => {
       expect(mockedLogEvent).toHaveBeenCalledWith(
         userID,
         { id: "formtestID", type: "Form" },
-        "PublishForm"
+        AuditLogEvent.PublishForm
       );
     });
 


### PR DESCRIPTION
# Summary | Résumé

Adds logs for create draft from published form and re-publish events.

<img width="949" height="468" alt="Screenshot 2026-07-16 at 7 18 18 AM" src="https://github.com/user-attachments/assets/8616659b-5b64-4a2d-a7a4-a446ab7dc14f" />
