### PR TITLE
chore: remove reference to old StatusCreatedAt index

### DIFF
--- a/lib/vault.ts
+++ b/lib/vault.ts
@@ -26,7 +26,6 @@ import { chunkArray } from "@lib/utils";
 import { TemplateAlreadyPublishedError } from "@lib/templates/internal/errors";
 import { getAppSetting } from "./appSettings";
 import { delay, getExponentialBackoffTimeInMS } from "./utils/retryability";
-import { isTemplateVersioningEnabled } from "@lib/templates/versioning/internal";
 
 /**
  * Checks if any submissions exist for a given form and type
@@ -64,7 +63,7 @@ export const submissionTypeExists = async (formID: string, status: VaultStatus) 
 
   const queryCommand = new QueryCommand({
     TableName: "Vault",
-    IndexName: "StatusCreatedAt",
+    IndexName: "StatusCreatedAt_v2",
     // To optimize query since we only need to check whether one type of submission type exists
     ScanIndexForward: shouldNavigateThroughStatusCreatedAtIndexInAscendingOrder(status),
     // Limit the amount of responses to 1.
@@ -121,8 +120,6 @@ export async function listAllSubmissions(
       responseDownloadLimit = Number(await getAppSetting("responseDownloadLimit"));
     }
 
-    const templateVersioningEnabled = await isTemplateVersioningEnabled();
-
     // We're going to request one more than the limit so we can consistently determine if there are more responses
     const responseRetrievalLimit = responseDownloadLimit + 1;
 
@@ -138,7 +135,7 @@ export async function listAllSubmissions(
     while (lastEvaluatedKey !== undefined) {
       const queryCommand: QueryCommand = new QueryCommand({
         TableName: "Vault",
-        IndexName: templateVersioningEnabled ? "StatusCreatedAt_v2" : "StatusCreatedAt",
+        IndexName: "StatusCreatedAt_v2",
         ExclusiveStartKey: lastEvaluatedKey ?? undefined,
         // Limit the amount of response to responseRetrievalLimit
         Limit: responseRetrievalLimit - accumulatedResponses.length,
@@ -152,9 +149,7 @@ export async function listAllSubmissions(
           ":formID": formID,
           ...(status && { ":status": status }),
         },
-        ProjectionExpression: templateVersioningEnabled
-          ? "FormID,#name,CreatedAt,#statusCreatedAtKey,Version"
-          : "FormID,#name,CreatedAt,#statusCreatedAtKey",
+        ProjectionExpression: "FormID,#name,CreatedAt,#statusCreatedAtKey,Version",
       });
 
       // eslint-disable-next-line no-await-in-loop
@@ -174,7 +169,7 @@ export async function listAllSubmissions(
               status: vaultStatusFromStatusCreatedAt(statusCreatedAt),
               name,
               createdAt,
-              ...(templateVersioningEnabled && { version: version ?? "1" }),
+              version: version ?? "1",
             })
           )
         );


### PR DESCRIPTION
# Summary | Résumé

- Removes reference to old `StatusCreatedAt` Vault index now that `StatusCreatedAt_v2` is live