### PR TITLE
chore: avoid deleting API key during template deletion when none exists

### DIFF
--- a/lib/templates/mutations/deleteTemplate.ts
+++ b/lib/templates/mutations/deleteTemplate.ts
@@ -24,17 +24,17 @@ export async function deleteTemplate(formID: string): Promise<FormRecord | null>
     throw e;
   });
 
-  // Check if the form is draft or not.
-  const template = await prisma.template.findFirstOrThrow({
+  const template = await prisma.template.findUnique({
     where: {
       id: formID,
     },
     select: {
       isPublished: true,
+      apiServiceAccount: { select: { id: true } },
     },
   });
 
-  if (!template) throw new TemplateNotFoundError();
+  if (template === null) throw new TemplateNotFoundError();
 
   // Only check submissions if the form is published.
   if (template.isPublished) {
@@ -44,7 +44,9 @@ export async function deleteTemplate(formID: string): Promise<FormRecord | null>
   }
 
   // Check and delete any API keys from IDP
-  await deleteKey(formID);
+  if (template.apiServiceAccount !== null) {
+    await deleteKey(formID);
+  }
 
   const dateIn30Days = new Date(Date.now() + 2592000000); // 30 days = 60 (seconds) * 60 (minutes) * 24 (hours) * 30 (days) * 1000 (to ms)
   const templateMarkedAsDeleted = await prisma.template


### PR DESCRIPTION
# Summary | Résumé

Context: while investigating on a different issue I noticed that, for a form created with no API key, we always had a `DeleteAPIKey` audit log created upon form deletion

- Adds condition to avoid deleting API key during template deletion when none exists