### PR TITLE
chore: Limit default of form element to verifying Canadian addresses only [AddressComplete] 

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/AddressCompleteOptions.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/components/dialogs/MoreDialog/AddressCompleteOptions.tsx
@@ -16,6 +16,8 @@ export const AddressCompleteOptions = ({
     return null;
   }
 
+  const isCanadianOnly = item.properties.addressComponents?.canadianOnly ?? true;
+
   const updateAddressComponents = (props: AddressComponents) => {
     // check if the addresscomponent exists, if it doesn't make it.
     if (item.properties.addressComponents == undefined) {
@@ -45,15 +47,9 @@ export const AddressCompleteOptions = ({
 
       <Checkbox
         id={`addressComponent-${item.id}-id-canadianOnly`}
-        value={
-          `addressComponent-${item.id}-value-canadianOnly-` +
-          item.properties.addressComponents?.canadianOnly
-        }
-        key={
-          `addressComponent-${item.id}-canadianOnly-` +
-          item.properties.addressComponents?.canadianOnly
-        }
-        defaultChecked={item.properties.addressComponents?.canadianOnly}
+        value={`addressComponent-${item.id}-value-canadianOnly-` + isCanadianOnly}
+        key={`addressComponent-${item.id}-canadianOnly-` + isCanadianOnly}
+        checked={isCanadianOnly}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           updateAddressComponents({ canadianOnly: e.target.checked });
         }}
@@ -61,7 +57,7 @@ export const AddressCompleteOptions = ({
       ></Checkbox>
 
       <h4 className="mt-4">{t("addElementDialog.addressComplete.fields")}</h4>
-      <p className="mb-4 mt-2">{t("addElementDialog.addressComplete.fieldsDesc")}</p>
+      <p className="mt-2 mb-4">{t("addElementDialog.addressComplete.fieldsDesc")}</p>
 
       <Radio
         className="mt-2"

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/PanelBody.tsx
@@ -57,6 +57,7 @@ export const PanelBody = ({
     properties[localizeField(LocalizedElementProperties.DESCRIPTION, translationLanguagePriority)];
 
   const describedById = description ? `item${item.id}-describedby` : undefined;
+  const isCanadianOnly = item.properties.addressComponents?.canadianOnly ?? true;
 
   const isInvalid = isFileUpload && !hasApiKeyId;
 
@@ -124,7 +125,7 @@ export const PanelBody = ({
               {isAddressComplete && (
                 <div>
                   <div>
-                    {!item.properties.addressComponents?.canadianOnly && (
+                    {!isCanadianOnly && (
                       <div className="mt-5 cursor-not-allowed rounded-sm bg-gray-100 p-2 text-slate-600">
                         {t("addElementDialog.addressComplete.country")}
                       </div>
@@ -136,15 +137,14 @@ export const PanelBody = ({
                       {t("addElementDialog.addressComplete.city")}
                     </div>
                     <div className="mt-5 cursor-not-allowed rounded-sm bg-gray-100 p-2 text-slate-600">
-                      {item.properties.addressComponents?.canadianOnly &&
-                        t("addElementDialog.addressComplete.components.province")}
-                      {!item.properties.addressComponents?.canadianOnly &&
+                      {isCanadianOnly && t("addElementDialog.addressComplete.components.province")}
+                      {!isCanadianOnly &&
                         t("addElementDialog.addressComplete.components.provinceOrState")}
                     </div>
                     <div className="mt-5 cursor-not-allowed rounded-sm bg-gray-100 p-2 text-slate-600">
-                      {item.properties.addressComponents?.canadianOnly &&
+                      {isCanadianOnly &&
                         t("addElementDialog.addressComplete.components.postalCode")}
-                      {!item.properties.addressComponents?.canadianOnly &&
+                      {!isCanadianOnly &&
                         t("addElementDialog.addressComplete.components.postalCodeOrZip")}
                     </div>
                   </div>

--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/AddressComplete.tsx
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/edit/components/elements/element-dialog/descriptions/AddressComplete.tsx
@@ -25,7 +25,7 @@ export const AddressComplete = () => {
       <ExampleWrapper>
         <h4 className="mb-4">{t("addElementDialog.addressComplete.whatIsYourAddress")}</h4>
         <div>
-          <AddressCompleteComponent id="test-address" name="test-address" canadianOnly={false} />
+          <AddressCompleteComponent id="test-address" name="test-address" canadianOnly={true} />
         </div>
       </ExampleWrapper>
     </div>


### PR DESCRIPTION
# Summary | Résumé

- Updates customize checkbox to default to Canadian only

Part of https://github.com/cds-snc/platform-forms-client/issues/7466