### PR TITLE
poc - use activity 

### DIFF
--- a/components/clientComponents/forms/ConditionalWrapper/ConditionalWrapper.tsx
+++ b/components/clientComponents/forms/ConditionalWrapper/ConditionalWrapper.tsx
@@ -1,46 +1,27 @@
 "use client";
-import React from "react";
+import { Activity, type ReactElement } from "react";
 import { useGCFormsContext } from "@lib/hooks/useGCFormContext";
 import { type ConditionalRule, type FormElement } from "@gcforms/types";
-import { inGroup, checkVisibilityRecursive } from "@gcforms/core";
 
 export const ConditionalWrapper = ({
   children,
   element,
-  rules,
 }: {
-  children: React.ReactElement;
+  children: ReactElement;
   element: FormElement;
   rules: ConditionalRule[] | null;
   lang: string;
 }) => {
-  const { getValues, currentGroup, groups, formRecord } = useGCFormsContext();
+  const { visibleElementIds } = useGCFormsContext();
 
   // Check if the element is a child of a dynamic element
   if (element.subId) {
     return children;
   }
 
-  // Check if we're using groups and if the current element is in a group
-  if (
-    currentGroup &&
-    groups &&
-    Object.keys(groups).length >= 1 &&
-    groups &&
-    !inGroup(currentGroup, element.id, groups)
-  )
-    return null;
-
-  // If there's no rule or no choiceId, just return the children
-  if (!rules || rules.length < 1) return children;
-
-  const values = getValues() || {};
-
-  const isVisible = checkVisibilityRecursive(formRecord, element, values);
-
-  if (!isVisible) {
-    return null;
-  }
-
-  return children;
+  return (
+    <Activity mode={visibleElementIds.has(element.id.toString()) ? "visible" : "hidden"}>
+      {children}
+    </Activity>
+  );
 };

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -11,6 +11,8 @@ import {
   mapIdsToValues,
   getValuesWithMatchedIds,
   getVisibleGroupsBasedOnValuesRecursive,
+  getVisibleElementIdsForGroup,
+  getDeepVisibleElementIds,
 } from "@gcforms/core";
 
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
@@ -28,6 +30,8 @@ interface GCFormsContextValueType {
   updateValues: ({ formValues }: { formValues: FormValues }) => void;
   getValues: () => FormValues;
   matchedIds: string[];
+  visibleElementIds: Set<string>;
+  deepVisibleElementIds: Set<string>;
   groups?: GroupsType;
   currentGroup: string | null;
   getPreviousGroup: (currentGroup: string) => string;
@@ -55,6 +59,14 @@ interface GCFormsContextValueType {
   };
 }
 
