### PR TITLE
fix: Refresh treeview when deleting a page

### DIFF
--- a/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/headless-treeview/handlers/handleDelete.ts
+++ b/app/(gcforms)/[locale]/(form administration)/form-builder/components/shared/right-panel/headless-treeview/handlers/handleDelete.ts
@@ -45,7 +45,7 @@ export const handleDelete = async (
     autoFlowAll();
     setOpenConfirmDeleteDialog(false);
 
-    tree.rebuildTree();
+    queueMicrotask(() => tree.rebuildTree());
 
     onSuccess && onSuccess();
 


### PR DESCRIPTION
# Summary | Résumé

Fixes #7840

The problem was one of timing - the synchronous rebuildTree function was running too early.

The tree refresh API is tree.rebuildTree(), which was already being called in handleDelete.ts. The issue was that it ran in the same task as the Zustand mutations, while createSafeDataLoader was still holding its cached tree snapshot. Missing items then fell back to displaying their IDs.

The fix was to defer the existing rebuild by one microtask which  lets the loader clear its cache before Headless Tree reloads the structure, so the deleted group and children should disappear rather than render as ID placeholders.
