### PR TITLE
chore: Remove unnecessary warning to reduce noise

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -181,9 +181,6 @@ export const getSubmissionsByFormat = AuthenticatedAction(
         // was requested. This covers the case where responses were collected
         // before any versions were created and the UI requests version 1.
         if (fullFormTemplate === null && templateVersioningEnabled && templateVersionNumber === 1) {
-          logMessage.warn(
-            `Requested template version ${templateVersionNumber} not found for form ${formID}, attempting non-versioned fallback to version 1`
-          );
           fullFormTemplate = await getFullTemplateByID(formID);
         }
 


### PR DESCRIPTION
# Summary | Résumé

No need to log when falling back to original template