### PR TITLE
fix: star rating contrast

### DIFF
--- a/components/clientComponents/forms/StarRating/StarItem.tsx
+++ b/components/clientComponents/forms/StarRating/StarItem.tsx
@@ -1,4 +1,5 @@
 import { Fragment, memo } from "react";
+import { StarRatingIcon } from "@root/components/serverComponents/icons";
 
 interface StarItemProps {
   starValue: number;
@@ -63,9 +64,7 @@ export const StarItem = memo(function StarItem({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        <span className={active ? "text-yellow-400" : "text-gray-300"} aria-hidden="true">
-          ★
-        </span>
+        <StarRatingIcon className="size-12" active={active} title={ariaLabel} />
       </label>
     </Fragment>
   );

--- a/components/serverComponents/icons/StarRatingIcon.tsx
+++ b/components/serverComponents/icons/StarRatingIcon.tsx
@@ -24,6 +24,9 @@ export const StarRatingIcon = ({
     <path
       d="M12 2.5l2.93 5.94 6.56.95-4.74 4.62 1.12 6.53L12 17.45l-5.87 3.09 1.12-6.53-4.74-4.62 6.56-.95L12 2.5z"
       fill="currentColor"
+      stroke="currentColor"
+      strokeLinejoin="round"
+      strokeWidth="0.5"
     />
   </svg>
 );

--- a/components/serverComponents/icons/StarRatingIcon.tsx
+++ b/components/serverComponents/icons/StarRatingIcon.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@lib/utils";
+
+export const StarRatingIcon = ({
+  active = false,
+  className,
+  title,
+}: {
+  active?: boolean;
+  className?: string;
+  title?: string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    width="24"
+    // className if passed will override since CN is used to merge
+    className={cn(active ? "text-gcds-yellow-400" : "text-gray-300", className)}
+    viewBox="0 0 24 24"
+    focusable="false"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : "presentation"}
+  >
+    {title && <title>{title}</title>}
+    <path
+      d="M12 2.5l2.93 5.94 6.56.95-4.74 4.62 1.12 6.53L12 17.45l-5.87 3.09 1.12-6.53-4.74-4.62 6.56-.95L12 2.5z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/components/serverComponents/icons/index.ts
+++ b/components/serverComponents/icons/index.ts
@@ -85,5 +85,6 @@ export { CheckNoBorderIcon } from "./CheckNoBorderIcon";
 export { XIcon } from "./XIcon";
 export { ArchiveIcon } from "./ArchiveIcon";
 export { StarIcon } from "./StarIcon";
+export { StarRatingIcon } from "./StarRatingIcon";
 export { PersonIcon } from "./PersonIcon";
 export { ClosedStatusIcon } from "./ClosedStatusIcon";


### PR DESCRIPTION
# Summary | Résumé

Updates the Star Rating component to use an SVG over a text symbol to pass contrast checker tools. 

Example Test form:
https://ivkhfjahicfj3222igdk3qqlti0psvwa.lambda-url.ca-central-1.on.aws/en/id/cmsz2e4lw00000bl4mj3rff3z

## Proposed Stars

<img width="463" height="269" alt="Screenshot 2026-08-18 at 3 32 06 PM" src="https://github.com/user-attachments/assets/637e3cc8-cdf6-439d-a23a-e71b475510b3" />

## Old Stars (contrast fail)

<img width="485" height="326" alt="Screenshot 2026-08-18 at 3 31 02 PM" src="https://github.com/user-attachments/assets/89338401-9c42-4584-9367-fac39ac4ccc3" />
