### PR TITLE
chore: remove formPurpose database migration script

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.7] - 2026-07-29
+
+- Removed migration process for legacy forms with no set `formPurpose`
+
 ## [1.1.6] - 2026-07-27
 
 - Added migration process for legacy forms with no set `formPurpose`

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -135,23 +135,6 @@ async function createSecurityQuestions() {
   });
 }
 
-// Can be removed once migration ran in Production
-async function migrateLegacyFormPurpose() {
-  console.log("Start migrating forms by setting formPurpose to 'n/a'");
-
-  const migrationResult = await prisma.template.updateMany({
-    where: {
-      isPublished: true,
-      formPurpose: "",
-    },
-    data: {
-      formPurpose: "n/a",
-    },
-  });
-
-  console.log(`${migrationResult.count} forms were migrated for formPurpose`);
-}
-
 async function main() {
   const {
     values: { environment = "development" },
@@ -187,9 +170,6 @@ async function main() {
         },
       });
     }
-
-    console.log("Running formPurpose database migration");
-    await migrateLegacyFormPurpose();
   } catch (e) {
     console.error(e);
     process.exit(1);


### PR DESCRIPTION
# Summary | Résumé

- Removes `formPurpose` database migration script now that it ran once in Production (with https://github.com/cds-snc/platform-forms-client/releases/tag/v4.20.0)