### PR TITLE
fix: nest legend reset

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [2.2.19] - 2026-07-30
+## [2.2.20] - 2026-07-30
 
-- Update fieldset styles
+- Fixes legend reset nesting to apply only to fieldset
 
 ## [2.2.18] - 2026-07-22
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/core",
-  "version": "2.2.19",
+  "version": "2.2.20",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/styles/_fieldset.scss
+++ b/packages/core/src/styles/_fieldset.scss
@@ -7,15 +7,15 @@
     border: 0;
     padding: 0;
     min-inline-size: auto;
-  }
 
-  legend {
-    padding: 0;
-  }
+    legend {
+      padding: 0;
+    }
 
-  slot {
-    display: block;
-    margin: 0;
+    slot {
+      display: block;
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Ensure legend reset only applies for fieldset.


Issue:
<img width="863" height="463" alt="Screenshot 2026-07-30 at 2 24 18 PM" src="https://github.com/user-attachments/assets/0286ab8f-ca65-4402-93fb-e45ec57a28bf" />
