### PR TITLE
fix: add fallback solution for when an email fails to be sent through the Notification pipeline

### DIFF
--- a/lib/integration/notifyConnector.ts
+++ b/lib/integration/notifyConnector.ts
@@ -63,7 +63,12 @@ async function sendEmail(
             content,
           });
         } else {
-          await sendImmediate({ emails: to, content });
+          await sendImmediate({ emails: to, content }).catch((error) => {
+            logMessage.warn(
+              `Failed to send immediate email to ${to.join(", ")} through Notification pipeline. Will try to send it directly from the application. Reason: ${(error as Error).message}`
+            );
+            return sendEmailDirectlyFromApp(to, content);
+          });
         }
 
         return;
@@ -71,21 +76,25 @@ async function sendEmail(
 
       logMessage.debug("Sending email directly through GC Notify");
 
-      await Promise.all(
-        to.map((emailAddress) =>
-          gcNotifyConnector.sendEmail(emailAddress, content).catch((error) => {
-            logMessage.warn(
-              `Failed to send email to ${emailAddress} through GC Notify. Reason: ${(error as Error).message}`
-            );
-          })
-        )
-      );
+      await sendEmailDirectlyFromApp(to, content);
     } catch (error) {
       logMessage.error(
-        `Failed to send email to ${to.join(", ")} through GC Notify. Reason: ${(error as Error).message}`
+        `Failed to send email to ${to.join(", ")}. Reason: ${(error as Error).message}`
       );
 
       throw error;
     }
   });
+}
+
+async function sendEmailDirectlyFromApp(to: string[], content: EmailContent): Promise<void[]> {
+  return Promise.all(
+    to.map((emailAddress) =>
+      gcNotifyConnector.sendEmail(emailAddress, content).catch((error) => {
+        logMessage.warn(
+          `Failed to send email to ${emailAddress} from the application to GC Notify. Reason: ${(error as Error).message}`
+        );
+      })
+    )
+  );
 }

--- a/lib/tests/notifyConnector.test.ts
+++ b/lib/tests/notifyConnector.test.ts
@@ -65,6 +65,7 @@ describe("sendDefaultEmail", () => {
 
     it("routes to sendImmediate when the notification flag is on and there is no file attachment", async () => {
       mocks.checkOne.mockResolvedValue(true);
+      mocks.notificationSendImmediate.mockResolvedValueOnce({});
 
       await sendDefaultEmail({
         to: ["user@example.com"],
@@ -111,7 +112,7 @@ describe("sendDefaultEmail", () => {
       expect(mocks.gcNotifySendEmail).not.toHaveBeenCalled();
     });
 
-    it("falls back to GC Notify when the notification flag is off", async () => {
+    it("falls back to direct GC Notify call when the notification flag is off", async () => {
       mocks.checkOne.mockResolvedValue(false);
 
       await sendDefaultEmail({ to: ["user@example.com"], subject: "", body: "" });
@@ -125,7 +126,7 @@ describe("sendDefaultEmail", () => {
       expect(mocks.notificationSendImmediate).not.toHaveBeenCalled();
     });
 
-    it("falls back to GC Notify when bypassNotificationPipeline is true, even if the flag is on", async () => {
+    it("falls back to direct GC Notify call when bypassNotificationPipeline is true, even if the flag is on", async () => {
       mocks.checkOne.mockResolvedValue(true);
 
       await sendDefaultEmail({
@@ -139,6 +140,19 @@ describe("sendDefaultEmail", () => {
 
       expect(mocks.gcNotifySendEmail).toHaveBeenCalledWith("user@example.com", expect.any(Object));
       expect(mocks.notificationSendImmediate).not.toHaveBeenCalled();
+    });
+
+    it("falls back to direct GC Notify call when use of sendImmediate throws an error", async () => {
+      mocks.checkOne.mockResolvedValue(true);
+      mocks.notificationSendImmediate.mockRejectedValueOnce(new Error("Something wrong happened"));
+
+      await sendDefaultEmail({
+        to: ["user@example.com"],
+        subject: "",
+        body: "",
+      });
+
+      expect(mocks.gcNotifySendEmail).toHaveBeenCalledWith("user@example.com", expect.any(Object));
     });
 
     it("sends to all addresses when an array of emails is provided", async () => {
@@ -170,7 +184,7 @@ describe("sendDefaultEmail", () => {
       await sendDefaultEmail({ to: ["user@example.com"], subject: "", body: "" });
 
       expect(mocks.logWarn).toHaveBeenCalledWith(
-        "Failed to send email to user@example.com through GC Notify. Reason: Notify API unavailable"
+        "Failed to send email to user@example.com from the application to GC Notify. Reason: Notify API unavailable"
       );
     });
   });


### PR DESCRIPTION
# Summary | Résumé

Context: https://gcdigital.slack.com/archives/C05G766KW49/p1786033328562449

- Adds fallback solution for when an email fails to be sent through the Notification pipeline