### PR TITLE
chore: Add component property defaults for FormattedDate

### DIFF
--- a/components/clientComponents/forms/FormattedDate/defaults.ts
+++ b/components/clientComponents/forms/FormattedDate/defaults.ts
@@ -1,0 +1,4 @@
+export const formattedDateDefaultElementProperties = {
+  autoComplete: "",
+  dateFormat: "YYYY-MM-DD",
+};

--- a/lib/utils/form-builder/itemHelper.ts
+++ b/lib/utils/form-builder/itemHelper.ts
@@ -1,6 +1,7 @@
 import { FormElement, FormElementTypes, ValidationInputType } from "@lib/types";
 import { Language, LocalizedElementProperties } from "../../types/form-builder-types";
 import { isValidatedTextType, isAutoCompleteField } from "@lib/utils/form-builder";
+import { formattedDateDefaultElementProperties } from "@clientComponents/forms/FormattedDate/defaults";
 
 type ElementType =
   | keyof typeof FormElementTypes
@@ -136,6 +137,13 @@ export const createElement = (element: FormElement, type: string) => {
     newElement.properties.validation = {
       required: true,
       all: true,
+    };
+  }
+
+  if (type === FormElementTypes.formattedDate) {
+    newElement.properties = {
+      ...newElement.properties,
+      ...formattedDateDefaultElementProperties,
     };
   }
 


### PR DESCRIPTION
# Summary | Résumé

Just implementing the pattern introduced in #7647 - introduces a defaults.ts file in the component directory that contains configuration properties for the component and their defaults. This then gets applied to the element on creation in itemHelpert.ts

This doesn't really change anything for FormattedDate as we can't back out of the code that hardcodes a default based on the non-existence of the property when a new element is created now (for backwards compatibility). The intent here is consistency.