### PR TITLE
fix: add auto-flow before save

### DIFF
--- a/lib/hooks/__tests__/useTemplateContext.test.tsx
+++ b/lib/hooks/__tests__/useTemplateContext.test.tsx
@@ -8,6 +8,7 @@ import {
   SaveTemplateProvider,
   useTemplateContext,
 } from "@lib/hooks/form-builder/useTemplateContext";
+import { FormProperties } from "@lib/types";
 
 type OperationResult = {
   formRecord: {
@@ -18,7 +19,8 @@ type OperationResult = {
 };
 
 const { createOrUpdateTemplateMock, mockStore, subscribeMock } = vi.hoisted(() => ({
-  createOrUpdateTemplateMock: vi.fn<() => Promise<OperationResult>>(),
+  createOrUpdateTemplateMock:
+    vi.fn<(input: { formConfig: FormProperties }) => Promise<OperationResult>>(),
   mockStore: {
     getDeliveryOption: vi.fn(() => undefined),
     getId: vi.fn(() => "form-1"),
@@ -226,5 +228,69 @@ describe("useTemplateContext saveDraft concurrency", () => {
     });
 
     expect(createOrUpdateTemplateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("autoflows automatic groups before saving", async () => {
+    const pageId = "b34a213b-fa2e-4a9b-a255-6dc956b27558";
+    const formConfig = {
+      groups: {
+        end: {
+          name: "End",
+          titleEn: "End",
+          titleFr: "End",
+          autoFlow: true,
+          elements: [],
+          nextAction: "start",
+        },
+        start: {
+          name: "Start",
+          titleEn: "Start",
+          titleFr: "Start",
+          autoFlow: true,
+          elements: [],
+          nextAction: "review",
+        },
+        review: {
+          name: "Review",
+          titleEn: "Review",
+          titleFr: "Review",
+          autoFlow: true,
+          elements: [],
+        },
+        [pageId]: {
+          name: "New page",
+          titleEn: "",
+          titleFr: "",
+          autoFlow: true,
+          elements: [],
+          nextAction: "end",
+        },
+      },
+      groupsLayout: [pageId],
+    };
+    mockStore.getSchema.mockReturnValue(JSON.stringify(formConfig));
+    createOrUpdateTemplateMock.mockResolvedValue({
+      formRecord: { id: "form-1", updatedAt: new Date().toISOString() },
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SaveTemplateProvider>{children}</SaveTemplateProvider>
+    );
+
+    const { result } = renderHook(() => useTemplateContext(), { wrapper });
+
+    await act(async () => {
+      await result.current.saveDraft();
+    });
+
+    const savedForm = createOrUpdateTemplateMock.mock.calls[0][0].formConfig;
+    if (!savedForm.groups) {
+      throw new Error("Expected saved form groups");
+    }
+
+    expect(savedForm.groups.start?.nextAction).toBe(pageId);
+    expect(savedForm.groups[pageId]?.nextAction).toBe("review");
+    expect(savedForm.groups.review?.nextAction).toBe("end");
+    expect(savedForm.groups.end?.nextAction).toBeUndefined();
   });
 });

--- a/lib/hooks/form-builder/useTemplateContext.tsx
+++ b/lib/hooks/form-builder/useTemplateContext.tsx
@@ -10,8 +10,7 @@ import { useSubscibeToTemplateStore } from "@lib/store/hooks/useSubscibeToTempla
 import { UpdateTemplateAction } from "@root/lib/templates/types";
 import { FormProperties } from "@lib/types";
 import { useAppUpdate } from "../useAppUpdate";
-import { autoFlowAllNextActions, groupsHaveCustomRules } from "@lib/groups/utils/setNextAction";
-import { orderGroups } from "@lib/utils/form-builder/orderUsingGroupsLayout";
+import { autoFlowFormIfPossible } from "@lib/utils/form-builder/autoFlowFormIfPossible";
 
 export type SaveDraftStatus = "saved" | "skipped" | "invalid" | "locked" | "error";
 
@@ -42,25 +41,6 @@ const defaultTemplateApi: TemplateApiType = {
 type TrackedTemplateState = [form: FormProperties];
 
 const TemplateApiContext = createContext<TemplateApiType>(defaultTemplateApi);
-
-const autoFlowFormIfPossible = (formConfig: FormProperties): FormProperties => {
-  const groups = formConfig.groups;
-
-  if (!groups || !formConfig.groupsLayout?.length || groupsHaveCustomRules(Object.values(groups))) {
-    return formConfig;
-  }
-
-  const orderedGroups = orderGroups(groups, formConfig.groupsLayout);
-
-  if (!orderedGroups) {
-    return formConfig;
-  }
-
-  return {
-    ...formConfig,
-    groups: autoFlowAllNextActions({ ...orderedGroups }, true),
-  };
-};
 
 export function SaveTemplateProvider({ children }: { children: React.ReactNode }) {
   const [updatedAt, setUpdatedAt] = useState<number | undefined>();

--- a/lib/hooks/form-builder/useTemplateContext.tsx
+++ b/lib/hooks/form-builder/useTemplateContext.tsx
@@ -10,6 +10,8 @@ import { useSubscibeToTemplateStore } from "@lib/store/hooks/useSubscibeToTempla
 import { UpdateTemplateAction } from "@root/lib/templates/types";
 import { FormProperties } from "@lib/types";
 import { useAppUpdate } from "../useAppUpdate";
+import { autoFlowAllNextActions, groupsHaveCustomRules } from "@lib/groups/utils/setNextAction";
+import { orderGroups } from "@lib/utils/form-builder/orderUsingGroupsLayout";
 
 export type SaveDraftStatus = "saved" | "skipped" | "invalid" | "locked" | "error";
 
@@ -40,6 +42,25 @@ const defaultTemplateApi: TemplateApiType = {
 type TrackedTemplateState = [form: FormProperties];
 
 const TemplateApiContext = createContext<TemplateApiType>(defaultTemplateApi);
+
+const autoFlowFormIfPossible = (formConfig: FormProperties): FormProperties => {
+  const groups = formConfig.groups;
+
+  if (!groups || !formConfig.groupsLayout?.length || groupsHaveCustomRules(Object.values(groups))) {
+    return formConfig;
+  }
+
+  const orderedGroups = orderGroups(groups, formConfig.groupsLayout);
+
+  if (!orderedGroups) {
+    return formConfig;
+  }
+
+  return {
+    ...formConfig,
+    groups: autoFlowAllNextActions({ ...orderedGroups }, true),
+  };
+};
 
 export function SaveTemplateProvider({ children }: { children: React.ReactNode }) {
   const [updatedAt, setUpdatedAt] = useState<number | undefined>();
@@ -90,11 +111,13 @@ export function SaveTemplateProvider({ children }: { children: React.ReactNode }
       return { status: "locked" };
     }
 
-    const formConfig = safeJSONParse<FormProperties>(getSchema());
+    const parsedFormConfig = safeJSONParse<FormProperties>(getSchema());
 
-    if (!formConfig) {
+    if (!parsedFormConfig) {
       return { status: "invalid" };
     }
+
+    const formConfig = autoFlowFormIfPossible(parsedFormConfig);
 
     try {
       const operationResult = await createOrUpdateTemplate({
@@ -146,6 +169,7 @@ export function SaveTemplateProvider({ children }: { children: React.ReactNode }
       // Avoid a redundant trailing write when no additional local edits were made.
       const id = getId();
       if (!templateIsDirty.current && id !== "") {
+        // eslint-disable-next-line
         return drainQueuedSaves(latestResult);
       }
 

--- a/lib/utils/form-builder/autoFlowFormIfPossible.ts
+++ b/lib/utils/form-builder/autoFlowFormIfPossible.ts
@@ -1,0 +1,22 @@
+import { FormProperties } from "@lib/types";
+import { autoFlowAllNextActions, groupsHaveCustomRules } from "@lib/groups/utils/setNextAction";
+import { orderGroups } from "./orderUsingGroupsLayout";
+
+export const autoFlowFormIfPossible = (formConfig: FormProperties): FormProperties => {
+  const groups = formConfig.groups;
+
+  if (!groups || !formConfig.groupsLayout?.length || groupsHaveCustomRules(Object.values(groups))) {
+    return formConfig;
+  }
+
+  const orderedGroups = orderGroups(groups, formConfig.groupsLayout);
+
+  if (!orderedGroups) {
+    return formConfig;
+  }
+
+  return {
+    ...formConfig,
+    groups: autoFlowAllNextActions({ ...orderedGroups }, true),
+  };
+};


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/7706

There's a bug in the app where pages are not linking to each other properly for logged in users.

This PR updates the save flow to try to auto-flow if possible before a save fires. 

Example incorrect json test file
[my-form-v1-2026-08-13.json](https://github.com/user-attachments/files/31038321/my-form-v1-2026-08-13.json)

On staging upload the attached json --- note the broken flow.

Upload the same file and note the form branch "fixes" itself



**To reproduce manually** 

- Go to `/edit`
- Give the form a title "My form" ...auto save happens
- Click on "Form set-up" to open the treeview
- Click new page +
- Click branching - `/edit/logic `

The new page links to review but the start page doesn't link to "new page"

Given the user hasn't customized the page flow this should be a standard linear flow

**Important:** 

Doing the same steps as an unauthorized user works perfect branching shows Start page -> new page -> review page.  Clearly this has something to do with saving to the database and the rules for "autoflow" possibly getting missed ... possibly a sync or race condition.  Ensuring we just call auto-flow if possible before the save will fix any of those cases.

---


**Fixed**

https://github.com/user-attachments/assets/73961dc5-a402-444f-91eb-8b09fe5c324a




