### PR TITLE
chore: include published drafts

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.test.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+import { useParams } from "next/navigation";
+
+import { Card } from "./Card";
+import { TAB_STATUS, type FormsTemplateWithLockInfo } from "../types";
+
+vi.mock("../client/DraftEditLink", () => ({
+  DraftEditLink: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../client/Menu", () => ({
+  Menu: () => <div data-testid="card-menu" />,
+}));
+
+vi.mock("../client/Unarchive", () => ({
+  Unarchive: () => null,
+}));
+
+vi.mock("@gcforms/announce", () => ({
+  announce: vi.fn(),
+  Priority: { HIGH: "high" },
+}));
+
+const mockedUseParams = vi.mocked(useParams);
+
+describe("Card", () => {
+  beforeEach(() => {
+    mockedUseParams.mockReturnValue({ locale: "en" });
+  });
+
+  it("links the published status to the live form and leaves the draft version unlinked for published drafts on the drafts tab", async () => {
+    const card: FormsTemplateWithLockInfo = {
+      id: "form-123",
+      titleEn: "My form",
+      titleFr: "Mon formulaire",
+      deliveryOption: { emailAddress: "" },
+      name: "My form - v2",
+      isPublished: true,
+      hasDraft: true,
+      currentDraftVersion: 3,
+      currentPublishedVersion: 2,
+      ttl: null,
+      date: new Date("2026-07-20T00:00:00.000Z").toISOString(),
+      overdue: false,
+      hasEditLock: false,
+      collaboratorCount: {
+        userCount: 1,
+        pendingUserCount: 0,
+      },
+      closingDate: null,
+      lastEditedBy: null,
+    };
+
+    render(<Card card={card} status={TAB_STATUS.DRAFT} />);
+
+    expect(screen.getByText("Published- version 2").closest("a")).toHaveAttribute(
+      "href",
+      "/en/id/form-123"
+    );
+    expect(screen.queryByRole("link", { name: "Draft - version 3" })).not.toBeInTheDocument();
+    expect(screen.getByText("Draft - version 3")).toBeInTheDocument();
+  });
+});

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
@@ -51,15 +51,18 @@ const DraftVersionNumber = memo(
     hasDraft,
     draftVersionNumber,
     isPublished,
+    linkDraftVersion,
   }: {
     language: string;
     cardId: string;
     hasDraft: boolean;
     draftVersionNumber?: number;
     isPublished: boolean;
+    linkDraftVersion?: boolean;
   }) => {
     const { t } = useTranslation("my-forms");
     const link = `/${language}/form-builder/${cardId}/edit`;
+    const label = t("card.draftVersion", { draftVersionNumber: draftVersionNumber });
 
     if (isPublished && hasDraft && draftVersionNumber) {
       return (
@@ -68,9 +71,13 @@ const DraftVersionNumber = memo(
             className="mr-2 inline-block h-3 w-3 rounded-full bg-yellow-400"
             aria-hidden="true"
           ></span>
-          <Link href={link} prefetch={false}>
-            {t("card.draftVersion", { draftVersionNumber: draftVersionNumber })}
-          </Link>
+          {linkDraftVersion ? (
+            <Link href={link} prefetch={false}>
+              {label}
+            </Link>
+          ) : (
+            <span>{label}</span>
+          )}
         </div>
       );
     }
@@ -90,6 +97,8 @@ const CardBanner = memo(
     draftVersionNumber,
     isPublished,
     isClosed,
+    liveFormLink,
+    linkDraftVersion,
   }: {
     language: string;
     cardId: string;
@@ -98,6 +107,8 @@ const CardBanner = memo(
     draftVersionNumber?: number;
     isPublished: boolean;
     isClosed: boolean;
+    liveFormLink?: string;
+    linkDraftVersion?: boolean;
   }) => {
     const { t } = useTranslation("my-forms");
     const bulletColor = isClosed
@@ -111,18 +122,25 @@ const CardBanner = memo(
         ? t("card.versionNumber", { publishedVersionNumber: publishedVersionNumber })
         : "";
 
+    const publishedLabel = isClosed
+      ? t("card.states.closed")
+      : isPublished
+        ? t("card.states.published") + t(publishedVersionText ? `${publishedVersionText}` : "")
+        : t("card.states.draft");
+
     return (
       <>
         <div className="mt-4 flex items-center gap-1 self-start text-sm" aria-hidden="true">
           <span
             className={`inline-block h-3 w-3 rounded-full border-1 border-slate-50 ${bulletColor}`}
           />
-          {isClosed
-            ? t("card.states.closed")
-            : isPublished
-              ? t("card.states.published") +
-                t(publishedVersionText ? `${publishedVersionText}` : "")
-              : t("card.states.draft")}
+          {liveFormLink ? (
+            <Link href={liveFormLink} prefetch={false}>
+              {publishedLabel}
+            </Link>
+          ) : (
+            publishedLabel
+          )}
         </div>
 
         <DraftVersionNumber
@@ -131,6 +149,7 @@ const CardBanner = memo(
           isPublished={isPublished}
           hasDraft={hasDraft}
           draftVersionNumber={draftVersionNumber}
+          linkDraftVersion={linkDraftVersion}
         />
       </>
     );
@@ -445,6 +464,9 @@ const CardComponent = ({
       ),
     [card.collaboratorCount.userCount, card.collaboratorCount.pendingUserCount]
   );
+  const isPublishedDraftOnDraftTab =
+    status === TAB_STATUS.DRAFT && card.isPublished && card.hasDraft;
+  const liveFormLink = isPublishedDraftOnDraftTab ? `/${language}/id/${card.id}` : undefined;
 
   const wrapperClass = `grid h-full max-w-[16em] min-w-[16em] grid-cols-[1fr_auto] gap-2 rounded-md border-1 border-slate-300 pt-2 pr-3 pb-4 pl-5 shadow-lg shadow-slate-900/5 ${card.editLockInfo ? "bg-yellow-50" : card.overdue ? "bg-red-50" : ""}`;
   return (
@@ -456,7 +478,7 @@ const CardComponent = ({
           isPublished={card.isPublished}
           isClosed={cardState === CARD_STATE.CLOSED}
           collaboratorCount={collaboratorCount}
-          linkToEdit={status === TAB_STATUS.DRAFT && card.isPublished && card.hasDraft}
+          linkToEdit={isPublishedDraftOnDraftTab}
         />
         <CardCollaboratorCount collaboratorCount={collaboratorCount} />
         <Suspense fallback={<Skeleton count={2} className="my-3 w-[300px]" />}>
@@ -467,7 +489,7 @@ const CardComponent = ({
             overdue={card.overdue}
             ttl={card.ttl}
             language={language}
-            isPublishedDraft={status === TAB_STATUS.DRAFT && card.isPublished && card.hasDraft}
+            isPublishedDraft={isPublishedDraftOnDraftTab}
           />
         </Suspense>
         <div className="mt-auto">
@@ -496,6 +518,8 @@ const CardComponent = ({
             draftVersionNumber={card.currentDraftVersion ?? undefined}
             isPublished={card.isPublished}
             isClosed={cardState === CARD_STATE.CLOSED}
+            liveFormLink={liveFormLink}
+            linkDraftVersion={!isPublishedDraftOnDraftTab}
           />
           {cardState === CARD_STATE.PUBLISHED && <CardFooterPublished cardId={card.id} />}
         </div>

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
@@ -8,7 +8,13 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { cn, dateHasPast } from "@root/lib/utils";
 
-import { CARD_STATE, CardState, FormsTemplateWithLockInfo, FormTabStatus } from "../types";
+import {
+  CARD_STATE,
+  CardState,
+  FormsTemplateWithLockInfo,
+  FormTabStatus,
+  TAB_STATUS,
+} from "../types";
 import { DraftEditLink } from "../client/DraftEditLink";
 import { Menu } from "../client/Menu";
 import { Unarchive } from "../client/Unarchive";
@@ -140,6 +146,7 @@ const CardLinks = memo(
     overdue,
     ttl,
     language,
+    isPublishedDraft,
   }: {
     id: string;
     isPublished: boolean;
@@ -147,6 +154,8 @@ const CardLinks = memo(
     overdue: boolean;
     ttl?: Date | null;
     language: string;
+    // true when this card is a published template that also has a draft
+    isPublishedDraft?: boolean;
   }) => {
     const { t } = useTranslation("my-forms");
     const responsesLink = `/${language}/form-builder/${id}/responses`;
@@ -169,7 +178,7 @@ const CardLinks = memo(
         )}
 
         {/* Vault delivery */}
-        {deliveryOption && ttl == null && !deliveryOption.emailAddress && (
+        {deliveryOption && ttl == null && !deliveryOption.emailAddress && !isPublishedDraft && (
           <>
             {overdue ? (
               <Link
@@ -194,7 +203,7 @@ const CardLinks = memo(
         )}
 
         {/* Settings link - only for published non-archived forms */}
-        {ttl == null && (
+        {ttl == null && !isPublishedDraft && (
           <Link
             className="mt-2 mb-4 block text-sm focus:fill-slate-500 active:fill-slate-500"
             href={settingsLink}
@@ -217,12 +226,14 @@ const CardTitle = memo(
     isPublished,
     collaboratorCount,
     isClosed,
+    linkToEdit,
   }: {
     id: string;
     name: string;
     isPublished: boolean;
     collaboratorCount: number;
     isClosed: boolean;
+    linkToEdit?: boolean;
   }) => {
     const {
       t,
@@ -243,7 +254,7 @@ const CardTitle = memo(
           {content}
         </span>
       );
-    } else if (isPublished) {
+    } else if (isPublished && !linkToEdit) {
       titleElement = (
         <Link className={classesLink} href={`/${language}/id/${id}`} prefetch={false}>
           {content}
@@ -445,6 +456,7 @@ const CardComponent = ({
           isPublished={card.isPublished}
           isClosed={cardState === CARD_STATE.CLOSED}
           collaboratorCount={collaboratorCount}
+          linkToEdit={status === TAB_STATUS.DRAFT && card.isPublished && card.hasDraft}
         />
         <CardCollaboratorCount collaboratorCount={collaboratorCount} />
         <Suspense fallback={<Skeleton count={2} className="my-3 w-[300px]" />}>
@@ -455,6 +467,7 @@ const CardComponent = ({
             overdue={card.overdue}
             ttl={card.ttl}
             language={language}
+            isPublishedDraft={status === TAB_STATUS.DRAFT && card.isPublished && card.hasDraft}
           />
         </Suspense>
         <div className="mt-auto">

--- a/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/page.tsx
@@ -118,9 +118,19 @@ export default async function Page(props: {
   // Brace yourself, Prisma is a bit... hopefully the comments below help.
   const options: TemplateOptions = {
     requestedWhere: {
-      // Published filter: use DB field isPublished since have it, this also indirectly defines Draft since draft=!published
-      isPublished:
-        status === TAB_STATUS.PUBLISHED ? true : status === TAB_STATUS.DRAFT ? false : undefined,
+      // Published filter: when viewing Drafts, include both unpublished templates
+      // and published templates that have an active draft (published drafts).
+      ...(status === TAB_STATUS.DRAFT
+        ? {
+            OR: [
+              { isPublished: false },
+              { AND: [{ isPublished: true }, { currentDraftVersionId: { not: null } }] },
+            ],
+          }
+        : {
+            // default published filter for other tabs
+            isPublished: status === TAB_STATUS.PUBLISHED ? true : undefined,
+          }),
       // Archived filter: ttl: { not: null } for archived, null (must have no ttl) for all others except closed (no filter)
       ttl:
         status === TAB_STATUS.ARCHIVED


### PR DESCRIPTION
# Summary | Résumé

Update to include published drafts under the drafts section of `/forms`



Card under draft status 
<img width="352" height="309" alt="screenshot_2026-07-20_at_2 11 28___pm_360" src="https://github.com/user-attachments/assets/36b7e52f-5b26-4bad-80c7-b25ce3ef0974" />

Same card under published
<img width="335" height="315" alt="screenshot_2026-07-20_at_2 11 45___pm_360" src="https://github.com/user-attachments/assets/affe0034-0bef-484e-ae53-feebbe18779b" />
