### PR TITLE
chore: update archive card

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Card.tsx
@@ -180,14 +180,9 @@ const CardLinks = memo(
     const responsesLink = `/${language}/form-builder/${id}/responses`;
     const settingsLink = `/${language}/form-builder/${id}/settings`;
 
-    if (!isPublished) {
-      return <div className="mb-4" />;
-    }
-
     return (
       <div className="mt-2">
         {ttl != null && <Unarchive id={id} isPublished={isPublished} language={language} />}
-
         {/* Email delivery */}
         {deliveryOption && deliveryOption.emailAddress && (
           <span className="mt-4 block text-sm">
@@ -195,7 +190,6 @@ const CardLinks = memo(
             {t("card.deliveryOption.email")} {deliveryOption.emailAddress}
           </span>
         )}
-
         {/* Vault delivery */}
         {deliveryOption && ttl == null && !deliveryOption.emailAddress && !isPublishedDraft && (
           <>
@@ -220,7 +214,6 @@ const CardLinks = memo(
             )}
           </>
         )}
-
         {/* Settings link - only for published non-archived forms */}
         {ttl == null && !isPublishedDraft && (
           <Link
@@ -246,6 +239,7 @@ const CardTitle = memo(
     collaboratorCount,
     isClosed,
     linkToEdit,
+    status,
   }: {
     id: string;
     name: string;
@@ -253,6 +247,7 @@ const CardTitle = memo(
     collaboratorCount: number;
     isClosed: boolean;
     linkToEdit?: boolean;
+    status: FormTabStatus;
   }) => {
     const {
       t,
@@ -267,7 +262,7 @@ const CardTitle = memo(
     const content = name ? name : t("card.unnamedForm");
     let titleElement: React.ReactNode;
 
-    if (isClosed) {
+    if (isClosed || status === TAB_STATUS.ARCHIVED) {
       titleElement = (
         <span className={classes} title={name}>
           {content}
@@ -479,6 +474,7 @@ const CardComponent = ({
           isClosed={cardState === CARD_STATE.CLOSED}
           collaboratorCount={collaboratorCount}
           linkToEdit={isPublishedDraftOnDraftTab}
+          status={status}
         />
         <CardCollaboratorCount collaboratorCount={collaboratorCount} />
         <Suspense fallback={<Skeleton count={2} className="my-3 w-[300px]" />}>

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Menu.tsx
@@ -122,13 +122,20 @@ export const Menu = ({
   const unfilteredMenuItemList = useMemo(
     () => [
       {
-        filtered: isPublished ? false : true || (ttl ? true : false),
+        filtered:
+          status !== TAB_STATUS.ARCHIVED && isPublished ? false : true || (ttl ? true : false),
         title: t("card.menu.copyLink"),
         callback: copyLinkCallback,
       },
       {
         filtered:
-          templateVersioningEnabled && !isEmailDelivery && isPublished && !hasDraft ? false : true,
+          templateVersioningEnabled &&
+          !isEmailDelivery &&
+          status !== TAB_STATUS.ARCHIVED &&
+          isPublished &&
+          !hasDraft
+            ? false
+            : true,
         title: t("card.menu.createDraftVersion"),
         callback: () => {
           try {

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Unarchive.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Unarchive.tsx
@@ -2,47 +2,31 @@
 import { memo } from "react";
 import { useTranslation } from "@i18n/client";
 import { clearTemplateStorage } from "@lib/store/utils";
-import { cloneForm, restoreForm } from "../../actions";
+import { restoreForm } from "../../actions";
 import { toast, ToastContainer } from "@formBuilder/components/shared/Toast";
 
-export const Unarchive = memo(
-  ({ id, isPublished, language }: { id: string; isPublished: boolean; language: string }) => {
-    const { t } = useTranslation("my-forms");
+export const Unarchive = memo(({ id }: { id: string; isPublished: boolean; language: string }) => {
+  const { t } = useTranslation("my-forms");
 
-    return (
-      <>
-        <button
-          className="action my-4 block text-sm whitespace-nowrap underline"
-          onClick={async () => {
-            if (!isPublished) {
-              const { error } = (await restoreForm(id)) ?? {};
+  return (
+    <>
+      <button
+        className="action my-4 block text-sm whitespace-nowrap underline"
+        onClick={async () => {
+          const { error } = (await restoreForm(id)) ?? {};
 
-              if (error) {
-                toast.error(t("errors.formUnarchiveFailed"));
-              }
-              clearTemplateStorage(id);
-            } else {
-              try {
-                const res = await cloneForm(id, true, language);
-                if (res && res.formRecord && !res.error) {
-                  toast.success(t("card.menu.cloneSuccess"));
-                  window.location.href = `/${language}/form-builder/${res.formRecord.id}/edit`;
-                  return;
-                }
-                throw new Error(res?.error || "Clone failed");
-              } catch (e) {
-                toast.error(t("card.menu.cloneFailed"));
-              }
-            }
-          }}
-        >
-          {isPublished ? t("actions.duplicatePublishedForm") : t("actions.unarchiveForm")}
-        </button>
-        <div className="sticky top-0">
-          <ToastContainer autoClose={false} containerId="default" />
-        </div>
-      </>
-    );
-  }
-);
+          if (error) {
+            toast.error(t("errors.formUnarchiveFailed"));
+          }
+          clearTemplateStorage(id);
+        }}
+      >
+        {t("actions.unarchiveForm")}
+      </button>
+      <div className="sticky top-0">
+        <ToastContainer autoClose={false} containerId="default" />
+      </div>
+    </>
+  );
+});
 Unarchive.displayName = "Unarchive";


### PR DESCRIPTION
# Summary | Résumé

- Unlinks card title --- the form is "deleted" so the link will be a `404`
- Updates code to show restore form for draft and published views
- Removes "edit published" from `...` menu
- Hides `copy link` for archived forms --- `404`