### PR TITLE
chore: fix casing for icon

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2026-08-21
+
+- Fix collapsible icon warnings
+
 ## [1.0.21] - 2026-08-19
 
 - Enable collapsible / details extension

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/editor",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/editor/src/icons/CollapsibleIcon.tsx
+++ b/packages/editor/src/icons/CollapsibleIcon.tsx
@@ -5,14 +5,14 @@ export const CollapsibleIcon = () => (
     <path
       d="M3 14.5H10M3 21H10M3 17.75H10"
       stroke="#64748B"
-      stroke-width="2"
-      stroke-linecap="round"
+      strokeWidth="2"
+      strokeLinecap="round"
     />
     <path
       d="M14 14.5L21 14.5M14 21H21M14 17.75L21 17.75"
       stroke="black"
-      stroke-width="2"
-      stroke-linecap="round"
+      strokeWidth="2"
+      strokeLinecap="round"
     />
   </svg>
 );


### PR DESCRIPTION
# Summary | Résumé

Fixes some dev warning for 

`stroke-width` vs strokeWidth`

 `stroke-linecap`  vs `strokeLinecap`


<img width="500" alt="Screenshot 2026-08-21 at 7 33 27 AM" src="https://github.com/user-attachments/assets/e7ff51d0-0351-4881-aea6-7ac4d13acf37" />


<img width="500" alt="Screenshot 2026-08-21 at 7 33 39 AM" src="https://github.com/user-attachments/assets/526097b3-eb33-4763-9618-b6de5822be40" />
