### PR TITLE
fix: publish button useEffect set state

### DIFF
--- a/components/clientComponents/globals/Header/PublishMenu/PublishButton.tsx
+++ b/components/clientComponents/globals/Header/PublishMenu/PublishButton.tsx
@@ -166,11 +166,6 @@ export const PublishButton = ({ locale }: { locale: string }) => {
     marginTop: "1rem",
   } as CSSProperties;
 
-  useEffect(() => {
-    setPublishing(false);
-    setError(false);
-  }, [formId, isPublished, currentPublishedVersionId, currentDraftVersionId]);
-
   const triggerClassName = isPublishReady
     ? "publish-menu-trigger hover:text-slate-900 focus:text-slate-900 flex cursor-pointer items-center gap-2 rounded border-1 border-emerald-700 bg-emerald-50 px-3 py-1 hover:bg-emerald-100 focus:bg-emerald-100"
     : "publish-menu-trigger hover:text-white-default focus:text-white-default flex cursor-pointer items-center gap-2 rounded border-1 border-slate-500 px-3 py-1 hover:bg-gray-600 focus:bg-gray-600";


### PR DESCRIPTION
# Summary | Résumé

The original code had a set state call in a useEffect that was causing a linting and browser console error. 

The fix was to remove the useEffect. These states updated in the useEffect would automatically be initialized to false, and event handlers would manage updates. They'll naturally reset when the component re-renders with a different form etc.


