### PR TITLE
chore: remove hCaptcha feature flag 

### DIFF
--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
@@ -27,11 +27,6 @@ import { shouldCheckCaptcha } from "@lib/utils/shouldCheckCaptcha";
 
 import { randomUUID } from "crypto";
 
-// Block submissions when hCaptcha verification fails, including failed scores, API failures after
-// retries, missing or expired tokens, and invalid configuration.
-// ⚠️ Set to false to allow submissions despite verification failures.
-const HCAPTCHA_FAILURE_BLOCKING_ENABLED = true;
-
 // Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function isFormClosed(formId: string): Promise<boolean> {
@@ -78,7 +73,7 @@ export async function submitForm(
 
       if (shouldVerifyHCaptcha) {
         const captchaVerified = await verifyHCaptchaToken(captchaToken || "", formId);
-        if (HCAPTCHA_FAILURE_BLOCKING_ENABLED && !captchaVerified) {
+        if (!captchaVerified) {
           return {
             id: formId,
             error: {

--- a/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
+++ b/app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.ts
@@ -27,6 +27,11 @@ import { shouldCheckCaptcha } from "@lib/utils/shouldCheckCaptcha";
 
 import { randomUUID } from "crypto";
 
+// Block submissions when hCaptcha verification fails, including failed scores, API failures after
+// retries, missing or expired tokens, and invalid configuration.
+// ⚠️ Set to false to allow submissions despite verification failures.
+const HCAPTCHA_FAILURE_BLOCKING_ENABLED = true;
+
 // Public facing functions - they can be used by anyone who finds the associated server action identifer
 
 export async function isFormClosed(formId: string): Promise<boolean> {
@@ -72,10 +77,8 @@ export async function submitForm(
       const shouldVerifyHCaptcha = shouldCheckCaptcha(template?.isPublished, isPreview);
 
       if (shouldVerifyHCaptcha) {
-        const hCaptchaBlockingMode = await checkOne(FeatureFlags.hCaptcha);
-        // hCaptcha runs regardless but only block submissions if the feature flag is enabled
         const captchaVerified = await verifyHCaptchaToken(captchaToken || "", formId);
-        if (hCaptchaBlockingMode && !captchaVerified) {
+        if (HCAPTCHA_FAILURE_BLOCKING_ENABLED && !captchaVerified) {
           return {
             id: formId,
             error: {

--- a/i18n/translations/en/admin-flags.json
+++ b/i18n/translations/en/admin-flags.json
@@ -22,10 +22,6 @@
       "title": "formTimer",
       "description": "Enable formTimer to delay a form submission and help prevent spam"
     },
-    "hCaptcha": {
-      "title": "hCaptcha",
-      "description": "Enable hCaptcha spam prevention"
-    },
     "topBanner": {
       "title": "Banner",
       "description": "Enable warning banner to be visible"

--- a/i18n/translations/fr/admin-flags.json
+++ b/i18n/translations/fr/admin-flags.json
@@ -22,10 +22,6 @@
       "title": "formTimer",
       "description": "Activer formTimer pour retarder l'envoi d'un formulaire et contribuer à prévenir le spam"
     },
-    "hCaptcha": {
-      "title": "hCaptcha",
-      "description": "Activer la prévention anti-spam hCaptcha"
-    },
     "topBanner": {
       "title": "Bannière",
       "description": "Activer la bannière d'avertissement pour qu'elle soit visible"

--- a/lib/cache/types.ts
+++ b/lib/cache/types.ts
@@ -7,7 +7,6 @@ export const UserFeatureFlags = {
 
 export const FeatureFlags = {
   formTimer: "formTimer",
-  hCaptcha: "hCaptcha",
   notification: "notification",
   topBanner: "topBanner",
   zitadelLogin: "zitadelLogin",

--- a/lib/flags/default_flag_settings.json
+++ b/lib/flags/default_flag_settings.json
@@ -1,7 +1,6 @@
 {
   "addressComplete": false,
   "formTimer": false,
-  "hCaptcha": false,
   "notification": false,
   "topBanner": false,
   "responsesPilot": false,

--- a/lib/validation/hCaptcha.ts
+++ b/lib/validation/hCaptcha.ts
@@ -4,7 +4,9 @@ import { logMessage } from "@lib/logger";
 import { withRetry } from "../utils/retry";
 
 /**
- * Verifies the client hCaptcha token is valid using the hCaptcha API
+ * Verifies the client hCaptcha token is valid using the hCaptcha API.
+ * Block submissions when hCaptcha verification fails, including failed scores, API failures after
+ * retries, missing or expired tokens, and invalid configuration.
  *
  * @param token captcha token to verify
  * @returns boolean true if the token is valid


### PR DESCRIPTION
# Summary | Résumé

This PR removes the hCaptcha feature flag. The reasoning: the feature is not going anywhere and will always be ON. 

## Testing

Open a published form and make sure it submits as expected.