### PR TITLE
chore: Add onboarding checklist item for GitHub team access

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding.md
+++ b/.github/ISSUE_TEMPLATE/onboarding.md
@@ -41,6 +41,7 @@ assignees: ''
 
 ## Tooling access
 - [ ] Set-up access to Github, Google Drive, Figma, and other required accounts
+- [ ] Add to our [Github team](https://github.com/orgs/cds-snc/teams/forms-platform)
 
 ## GC Forms itself
 _Feel free to create accounts, explore docs and play around in the app_


### PR DESCRIPTION
Added a new checklist item for our Onboarding template: ensuring new team members are added to our [GitHub team](https://github.com/orgs/cds-snc/teams/forms-platform).