### PR TITLE
fix: form-filler sticky bar a11y update

### DIFF
--- a/components/clientComponents/forms/Form/FormActions.tsx
+++ b/components/clientComponents/forms/Form/FormActions.tsx
@@ -1,6 +1,7 @@
 import { type Language } from "@lib/types/form-builder-types";
 import { FormProperties } from "@lib/types";
 import { SaveAndResume } from "@clientComponents/forms/SaveAndResume/SaveAndResume";
+import { useTranslation } from "@root/i18n/client";
 
 export const FormActions = ({
   children,
@@ -16,12 +17,19 @@ export const FormActions = ({
   formId: string;
   dirty: boolean;
 }) => {
+  const { t } = useTranslation("form-builder");
+
   if (!saveAndResumeEnabled || !dirty) {
     return children;
   }
 
+  // Z-index added as a precaution to ensure stack context when "floating" - this should also remain on top of any future "floating" content
   return (
-    <div className="border-gcds-blue-muted bg-gcds-blue-100 sticky bottom-0 -mx-5 mt-10 flex p-4">
+    <div
+      className="border-gcds-blue-muted bg-gcds-blue-100 sticky bottom-0 z-10 -mx-5 mt-10 flex p-4"
+      role="region"
+      aria-label={t("formActions")}
+    >
       <div className="flex w-full justify-between">
         {children}
         <SaveAndResume language={language as Language} formId={formId} />

--- a/components/clientComponents/forms/Form/FormActions.tsx
+++ b/components/clientComponents/forms/Form/FormActions.tsx
@@ -23,10 +23,9 @@ export const FormActions = ({
     return children;
   }
 
-  // Z-index added as a precaution to ensure stack context when "floating" - this should also remain on top of any future "floating" content
   return (
     <div
-      className="border-gcds-blue-muted bg-gcds-blue-100 sticky bottom-0 z-10 -mx-5 mt-10 flex p-4"
+      className="border-gcds-blue-muted bg-gcds-blue-100 sticky bottom-0 -mx-5 mt-10 flex p-4"
       role="region"
       aria-label={t("formActions")}
     >

--- a/i18n/translations/en/form-builder.json
+++ b/i18n/translations/en/form-builder.json
@@ -1707,5 +1707,6 @@
     "description": "Change a form that's already live",
     "button": "Edit form"
   },
-  "formDownloadFailed": "Failed to download the form."
+  "formDownloadFailed": "Failed to download the form.",
+  "formActions": "Form actions"
 }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1714,5 +1714,6 @@
     "description": "Modifier un formulaire déjà en production",
     "button": "Mettre à jour"
   },
-  "formDownloadFailed": "Le téléchargement du formulaire a échoué."
+  "formDownloadFailed": "Le téléchargement du formulaire a échoué.",
+  "formActions": "[FR]Form actions"
 }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1716,5 +1716,4 @@
   },
   "formDownloadFailed": "Le téléchargement du formulaire a échoué.",
   "formActions": "Actions liées au formulaire"
- "
 }

--- a/i18n/translations/fr/form-builder.json
+++ b/i18n/translations/fr/form-builder.json
@@ -1715,5 +1715,6 @@
     "button": "Mettre à jour"
   },
   "formDownloadFailed": "Le téléchargement du formulaire a échoué.",
-  "formActions": "[FR]Form actions"
+  "formActions": "Actions liées au formulaire"
+ "
 }


### PR DESCRIPTION
# Summary | Résumé

Adds an aria role and label to the sticky bar to improve accessibility. This way it will show up in the landmarks list.
Also added a z-index to help make sure the sticky bar remains on top of other content - current and future.