### PR TITLE
chore: added formPurpose migration process for legacy forms

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-07-27
+
+- Added migration process for legacy forms with no set `formPurpose`
+
 ## [1.1.5] - 2026-07-22
 
 - Republish package following failed NPM publication

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -135,6 +135,23 @@ async function createSecurityQuestions() {
   });
 }
 
+// Can be removed once migration ran in Production
+async function migrateLegacyFormPurpose() {
+  console.log("Start migrating forms by setting formPurpose to 'n/a'");
+
+  const migrationResult = await prisma.template.updateMany({
+    where: {
+      isPublished: true,
+      formPurpose: "",
+    },
+    data: {
+      formPurpose: "n/a",
+    },
+  });
+
+  console.log(`${migrationResult.count} forms were migrated for formPurpose`);
+}
+
 async function main() {
   const {
     values: { environment = "development" },
@@ -154,6 +171,7 @@ async function main() {
       console.log(`Creating ${environment} Users`);
       await createUsers(environment);
     }
+
     if (environment === "development" && developerEmail && developerName) {
       // associate templates to developer
       console.log("Adding existing templates to developer account");
@@ -169,6 +187,9 @@ async function main() {
         },
       });
     }
+
+    console.log("Running formPurpose database migration");
+    await migrateLegacyFormPurpose();
   } catch (e) {
     console.error(e);
     process.exit(1);


### PR DESCRIPTION
# Summary | Résumé

closes #7569

- Adds migration code to make sure legacy forms get a `formPurpose` equal to `"n/a"` instead of `""`

Note: we will have to monitor deployment process in both Staging and Production to make sure migration was successful.