### PR TITLE
fix: Clear relevant rules when removing an Element

### DIFF
--- a/lib/store/helpers/remove/remove.ts
+++ b/lib/store/helpers/remove/remove.ts
@@ -1,4 +1,5 @@
 import { original } from "immer";
+import { cleanChoiceIdsFromRules } from "@gcforms/core";
 import { type TemplateStore } from "../../types";
 import { removeElementById, removeById, removeGroupElement } from "@lib/utils/form-builder";
 
@@ -8,6 +9,13 @@ export const remove: TemplateStore<"remove"> =
     set((state) => {
       state.form.elements = removeElementById(state.form.elements, elementId);
       state.form.layout = removeById(state.form.layout, elementId);
+
+      state.form.elements.forEach((element) => {
+        const rules = element.properties.conditionalRules;
+        if (rules) {
+          element.properties.conditionalRules = cleanChoiceIdsFromRules(String(elementId), rules);
+        }
+      });
 
       if (groupId && state.form.groups) {
         const groups = removeGroupElement({ ...original(state.form.groups) }, groupId, elementId);


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue - See: https://github.com/cds-snc/platform-forms-client/issues/7841

Remove all conditional rules on removing an element.