### PR TITLE
Chore: use version endpoint only as needed

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/apiClient.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/apiClient.ts
@@ -89,7 +89,12 @@ export class GCFormsApiClient {
       return Promise.resolve(this.cachedFormTemplate);
     }
 
-    const endpoint = `/forms/${this.formId}/template?version=${selectedVersion}`;
+    let endpoint = `/forms/${this.formId}/template`;
+
+    if (selectedVersion > 1) {
+      endpoint += `?version=${selectedVersion}`;
+    }
+
     return this.httpClient
       .get<FormProperties>(endpoint)
       .then((response) => {


### PR DESCRIPTION
# Summary | Résumé

Updates the response pilot to no use version endpoint for templates with a version <=1