+const setsAreEqual = (first: Set<string>, second: Set<string>) => {
+  if (first.size !== second.size) return false;
+  for (const value of first) {
+    if (!second.has(value)) return false;
+  }
+  return true;
+};
+
 const GCFormsContext = createContext<GCFormsContextValueType | undefined>(undefined);
 
 export const GCFormsProvider = ({
@@ -69,6 +81,12 @@ export const GCFormsProvider = ({
   const values = useRef({});
   const history = useRef<string[]>([LOCKED_GROUPS.START]);
   const [matchedIds, setMatchedIds] = useState<string[]>([]);
+  const [visibleElementIds, setVisibleElementIds] = useState(() =>
+    getVisibleElementIdsForGroup(formRecord, {}, initialGroup)
+  );
+  const [deepVisibleElementIds, setDeepVisibleElementIds] = useState(() =>
+    getDeepVisibleElementIds(formRecord, {})
+  );
   const [currentGroup, setCurrentGroup] = useState<string | null>(initialGroup);
   const [submissionId, setSubmissionId] = useState<string | undefined>(undefined);
   const [submissionDate, setSubmissionDate] = useState<string | undefined>(undefined);
@@ -119,11 +137,27 @@ export const GCFormsProvider = ({
     if (!idArraysMatch(matchedIds, valueIds)) {
       setMatchedIds(valueIds);
     }
+    const nextVisibleElementIds = getVisibleElementIdsForGroup(
+      formRecord,
+      formValues,
+      currentGroup
+    );
+    const nextDeepVisibleElementIds = getDeepVisibleElementIds(formRecord, formValues);
+    setVisibleElementIds((previous) =>
+      setsAreEqual(previous, nextVisibleElementIds) ? previous : nextVisibleElementIds
+    );
+    setDeepVisibleElementIds((previous) =>
+      setsAreEqual(previous, nextDeepVisibleElementIds) ? previous : nextDeepVisibleElementIds
+    );
   };
 
   // Helper to not expose the setter
   const setGroup = (group: string | null) => {
     setCurrentGroup(group);
+    const nextVisibleElementIds = getVisibleElementIdsForGroup(formRecord, values.current, group);
+    setVisibleElementIds((previous) =>
+      setsAreEqual(previous, nextVisibleElementIds) ? previous : nextVisibleElementIds
+    );
   };
 
   const getValues = () => {
@@ -191,6 +225,8 @@ export const GCFormsProvider = ({
         updateValues,
         getValues,
         matchedIds,
+        visibleElementIds,
+        deepVisibleElementIds,
         groups,
         currentGroup,
         getPreviousGroup,
@@ -227,6 +263,8 @@ export const useGCFormsContext = () => {
       submissionDate: undefined,
       setSubmissionDate: () => void 0,
       matchedIds: [""],
+      visibleElementIds: new Set(),
+      deepVisibleElementIds: new Set(),
       groups: {},
       currentGroup: "",
       getPreviousGroup: () => "",

--- a/packages/core/src/formContextRecursiveVisibility.test.ts
+++ b/packages/core/src/formContextRecursiveVisibility.test.ts
@@ -1,5 +1,9 @@
 import { FormElement, PublicFormRecord } from "@gcforms/types";
-import { checkVisibilityRecursive } from "./visibility";
+import {
+  checkVisibilityRecursive,
+  getDeepVisibleElementIds,
+  getVisibleElementIdsForGroup,
+} from "./visibility";
 
 describe("Recursive visibility check", () => {
   test("Simple recursive test", async () => {
@@ -176,6 +180,15 @@ describe("Recursive visibility check", () => {
 
     const isVisible2 = checkVisibilityRecursive(formRecord, element, valuesVisible6);
     expect(isVisible2).toEqual(true);
+
+    expect([...getVisibleElementIdsForGroup(formRecord, valuesHidden6, "start")]).toEqual(["1"]);
+    expect([...getVisibleElementIdsForGroup(formRecord, valuesVisible6, "start")]).toEqual([
+      "1",
+      "2",
+      "6",
+    ]);
+    expect([...getDeepVisibleElementIds(formRecord, valuesHidden6)]).toEqual(["1"]);
+    expect([...getDeepVisibleElementIds(formRecord, valuesVisible6)]).toEqual(["1", "2", "6"]);
   });
 
   test("Complex recursive test", async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,8 @@ export {
   checkPageVisibility,
   checkVisibilityRecursive,
   isElementVisible,
+  getVisibleElementIdsForGroup,
+  getDeepVisibleElementIds,
 } from "./visibility";
 
 export {

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -6,6 +6,7 @@ import {
   getValuesWithMatchedIds,
   findGroupByElementId,
   inGroup,
+  mapIdsToValues,
 } from "./helpers";
 
 /**
@@ -220,3 +221,106 @@ export const isElementVisible = (
 
   return checkVisibilityRecursive(formRecord, element, values);
 };
+
+const getVisibleGroupIds = (formRecord: PublicFormRecord, values: FormValues) => {
+  if (!formRecord.form.groups || Object.keys(formRecord.form.groups).length === 0) {
+    return undefined;
+  }
+
+  const valuesWithMatchedIds = getValuesWithMatchedIds(formRecord.form.elements, values);
+  return new Set(getVisibleGroupsBasedOnValuesRecursive(formRecord, valuesWithMatchedIds, "start"));
+};
+
+const isElementInVisibleGroup = (
+  formRecord: PublicFormRecord,
+  element: FormElement,
+  visibleGroupIds: Set<string> | undefined
+) => {
+  if (!visibleGroupIds) return true;
+
+  const groupId = findGroupByElementId(formRecord, element.id);
+  return !groupId || visibleGroupIds.has(groupId);
+};
+
+const getConditionallyVisible = (
+  element: FormElement,
+  formRecord: PublicFormRecord,
+  matchedIds: Set<string>,
+  visibleGroupIds: Set<string> | undefined,
+  checked: Record<string, boolean>
+): boolean => {
+  const elementId = element.id.toString();
+  if (checked[elementId] !== undefined) return checked[elementId];
+
+  const rules = element.properties.conditionalRules;
+  if (!rules || rules.length === 0) {
+    return isElementInVisibleGroup(formRecord, element, visibleGroupIds);
+  }
+
+  checked[elementId] = false;
+
+  const isVisible =
+    isElementInVisibleGroup(formRecord, element, visibleGroupIds) &&
+    rules.some((rule) => {
+      const [parentId] = rule.choiceId.split(".");
+      const parent = getElementById(formRecord.form.elements, parentId);
+
+      if (!parent) return matchedIds.has(rule.choiceId);
+
+      return (
+        getConditionallyVisible(parent, formRecord, matchedIds, visibleGroupIds, checked) &&
+        matchedIds.has(rule.choiceId)
+      );
+    });
+
+  checked[elementId] = isVisible;
+  return isVisible;
+};
+
+const getVisibleElementIds = (
+  formRecord: PublicFormRecord,
+  values: FormValues,
+  currentGroup?: string | null,
+  deep = false
+) => {
+  const groups = formRecord.form.groups as GroupsType | undefined;
+  const visibleGroupIds = getVisibleGroupIds(formRecord, values);
+  const matchedIds = new Set(mapIdsToValues(formRecord.form.elements, values));
+  const checked: Record<string, boolean> = {};
+  const visibleElementIds = new Set<string>();
+
+  for (const element of formRecord.form.elements) {
+    if (element.subId) {
+      visibleElementIds.add(element.id.toString());
+      continue;
+    }
+
+    if (
+      !deep &&
+      currentGroup &&
+      groups &&
+      Object.keys(groups).length >= 1 &&
+      !inGroup(currentGroup, element.id, groups)
+    ) {
+      continue;
+    }
+
+    const isVisible = deep
+      ? getConditionallyVisible(element, formRecord, matchedIds, visibleGroupIds, checked)
+      : !element.properties.conditionalRules?.length ||
+        getConditionallyVisible(element, formRecord, matchedIds, visibleGroupIds, checked);
+
+    if (isVisible) visibleElementIds.add(element.id.toString());
+  }
+
+  return visibleElementIds;
+};
+
+export const getVisibleElementIdsForGroup = (
+  formRecord: PublicFormRecord,
+  values: FormValues,
+  currentGroup?: string | null
+) => getVisibleElementIds(formRecord, values, currentGroup);
+
+export const getDeepVisibleElementIds = (formRecord: PublicFormRecord, values: FormValues) =>
+  getVisibleElementIds(formRecord, values, null, true);


### PR DESCRIPTION
# Summary | Résumé

1. We have elements that can change match ids --- broadcasters
2. We have elements that are visible based on rules / matched ids --- listeners

When a broadcaster value is changed:

We can have global state / context to create a new visibility Set based on the new values

2 functions

visibility Set -- shallow
visibility Set --- deep

Shallow contains only elements in the current group that are visible (based on group, rules)

Deep contains elements for the entire form that are visible

{
el1: true
el2: true
el3: false
}

when a broadcaster value is chnage the visiblilty set is updated once at the top level

//
currentGroup.items.map(el

    // use https://react.dev/reference/react/Activity and base the mode on if the el exists in the visiblilty set
    <Activity mode={visibility[el.id]}>
            <element />
    </Activity>

)

Activity basically replaces ConditionalWrapper --- and is basically an on / off switch all the work is done once higher up which should save a bunch of recursive looping per element


