### PR TITLE
chore: address complete rate limiter followup

### DIFF
--- a/components/clientComponents/forms/AddressComplete/AddressComplete.test.tsx
+++ b/components/clientComponents/forms/AddressComplete/AddressComplete.test.tsx
@@ -414,7 +414,7 @@ describe("AddressComplete", () => {
     renderComponent();
 
     const streetInput = await screen.findByTestId("address-streetAddress-input");
-    await user.type(streetInput, "12");
+    await user.type(streetInput, "1");
 
     expect(getAddressCompleteChoicesMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("address-streetAddress-choices")).toHaveTextContent("");

--- a/components/clientComponents/forms/AddressComplete/AddressComplete.test.tsx
+++ b/components/clientComponents/forms/AddressComplete/AddressComplete.test.tsx
@@ -407,6 +407,19 @@ describe("AddressComplete", () => {
     expect(getAddressCompleteChoicesMock).toHaveBeenLastCalledWith("123 Main", "CAN", "en");
   });
 
+  it("does not search when the normalized query is shorter than the minimum", async () => {
+    const user = userEvent.setup();
+
+    getFlagMock.mockReturnValue(true);
+    renderComponent();
+
+    const streetInput = await screen.findByTestId("address-streetAddress-input");
+    await user.type(streetInput, "12");
+
+    expect(getAddressCompleteChoicesMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("address-streetAddress-choices")).toHaveTextContent("");
+  });
+
   it("localizes nested address descriptions in French", async () => {
     const user = userEvent.setup();
 

--- a/components/clientComponents/forms/AddressComplete/AddressComplete.tsx
+++ b/components/clientComponents/forms/AddressComplete/AddressComplete.tsx
@@ -27,10 +27,12 @@ import { countries } from "@lib/managedData/countries";
 import { useFeatureFlags } from "@lib/hooks/useFeatureFlags";
 import { isValidAddressSubFieldInvalid, getAddressSubFieldError } from "@gcforms/core";
 import {
+  MIN_ADDRESS_SEARCH_LENGTH,
   MAX_SEARCH_QUERY_LENGTH,
   MAX_ADDRESS_FIELD_LENGTH,
   MAX_POSTAL_CODE_LENGTH,
   normalizeAddressField,
+  normalizeQuery,
   normalizePostalCode,
 } from "./utils";
 
@@ -146,6 +148,13 @@ export const AddressComplete = (props: AddressCompleteProps): React.ReactElement
     } // Abandon if addressComplete is disabled.
 
     const query = e.target.value;
+
+    if (normalizeQuery(query).length < MIN_ADDRESS_SEARCH_LENGTH) {
+      debouncedSearchRef.current?.cancel?.();
+      setChoices([]);
+      setAddressResultCache([]);
+      return;
+    }
 
     if (matchesAddressPattern(query)) {
       await onAddressSet(query); // Do Search for Nested Address via ID instead of Query.

--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -353,14 +353,11 @@ const incrementAndCheckRateLimiting = async (
 ): Promise<boolean> => {
   try {
     const rateLimitMax = Number(await getAppSetting(RATE_LIMIT_MAX_SETTING[scope]));
-
     const rateLimitWindowSeconds = Number(
       await getAppSetting("addressCompleteRateLimitWindowSeconds")
     );
-
     if (!isPositiveSafeInteger(rateLimitMax) || !isPositiveSafeInteger(rateLimitWindowSeconds)) {
-      logMessage.error(new Error("Invalid AddressComplete rate limit configuration"));
-      return false;
+      throw new Error("Invalid configuration");
     }
 
     const redis = await getRedisInstance();
@@ -388,7 +385,10 @@ const incrementAndCheckRateLimiting = async (
       );
     }
     return isRateLimited;
-  } catch {
+  } catch (err) {
+    logMessage.error(
+      `AddressComplete rate limiting failed. Reason: ${err instanceof Error ? err.message : String(err)}`
+    );
     // Most likely case is Redis is down, just pass through to avoid breaking the form UX
     return false;
   }

--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -83,7 +83,8 @@ export const getAddressCompleteChoices = async (
     return { items: [], error: "API_KEY_MISSING" };
   }
 
-  // Avoid upstream calls for empty or very short queries that are unlikely to produce useful results.
+  // Do not call the API if the query is empty or only whitespace, as it will return a 1001 error (SearchTerm not supplied).
+  // Also avoid upstream calls for short queries that are unlikely to produce useful results.
   const normalizedQuery = normalizeQuery(query);
   if (normalizedQuery.length < MIN_ADDRESS_SEARCH_LENGTH) {
     return { items: [], error: null };

--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -9,7 +9,13 @@ import { getRedisInstance } from "@root/lib/integration/redisConnector";
 import { getClientIp } from "@root/lib/ip";
 import { getAppSetting } from "@root/lib/appSettings";
 import { isValidCanadaPostId, isValidCountryCode, isValidLanguage } from "./validation";
-import { normalizeAddressField, normalizeCountryCode, normalizeQuery } from "./utils";
+import {
+  isPositiveSafeInteger,
+  MIN_ADDRESS_SEARCH_LENGTH,
+  normalizeAddressField,
+  normalizeCountryCode,
+  normalizeQuery,
+} from "./utils";
 
 const autoCompleteUrl =
   "https://ws1.postescanada-canadapost.ca/AddressComplete/Interactive/Find/v2.10/json3.ws";
@@ -77,13 +83,9 @@ export const getAddressCompleteChoices = async (
     return { items: [], error: "API_KEY_MISSING" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
-    return { items: [], error: "RATE_LIMITED" };
-  }
-
-  // Do not call the API if the query is empty or only whitespace, as it will return a 1001 error (SearchTerm not supplied).
+  // Avoid upstream calls for empty or very short queries that are unlikely to produce useful results.
   const normalizedQuery = normalizeQuery(query);
-  if (!normalizedQuery || normalizedQuery === "") {
+  if (normalizedQuery.length < MIN_ADDRESS_SEARCH_LENGTH) {
     return { items: [], error: null };
   }
 
@@ -95,6 +97,10 @@ export const getAddressCompleteChoices = async (
   // No need to normalize language since the client should send exactly "en" or "fr"
   if (!isValidLanguage(language)) {
     return { items: [], error: "INVALID_INPUT" };
+  }
+
+  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+    return { items: [], error: "RATE_LIMITED" };
   }
 
   let params = "?";
@@ -135,10 +141,6 @@ export const getSelectedAddress = async (
     return { address: null, error: "API_KEY_MISSING" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
-    return { address: null, error: "RATE_LIMITED" };
-  }
-
   const normalizedCanadaPostId = normalizeAddressField(value);
   if (!isValidCanadaPostId(normalizedCanadaPostId)) {
     return { address: null, error: "INVALID_INPUT" };
@@ -151,6 +153,10 @@ export const getSelectedAddress = async (
 
   if (!isValidLanguage(language)) {
     return { address: null, error: "INVALID_INPUT" };
+  }
+
+  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+    return { address: null, error: "RATE_LIMITED" };
   }
 
   let params = "?";
@@ -195,10 +201,6 @@ export const getAddressCompleteRetrieve = async (
     return { items: [], error: "API_KEY_MISSING" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
-    return { items: [], error: "RATE_LIMITED" };
-  }
-
   const normalizedQuery = normalizeQuery(query);
   if (!isValidCanadaPostId(normalizedQuery)) {
     return { items: [], error: "INVALID_INPUT" };
@@ -211,6 +213,10 @@ export const getAddressCompleteRetrieve = async (
 
   if (!isValidLanguage(language)) {
     return { items: [], error: "INVALID_INPUT" };
+  }
+
+  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+    return { items: [], error: "RATE_LIMITED" };
   }
 
   let params = "?";
@@ -327,6 +333,11 @@ const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean> => {
     const rateLimitWindowSeconds = Number(
       await getAppSetting("addressCompleteRateLimitWindowSeconds")
     );
+
+    if (!isPositiveSafeInteger(rateLimitMax) || !isPositiveSafeInteger(rateLimitWindowSeconds)) {
+      logMessage.error(new Error("Invalid AddressComplete rate limit configuration"));
+      return false;
+    }
 
     const redis = await getRedisInstance();
     const key = `${RATE_LIMIT_KEY_PREFIX}:${ip}`;

--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -99,7 +99,7 @@ export const getAddressCompleteChoices = async (
     return { items: [], error: "INVALID_INPUT" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+  if (await incrementAndCheckRateLimiting(await getClientIp(), RATE_LIMIT_SCOPE.find)) {
     return { items: [], error: "RATE_LIMITED" };
   }
 
@@ -155,7 +155,7 @@ export const getSelectedAddress = async (
     return { address: null, error: "INVALID_INPUT" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+  if (await incrementAndCheckRateLimiting(await getClientIp(), RATE_LIMIT_SCOPE.retrieve)) {
     return { address: null, error: "RATE_LIMITED" };
   }
 
@@ -215,7 +215,7 @@ export const getAddressCompleteRetrieve = async (
     return { items: [], error: "INVALID_INPUT" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+  if (await incrementAndCheckRateLimiting(await getClientIp(), RATE_LIMIT_SCOPE.find)) {
     return { items: [], error: "RATE_LIMITED" };
   }
 
@@ -324,12 +324,26 @@ export async function matchesAddressPattern(input: string): Promise<boolean> {
   return nestedAddressPattern.test(input);
 }
 
-const RATE_LIMIT_KEY_PREFIX = "address-complete:rate-limit";
+const RATE_LIMIT_KEY_PREFIX = "address-complete";
+const RATE_LIMIT_SCOPE = {
+  find: "find",
+  retrieve: "retrieve",
+} as const;
+type RateLimitScope = (typeof RATE_LIMIT_SCOPE)[keyof typeof RATE_LIMIT_SCOPE];
+
+const RATE_LIMIT_MAX_SETTING = {
+  [RATE_LIMIT_SCOPE.find]: "addressCompleteFindRateLimitMax",
+  [RATE_LIMIT_SCOPE.retrieve]: "addressCompleteRetrieveRateLimitMax",
+} as const;
 
 // Returns true when the IP has exceeded the per-minute request "budget"
-const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean> => {
+const incrementAndCheckRateLimiting = async (
+  ip: string,
+  scope: RateLimitScope
+): Promise<boolean> => {
   try {
-    const rateLimitMax = Number(await getAppSetting("addressCompleteRateLimitMax"));
+    const rateLimitMax = Number(await getAppSetting(RATE_LIMIT_MAX_SETTING[scope]));
+
     const rateLimitWindowSeconds = Number(
       await getAppSetting("addressCompleteRateLimitWindowSeconds")
     );
@@ -340,22 +354,30 @@ const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean> => {
     }
 
     const redis = await getRedisInstance();
-    const key = `${RATE_LIMIT_KEY_PREFIX}:${ip}`;
+    const key = `${RATE_LIMIT_KEY_PREFIX}:${scope}:${ip}`;
 
     // Increment the related IPs count
     const pipeline = redis.pipeline();
     pipeline.incr(key);
     pipeline.expire(key, rateLimitWindowSeconds);
 
-    // Check whether that IP is beyond the threshold
     const results = await pipeline.exec();
 
-    // pipeline results are [error, value] tuples; index 0 is the incr result
+    // If there was an error incrementing ([error, value] tuple), just return false to avoid breaking the form UX
     const incrResult = results?.[0];
+    if (incrResult?.[0]) {
+      return false;
+    }
 
-    const count = (incrResult?.[1] ?? 0) as number;
-
-    return count > rateLimitMax;
+    // Check whether that IP is beyond the threshold and should be rate limited
+    const count = incrResult?.[1] as number;
+    const isRateLimited = count > rateLimitMax;
+    if (isRateLimited) {
+      logMessage.warn(
+        `AddressComplete user rate limited on ${scope} operation because they hit ${count}/${rateLimitMax} within ${rateLimitWindowSeconds}s.`
+      );
+    }
+    return isRateLimited;
   } catch {
     // Most likely case is Redis is down, just pass through to avoid breaking the form UX
     return false;

--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -87,7 +87,7 @@ export const getAddressCompleteChoices = async (
   // Also avoid upstream calls for short queries that are unlikely to produce useful results.
   const normalizedQuery = normalizeQuery(query);
   if (normalizedQuery.length < MIN_ADDRESS_SEARCH_LENGTH) {
-    return { items: [], error: null };
+    return { items: [], error: "INVALID_INPUT" };
   }
 
   const normalizedCountryCode = normalizeCountryCode(countryCode);
@@ -117,7 +117,7 @@ export const getAddressCompleteChoices = async (
     });
 
     if (!response.ok) {
-      return { items: [], error: "SERVICE_UNAVAILABLE" };
+      throw new Error(`Received non-OK response: ${response.status}`);
     }
 
     const responseData = await response.json();
@@ -128,6 +128,9 @@ export const getAddressCompleteChoices = async (
 
     return { items: (responseData?.Items as AddressCompleteChoice[]) || [], error: null };
   } catch (err: unknown) {
+    logMessage.warn(
+      `AddressComplete API request failed. Reason: ${err instanceof Error ? err.message : String(err)}`
+    );
     return { items: [], error: "NETWORK_ERROR" };
   }
 };
@@ -173,7 +176,7 @@ export const getSelectedAddress = async (
     });
 
     if (!response.ok) {
-      return { address: null, error: "SERVICE_UNAVAILABLE" };
+      throw new Error(`Received non-OK response: ${response.status}`);
     }
 
     const responseData = await response.json();
@@ -188,6 +191,9 @@ export const getSelectedAddress = async (
 
     return { address: addressComponents, error: null };
   } catch (err: unknown) {
+    logMessage.warn(
+      `AddressComplete API request failed. Reason: ${err instanceof Error ? err.message : String(err)}`
+    );
     return { address: null, error: "NETWORK_ERROR" };
   }
 };
@@ -233,7 +239,7 @@ export const getAddressCompleteRetrieve = async (
     });
 
     if (!response.ok) {
-      return { items: [], error: "SERVICE_UNAVAILABLE" };
+      throw new Error(`Received non-OK response: ${response.status}`);
     }
 
     const responseData = await response.json(); //Todo #4341  - Error Handling
@@ -244,6 +250,9 @@ export const getAddressCompleteRetrieve = async (
 
     return { items: (responseData?.Items as AddressCompleteChoice[]) || [], error: null };
   } catch (err: unknown) {
+    logMessage.warn(
+      `AddressComplete API request failed. Reason: ${err instanceof Error ? err.message : String(err)}`
+    );
     return { items: [], error: "NETWORK_ERROR" };
   }
 };

--- a/components/clientComponents/forms/AddressComplete/utils.ts
+++ b/components/clientComponents/forms/AddressComplete/utils.ts
@@ -189,6 +189,10 @@ export function getCountryCodeFromName(value?: string): string {
   return trimmed;
 }
 
+// 2 characters preserves early typeahead behavior while avoiding some noise.
+// e.g. 1 would be very broad (noisy) while 3 would delay useful results for short addresses.
+export const MIN_ADDRESS_SEARCH_LENGTH = 2;
+
 export const MAX_ADDRESS_FIELD_LENGTH = 200;
 export const normalizeAddressField = (value: string): string => {
   return truncateField(normalizeString(value), MAX_ADDRESS_FIELD_LENGTH);
@@ -207,4 +211,8 @@ export const normalizeCountryCode = (value: string): string => {
 export const MAX_POSTAL_CODE_LENGTH = 20;
 export const normalizePostalCode = (value: string): string => {
   return truncateField(normalizeString(value), MAX_POSTAL_CODE_LENGTH);
+};
+
+export const isPositiveSafeInteger = (value: number): boolean => {
+  return Number.isSafeInteger(value) && value > 0;
 };

--- a/components/clientComponents/forms/AddressComplete/utils.ts
+++ b/components/clientComponents/forms/AddressComplete/utils.ts
@@ -189,9 +189,7 @@ export function getCountryCodeFromName(value?: string): string {
   return trimmed;
 }
 
-// 2 characters preserves early typeahead behavior while avoiding some noise.
-// e.g. 1 would be very broad (noisy) while 3 would delay useful results for short addresses.
-export const MIN_ADDRESS_SEARCH_LENGTH = 2;
+export const MIN_ADDRESS_SEARCH_LENGTH = 3;
 
 export const MAX_ADDRESS_FIELD_LENGTH = 200;
 export const normalizeAddressField = (value: string): string => {

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9] - 2026-08-12
+
+- Add Another Address complete setting
+
 ## [1.1.8] - 2026-08-11
 
 - Add Address complete settings

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/database/src/fixtures/settings.ts
+++ b/packages/database/src/fixtures/settings.ts
@@ -76,25 +76,36 @@ const editLockRedirectIdleMs: Setting = {
   value: "1800000",
 };
 
-const addressCompleteRateLimitMax: Setting = {
-  internalId: "addressCompleteRateLimitMax",
-  nameEn: "Address Complete Rate Limit Max (count)",
-  nameFr: "Limite maximale du taux de complétion d'adresse (nombre)",
+const addressCompleteFindRateLimitMax: Setting = {
+  internalId: "addressCompleteFindRateLimitMax",
+  nameEn: "Address Complete Find Rate Limit Max (count)",
+  nameFr: "Limite maximale de recherche d'adresse complète (nombre)",
   descriptionEn:
-    "The maximim number of requests (within the threshold) before the user is rate limited.",
+    "The maximum number of typeahead find requests (within the threshold) before the user is rate limited.",
   descriptionFr:
-    "Le nombre maximal de requêtes (dans la limite du seuil) avant que l'utilisateur ne soit soumis à une limitation de débit.",
+    "Le nombre maximal de requêtes de recherche avec saisie semi-automatique (dans la limite du seuil) avant que l'utilisateur ne soit soumis à une limitation de débit.",
+  value: "400",
+};
+
+const addressCompleteRetrieveRateLimitMax: Setting = {
+  internalId: "addressCompleteRetrieveRateLimitMax",
+  nameEn: "Address Complete Retrieve Rate Limit Max (count)",
+  nameFr: "Limite maximale de récupération de l'adresse complète (nombre)",
+  descriptionEn:
+    "The maximum number of retrieve requests (within the threshold) before the user is rate limited.",
+  descriptionFr:
+    "Le nombre maximal de requêtes de récupération (dans la limite du seuil) avant que l'utilisateur ne soit soumis à une limitation de débit.",
   value: "200",
 };
 
 const addressCompleteRateLimitWindowSeconds: Setting = {
   internalId: "addressCompleteRateLimitWindowSeconds",
-  nameEn: "Address Complete Rate Limit Window (seconds)",
-  nameFr: "Fenêtre de limitation de débit complète de l'adresse (secondes)",
+  nameEn: "Address Complete Rate Limit Window",
+  nameFr: "Fenêtre de limite de débit pour Address Complete",
   descriptionEn:
-    "The window of time that as user is rate limited e.g. 200 requests per 60 seconds.",
+    "The window of time that as user is rate limited - applies to both `addressCompleteFindRateLimitMax` and `addressCompleteRetrieveRateLimitMax`.",
   descriptionFr:
-    "La fenêtre temporelle durant laquelle l'utilisateur est soumis à une limitation de débit (par exemple, 300 requêtes par tranche de 60 secondes).",
+    "La fenêtre temporelle durant laquelle l'utilisateur est soumis à une limitation de débit s'applique à la fois à `addressCompleteFindRateLimitMax` et à `addressCompleteRetrieveRateLimitMax`.",
   value: "60",
 };
 
@@ -106,7 +117,8 @@ const allSettings = [
   nagwarePhaseEscalated,
   responseDownloadLimit,
   editLockRedirectIdleMs,
-  addressCompleteRateLimitMax,
+  addressCompleteFindRateLimitMax,
+  addressCompleteRetrieveRateLimitMax,
   addressCompleteRateLimitWindowSeconds,
 ];
 


### PR DESCRIPTION
# Summary | Résumé

This PR mainly includes a change to add a new scope to the rate limiter. Other updates include code cleanup and adding a non-user identifiable log message when a user is rate limited.

The idea with Address Complete "scopes" is to give us more control over how we rate limit. The two scopes are: 
- `find` - rate limit with a separate key for find operations (app config value default 400 requests per minute)
- `retrieve` - rate limit with a separate key for retrieve operations (app config value default 200 requests per minute)

The log message is fired as a warning when a user in either scope is rate limited.

Also to help reduce "request noise" a minimum of two characters is now required before a request can be sent to Canada Post.