### PR TITLE
chore: disable Prisma usage data collection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ ENV COGNITO_USER_POOL_ID=$COGNITO_USER_POOL_ID
 ARG INDEX_SITE="false"
 ENV INDEX_SITE=$INDEX_SITE
 
+# Disable Prisma usage data collection (see https://www.prisma.io/docs/orm/v6/tools/prisma-cli#telemetry)
+ENV CHECKPOINT_DISABLE=1
+
 WORKDIR /src
 
 COPY --from=base /src/public ./public

--- a/Dockerfile.pr
+++ b/Dockerfile.pr
@@ -61,6 +61,9 @@ ENV LAMBDA_ENV=1
 # Use the REVIEW_ENV environment variable to determine if the app is running in a Review environment
 ENV REVIEW_ENV=1
 
+# Disable Prisma usage data collection (see https://www.prisma.io/docs/orm/v6/tools/prisma-cli#telemetry)
+ENV CHECKPOINT_DISABLE=1
+
 WORKDIR /src
 
 COPY --from=build /src/.next/standalone ./


### PR DESCRIPTION
# Summary | Résumé

Context: while working on VPC firewall report analysis I found out that Prisma was collecting usage data by sending requests to `checkpoint.prisma.io`. As of now, that feature is safe but I don't think it is worth keeping enabled and exposing our product to a possible attack vector.

- Disables Prisma usage data collection