### PR TITLE
fix: star rating excel issue

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/csvWriter.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/[id]/responses-pilot/lib/csvWriter.ts
@@ -8,6 +8,7 @@ import { sortByLayout } from "@lib/utils/form-builder";
 import { customTranslate } from "@lib/i18nHelpers";
 import { MappedAnswer } from "@lib/responses/mapper/types";
 import { mapAnswers } from "@lib/responses/mapper/mapAnswers";
+import { formatStarRatingAnswerForCsv } from "@root/components/clientComponents/forms/StarRating/utils";
 import { ResponseFilenameMapping } from "./processResponse";
 
 const specialChars = ["=", "+", "-", "@"];
@@ -225,6 +226,10 @@ export const getRow = ({
 
     if (!mappedAnswer) {
       return "-";
+    }
+
+    if (mappedAnswer.type === FormElementTypes.starRating) {
+      return formatStarRatingAnswerForCsv(String(mappedAnswer.answer));
     }
 
     if (mappedAnswer.answer instanceof Array) {

--- a/components/clientComponents/forms/StarRating/utils.test.ts
+++ b/components/clientComponents/forms/StarRating/utils.test.ts
@@ -4,6 +4,7 @@ import {
   parseStarRatingAnswer,
   formatStarRating,
   formatStarRatingAnswer,
+  formatStarRatingAnswerForCsv,
 } from "./utils";
 import { FormElementTypes } from "@lib/types";
 
@@ -84,6 +85,14 @@ describe("formatStarRatingAnswer", () => {
 
   it("formats a rating equal to numberOfStars", () => {
     expect(formatStarRatingAnswer(JSON.stringify({ value: 5, numberOfStars: 5 }))).toBe("5/5");
+  });
+});
+
+describe("formatStarRatingAnswerForCsv", () => {
+  it("prefixes the fraction so Excel keeps it as text", () => {
+    expect(formatStarRatingAnswerForCsv(JSON.stringify({ value: 5, numberOfStars: 5 }))).toBe(
+      "'5/5"
+    );
   });
 });
 

--- a/components/clientComponents/forms/StarRating/utils.ts
+++ b/components/clientComponents/forms/StarRating/utils.ts
@@ -42,6 +42,13 @@ export const formatStarRatingAnswer = (rawAnswer: string): string => {
   return parsed ? formatStarRating(parsed.value, parsed.numberOfStars) : rawAnswer || "-";
 };
 
+/**
+ * Prefixes a Star Rating CSV value so Excel keeps the fraction as text instead of parsing it as a date.
+ */
+export const formatStarRatingAnswerForCsv = (rawAnswer: string): string => {
+  return `'${formatStarRatingAnswer(rawAnswer)}`;
+};
+
 export const checkAndformatStarRatingAnswer = (item: Answer): string | undefined => {
   if (item.type !== FormElementTypes.starRating) {
     return undefined;

--- a/lib/responseDownloadFormats/csv/index.ts
+++ b/lib/responseDownloadFormats/csv/index.ts
@@ -3,7 +3,7 @@ import { FormResponseSubmissions } from "../types";
 import { FormElementTypes } from "@lib/types";
 import { customTranslate } from "@lib/i18nHelpers";
 import { sortByLayout } from "@lib/utils/form-builder";
-import { checkAndformatStarRatingAnswer } from "@root/components/clientComponents/forms/StarRating/utils";
+import { formatStarRatingAnswerForCsv } from "@root/components/clientComponents/forms/StarRating/utils";
 
 const specialChars = ["=", "+", "-", "@"];
 
@@ -66,9 +66,8 @@ export const transform = (formResponseSubmissions: FormResponseSubmissions) => {
           .join("\n");
       }
       let answerText = answer.answer;
-      const starRatingText = checkAndformatStarRatingAnswer(answer);
-      if (starRatingText !== undefined) {
-        return starRatingText;
+      if (answer.type === FormElementTypes.starRating) {
+        return formatStarRatingAnswerForCsv(String(answer.answer));
       }
       if (
         typeof answerText === "string" &&


### PR DESCRIPTION
# Summary | Résumé

Excel treats a star rating output value as a date e.g. `4/5` becomes `05-May`

(Current implementation)
One option is to try to force Excel to treat the data "raw" this PR add CSV prefix `'` to avoid Excel treating as date e.g. `'4/5`. The downside to this approach is that any non-Excel spreadsheet or app that reads CSV will probably show the prefix and make the data look a little "messy".

Another option is to add spacing in the output format. Excel will probably then not parse it as a date e.g. instead of `4/5` the output would be `4 / 5`.
