### PR TITLE
chore: Store addressComplete as JSON object and refactor rendering code

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses/[[...statusFilter]]/actions.ts
@@ -15,13 +15,7 @@ import {
   JSONResponse,
 } from "@lib/responseDownloadFormats/types";
 import { getFullTemplateByID } from "@lib/templates/queries/getFullTemplateByID";
-import {
-  AddressComponents,
-  FormElement,
-  FormElementTypes,
-  StartFromExclusiveResponse,
-  VaultStatus,
-} from "@lib/types";
+import { FormElement, FormElementTypes, StartFromExclusiveResponse, VaultStatus } from "@lib/types";
 import { isResponseId } from "@lib/validation/validation";
 import {
   confirmResponses,
@@ -47,11 +41,7 @@ import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 import { DateFormat, DateObject } from "@clientComponents/forms/FormattedDate/types";
 import { getFormattedDateFromObject } from "@clientComponents/forms/FormattedDate/utils";
 import { AddressElements } from "@clientComponents/forms/AddressComplete/types";
-import {
-  getAddressAsAnswerElements,
-  getAddressAsString,
-} from "@clientComponents/forms/AddressComplete/utils";
-import { serverTranslation } from "@i18n";
+import { getAddressAsString } from "@clientComponents/forms/AddressComplete/utils";
 import { traceFunction } from "@lib/otel";
 import { isTemplateVersioningEnabled } from "@lib/templates/versioning/internal";
 
@@ -156,9 +146,6 @@ export const getSubmissionsByFormat = AuthenticatedAction(
   > => {
     return traceFunction("generateSubmissionResponseFormats", async () => {
       try {
-        const { t: tEn } = await serverTranslation("form-builder-responses", { lang: "en" });
-        const { t: tFr } = await serverTranslation("form-builder-responses", { lang: "fr" });
-
         const responseConfirmLimit = Number(await getAppSetting("responseDownloadLimit"));
 
         const templateVersioningEnabled = await isTemplateVersioningEnabled();
@@ -275,59 +262,6 @@ export const getSubmissionsByFormat = AuthenticatedAction(
                         }
                       });
                     }),
-                  } as Answer;
-                }
-
-                // Handle "Split" AddressComplete in a similiar manner to dynamic fields.
-                if (
-                  question?.type === FormElementTypes.addressComplete &&
-                  question.properties.addressComponents?.splitAddress === true
-                ) {
-                  const addressObject = JSON.parse(answer as string) as AddressElements;
-
-                  const questionComponents = question.properties
-                    .addressComponents as AddressComponents;
-                  if (questionComponents.canadianOnly) {
-                    addressObject.country = "CAN";
-                  }
-
-                  const extraTranslations = {
-                    streetAddress: {
-                      en: tEn("addressComponents.streetAddress"),
-                      fr: tFr("addressComponents.streetAddress"),
-                    },
-                    city: {
-                      en: tEn("addressComponents.city"),
-                      fr: tFr("addressComponents.city"),
-                    },
-                    province: {
-                      en: tEn("addressComponents.province"),
-                      fr: tFr("addressComponents.province"),
-                    },
-                    postalCode: {
-                      en: tEn("addressComponents.postalCode"),
-                      fr: tFr("addressComponents.postalCode"),
-                    },
-                    country: {
-                      en: tEn("addressComponents.country"),
-                      fr: tFr("addressComponents.country"),
-                    },
-                  };
-
-                  const reviewElements = getAddressAsAnswerElements(
-                    question,
-                    addressObject,
-                    extraTranslations
-                  );
-
-                  const addressElements = [reviewElements];
-
-                  return {
-                    questionId: question.id,
-                    type: FormElementTypes.address,
-                    questionEn: question?.properties.titleEn,
-                    questionFr: question?.properties.titleFr,
-                    answer: addressElements,
                   } as Answer;
                 }
 
@@ -530,13 +464,19 @@ const getAnswerAsString = (question: FormElement | undefined, answer: unknown): 
       return "";
     }
 
