### PR TITLE
fix: make sure user is defined before accessing user attributes

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -314,7 +314,7 @@ const authFlowRedirect = (
   const origin = req.nextUrl.origin;
 
   // Ignore if user is in the auth flow of MfA
-  if (session && !onAuthFlow) {
+  if (session?.user && !onAuthFlow) {
     if (
       !session.user.hasSecurityQuestions &&
       !path.startsWith("/auth/setup-security-questions") &&


### PR DESCRIPTION
# Summary | Résumé

Context: https://gcdigital.slack.com/archives/C05G766KW49/p1785227425200069

- Modifies if statement to make sure session's user is defined before accessing its properties