### PR TITLE
bug: Re-uploading a form file with attachments results in missing upload

### DIFF
--- a/components/clientComponents/forms/ResumeForm/Upload.tsx
+++ b/components/clientComponents/forms/ResumeForm/Upload.tsx
@@ -15,6 +15,7 @@ import { ErrorResuming } from "./ErrorResuming";
 import { ErrorLoading } from "./ErrorLoading";
 import { useLogClient } from "@lib/hooks/LogClient/useLogClient";
 import { ResumeUploadIcon } from "@serverComponents/icons/ResumeUploadIcon";
+import { copyObjectExcludingFileContent } from "@lib/fileExtractor";
 
 // Prevent prototype pollution in JSON.parse https://stackoverflow.com/a/63927372
 const cleaner = (key: string, value: string) =>
@@ -73,15 +74,16 @@ export const Upload = ({ formId }: { formId: string }) => {
     currentGroup,
     responseLanguage,
   }: ResumeFormResponse) => {
+    const { formValuesWithoutFileContent } = copyObjectExcludingFileContent(values, {}, true);
+
     await saveSessionProgress({
       id,
-      values,
+      values: formValuesWithoutFileContent as FormValues,
       currentGroup,
       language: responseLanguage,
       restoredForm: true,
     });
     // Needed to support a hard refresh of the page and not client side routing
-    // eslint-disable-next-line @next/next/no-location-assign-relative-destination
 
     window.location.href = `/${language}/id/${id}`;
   };

--- a/components/clientComponents/forms/ResumeForm/Upload.tsx
+++ b/components/clientComponents/forms/ResumeForm/Upload.tsx
@@ -85,6 +85,7 @@ export const Upload = ({ formId }: { formId: string }) => {
     });
     // Needed to support a hard refresh of the page and not client side routing
 
+    // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = `/${language}/id/${id}`;
   };
 

--- a/lib/fileExtractor.ts
+++ b/lib/fileExtractor.ts
@@ -8,7 +8,7 @@ import {
 
 import { v4 as uuid } from "uuid";
 
-const isFileInput = (response: unknown): response is FileInputResponseWithContent => {
+export const isFileInput = (response: unknown): response is FileInputResponseWithContent => {
   return (
     response !== null &&
     typeof response === "object" &&
@@ -106,6 +106,18 @@ export const copyObjectExcludingFileContent = (
         id,
         name: originalState.name,
         size: originalState.size,
+      } as T;
+    }
+
+    if (
+      nullifyFileInput &&
+      "id" in originalState &&
+      "name" in originalState &&
+      "size" in originalState
+    ) {
+      return {
+        name: null,
+        size: null,
       } as T;
     }
 

--- a/lib/hooks/useGCFormContext.tsx
+++ b/lib/hooks/useGCFormContext.tsx
@@ -147,7 +147,11 @@ export const GCFormsProvider = ({
   };
 
   const getProgressData = () => {
-    const { formValuesWithoutFileContent } = copyObjectExcludingFileContent(values.current);
+    const { formValuesWithoutFileContent } = copyObjectExcludingFileContent(
+      values.current,
+      {},
+      true
+    );
 
     return {
       id: formRecord.id,


### PR DESCRIPTION
# Summary | Résumé

- Ensures we empty out file input fields when html file is download
- Ensures we empty out file inputs for any saved files that pre fixing the nullify issue

Fixes: #7855


BEGIN_COMMIT_OVERRIDE
fix: Re-uploading a form file with attachments results in missing upload
END_COMMIT_OVERRIDE