### PR TITLE
fix: publish status dropdown

### DIFF
--- a/components/clientComponents/globals/Header/PublishMenu/PublishButton.tsx
+++ b/components/clientComponents/globals/Header/PublishMenu/PublishButton.tsx
@@ -145,7 +145,7 @@ export const PublishButton = ({ locale }: { locale: string }) => {
   const showPublishAction = allChecksPass;
   const isTemplateVersioningEnabled = getFlag(FeatureFlags.templateVersioning);
   const showPublishedView = isTemplateVersioningEnabled
-    ? Boolean(currentPublishedVersionId && !currentDraftVersionId)
+    ? Boolean(isPublished && !currentDraftVersionId)
     : isPublished;
   const triggerLabel = showPublishedView ? t("published") : t("publish");
   const isPublishReady = !showPublishedView && allChecksPass && !!userCanPublish;


### PR DESCRIPTION
# Summary | Résumé

Fixes issue where publish dropdown was showing as being able to publish when no versioned template exits i.e. record wasn't backfilled.

Fixes: https://github.com/cds-snc/platform-forms-client/issues/7583