### PR TITLE
fix: Adds session check for edit-lock polling

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/client/Cards.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "@i18n/client";
 import { CARDS_PER_BATCH } from "../constants";
 import { useEditLockPolling } from "../hooks/useEditLockPolling";
 import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
+import { useSession } from "next-auth/react";
 import { NewFormButton } from "./NewFormButton";
 
 export const Cards = ({
@@ -21,6 +22,7 @@ export const Cards = ({
   pollIntervalMs: number;
 }) => {
   const { t } = useTranslation("my-forms");
+  const { status } = useSession();
   const [templates, setTemplates] = useState<FormsTemplateWithLockInfo[]>(initialTemplates);
   const [displayedCount, setDisplayedCount] = useState<number>(CARDS_PER_BATCH);
 
@@ -66,10 +68,11 @@ export const Cards = ({
   // Also include templates currently shown as locked (hasEditLock=true) so a lock release
   // is always detected even when hasDraft is stale in local state.
   const shouldPoll =
-    !tabStatus ||
-    tabStatus === TAB_STATUS.RECENTLY_EDITED ||
-    tabStatus === TAB_STATUS.DRAFT ||
-    tabStatus === TAB_STATUS.PUBLISHED;
+    status === "authenticated" &&
+    (!tabStatus ||
+      tabStatus === TAB_STATUS.RECENTLY_EDITED ||
+      tabStatus === TAB_STATUS.DRAFT ||
+      tabStatus === TAB_STATUS.PUBLISHED);
   const editableTemplates = useMemo(
     () =>
       templates.filter((t) => t.ttl === null && (!t.isPublished || t.hasDraft || t.hasEditLock)),

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/hooks/useEditLockPolling.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/hooks/useEditLockPolling.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
 import { FormsTemplateWithLockInfo, EditLocksResponse } from "../types";
-import { logMessage } from "@root/lib/logger";
 import { POLLING_TEMPLATE_CAP } from "../constants";
 
 const PROGRESSIVE_BACKOFF = {
@@ -78,35 +77,10 @@ export function useEditLockPolling({
       });
 
       if (!response.ok) {
-        // Stop polling if unauthenticated - the enabled flag should prevent this but guard anyway
-        if (response.status === 401) {
-          if (timeoutIdRef.current) {
-            clearTimeout(timeoutIdRef.current);
-            timeoutIdRef.current = null;
-          }
-          return;
-        }
-
-        // Handle permission errors by filtering out "invalid" templates we don't have access to.
-        // This seems to happen mainly with some Archived forms. This seems strange because the initial
-        // templates were pulled on page load without error. Regardless this helps handle invalid
-        // template cases where one invalid template will cause the remaining to fail.
-        if (response.status === 403) {
-          // Remove all templates from the failed batch to stop infinite 403 loop
-          // Note: The authorization check is all-or-nothing, so if ANY template is
-          // inaccessible, the entire batch fails. We remove all to be safe.
-          onUpdate((prevTemplates) => {
-            const failedTemplateIds = new Set(templateIds);
-            const filtered = prevTemplates.filter((t) => !failedTemplateIds.has(t.id));
-
-            if (filtered.length !== prevTemplates.length) {
-              logMessage.info(
-                `[useEditLockPolling] Removed ${prevTemplates.length - filtered.length} templates after 403 error. IDs: ${templateIds.join(", ")}`
-              );
-            }
-
-            return filtered;
-          });
+        // We only care about successful responses - stop any further polling
+        if (timeoutIdRef.current) {
+          clearTimeout(timeoutIdRef.current);
+          timeoutIdRef.current = null;
         }
         return;
       }

--- a/app/(gcforms)/[locale]/(form administration)/forms/components/hooks/useEditLockPolling.ts
+++ b/app/(gcforms)/[locale]/(form administration)/forms/components/hooks/useEditLockPolling.ts
@@ -39,7 +39,7 @@ export function useEditLockPolling({
   const abortControllerRef = useRef<AbortController | null>(null);
   const fetchInProgressRef = useRef(false);
   const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastActivityAtRef = useRef<number>(Date.now());
+  const lastActivityAtRef = useRef<number>(0);
 
   // Keep refs in sync with state
   useEffect(() => {
@@ -78,6 +78,15 @@ export function useEditLockPolling({
       });
 
       if (!response.ok) {
+        // Stop polling if unauthenticated - the enabled flag should prevent this but guard anyway
+        if (response.status === 401) {
+          if (timeoutIdRef.current) {
+            clearTimeout(timeoutIdRef.current);
+            timeoutIdRef.current = null;
+          }
+          return;
+        }
+
         // Handle permission errors by filtering out "invalid" templates we don't have access to.
         // This seems to happen mainly with some Archived forms. This seems strange because the initial
         // templates were pulled on page load without error. Regardless this helps handle invalid
@@ -202,6 +211,8 @@ export function useEditLockPolling({
     }
   }, []);
 
+  const scheduleNextPollRef = useRef<() => void>(() => undefined);
+
   const scheduleNextPoll = useCallback(() => {
     clearScheduledPoll();
 
@@ -211,9 +222,13 @@ export function useEditLockPolling({
 
     timeoutIdRef.current = setTimeout(() => {
       void fetchEditLockUpdates();
-      scheduleNextPoll();
+      scheduleNextPollRef.current();
     }, getDynamicPollIntervalMs());
   }, [clearScheduledPoll, fetchEditLockUpdates, getDynamicPollIntervalMs]);
+
+  useEffect(() => {
+    scheduleNextPollRef.current = scheduleNextPoll;
+  }, [scheduleNextPoll]);
 
   const markActivity = useCallback(() => {
     lastActivityAtRef.current = Date.now();
@@ -223,6 +238,7 @@ export function useEditLockPolling({
   // Poll for edit lock updates with progressive backoff based on inactivity.
   // Also pause/resume polling based on tab visibility.
   useEffect(() => {
+    lastActivityAtRef.current = Date.now();
     const startPolling = () => {
       if (document.hidden || !enabled) {
         return;


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where a user could be signed out and continue edit-lock polling - eventually causing them to be blocked at the firewall level.

The fix is to add an auth check to cancel polling attempts if unauthorized.

See [Slack thread](https://gcdigital.slack.com/archives/C01GFD150MC/p1785411960811629) for more info.

### Test

1. Sign into forms-forms and open the developer tools network panel - note the requests to edit-lock
2. In a separate tab open forms-form and sign out the same user from step 1
3. Go back to the original tab with the open network panel. You should see two edit-lock polling requests fail with a 401 and then no more polling requests (or 1 request on prod)