### PR TITLE
fix: publishing state

### DIFF
--- a/components/clientComponents/globals/Header/PublishMenu/PublishButton.tsx
+++ b/components/clientComponents/globals/Header/PublishMenu/PublishButton.tsx
@@ -106,6 +106,7 @@ export const PublishButton = ({ locale }: { locale: string }) => {
     const handleToggle = (event: Event) => {
       const open = (event as ToggleEvent).newState === "open";
       setIsOpen(open);
+      setPublishing(false);
 
       if (open) {
         const firstFocusable = popover.querySelector<HTMLElement>(


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/7652

Ensure "publishing" gets reset when opening the publish dialog

Note: This wasn't working given the form update redirects ... in turn we don't have an opportunity to update the state. 


https://github.com/user-attachments/assets/647c4875-3dfc-4eb1-9e29-b2f9dd356b86


