### PR TITLE
fix: prevent useEffect loop syncing data between GCFormsContext and Formik

### DIFF
--- a/debugging/useEffect.tsx
+++ b/debugging/useEffect.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+import { logMessage } from "@root/lib/logger";
+
+interface DependencyChange {
+  before: unknown;
+  after: unknown;
+}
+
+interface ChangedDeps {
+  [key: string | number]: DependencyChange;
+}
+
+export function useEffectDebugger(
+  effectFunction: () => void | (() => void),
+  dependencies: unknown[],
+  dependencyNames: (string | number)[] = []
+): void {
+  const previousDeps = useRef<unknown[]>([]);
+
+  useEffect(() => {
+    const changedDeps: ChangedDeps = dependencies.reduce<ChangedDeps>(
+      (accum, dependency, index) => {
+        if (previousDeps.current[index] !== dependency) {
+          const name = dependencyNames[index] || index;
+          accum[name] = {
+            before: previousDeps.current[index],
+            after: dependency,
+          };
+        }
+        return accum;
+      },
+      {}
+    );
+
+    if (Object.keys(changedDeps).length > 0) {
+      logMessage.debug(`[useEffect-Debugger] Triggered by: ${Object.keys(changedDeps)}`);
+      logMessage.debug(changedDeps);
+    } else {
+      logMessage.debug("[useEffect-Debugger] Triggered on initial mount");
+    }
+
+    previousDeps.current = dependencies;
+    return effectFunction();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+}

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -1,5 +1,13 @@
 "use client";
-import { createContext, useContext, ReactNode, useState, useRef } from "react";
+import {
+  createContext,
+  useContext,
+  ReactNode,
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+} from "react";
 
 import type { FormValues, GroupsType, PublicFormRecord } from "@gcforms/types";
 import { type Language } from "@lib/types/form-builder-types";
@@ -69,6 +77,7 @@ export const GCFormsProvider = ({
   const values = useRef({});
   const history = useRef<string[]>([LOCKED_GROUPS.START]);
   const [matchedIds, setMatchedIds] = useState<string[]>([]);
+  const matchedIdsRef = useRef<string[]>(matchedIds);
   const [currentGroup, setCurrentGroup] = useState<string | null>(initialGroup);
   const [submissionId, setSubmissionId] = useState<string | undefined>(undefined);
   const [submissionDate, setSubmissionDate] = useState<string | undefined>(undefined);
@@ -113,13 +122,24 @@ export const GCFormsProvider = ({
     }
   };
 
-  const updateValues = ({ formValues }: { formValues: FormValues }): void => {
-    values.current = formValues;
-    const valueIds = mapIdsToValues(formRecord.form.elements, formValues);
-    if (!idArraysMatch(matchedIds, valueIds)) {
-      setMatchedIds(valueIds);
-    }
-  };
+  const updateValues = useCallback(
+    ({ formValues }: { formValues: FormValues }): void => {
+      values.current = formValues;
+      const valueIds = mapIdsToValues(formRecord.form.elements, formValues);
+      if (!idArraysMatch(matchedIdsRef.current, valueIds)) {
+        setMatchedIds(valueIds);
+      }
+    },
+    // formRecord is stable for the lifetime of the provider, matchedIdsRef is read via ref
+    // so this identity stays stable across matchedIds updates and doesn't re-trigger consumers
+    [formRecord]
+  );
+
+  // Keep the ref in sync so updateValues can compare against the latest matchedIds
+  // without needing matchedIds itself as a dependency.
+  useEffect(() => {
+    matchedIdsRef.current = matchedIds;
+  }, [matchedIds]);
 
   // Helper to not expose the setter
   const setGroup = (group: string | null) => {

--- a/lib/hooks/useValueChanged.tsx
+++ b/lib/hooks/useValueChanged.tsx
@@ -1,11 +1,17 @@
 "use client";
 // import { useEffect } from "react";
+import { useState } from "react";
 import { useFormikContext } from "formik";
+import isEqual from "lodash.isequal";
 import { useGCFormsContext } from "./useGCFormContext";
 import { useEffectDebugger } from "@root/debugging/useEffect";
 import { mapIdsToValues } from "@gcforms/core";
 import { idArraysMatch } from "@lib/formContext";
 import type { FormValues } from "@gcforms/types";
+
+// Fields this hook writes back into formik values; excluded so writing them doesn't
+// re-trigger the effect below on their own.
+const META_KEYS = ["currentGroup", "groupHistory", "matchedIds"];
 
 /**
  * This is a workaround to allow setting custom values in the formik form values.
@@ -20,13 +26,24 @@ export const useFormValuesChanged = () => {
   const { updateValues, currentGroup, getGroupHistory, formRecord } = useGCFormsContext();
   const groupHistory = getGroupHistory();
 
+  const formValues = values as FormValues;
+  const nextUserValues = Object.fromEntries(
+    Object.entries(formValues).filter(([key]) => !META_KEYS.includes(key))
+  );
+
+  // Only replace the stored reference when the actual field values change, so writing
+  // currentGroup/groupHistory/matchedIds back into formik doesn't change this dependency.
+  const [userValues, setUserValues] = useState(nextUserValues);
+  if (!isEqual(userValues, nextUserValues)) {
+    setUserValues(nextUserValues);
+  }
+
   useEffectDebugger(
     () => {
       if (process.env.APP_ENV === "test") {
         // skip for test env
         return;
       }
-      const formValues = values as FormValues;
       updateValues({ formValues });
 
       // This is where you assign (set) the values that are added to formik form values in Form.tsx
@@ -41,7 +58,7 @@ export const useFormValuesChanged = () => {
         setFieldValue("matchedIds", nextMatchedIds);
       }
     },
-    [updateValues, values, setFieldValue, currentGroup, groupHistory, formRecord],
-    ["updateValues", "values", "setFieldValue", "currentGroup", "getGroupHistory", "formRecord"]
+    [updateValues, userValues, setFieldValue, currentGroup, groupHistory, formRecord],
+    ["updateValues", "userValues", "setFieldValue", "currentGroup", "groupHistory", "formRecord"]
   );
 };

--- a/lib/hooks/useValueChanged.tsx
+++ b/lib/hooks/useValueChanged.tsx
@@ -1,7 +1,11 @@
 "use client";
-import { useEffect } from "react";
+// import { useEffect } from "react";
 import { useFormikContext } from "formik";
 import { useGCFormsContext } from "./useGCFormContext";
+import { useEffectDebugger } from "@root/debugging/useEffect";
+import { mapIdsToValues } from "@gcforms/core";
+import { idArraysMatch } from "@lib/formContext";
+import type { FormValues } from "@gcforms/types";
 
 /**
  * This is a workaround to allow setting custom values in the formik form values.
@@ -13,19 +17,31 @@ import { useGCFormsContext } from "./useGCFormContext";
  */
 export const useFormValuesChanged = () => {
   const { values, setFieldValue } = useFormikContext();
-  const { updateValues, currentGroup, getGroupHistory, matchedIds } = useGCFormsContext();
+  const { updateValues, currentGroup, getGroupHistory, formRecord } = useGCFormsContext();
   const groupHistory = getGroupHistory();
 
-  useEffect(() => {
-    if (process.env.APP_ENV === "test") {
-      // skip for test env
-      return;
-    }
-    updateValues({ formValues: values as Record<string, string> });
+  useEffectDebugger(
+    () => {
+      if (process.env.APP_ENV === "test") {
+        // skip for test env
+        return;
+      }
+      const formValues = values as FormValues;
+      updateValues({ formValues });
 
-    // This is where you assign (set) the values that are added to formik form values in Form.tsx
-    setFieldValue("currentGroup", currentGroup);
-    setFieldValue("groupHistory", groupHistory);
-    setFieldValue("matchedIds", matchedIds);
-  }, [updateValues, values, setFieldValue, currentGroup, groupHistory, matchedIds]);
+      // This is where you assign (set) the values that are added to formik form values in Form.tsx
+      setFieldValue("currentGroup", currentGroup);
+      setFieldValue("groupHistory", groupHistory);
+
+      // Compute matchedIds directly from values instead of reading it back from GCFormsContext
+      // state, otherwise writing it into formik values re-triggers this effect an extra time.
+      const nextMatchedIds = mapIdsToValues(formRecord.form.elements, formValues);
+      const currentMatchedIds = (formValues.matchedIds as string[]) || [];
+      if (!idArraysMatch(currentMatchedIds, nextMatchedIds)) {
+        setFieldValue("matchedIds", nextMatchedIds);
+      }
+    },
+    [updateValues, values, setFieldValue, currentGroup, groupHistory, formRecord],
+    ["updateValues", "values", "setFieldValue", "currentGroup", "getGroupHistory", "formRecord"]
+  );
 };


### PR DESCRIPTION
# Summary | Résumé

Fixes redundant re-runs of the `useFormValuesChanged` effect (in `useValueChanged.tsx`) that fired 2-3 times for every single form value change (e.g. toggling a radio button), instead of once.

The effect depended on `matchedIds` and `updateValues` from `GCFormsContext`, and also wrote `matchedIds` back into formik's `values`. This created a feedback loop:
1. formik `values` changes → effect runs → `updateValues` updates `matchedIds` state in context
2. `matchedIds` state change re-renders the provider → `updateValues` gets a new identity and `matchedIds` changes → effect re-runs
3. that run calls `setFieldValue("matchedIds", ...)` → `values` changes again → effect re-runs a third time

## Changes
**useGCFormContext.tsx**
Wrap `updateValues` in `useCallback` and compare against a `matchedIdsRef` instead of the reactive `matchedIds` state, so its identity is stable across `matchedIds` updates.

**useValueChanged.tsx**
Compute `matchedIds` directly from the current form values instead of reading it back from context state, and depend on a `userValues` value (form values minus `currentGroup`/`groupHistory`/`matchedIds`, only updated via `isEqual` when real fields change) instead of the raw `values` object, so writing the injected fields back doesn't re-trigger the effect.

## Verification
The `useEffectDebugger` has been left in place for testing but **SHOULD BE REMOVED** before merge.