### PR TITLE
fix: Re-add a previous change from 7483 that was lost

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/clientSide.tsx
@@ -75,6 +75,20 @@ export const FormWrapper = ({
   const isMultiPageForm = showReviewPage(formRecord.form);
   useUpdateHeadTitle(getPageTitle(), isMultiPageForm);
 
+  const initialValues = useMemo(() => {
+    if (!cachedSession) {
+      return undefined;
+    }
+
+    if (!cachedSession.values) {
+      return undefined;
+    }
+
+    // Merge restored answers onto the current form defaults so any newly added
+    // elements still get an explicit empty initial value and participate in validation.
+    return mergeFormValuesWithInitialValues(formRecord, language, cachedSession.values);
+  }, [cachedSession, formRecord, language]);
+
   // Show confirmation page if submissionId is present
   if (submissionId && submissionDate) {
     return (
@@ -93,11 +107,7 @@ export const FormWrapper = ({
       {header}
 
       <Form
-        initialValues={
-          cachedSession
-            ? mergeFormValuesWithInitialValues(formRecord, language, cachedSession?.values)
-            : undefined
-        }
+        initialValues={initialValues || undefined}
         formRecord={formRecord}
         language={language}
         onSuccess={(formID, submissionId) => {


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where forms-form restore could break validation. Closes #7582. 

The issue was that the clientSide.tsx changes made in #7483 were lost in the changes made in the service worker feature #6876. The fix was to simply add these changes back.