### PR TITLE
chore: Remove ConditionalWrapper in testing context

### DIFF
--- a/components/clientComponents/forms/Checkbox/Checkbox.test.tsx
+++ b/components/clientComponents/forms/Checkbox/Checkbox.test.tsx
@@ -39,7 +39,11 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Checkbox component", (lang
     const user = userEvent.setup();
     render(
       <Formik onSubmit={() => {}} initialValues={{}}>
-        <GenerateElement element={checkboxData as unknown as FormElement} language={lang} />
+        <GenerateElement
+          element={checkboxData as unknown as FormElement}
+          language={lang}
+          isTestMode={true}
+        />
       </Formik>
     );
 
@@ -75,7 +79,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Checkbox component", (lang
     checkboxData.properties.validation!.required = true;
     render(
       <Formik onSubmit={() => {}} initialValues={{}}>
-        <GenerateElement element={checkboxData} language={lang} />
+        <GenerateElement element={checkboxData} language={lang} isTestMode={true} />
       </Formik>
     );
 

--- a/components/clientComponents/forms/Combobox/Combobox.test.tsx
+++ b/components/clientComponents/forms/Combobox/Combobox.test.tsx
@@ -55,7 +55,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Combobox component", (lang
   afterEach(() => cleanup());
 
   it("renders without errors", async () => {
-    render(<GenerateElement element={comboboxData} language={lang} />);
+    render(<GenerateElement element={comboboxData} language={lang} isTestMode={true} />);
 
     const title = lang === "en" ? comboboxData.properties.titleEn : comboboxData.properties.titleFr;
     const shortDescription =
@@ -104,17 +104,15 @@ describe("Combobox language switch", () => {
     const setErrorMock = vi.fn();
 
     // Intercept useField that Comboox uses and provide with a default French choice
-    vi.mocked(useField).mockReturnValueOnce(
-      [
-        {
-          value: "Colombie-Britannique",
-          name: "province",
-          onBlur: undefined,
-        },
-        { touched: null, error: null },
-        { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
-      ] as unknown as ReturnType<typeof useField>
-    );
+    vi.mocked(useField).mockReturnValueOnce([
+      {
+        value: "Colombie-Britannique",
+        name: "province",
+        onBlur: undefined,
+      },
+      { touched: null, error: null },
+      { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
+    ] as unknown as ReturnType<typeof useField>);
 
     const englishChoices = ["British Columbia", "Alberta", "Ontario"];
     const bilingualChoices = [
@@ -145,17 +143,15 @@ describe("Combobox language switch", () => {
     const setValueMock = vi.fn();
     const setErrorMock = vi.fn();
 
-    vi.mocked(useField).mockReturnValueOnce(
-      [
-        {
-          value: "British Columbia",
-          name: "province",
-          onBlur: undefined,
-        },
-        { touched: null, error: null },
-        { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
-      ] as unknown as ReturnType<typeof useField>
-    );
+    vi.mocked(useField).mockReturnValueOnce([
+      {
+        value: "British Columbia",
+        name: "province",
+        onBlur: undefined,
+      },
+      { touched: null, error: null },
+      { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
+    ] as unknown as ReturnType<typeof useField>);
 
     const frenchChoices = ["Colombie-Britannique", "Alberta", "Ontario"];
     const bilingualChoices = [
@@ -183,17 +179,15 @@ describe("Combobox language switch", () => {
     const setValueMock = vi.fn();
     const setErrorMock = vi.fn();
 
-    vi.mocked(useField).mockReturnValueOnce(
-      [
-        {
-          value: "British Columbia",
-          name: "province",
-          onBlur: undefined,
-        },
-        { touched: null, error: null },
-        { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
-      ] as unknown as ReturnType<typeof useField>
-    );
+    vi.mocked(useField).mockReturnValueOnce([
+      {
+        value: "British Columbia",
+        name: "province",
+        onBlur: undefined,
+      },
+      { touched: null, error: null },
+      { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
+    ] as unknown as ReturnType<typeof useField>);
 
     const englishChoices = ["British Columbia", "Alberta", "Ontario"];
     const bilingualChoices = [
@@ -219,31 +213,21 @@ describe("Combobox language switch", () => {
     const setValueMock = vi.fn();
     const setErrorMock = vi.fn();
 
-    vi.mocked(useField).mockReturnValueOnce(
-      [
-        {
-          value: "Some Value",
-          name: "field",
-          onBlur: undefined,
-        },
-        { touched: null, error: null },
-        { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
-      ] as unknown as ReturnType<typeof useField>
-    );
+    vi.mocked(useField).mockReturnValueOnce([
+      {
+        value: "Some Value",
+        name: "field",
+        onBlur: undefined,
+      },
+      { touched: null, error: null },
+      { setValue: setValueMock, setError: setErrorMock, setTouched: vi.fn() },
+    ] as unknown as ReturnType<typeof useField>);
 
     const choices = ["Some Value", "Other Value"];
 
-    render(
-      <Combobox
-        id="test-combobox"
-        name="field"
-        lang="en"
-        choices={choices}
-      />
-    );
+    render(<Combobox id="test-combobox" name="field" lang="en" choices={choices} />);
 
     // setValue should NOT be called without allChoices
     expect(setValueMock).not.toHaveBeenCalled();
   });
 });
-

--- a/components/clientComponents/forms/Dropdown/Dropdown.test.tsx
+++ b/components/clientComponents/forms/Dropdown/Dropdown.test.tsx
@@ -13,10 +13,7 @@ vi.mock("formik", async () => {
   const actual = await vi.importActual<typeof import("formik")>("formik");
   return {
     ...actual,
-    useField: vi.fn(() => [
-      { field: { value: "" } },
-      { meta: { touched: null, error: null } },
-    ]),
+    useField: vi.fn(() => [{ field: { value: "" } }, { meta: { touched: null, error: null } }]),
   };
 });
 
@@ -53,7 +50,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Dropdown component", (lang
 
   it("renders without errors", async () => {
     const user = userEvent.setup();
-    render(<GenerateElement element={dropdownData} language={lang} />);
+    render(<GenerateElement element={dropdownData} language={lang} isTestMode={true} />);
 
     const title = lang === "en" ? dropdownData.properties.titleEn : dropdownData.properties.titleFr;
     const description =
@@ -78,7 +75,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Dropdown component", (lang
 
   it("required elements display properly", () => {
     dropdownData.properties.validation!.required = true;
-    render(<GenerateElement element={dropdownData} language={lang} />);
+    render(<GenerateElement element={dropdownData} language={lang} isTestMode={true} />);
     expect(screen.queryByTestId("required")).toBeInTheDocument();
     dropdownData.properties.validation!.required = false;
   });

--- a/components/clientComponents/forms/DynamicRow/DynamicRow.test.tsx
+++ b/components/clientComponents/forms/DynamicRow/DynamicRow.test.tsx
@@ -87,7 +87,7 @@ describe.each([["en"], ["fr"]])("Generate a dynamic row", (lang) => {
         // @ts-expect-error - test data missing required FormRecord fields
         <Form formRecord={formRecord} t={(key) => key} language={lang}>
           {/* @ts-expect-error - test data has string type instead of FormElementTypes */}
-          <GenerateElement element={dynamicRowData} language={lang} />
+          <GenerateElement element={dynamicRowData} language={lang} isTestMode={true} />
         </Form>
       );
 
@@ -119,7 +119,7 @@ describe.each([["en"], ["fr"]])("Generate a dynamic row", (lang) => {
         // @ts-expect-error - test data missing required FormRecord fields
         <Form formRecord={formRecord} t={(key) => key} language={lang}>
           {/* @ts-expect-error - test data has string type instead of FormElementTypes */}
-          <GenerateElement element={dynamicRowData} language={lang} />
+          <GenerateElement element={dynamicRowData} language={lang} isTestMode={true} />
         </Form>
       );
       // mocking scroll into view function (not implemented in jsdom)
@@ -171,7 +171,7 @@ describe.each([["en"], ["fr"]])("Generate a dynamic row", (lang) => {
         // @ts-expect-error - test data missing required FormRecord fields
         <Form formRecord={formRecord} t={(key) => key} language={lang}>
           {/* @ts-expect-error - test data has string type instead of FormElementTypes */}
-          <GenerateElement element={dynamicRowData} language={lang} />
+          <GenerateElement element={dynamicRowData} language={lang} isTestMode={true} />
         </Form>
       );
       // mocking scroll into view function (not implemented in jsdom)
@@ -210,7 +210,7 @@ describe.each([["en"], ["fr"]])("Generate a dynamic row", (lang) => {
         // @ts-expect-error - test data missing required FormRecord fields
         <Form formRecord={formRecord} t={(key) => key} language={lang}>
           {/* @ts-expect-error - test data has string type instead of FormElementTypes */}
-          <GenerateElement element={dynamicRowData} language={lang} />
+          <GenerateElement element={dynamicRowData} language={lang} isTestMode={true} />
         </Form>
       );
       // mocking scroll into view function (not implemented in jsdom)
@@ -252,7 +252,7 @@ describe.each([["en"], ["fr"]])("Generate a dynamic row", (lang) => {
         // @ts-expect-error - test data missing required FormRecord fields
         <Form formRecord={formRecord} t={(key) => key} language={lang}>
           {/* @ts-expect-error - test data has string type instead of FormElementTypes */}
-          <GenerateElement element={dynamicRowData} language={lang} />
+          <GenerateElement element={dynamicRowData} language={lang} isTestMode={true} />
         </Form>
       );
 

--- a/components/clientComponents/forms/FormGroup/FormGroup.test.tsx
+++ b/components/clientComponents/forms/FormGroup/FormGroup.test.tsx
@@ -38,11 +38,17 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Generate a form group", (l
   test("renders properly", () => {
     render(
       <Formik onSubmit={() => {}} initialValues={{}}>
-        <GenerateElement element={radioButtonData} language={lang} />
+        <GenerateElement element={radioButtonData} language={lang} isTestMode={true} />
       </Formik>
     );
-    const title = (lang === "en" ? radioButtonData.properties.titleEn : radioButtonData.properties.titleFr) as string;
-    const description = (lang === "en" ? radioButtonData.properties.descriptionEn : radioButtonData.properties.descriptionFr) as string;
+    const title = (
+      lang === "en" ? radioButtonData.properties.titleEn : radioButtonData.properties.titleFr
+    ) as string;
+    const description = (
+      lang === "en"
+        ? radioButtonData.properties.descriptionEn
+        : radioButtonData.properties.descriptionFr
+    ) as string;
 
     // Title are rendered
     screen.getAllByText(title).forEach((input) => {

--- a/components/clientComponents/forms/Radio/Radio.test.tsx
+++ b/components/clientComponents/forms/Radio/Radio.test.tsx
@@ -41,7 +41,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)(
     test("renders without errors", () => {
       render(
         <Formik onSubmit={() => {}} initialValues={{}}>
-          <GenerateElement element={radioButtonData} language={lang} />
+          <GenerateElement element={radioButtonData} language={lang} isTestMode={true} />
         </Formik>
       );
       const title =
@@ -70,7 +70,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)(
       radioButtonData.properties.validation!.required = false as boolean;
       render(
         <Formik onSubmit={() => {}} initialValues={{}}>
-          <GenerateElement element={radioButtonData} language={lang} />
+          <GenerateElement element={radioButtonData} language={lang} isTestMode={true} />
         </Formik>
       );
       expect(screen.queryByTestId("required")).not.toBeInTheDocument();

--- a/components/clientComponents/forms/RichText/RichText.test.tsx
+++ b/components/clientComponents/forms/RichText/RichText.test.tsx
@@ -28,7 +28,7 @@ describe("Generate a rich text element", () => {
   afterEach(() => cleanup());
 
   it.each([["en"], ["fr"]] as Array<[Language]>)("renders properly", (lang: Language) => {
-    render(<GenerateElement element={richTextData} language={lang} />);
+    render(<GenerateElement element={richTextData} language={lang} isTestMode={true} />);
     const title = lang === "en" ? richTextData.properties.titleEn : richTextData.properties.titleFr;
     const description =
       lang === "en" ? richTextData.properties.descriptionEn : richTextData.properties.descriptionFr;
@@ -49,7 +49,7 @@ describe("Generate a rich text element", () => {
         descriptionFr: "",
       },
     } as const as FormElement;
-    render(<GenerateElement element={emptyRichTextData} language="en" />);
+    render(<GenerateElement element={emptyRichTextData} language="en" isTestMode={true} />);
     expect(screen.queryByRole("label")).not.toBeInTheDocument();
     expect(screen.queryByTestId("richText")).not.toBeInTheDocument();
   });
@@ -58,14 +58,14 @@ describe("Generate a rich text element", () => {
     const richTextWithHTML = { ...richTextData } as FormElement;
     richTextWithHTML.properties.descriptionEn =
       "Testing <script data-testid='script'>alert('pwned')</script> this";
-    render(<GenerateElement element={richTextWithHTML} language="en" />);
+    render(<GenerateElement element={richTextWithHTML} language="en" isTestMode={true} />);
     expect(screen.queryByTestId("script")).not.toBeInTheDocument();
   });
 
   it("Renders link with target attribute", () => {
     const richTextWithHTML = { ...richTextData } as FormElement;
     richTextWithHTML.properties.descriptionEn = "Testing [link](https://google.ca) this";
-    render(<GenerateElement element={richTextWithHTML} language="en" />);
+    render(<GenerateElement element={richTextWithHTML} language="en" isTestMode={true} />);
     expect(screen.queryByRole("link")).toHaveAttribute("target");
   });
 
@@ -74,7 +74,7 @@ describe("Generate a rich text element", () => {
     richTextWithCollapsible.properties.descriptionEn =
       ":::collapsible Learn more about this topic\nAdditional information.\n:::";
 
-    render(<GenerateElement element={richTextWithCollapsible} language="en" />);
+    render(<GenerateElement element={richTextWithCollapsible} language="en" isTestMode={true} />);
 
     expect(document.querySelector("details")).toBeInTheDocument();
     expect(screen.getByText("Learn more about this topic")).toBeInTheDocument();

--- a/components/clientComponents/forms/TextArea/TextArea.test.tsx
+++ b/components/clientComponents/forms/TextArea/TextArea.test.tsx
@@ -62,7 +62,7 @@ describe("Generate a text area", () => {
     "renders without errors",
     (lang: Language) => {
       it("renders without errors", () => {
-        render(<GenerateElement element={textAreaData} language={lang} />);
+        render(<GenerateElement element={textAreaData} language={lang} isTestMode={true} />);
 
         const title = (
           lang === "en" ? textAreaData.properties.titleEn : textAreaData.properties.titleFr
@@ -98,7 +98,9 @@ describe("Accessibility tests for the textarea component.", () => {
   let localScreen: ReturnType<typeof render>;
 
   beforeEach(() => {
-    localScreen = render(<GenerateElement element={textAreaData2} language={"en"} />);
+    localScreen = render(
+      <GenerateElement element={textAreaData2} language={"en"} isTestMode={true} />
+    );
   });
   it("checks the `aria-describedby` attribute", () => {
     // initial attribute has no value since the description is empty.

--- a/components/clientComponents/forms/TextInput/TextInput.test.tsx
+++ b/components/clientComponents/forms/TextInput/TextInput.test.tsx
@@ -41,7 +41,7 @@ const textInputData = {
 describe.each([["en"], ["fr"]] as Array<[Language]>)("Generate a text input", (lang: Language) => {
   afterEach(() => cleanup());
   it("renders without errors", () => {
-    render(<GenerateElement element={textInputData} language={lang} />);
+    render(<GenerateElement element={textInputData} language={lang} isTestMode={true} />);
 
     const title = (
       lang === "en" ? textInputData.properties.titleEn : textInputData.properties.titleFr
@@ -70,7 +70,7 @@ describe.each([["en"], ["fr"]] as Array<[Language]>)("Generate a text input", (l
 
 describe("Check attributes on rendered text input", () => {
   it("has the correct autoComplete value", () => {
-    render(<GenerateElement element={textInputData} language={"en"} />);
+    render(<GenerateElement element={textInputData} language={"en"} isTestMode={true} />);
     const textbox = screen.getByRole("textbox");
     expect(textbox.getAttribute("autoComplete")).toBe("name");
   });

--- a/lib/formBuilder.tsx
+++ b/lib/formBuilder.tsx
@@ -520,10 +520,16 @@ export const mergeFormValuesWithInitialValues = (
 type GenerateElementProps = {
   element: FormElement;
   language: string;
+  isTestMode?: boolean;
 };
 export const GenerateElement = (props: GenerateElementProps): React.ReactElement => {
-  const { element, language } = props;
+  const { element, language, isTestMode } = props;
   const generatedElement = _buildForm(element, language);
+
+  if (isTestMode) {
+    return generatedElement;
+  }
+
   return (
     <ConditionalWrapper
       element={element}


### PR DESCRIPTION
# Summary | Résumé

Cherry picked from #7781 to reduce noise on that PR.
When testing individual components, no need to wrap them in ConditionalWrapper.