### PR TITLE
chore: add show hide e2e test

### DIFF
--- a/__fixtures__/showHideGroupsTest.json
+++ b/__fixtures__/showHideGroupsTest.json
@@ -1,0 +1,225 @@
+{
+  "groups": {
+    "end": {
+      "name": "End",
+      "titleEn": "Confirmation page",
+      "titleFr": "Confirmation page",
+      "autoFlow": true,
+      "elements": []
+    },
+    "start": {
+      "name": "Start",
+      "titleEn": "Start page",
+      "titleFr": "Start page",
+      "autoFlow": false,
+      "elements": ["1", "2", "3", "4"],
+      "nextAction": [
+        {
+          "groupId": "ba4645d7-ad61-4b5c-b8cf-5d5a8fe0ea80",
+          "choiceId": "1.0"
+        },
+        {
+          "groupId": "ec47cc35-3bfe-40c0-820c-0678c738515b",
+          "choiceId": "1.1"
+        }
+      ]
+    },
+    "review": {
+      "name": "Review",
+      "titleEn": "End (Review page and Confirmation)",
+      "titleFr": "End (Review page and Confirmation)",
+      "autoFlow": true,
+      "elements": [],
+      "nextAction": "end"
+    },
+    "ba4645d7-ad61-4b5c-b8cf-5d5a8fe0ea80": {
+      "name": "Page A",
+      "titleEn": "Page A",
+      "titleFr": "",
+      "autoFlow": true,
+      "elements": ["7", "8"],
+      "nextAction": "ec47cc35-3bfe-40c0-820c-0678c738515b"
+    },
+    "ec47cc35-3bfe-40c0-820c-0678c738515b": {
+      "name": "Page B",
+      "titleEn": "Page B",
+      "titleFr": "",
+      "autoFlow": true,
+      "elements": ["5", "6"],
+      "nextAction": "review"
+    }
+  },
+  "layout": [1, 2, 3, 4, 7, 8, 5, 6],
+  "titleEn": "Show hide form",
+  "titleFr": "",
+  "elements": [
+    {
+      "id": 7,
+      "type": "textField",
+      "uuid": "dd5b847c-e4cf-408d-a03e-7684f7bc4a6f",
+      "properties": {
+        "tags": [],
+        "choices": [],
+        "titleEn": "Question A",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "textField",
+      "uuid": "98c81fd2-8271-418f-9824-0545adbb4f5d",
+      "properties": {
+        "tags": [],
+        "choices": [],
+        "titleEn": "A - show optional",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [{ "choiceId": "2.0" }]
+      }
+    },
+    {
+      "id": 5,
+      "type": "textField",
+      "uuid": "a5700c8a-f227-44d4-8fc8-483d68ec008f",
+      "properties": {
+        "tags": [],
+        "choices": [],
+        "titleEn": "Question B",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "textField",
+      "uuid": "1e50589a-7198-4cb7-9bed-d16c16ffeae6",
+      "properties": {
+        "tags": [],
+        "choices": [],
+        "titleEn": "B - show optional",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [{ "choiceId": "2.1" }]
+      }
+    },
+    {
+      "id": 1,
+      "type": "radio",
+      "uuid": "83a1264b-c9cb-48f7-be89-d743e9996963",
+      "properties": {
+        "tags": [],
+        "choices": [
+          { "en": "Page A", "fr": "" },
+          { "en": "Page B", "fr": "" }
+        ],
+        "titleEn": "Which page do you want to go to?",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "checkbox",
+      "uuid": "9ebc9b70-4e80-4213-8d21-f91f2357c93f",
+      "properties": {
+        "tags": [],
+        "choices": [
+          { "en": "Show on page A", "fr": "" },
+          { "en": "Show on page B", "fr": "" }
+        ],
+        "titleEn": "Show on another page",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "dropdown",
+      "uuid": "906934fe-5b0c-4a51-b8de-320bd8040130",
+      "properties": {
+        "tags": [],
+        "choices": [
+          { "en": "Yes", "fr": "" },
+          { "en": "No", "fr": "" },
+          { "en": "Other ", "fr": "Autre " }
+        ],
+        "titleEn": "Do you agree?",
+        "titleFr": "",
+        "questionId": "",
+        "validation": { "required": false },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "textField",
+      "properties": {
+        "choices": [{ "en": "", "fr": "" }],
+        "titleEn": "Other ",
+        "titleFr": "Autre ",
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": "",
+        "conditionalRules": [{ "choiceId": "3.2" }]
+      }
+    }
+  ],
+  "confirmation": {
+    "descriptionEn": "",
+    "descriptionFr": "",
+    "referrerUrlEn": "",
+    "referrerUrlFr": ""
+  },
+  "groupsLayout": ["ba4645d7-ad61-4b5c-b8cf-5d5a8fe0ea80", "ec47cc35-3bfe-40c0-820c-0678c738515b"],
+  "introduction": { "descriptionEn": "", "descriptionFr": "" },
+  "privacyPolicy": { "descriptionEn": "", "descriptionFr": "" },
+  "lastGeneratedElementId": 8
+}

--- a/tests/e2e/forms/show-hide-groups.spec.ts
+++ b/tests/e2e/forms/show-hide-groups.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, type Page } from "@playwright/test";
+import { DatabaseHelper } from "../../helpers/database-helper";
+
+test.describe("Show/Hide across groups", { tag: "@published-form" }, () => {
+  let dbHelper: DatabaseHelper;
+  let formId: string;
+  let publishedFormPath: string;
+
+  test.beforeAll(async () => {
+    dbHelper = new DatabaseHelper();
+    formId = await dbHelper.createTemplate({
+      fixtureName: "showHideGroupsTest",
+      published: true,
+    });
+    publishedFormPath = `en/id/${formId}`;
+  });
+
+  test.afterAll(async () => {
+    if (formId) {
+      await dbHelper.deleteTemplate(formId);
+    }
+  });
+
+  const fillOtherField = async (page: Page) => {
+    const agreement = page.getByRole("combobox", { name: "Do you agree?" });
+    await agreement.selectOption("Other ");
+
+    const otherField = page.locator('[id="4"]');
+    await expect(otherField).toBeVisible();
+    await otherField.fill("Other response");
+    await expect(otherField).toHaveValue("Other response");
+  };
+
+  test("shows the Page A optional field after returning and selecting it", async ({ page }) => {
+    await page.goto(publishedFormPath);
+
+    await fillOtherField(page);
+    await page.locator('label[for="1.0"]').click();
+    await expect(page.locator('[id="1.0"]')).toBeChecked();
+    await page.getByTestId("nextButton").click();
+    await expect(page.getByRole("heading", { level: 2, name: "Page A" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Question A" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Question B" })).toBeHidden();
+
+    const optionalField = page.getByRole("textbox", { name: "A - show optional" });
+    await expect(optionalField).toBeHidden();
+
+    await page.getByTestId("backButtonGroup").click();
+    await page.locator('label[for="2.0"]').click();
+    await expect(page.locator('[id="2.0"]')).toBeChecked();
+    await page.getByTestId("nextButton").click();
+
+    await expect(page.getByRole("heading", { level: 2, name: "Page A" })).toBeVisible();
+    await expect(optionalField).toBeVisible();
+  });
+
+  test("shows the Page B optional field after returning and selecting it", async ({ page }) => {
+    await page.goto(publishedFormPath);
+
+    await fillOtherField(page);
+    await page.locator('label[for="1.1"]').click();
+    await expect(page.locator('[id="1.1"]')).toBeChecked();
+    await page.getByTestId("nextButton").click();
+    await expect(page.getByRole("heading", { level: 2, name: "Page B" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Question B" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Question A" })).toBeHidden();
+
+    const optionalField = page.getByRole("textbox", { name: "B - show optional" });
+    await expect(optionalField).toBeHidden();
+
+    await page.getByTestId("backButtonGroup").click();
+    await page.locator('label[for="2.1"]').click();
+    await expect(page.locator('[id="2.1"]')).toBeChecked();
+    await page.getByTestId("nextButton").click();
+
+    await expect(page.getByRole("heading", { level: 2, name: "Page B" })).toBeVisible();
+    await expect(optionalField).toBeVisible();
+  });
+
+  test("updates the destination when the radio choice changes after going back", async ({
+    page,
+  }) => {
+    // Purpose: protect group nextAction synchronization when a user changes their destination.
+    await page.goto(publishedFormPath);
+    await fillOtherField(page);
+
+    await page.locator('label[for="1.0"]').click();
+    await page.getByTestId("nextButton").click();
+    await expect(page.getByRole("heading", { level: 2, name: "Page A" })).toBeVisible();
+
+    await page.getByTestId("backButtonGroup").click();
+    await page.locator('label[for="1.1"]').click();
+    await expect(page.locator('[id="1.1"]')).toBeChecked();
+    await page.getByTestId("nextButton").click();
+
+    await expect(page.getByRole("heading", { level: 2, name: "Page B" })).toBeVisible();
+  });
+
+  test("hides a page field again when its visibility checkbox is unchecked", async ({ page }) => {
+    // Purpose: verify visibility responds to both checked and unchecked checkbox values.
+    await page.goto(publishedFormPath);
+    await fillOtherField(page);
+
+    await page.locator('label[for="1.0"]').click();
+    await page.locator('label[for="2.0"]').click();
+    await page.getByTestId("nextButton").click();
+
+    const optionalField = page.getByRole("textbox", { name: "A - show optional" });
+    await expect(optionalField).toBeVisible();
+
+    await page.getByTestId("backButtonGroup").click();
+    await page.locator('label[for="2.0"]').click();
+    await expect(page.locator('[id="2.0"]')).not.toBeChecked();
+    await page.getByTestId("nextButton").click();
+
+    await expect(optionalField).toBeHidden();
+  });
+
+  test("shows both page fields when both visibility checkboxes are selected", async ({ page }) => {
+    // Purpose: verify checkbox array values independently control fields on different pages.
+    await page.goto(publishedFormPath);
+    await fillOtherField(page);
+
+    await page.locator('label[for="1.0"]').click();
+    await page.locator('label[for="2.0"]').click();
+    await page.locator('label[for="2.1"]').click();
+    await page.getByTestId("nextButton").click();
+
+    await expect(page.getByRole("textbox", { name: "A - show optional" })).toBeVisible();
+    await page.getByTestId("nextButton").click();
+
+    await expect(page.getByRole("heading", { level: 2, name: "Page B" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "B - show optional" })).toBeVisible();
+  });
+
+  test("hides the Other field when the dropdown changes away from Other", async ({ page }) => {
+    // Purpose: verify a conditional field reacts when its source value changes.
+    await page.goto(publishedFormPath);
+    await fillOtherField(page);
+
+    await page.getByRole("combobox", { name: "Do you agree?" }).selectOption("Yes");
+    await expect(page.locator('[id="4"]')).toBeHidden();
+  });
+
+  test("preserves the Other field value when navigating back to the start page", async ({
+    page,
+  }) => {
+    // Purpose: verify unrelated navigation does not lose an entered conditional field value.
+    await page.goto(publishedFormPath);
+    await fillOtherField(page);
+
+    await page.locator('label[for="1.0"]').click();
+    await page.getByTestId("nextButton").click();
+    await page.getByTestId("backButtonGroup").click();
+
+    await expect(page.locator('[id="4"]')).toBeVisible();
+    await expect(page.locator('[id="4"]')).toHaveValue("Other response");
+  });
+
+  test("does not show hidden optional fields on the review page", async ({ page }) => {
+    // Purpose: verify fields hidden by conditional logic are excluded from review output.
+    await page.goto(publishedFormPath);
+    await fillOtherField(page);
+
+    await page.locator('label[for="1.0"]').click();
+    await page.getByTestId("nextButton").click();
+    await page.getByTestId("nextButton").click();
+    await page.getByTestId("nextButton").click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 2,
+        name: "Review your answers before submitting the form.",
+      })
+    ).toBeVisible();
+
+    const reviewList = page.locator(".my-16");
+    await expect(reviewList.getByText("A - show optional", { exact: true })).toHaveCount(0);
+    await expect(reviewList.getByText("B - show optional", { exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

Adds e2e test for show hide

- Simple "other field"
- Page branching
- Conditional fields that show up other pages