-    if (question.properties.addressComponents?.splitAddress === true) {
-      return answer as string; //Address was split, return as is.
-    }
-
     try {
-      const addressObject = JSON.parse(answer as string) as AddressElements;
-      return getAddressAsString(addressObject);
+      let addressObject: AddressElements;
+
+      if (typeof answer === "string") {
+        addressObject = JSON.parse(answer) as AddressElements;
+        return getAddressAsString(
+          addressObject,
+          question.properties.addressComponents?.splitAddress
+        );
+      }
+
+      addressObject = answer as AddressElements;
+      return getAddressAsString(addressObject, question.properties.addressComponents?.splitAddress);
     } catch (e) {
       // If the answer is somehow not parseable as JSON, return it as is
       return answer as string;

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/normalizeFormResponses.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/normalizeFormResponses.ts
@@ -6,9 +6,7 @@ import {
   FormElementTypes,
   Response,
 } from "@lib/types";
-import { isValidDateObject } from "@root/components/clientComponents/forms/FormattedDate/utils";
-import { logMessage } from "@root/lib/logger";
-import { DateObject } from "@root/packages/types/src";
+import { logMessage } from "@lib/logger";
 
 interface FileInputObj extends FileInputResponse {
   name: string | null;
@@ -59,21 +57,15 @@ const dynamicRowFiller = (values: Responses[], element: FormElement): Responses[
   return newValues;
 };
 
-/**
- * Deserialize a date object from a JSON string
- *
- * @param value
- * @returns DateObject | string
- */
-export const deserializeDateObject = (value: string): DateObject | string => {
+const deserializeJsonObject = (value: string): Record<string, unknown> | string => {
   try {
     const parsed = JSON.parse(value);
 
-    if (isValidDateObject(parsed)) {
+    if (typeof parsed === "object" && parsed !== null) {
       return parsed;
     }
   } catch (e) {
-    logMessage.info(`Failed to parse date object value: ${value}, error: ${JSON.stringify(e)}`);
+    logMessage.info(`Failed to parse JSON object value: ${value}, error: ${JSON.stringify(e)}`);
   }
 
   return value;
@@ -124,12 +116,10 @@ export const fillData = (
       case FormElementTypes.fileInput:
         return fileInputFiller(value as Response);
       case FormElementTypes.formattedDate:
+      case FormElementTypes.addressComplete:
         if (typeof value === "string") {
-          return deserializeDateObject(value);
+          return deserializeJsonObject(value);
         }
-        return value;
-      case FormElementTypes.address:
-        // @TODO: deserialize address object as above
         return value;
       default:
         return value;

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/addressComplete.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/server/tests/fixtures/addressComplete.ts
@@ -15,5 +15,11 @@ export const submission = {
 };
 
 export const result = {
-  "1": '{"streetAddress":"555 A street","city":"Ottawa","province":"Ontario","postalCode":"K2P 1P4","country":"Canada"}',
+  "1": {
+    streetAddress: "555 A street",
+    city: "Ottawa",
+    province: "Ontario",
+    postalCode: "K2P 1P4",
+    country: "Canada",
+  },
 };

--- a/components/clientComponents/forms/AddressComplete/utils.ts
+++ b/components/clientComponents/forms/AddressComplete/utils.ts
@@ -2,8 +2,9 @@ import { FormElement, FormElementTypes } from "@lib/types";
 import type { AddressValidationError } from "@gcforms/core";
 import enReview from "@i18n/translations/en/review.json";
 import frReview from "@i18n/translations/fr/review.json";
+import enResponses from "@i18n/translations/en/form-builder-responses.json";
+import frResponses from "@i18n/translations/fr/form-builder-responses.json";
 import { AddressElements } from "./types";
-import { Answer } from "@lib/responseDownloadFormats/types";
 
 type AddressFieldKey = keyof AddressValidationError["fields"];
 
@@ -67,7 +68,14 @@ export const getAddressFieldLabel = (
     : addressErrorSummaryLabels[fieldKey].en;
 };
 
-export const getAddressAsString = (address: AddressElements): string => {
+export const getAddressAsString = (address: AddressElements, split?: boolean): string => {
+  if (split) {
+    let addressString = "";
+    for (const key in address) {
+      addressString += `${getNestedTranslation(enResponses, `addressComponents.${key}`) ?? key}\n${getNestedTranslation(frResponses, `addressComponents.${key}`) ?? key}: ${address[key as keyof AddressElements]}\n`;
+    }
+    return addressString;
+  }
   return `${address.streetAddress}, ${address.city}, ${address.province} ${address.postalCode} ${address.country}`;
 };
 
@@ -87,26 +95,6 @@ export const getAddressAsReviewElements = (
     });
   }
   return returnArray;
-};
-
-export const getAddressAsAnswerElements = (
-  question: FormElement,
-  address: AddressElements,
-  extraTranslations: { [key: string]: { en: string; fr: string } }
-): Answer[] => {
-  const answerArray = [];
-  for (const key in address) {
-    const answerObj: Answer = {
-      questionId: question.id,
-      questionEn: extraTranslations[key as keyof AddressElements].en,
-      questionFr: extraTranslations[key as keyof AddressElements].fr,
-      answer: address[key as keyof AddressElements],
-    };
-
-    answerArray.push(answerObj);
-  }
-
-  return answerArray;
 };
 
 // This regex is an attempt to correct that until the API is updated.

--- a/lib/responses/mapper/utils/toString.ts
+++ b/lib/responses/mapper/utils/toString.ts
@@ -61,13 +61,9 @@ export const getAnswerAsString = (
       return "";
     }
 
-    if (question.properties.addressComponents?.splitAddress === true) {
-      return answer as string; //Address was split, return as is.
-    }
-
     try {
-      const addressObject = JSON.parse(answer as string) as AddressElements;
-      return getAddressAsString(addressObject);
+      const addressObject = answer as AddressElements;
+      return getAddressAsString(addressObject, question.properties.addressComponents?.splitAddress);
     } catch (e) {
       // If the answer is somehow not parseable as JSON, return it as is
       return answer as string;


### PR DESCRIPTION
# Summary | Résumé

### Store AddressComplete as JSON object
When dealing with structured data in Responses, the data is serialized for passing around between form inputs and Formik etc, but needs to be deserialized before sending to the Vault so that we don't have to constantly deserialize when pulling the data out. This PR brings AddressComplete inline with FormattedDate in that regard by normalizing the response on the way into the Vault.

### Refactor AddressComplete render as string code
We were doing two different string transformations in two separate locations (Split addresses vs non-split). This combines them into a single getAddressAsString function.