### PR TITLE
bug: handle no version for form download

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/actions.ts
@@ -233,7 +233,15 @@ export const getDownloadableFormVersionConfig = AuthenticatedAction(
       }
 
       if (!versionId) {
-        throw new Error("Version Id Required");
+        // No version id provided (likely templates created before versioning).
+        // Fallback to returning the full template record.
+        const formRecord = await getFullTemplateByID(formId, false);
+
+        if (!formRecord) {
+          throw new Error("Form Not Found");
+        }
+
+        return { formConfig: formRecord.form };
       }
 
       const versionRecord = await getTemplateVersionById(versionId);

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/DownloadForm.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/settings/components/DownloadForm.tsx
@@ -44,7 +44,7 @@ export const DownloadForm = ({ versions }: Props) => {
       const result = res as { error?: unknown; formConfig?: unknown };
 
       if (result.error || !result.formConfig) {
-        toast.error(t("errors.formDownloadFailed"));
+        toast.error(t("formDownloadFailed"));
         return;
       }
 
@@ -58,7 +58,7 @@ export const DownloadForm = ({ versions }: Props) => {
 
       await downloadDataAsBlob(data, filename, { "application/json": [".json"] });
     } catch (err) {
-      toast.error(t("errors.formDownloadFailed"));
+      toast.error(t("formDownloadFailed"));
     }
   };
 

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
@@ -55,7 +55,7 @@ export const Menu = ({
         if (error === "Form Not Found") {
           toast.error(t("errors.formDownloadNotExist"));
         } else {
-          toast.error(t("errors.formDownloadFailed"));
+          toast.error(t("formDownloadFailed"));
         }
       }
 

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1701,5 +1701,6 @@
     "title": "Edit and re-publish",
     "description": "Make an edit to your form while it is published",
     "button": "Edit form"
-  }
+  },
+  "formDownloadFailed": "Failed to download the form."
 }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1703,5 +1703,6 @@
   },
   "fileUploadApiWarning": {
     "text": "La méthode de livraison n'est pas configurée sur API. Générez une clé API pour permettre le téléchargement de fichiers et la récupération des données de réponse via l'API."
-  }
+  },
+  "formDownloadFailed": "Le téléchargement du formulaire a échoué."
 }


### PR DESCRIPTION
# Summary | Résumé

Fixes a bug that can happen if a form is created and we later turn the template versioning on --- without having a backfill in the versions table.

Ref: https://github.com/cds-snc/platform-forms-client/pull/7515