### PR TITLE
chore: address complete rate limiter update

### DIFF
--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -7,7 +7,7 @@ import { logMessage } from "@lib/logger";
 import { type Language } from "@lib/types/form-builder-types";
 import { getClientIp } from "@root/lib/ip";
 import { isValidCanadaPostId, isValidCountryCode, isValidLanguage } from "./validation";
-import { checkRateLimited, incrementAndCheckRateLimiting } from "./rateLimiter";
+import { isRateLimited, recordAndCheckRateLimit } from "./rateLimiter";
 import {
   MIN_ADDRESS_SEARCH_LENGTH,
   normalizeAddressField,
@@ -72,7 +72,7 @@ const hasItems0Error = (responseData: unknown): boolean => {
 };
 
 // Function returns address complete list of choices.
-// Note: find requests are not rate limited because the do not incur a cost to the API
+// Note: find requests are not rate limited because they do not incur a cost to the API
 export const getAddressCompleteChoices = async (
   query: string,
   countryCode: string,
@@ -99,8 +99,8 @@ export const getAddressCompleteChoices = async (
     return { items: [], error: "INVALID_INPUT" };
   }
 
-  // Avoid showing find results if rate limited
-  if (await checkRateLimited(await getClientIp())) {
+  // Avoid showing find results if rate limited for UX reasons
+  if (await isRateLimited(await getClientIp())) {
     return { items: [], error: "RATE_LIMITED" };
   }
 
@@ -160,7 +160,7 @@ export const getSelectedAddress = async (
   }
 
   // Increment the rate limit for paid Retrieve requests
-  if (await incrementAndCheckRateLimiting(await getClientIp())) {
+  if (await recordAndCheckRateLimit(await getClientIp())) {
     return { address: null, error: "RATE_LIMITED" };
   }
 
@@ -223,8 +223,8 @@ export const getAddressCompleteRetrieve = async (
     return { items: [], error: "INVALID_INPUT" };
   }
 
-  // Check the existing rate limit for free Find requests
-  if (await checkRateLimited(await getClientIp())) {
+  // Avoid showing find results if rate limited for UX reasons
+  if (await isRateLimited(await getClientIp())) {
     return { items: [], error: "RATE_LIMITED" };
   }
 

--- a/components/clientComponents/forms/AddressComplete/actions.ts
+++ b/components/clientComponents/forms/AddressComplete/actions.ts
@@ -5,12 +5,10 @@ import { AddressCompleteChoice, AddressCompleteResult, AddressElements } from ".
 import { Answer } from "@lib/responseDownloadFormats/types";
 import { logMessage } from "@lib/logger";
 import { type Language } from "@lib/types/form-builder-types";
-import { getRedisInstance } from "@root/lib/integration/redisConnector";
 import { getClientIp } from "@root/lib/ip";
-import { getAppSetting } from "@root/lib/appSettings";
 import { isValidCanadaPostId, isValidCountryCode, isValidLanguage } from "./validation";
+import { checkRateLimited, incrementAndCheckRateLimiting } from "./rateLimiter";
 import {
-  isPositiveSafeInteger,
   MIN_ADDRESS_SEARCH_LENGTH,
   normalizeAddressField,
   normalizeCountryCode,
@@ -74,6 +72,7 @@ const hasItems0Error = (responseData: unknown): boolean => {
 };
 
 // Function returns address complete list of choices.
+// Note: find requests are not rate limited because the do not incur a cost to the API
 export const getAddressCompleteChoices = async (
   query: string,
   countryCode: string,
@@ -100,7 +99,8 @@ export const getAddressCompleteChoices = async (
     return { items: [], error: "INVALID_INPUT" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp(), RATE_LIMIT_SCOPE.find)) {
+  // Avoid showing find results if rate limited
+  if (await checkRateLimited(await getClientIp())) {
     return { items: [], error: "RATE_LIMITED" };
   }
 
@@ -159,7 +159,8 @@ export const getSelectedAddress = async (
     return { address: null, error: "INVALID_INPUT" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp(), RATE_LIMIT_SCOPE.retrieve)) {
+  // Increment the rate limit for paid Retrieve requests
+  if (await incrementAndCheckRateLimiting(await getClientIp())) {
     return { address: null, error: "RATE_LIMITED" };
   }
 
@@ -222,7 +223,8 @@ export const getAddressCompleteRetrieve = async (
     return { items: [], error: "INVALID_INPUT" };
   }
 
-  if (await incrementAndCheckRateLimiting(await getClientIp(), RATE_LIMIT_SCOPE.find)) {
+  // Check the existing rate limit for free Find requests
+  if (await checkRateLimited(await getClientIp())) {
     return { items: [], error: "RATE_LIMITED" };
   }
 
@@ -333,63 +335,3 @@ const nestedAddressPattern = /\s+-\s+\d+\s+(Addresses|Adresses)$/i;
 export async function matchesAddressPattern(input: string): Promise<boolean> {
   return nestedAddressPattern.test(input);
 }
-
-const RATE_LIMIT_KEY_PREFIX = "address-complete";
-const RATE_LIMIT_SCOPE = {
-  find: "find",
-  retrieve: "retrieve",
-} as const;
-type RateLimitScope = (typeof RATE_LIMIT_SCOPE)[keyof typeof RATE_LIMIT_SCOPE];
-
-const RATE_LIMIT_MAX_SETTING = {
-  [RATE_LIMIT_SCOPE.find]: "addressCompleteFindRateLimitMax",
-  [RATE_LIMIT_SCOPE.retrieve]: "addressCompleteRetrieveRateLimitMax",
-} as const;
-
-// Returns true when the IP has exceeded the per-minute request "budget"
-const incrementAndCheckRateLimiting = async (
-  ip: string,
-  scope: RateLimitScope
-): Promise<boolean> => {
-  try {
-    const rateLimitMax = Number(await getAppSetting(RATE_LIMIT_MAX_SETTING[scope]));
-    const rateLimitWindowSeconds = Number(
-      await getAppSetting("addressCompleteRateLimitWindowSeconds")
-    );
-    if (!isPositiveSafeInteger(rateLimitMax) || !isPositiveSafeInteger(rateLimitWindowSeconds)) {
-      throw new Error("Invalid configuration");
-    }
-
-    const redis = await getRedisInstance();
-    const key = `${RATE_LIMIT_KEY_PREFIX}:${scope}:${ip}`;
-
-    // Increment the related IPs count
-    const pipeline = redis.pipeline();
-    pipeline.incr(key);
-    pipeline.expire(key, rateLimitWindowSeconds);
-
-    const results = await pipeline.exec();
-
-    // If there was an error incrementing ([error, value] tuple), just return false to avoid breaking the form UX
-    const incrResult = results?.[0];
-    if (incrResult?.[0]) {
-      return false;
-    }
-
-    // Check whether that IP is beyond the threshold and should be rate limited
-    const count = incrResult?.[1] as number;
-    const isRateLimited = count > rateLimitMax;
-    if (isRateLimited) {
-      logMessage.warn(
-        `AddressComplete user rate limited on ${scope} operation because they hit ${count}/${rateLimitMax} within ${rateLimitWindowSeconds}s.`
-      );
-    }
-    return isRateLimited;
-  } catch (err) {
-    logMessage.error(
-      `AddressComplete rate limiting failed. Reason: ${err instanceof Error ? err.message : String(err)}`
-    );
-    // Most likely case is Redis is down, just pass through to avoid breaking the form UX
-    return false;
-  }
-};

--- a/components/clientComponents/forms/AddressComplete/rateLimiter.test.ts
+++ b/components/clientComponents/forms/AddressComplete/rateLimiter.test.ts
@@ -18,7 +18,7 @@ vi.mock("@lib/logger", () => ({
 import { getAppSetting } from "@root/lib/appSettings";
 import { getRedisInstance } from "@root/lib/integration/redisConnector";
 import { logMessage } from "@lib/logger";
-import { checkRateLimited, incrementAndCheckRateLimiting } from "./rateLimiter";
+import { isRateLimited, recordAndCheckRateLimit } from "./rateLimiter";
 
 const TEST_IP = "111.111.111.111";
 const TEST_KEY = `address-complete:rate-limit:${TEST_IP}`;
@@ -33,6 +33,7 @@ const makePipeline = () => ({
 
 const makeRedis = (pipeline: ReturnType<typeof makePipeline>) => ({
   get: vi.fn(),
+  del: vi.fn(),
   pipeline: vi.fn(() => pipeline),
 });
 
@@ -59,11 +60,11 @@ describe("AddressComplete rate limiter", () => {
     ]);
   });
 
-  describe("checkRateLimited", () => {
+  describe("isRateLimited", () => {
     it("returns false and does not increment when the stored count is below the limit", async () => {
       redis.get.mockResolvedValue("1");
 
-      await expect(checkRateLimited(TEST_IP)).resolves.toBe(false);
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(false);
       expect(redis.get).toHaveBeenCalledWith(TEST_KEY);
       expect(pipeline.incr).not.toHaveBeenCalled();
     });
@@ -71,33 +72,41 @@ describe("AddressComplete rate limiter", () => {
     it("returns true and does not log when count is above the limit", async () => {
       redis.get.mockResolvedValue("3");
 
-      await expect(checkRateLimited(TEST_IP)).resolves.toBe(true);
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(true);
       expect(logMessage.warn).not.toHaveBeenCalled();
     });
 
     it("fails open and does not throw when Redis is unavailable", async () => {
       (getRedisInstance as Mock).mockRejectedValue(new Error("Redis connection refused"));
 
-      await expect(checkRateLimited(TEST_IP)).resolves.toBe(false);
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(false);
       expect(logMessage.error).toHaveBeenCalledOnce();
     });
 
     it("fails open and does not throw when a setting is invalid", async () => {
       (getAppSetting as Mock).mockResolvedValue("not-a-number");
 
-      await expect(checkRateLimited(TEST_IP)).resolves.toBe(false);
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(false);
       expect(logMessage.error).toHaveBeenCalledOnce();
+    });
+
+    it("fails open when the stored count is malformed", async () => {
+      redis.get.mockResolvedValue("not-a-number");
+
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+      expect(logMessage.warn).not.toHaveBeenCalled();
     });
   });
 
-  describe("incrementAndCheckRateLimiting", () => {
+  describe("recordAndCheckRateLimit", () => {
     it("increments the counter and returns false when below the limit", async () => {
       pipeline.exec.mockResolvedValue([
         [null, 1],
         [null, 1],
       ]);
 
-      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(false);
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
       expect(pipeline.incr).toHaveBeenCalledWith(TEST_KEY);
       expect(pipeline.expire).toHaveBeenCalledWith(TEST_KEY, RATE_LIMIT_WINDOW);
       // Does not perform a separate Redis GET — uses the pipeline result directly
@@ -112,7 +121,7 @@ describe("AddressComplete rate limiter", () => {
         [null, 1],
       ]);
 
-      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(true);
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(true);
       expect(pipeline.incr).toHaveBeenCalledWith(TEST_KEY);
       expect(pipeline.expire).toHaveBeenCalledWith(TEST_KEY, RATE_LIMIT_WINDOW);
       expect(redis.get).not.toHaveBeenCalled();
@@ -122,24 +131,79 @@ describe("AddressComplete rate limiter", () => {
     it("fails open and does not throw when Redis is unavailable", async () => {
       (getRedisInstance as Mock).mockRejectedValue(new Error("Redis connection refused"));
 
-      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(false);
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
       expect(logMessage.error).toHaveBeenCalledOnce();
     });
 
     it("fails open and does not throw when a setting is invalid", async () => {
       (getAppSetting as Mock).mockResolvedValue("not-a-number");
 
-      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(false);
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
       expect(logMessage.error).toHaveBeenCalledOnce();
+    });
+
+    it("fails open when incrementing returns an error", async () => {
+      pipeline.exec.mockResolvedValue([
+        [new Error("increment failed"), null],
+        [null, 1],
+      ]);
+
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+
+    it("fails open when Redis returns no pipeline results", async () => {
+      pipeline.exec.mockResolvedValue(undefined);
+
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+      expect(redis.del).toHaveBeenCalledWith(TEST_KEY);
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+
+    it("fails open when expiring the key returns an error", async () => {
+      pipeline.exec.mockResolvedValue([
+        [null, RATE_LIMIT_MAX + 1],
+        [new Error("expiry failed"), null],
+      ]);
+
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+      expect(redis.del).toHaveBeenCalledWith(TEST_KEY);
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+
+    it("fails open when expiring the key does not report success", async () => {
+      pipeline.exec.mockResolvedValue([
+        [null, RATE_LIMIT_MAX + 1],
+        [null, 0],
+      ]);
+
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+      expect(redis.del).toHaveBeenCalledWith(TEST_KEY);
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+
+    it("fails open when the increment count is malformed", async () => {
+      pipeline.exec.mockResolvedValue([
+        [null, "not-a-number"],
+        [null, 1],
+      ]);
+
+      await expect(recordAndCheckRateLimit(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+      expect(logMessage.warn).not.toHaveBeenCalled();
     });
   });
 
-  describe("checkRateLimited regression: repeated Find checks do not increment or log", () => {
+  describe("isRateLimited regression: repeated Find checks do not increment or log", () => {
     it("reads Redis twice but never increments or warns on consecutive calls above the limit", async () => {
       redis.get.mockResolvedValue("3");
 
-      await expect(checkRateLimited(TEST_IP)).resolves.toBe(true);
-      await expect(checkRateLimited(TEST_IP)).resolves.toBe(true);
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(true);
+      await expect(isRateLimited(TEST_IP)).resolves.toBe(true);
 
       expect(redis.get).toHaveBeenCalledTimes(2);
       expect(pipeline.incr).not.toHaveBeenCalled();

--- a/components/clientComponents/forms/AddressComplete/rateLimiter.test.ts
+++ b/components/clientComponents/forms/AddressComplete/rateLimiter.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
+
+vi.mock("@root/lib/appSettings", () => ({
+  getAppSetting: vi.fn(),
+}));
+
+vi.mock("@root/lib/integration/redisConnector", () => ({
+  getRedisInstance: vi.fn(),
+}));
+
+vi.mock("@lib/logger", () => ({
+  logMessage: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { getAppSetting } from "@root/lib/appSettings";
+import { getRedisInstance } from "@root/lib/integration/redisConnector";
+import { logMessage } from "@lib/logger";
+import { checkRateLimited, incrementAndCheckRateLimiting } from "./rateLimiter";
+
+const TEST_IP = "111.111.111.111";
+const TEST_KEY = `address-complete:rate-limit:${TEST_IP}`;
+const RATE_LIMIT_MAX = 2;
+const RATE_LIMIT_WINDOW = 60;
+
+const makePipeline = () => ({
+  incr: vi.fn(),
+  expire: vi.fn(),
+  exec: vi.fn(),
+});
+
+const makeRedis = (pipeline: ReturnType<typeof makePipeline>) => ({
+  get: vi.fn(),
+  pipeline: vi.fn(() => pipeline),
+});
+
+describe("AddressComplete rate limiter", () => {
+  let pipeline: ReturnType<typeof makePipeline>;
+  let redis: ReturnType<typeof makeRedis>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pipeline = makePipeline();
+    redis = makeRedis(pipeline);
+
+    (getAppSetting as Mock).mockImplementation(async (setting: string) => {
+      if (setting === "addressCompleteRetrieveRateLimitMax") return String(RATE_LIMIT_MAX);
+      if (setting === "addressCompleteRateLimitWindowSeconds") return String(RATE_LIMIT_WINDOW);
+      throw new Error(`Unexpected setting: ${setting}`);
+    });
+    (getRedisInstance as Mock).mockResolvedValue(redis);
+    redis.get.mockResolvedValue("0");
+    // Default pipeline result: first increment returns count 1, no error
+    pipeline.exec.mockResolvedValue([
+      [null, 1],
+      [null, 1],
+    ]);
+  });
+
+  describe("checkRateLimited", () => {
+    it("returns false and does not increment when the stored count is below the limit", async () => {
+      redis.get.mockResolvedValue("1");
+
+      await expect(checkRateLimited(TEST_IP)).resolves.toBe(false);
+      expect(redis.get).toHaveBeenCalledWith(TEST_KEY);
+      expect(pipeline.incr).not.toHaveBeenCalled();
+    });
+
+    it("returns true and does not log when count is above the limit", async () => {
+      redis.get.mockResolvedValue("3");
+
+      await expect(checkRateLimited(TEST_IP)).resolves.toBe(true);
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+
+    it("fails open and does not throw when Redis is unavailable", async () => {
+      (getRedisInstance as Mock).mockRejectedValue(new Error("Redis connection refused"));
+
+      await expect(checkRateLimited(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+    });
+
+    it("fails open and does not throw when a setting is invalid", async () => {
+      (getAppSetting as Mock).mockResolvedValue("not-a-number");
+
+      await expect(checkRateLimited(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("incrementAndCheckRateLimiting", () => {
+    it("increments the counter and returns false when below the limit", async () => {
+      pipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 1],
+      ]);
+
+      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(false);
+      expect(pipeline.incr).toHaveBeenCalledWith(TEST_KEY);
+      expect(pipeline.expire).toHaveBeenCalledWith(TEST_KEY, RATE_LIMIT_WINDOW);
+      // Does not perform a separate Redis GET — uses the pipeline result directly
+      expect(redis.get).not.toHaveBeenCalled();
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+
+    it("increments the counter, rate limits, and logs once when the count first crosses the limit", async () => {
+      // count === max + 1 triggers the one-time warning
+      pipeline.exec.mockResolvedValue([
+        [null, RATE_LIMIT_MAX + 1],
+        [null, 1],
+      ]);
+
+      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(true);
+      expect(pipeline.incr).toHaveBeenCalledWith(TEST_KEY);
+      expect(pipeline.expire).toHaveBeenCalledWith(TEST_KEY, RATE_LIMIT_WINDOW);
+      expect(redis.get).not.toHaveBeenCalled();
+      expect(logMessage.warn).toHaveBeenCalledOnce();
+    });
+
+    it("fails open and does not throw when Redis is unavailable", async () => {
+      (getRedisInstance as Mock).mockRejectedValue(new Error("Redis connection refused"));
+
+      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+    });
+
+    it("fails open and does not throw when a setting is invalid", async () => {
+      (getAppSetting as Mock).mockResolvedValue("not-a-number");
+
+      await expect(incrementAndCheckRateLimiting(TEST_IP)).resolves.toBe(false);
+      expect(logMessage.error).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("checkRateLimited regression: repeated Find checks do not increment or log", () => {
+    it("reads Redis twice but never increments or warns on consecutive calls above the limit", async () => {
+      redis.get.mockResolvedValue("3");
+
+      await expect(checkRateLimited(TEST_IP)).resolves.toBe(true);
+      await expect(checkRateLimited(TEST_IP)).resolves.toBe(true);
+
+      expect(redis.get).toHaveBeenCalledTimes(2);
+      expect(pipeline.incr).not.toHaveBeenCalled();
+      expect(logMessage.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/components/clientComponents/forms/AddressComplete/rateLimiter.ts
+++ b/components/clientComponents/forms/AddressComplete/rateLimiter.ts
@@ -9,29 +9,20 @@ const RATE_LIMIT_KEY_PREFIX = "address-complete:rate-limit";
 const RATE_LIMIT_MAX_SETTING = "addressCompleteRetrieveRateLimitMax";
 const RATE_LIMIT_WINDOW_SETTING = "addressCompleteRateLimitWindowSeconds";
 
-const getRateLimitMax = async (): Promise<number> => {
-  const max = Number(await getAppSetting(RATE_LIMIT_MAX_SETTING));
-  if (!isPositiveSafeInteger(max)) {
+const loadSetting = async (key: string): Promise<number> => {
+  const value = Number(await getAppSetting(key));
+  if (!isPositiveSafeInteger(value)) {
     throw new Error("Invalid configuration");
   }
 
-  return max;
-};
-
-const getRateLimitWindowSeconds = async (): Promise<number> => {
-  const windowSeconds = Number(await getAppSetting(RATE_LIMIT_WINDOW_SETTING));
-  if (!isPositiveSafeInteger(windowSeconds)) {
-    throw new Error("Invalid configuration");
-  }
-
-  return windowSeconds;
+  return value;
 };
 
 const evaluateRateLimit = (count: number, max: number, shouldLog = false): boolean => {
   const isRateLimited = count > max;
-  // Only log the first time a user is rate limited to avoid spamming the logs.
+  // Only log on the first request over the limit to avoid spamming the logs.
   if (shouldLog && count === max + 1) {
-    logMessage.warn(`AddressComplete user has been rate limited.`);
+    logMessage.warn(`Address Complete: User has been rate limited (${count}/${max} requests)`);
   }
 
   return isRateLimited;
@@ -39,7 +30,7 @@ const evaluateRateLimit = (count: number, max: number, shouldLog = false): boole
 
 export const checkRateLimited = async (ip: string): Promise<boolean> => {
   try {
-    const max = await getRateLimitMax();
+    const max = await loadSetting(RATE_LIMIT_MAX_SETTING);
     const redis = await getRedisInstance();
     const count = Number((await redis.get(`${RATE_LIMIT_KEY_PREFIX}:${ip}`)) ?? 0);
 
@@ -52,12 +43,11 @@ export const checkRateLimited = async (ip: string): Promise<boolean> => {
   }
 };
 
-// Handles the rate limit for paid Retrieve requests and checks whether the user is rate limited.
 export const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean> => {
   try {
     const [max, windowSeconds] = await Promise.all([
-      getRateLimitMax(),
-      getRateLimitWindowSeconds(),
+      loadSetting(RATE_LIMIT_MAX_SETTING),
+      loadSetting(RATE_LIMIT_WINDOW_SETTING),
     ]);
     const redis = await getRedisInstance();
     const key = `${RATE_LIMIT_KEY_PREFIX}:${ip}`;
@@ -67,13 +57,13 @@ export const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean
     pipeline.expire(key, windowSeconds);
     const results = await pipeline.exec();
 
-    // If incrementing fails, fail open to avoid breaking the form UX.
-    const incrResult = results?.[0];
-    if (incrResult?.[0]) {
+    // If incrementing fails ([error, value] tuple), fail open to avoid breaking the form UX.
+    const [incrError, incrCount] = results?.[0] ?? [];
+    if (incrError) {
       return false;
     }
 
-    const count = Number(incrResult?.[1] ?? 0);
+    const count = Number(incrCount ?? 0);
     return evaluateRateLimit(count, max, true);
   } catch (err) {
     logMessage.error(

--- a/components/clientComponents/forms/AddressComplete/rateLimiter.ts
+++ b/components/clientComponents/forms/AddressComplete/rateLimiter.ts
@@ -18,6 +18,15 @@ const loadSetting = async (key: string): Promise<number> => {
   return value;
 };
 
+const parseRateLimitCount = (value: unknown): number => {
+  const count = Number(value ?? 0);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error("Invalid rate limit count");
+  }
+
+  return count;
+};
+
 const evaluateRateLimit = (count: number, max: number, shouldLog = false): boolean => {
   const isRateLimited = count > max;
   // Only log on the first request over the limit to avoid spamming the logs.
@@ -28,11 +37,11 @@ const evaluateRateLimit = (count: number, max: number, shouldLog = false): boole
   return isRateLimited;
 };
 
-export const checkRateLimited = async (ip: string): Promise<boolean> => {
+export const isRateLimited = async (ip: string): Promise<boolean> => {
   try {
     const max = await loadSetting(RATE_LIMIT_MAX_SETTING);
     const redis = await getRedisInstance();
-    const count = Number((await redis.get(`${RATE_LIMIT_KEY_PREFIX}:${ip}`)) ?? 0);
+    const count = parseRateLimitCount(await redis.get(`${RATE_LIMIT_KEY_PREFIX}:${ip}`));
 
     return evaluateRateLimit(count, max);
   } catch (err) {
@@ -43,7 +52,7 @@ export const checkRateLimited = async (ip: string): Promise<boolean> => {
   }
 };
 
-export const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean> => {
+export const recordAndCheckRateLimit = async (ip: string): Promise<boolean> => {
   try {
     const [max, windowSeconds] = await Promise.all([
       loadSetting(RATE_LIMIT_MAX_SETTING),
@@ -57,13 +66,23 @@ export const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean
     pipeline.expire(key, windowSeconds);
     const results = await pipeline.exec();
 
-    // If incrementing fails ([error, value] tuple), fail open to avoid breaking the form UX.
     const [incrError, incrCount] = results?.[0] ?? [];
     if (incrError) {
-      return false;
+      throw new Error(incrError instanceof Error ? incrError.message : String(incrError));
     }
 
-    const count = Number(incrCount ?? 0);
+    const [expireError, expireResult] = results?.[1] ?? [];
+    // Cleanup the key if the expire command fails to avoid leaving a key that never expires
+    if (expireError || expireResult !== 1) {
+      await redis.del(key);
+      throw new Error(
+        expireError instanceof Error
+          ? expireError.message
+          : String(expireError ?? `Unexpected expiry result: ${expireResult}`)
+      );
+    }
+
+    const count = parseRateLimitCount(incrCount);
     return evaluateRateLimit(count, max, true);
   } catch (err) {
     logMessage.error(

--- a/components/clientComponents/forms/AddressComplete/rateLimiter.ts
+++ b/components/clientComponents/forms/AddressComplete/rateLimiter.ts
@@ -1,0 +1,85 @@
+import "server-only";
+
+import { logMessage } from "@lib/logger";
+import { getAppSetting } from "@root/lib/appSettings";
+import { getRedisInstance } from "@root/lib/integration/redisConnector";
+import { isPositiveSafeInteger } from "./utils";
+
+const RATE_LIMIT_KEY_PREFIX = "address-complete:rate-limit";
+const RATE_LIMIT_MAX_SETTING = "addressCompleteRetrieveRateLimitMax";
+const RATE_LIMIT_WINDOW_SETTING = "addressCompleteRateLimitWindowSeconds";
+
+const getRateLimitMax = async (): Promise<number> => {
+  const max = Number(await getAppSetting(RATE_LIMIT_MAX_SETTING));
+  if (!isPositiveSafeInteger(max)) {
+    throw new Error("Invalid configuration");
+  }
+
+  return max;
+};
+
+const getRateLimitWindowSeconds = async (): Promise<number> => {
+  const windowSeconds = Number(await getAppSetting(RATE_LIMIT_WINDOW_SETTING));
+  if (!isPositiveSafeInteger(windowSeconds)) {
+    throw new Error("Invalid configuration");
+  }
+
+  return windowSeconds;
+};
+
+const evaluateRateLimit = (count: number, max: number, shouldLog = false): boolean => {
+  const isRateLimited = count > max;
+  // Only log the first time a user is rate limited to avoid spamming the logs.
+  if (shouldLog && count === max + 1) {
+    logMessage.warn(`AddressComplete user has been rate limited.`);
+  }
+
+  return isRateLimited;
+};
+
+export const checkRateLimited = async (ip: string): Promise<boolean> => {
+  try {
+    const max = await getRateLimitMax();
+    const redis = await getRedisInstance();
+    const count = Number((await redis.get(`${RATE_LIMIT_KEY_PREFIX}:${ip}`)) ?? 0);
+
+    return evaluateRateLimit(count, max);
+  } catch (err) {
+    logMessage.error(
+      `AddressComplete rate limit check failed. Reason: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return false;
+  }
+};
+
+// Handles the rate limit for paid Retrieve requests and checks whether the user is rate limited.
+export const incrementAndCheckRateLimiting = async (ip: string): Promise<boolean> => {
+  try {
+    const [max, windowSeconds] = await Promise.all([
+      getRateLimitMax(),
+      getRateLimitWindowSeconds(),
+    ]);
+    const redis = await getRedisInstance();
+    const key = `${RATE_LIMIT_KEY_PREFIX}:${ip}`;
+
+    const pipeline = redis.pipeline();
+    pipeline.incr(key);
+    pipeline.expire(key, windowSeconds);
+    const results = await pipeline.exec();
+
+    // If incrementing fails, fail open to avoid breaking the form UX.
+    const incrResult = results?.[0];
+    if (incrResult?.[0]) {
+      return false;
+    }
+
+    const count = Number(incrResult?.[1] ?? 0);
+    return evaluateRateLimit(count, max, true);
+  } catch (err) {
+    logMessage.error(
+      `AddressComplete rate limiting failed. Reason: ${err instanceof Error ? err.message : String(err)}`
+    );
+    // Redis is probably down, so pass through to avoid breaking the form UX.
+    return false;
+  }
+};

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10] - 2026-08-12
+
+- Remove the previously added additional address complete setting
+
 ## [1.1.9] - 2026-08-12
 
 - Add Another Address complete setting

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/database",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/database/src/fixtures/settings.ts
+++ b/packages/database/src/fixtures/settings.ts
@@ -83,7 +83,7 @@ const addressCompleteRetrieveRateLimitMax: Setting = {
   descriptionEn: "The maximum number of retrieve requests before the user is rate limited.",
   descriptionFr:
     "Le nombre maximal de requêtes de récupération avant que l'utilisateur ne soit soumis à une limitation de débit.",
-  value: "200",
+  value: "12",
 };
 
 const addressCompleteRateLimitWindowSeconds: Setting = {

--- a/packages/database/src/fixtures/settings.ts
+++ b/packages/database/src/fixtures/settings.ts
@@ -76,25 +76,13 @@ const editLockRedirectIdleMs: Setting = {
   value: "1800000",
 };
 
-const addressCompleteFindRateLimitMax: Setting = {
-  internalId: "addressCompleteFindRateLimitMax",
-  nameEn: "Address Complete Find Rate Limit Max (count)",
-  nameFr: "Limite maximale de recherche d'adresse complète (nombre)",
-  descriptionEn:
-    "The maximum number of typeahead find requests (within the threshold) before the user is rate limited.",
-  descriptionFr:
-    "Le nombre maximal de requêtes de recherche avec saisie semi-automatique (dans la limite du seuil) avant que l'utilisateur ne soit soumis à une limitation de débit.",
-  value: "400",
-};
-
 const addressCompleteRetrieveRateLimitMax: Setting = {
   internalId: "addressCompleteRetrieveRateLimitMax",
   nameEn: "Address Complete Retrieve Rate Limit Max (count)",
   nameFr: "Limite maximale de récupération de l'adresse complète (nombre)",
-  descriptionEn:
-    "The maximum number of retrieve requests (within the threshold) before the user is rate limited.",
+  descriptionEn: "The maximum number of retrieve requests before the user is rate limited.",
   descriptionFr:
-    "Le nombre maximal de requêtes de récupération (dans la limite du seuil) avant que l'utilisateur ne soit soumis à une limitation de débit.",
+    "Le nombre maximal de requêtes de récupération avant que l'utilisateur ne soit soumis à une limitation de débit.",
   value: "200",
 };
 
@@ -102,10 +90,9 @@ const addressCompleteRateLimitWindowSeconds: Setting = {
   internalId: "addressCompleteRateLimitWindowSeconds",
   nameEn: "Address Complete Rate Limit Window",
   nameFr: "Fenêtre de limite de débit pour Address Complete",
-  descriptionEn:
-    "The window of time that as user is rate limited - applies to both `addressCompleteFindRateLimitMax` and `addressCompleteRetrieveRateLimitMax`.",
+  descriptionEn: "The window of time that as user is rate limited.",
   descriptionFr:
-    "La fenêtre temporelle durant laquelle l'utilisateur est soumis à une limitation de débit s'applique à la fois à `addressCompleteFindRateLimitMax` et à `addressCompleteRetrieveRateLimitMax`.",
+    "La fenêtre temporelle durant laquelle l'utilisateur est soumis à une limitation de débit.",
   value: "60",
 };
 
@@ -117,7 +104,6 @@ const allSettings = [
   nagwarePhaseEscalated,
   responseDownloadLimit,
   editLockRedirectIdleMs,
-  addressCompleteFindRateLimitMax,
   addressCompleteRetrieveRateLimitMax,
   addressCompleteRateLimitWindowSeconds,
 ];


### PR DESCRIPTION
# Summary | Résumé

Our focus has moved from protecting the entire Address Complete end point from abuse to mainly the retrieve requests. The reason is retrieve requests cost money while find requests are free. Plus if a malicious user decides to spam the endpoint with find requests, the AWS rate limiter will eventually block them.

This PR refactors the rate limiter logic to only rate limit retrieve requests. The only catch is that since a find request cannot be fully completed without a retrieve request (UX reasons), the find requests have a check if the user is rate limited and if so blocks find requests also.

## How to test

1. Update the "Address Complete Retrieve Rate Limit Max (count)" app setting to something easy to test like `2`
2. Open a published form with an Address Complete element
3. Type in and select an address twice
4. Try again and both the typeahead and retrieve results should be disabled (rate limit)
5. Wait a minute and try again and you should no longer be rate limited

