### PR TITLE
fix: focus error summary for errors

### DIFF
--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -105,6 +105,7 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
 
     if (!props.isValid && !canFocusOnError) {
       if (props.submitCount > lastSubmitCount) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setCanFocusOnError(true);
         setLastSubmitCount(props.submitCount);
       }
@@ -116,7 +117,21 @@ const InnerForm: React.FC<InnerFormProps> = (props) => {
   }, [formStatusError, errorList, lastSubmitCount, canFocusOnError]);
 
   useEffect(() => {
+    const handleContinueValidationError = () => setCanFocusOnError(true);
+
+    document.addEventListener(EventKeys.continueValidationError, handleContinueValidationError);
+
+    return () => {
+      document.removeEventListener(
+        EventKeys.continueValidationError,
+        handleContinueValidationError
+      );
+    };
+  }, []);
+
+  useEffect(() => {
     if (typeof window !== "undefined") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsServer(false);
     }
   }, [setIsServer]);

--- a/components/clientComponents/forms/NextButton/NextButton.tsx
+++ b/components/clientComponents/forms/NextButton/NextButton.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/navigation";
 import { formHasGroups } from "@root/lib/utils/form-builder/formHasGroups";
 import { showReviewPage as hasReviewPage } from "@lib/utils/form-builder/showReviewPage";
 import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headless-treeview/constants";
+import { EventKeys, useCustomEvent } from "@lib/hooks/useCustomEvent";
 
 export const NextButton = ({
   validateForm,
@@ -37,6 +38,7 @@ export const NextButton = ({
   const { updateFormDelay } = useFormDelay();
   const { t } = useTranslation("form-builder");
   const router = useRouter();
+  const { Event } = useCustomEvent();
 
   const checkIfFormClosed = async () => {
     if (await isFormClosed(formRecord.id)) {
@@ -124,6 +126,8 @@ export const NextButton = ({
             updateFormDelay(formRecord.form, currentGroup);
             handleNextAction();
             focusHeadingBySelector("form h2");
+          } else {
+            Event.fire(EventKeys.continueValidationError);
           }
         }}
         dataTestId="nextButton"
@@ -132,7 +136,7 @@ export const NextButton = ({
           t("next", { lng: language })
         ) : (
           <>
-            <span className="hidden laptop:block">{t("next", { lng: language })}</span>
+            <span className="laptop:block hidden">{t("next", { lng: language })}</span>
             <ForwardArrowIcon24x24 className="fill-white" title={t("next", { lng: language })} />
           </>
         )}

--- a/lib/hooks/useCustomEvent.tsx
+++ b/lib/hooks/useCustomEvent.tsx
@@ -26,6 +26,7 @@ export const EventKeys = {
   submitProgress: "submit-progress",
   openUnconfirmedApiKeyDialog: "open-unconfirmed-api-key-dialog",
   openCreateDraftConfirmDialog: "open-create-draft-confirm-dialog",
+  continueValidationError: "continue-validation-error",
 } as const;
 
 export const useCustomEvent = () => {


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/7390

Fixes issue where given a form that is multi-page if all required fields are left empty and you press continue the error summary is focused.  However if you fill out a required field and other required fields are left empty pressing continue did not re-focus the error summary.

This PR adds a custom event to the continue button to allow us to re-set the can focus state anytime a continue button is pressed.

Example form
[error-summary.json](https://github.com/user-attachments/files/31222750/error-summary.json)



https://github.com/user-attachments/assets/d2894615-3796-400d-9d4c-b70b7fcd6a3f


