### PR TITLE
fix: getTemplateVersionState bug fix

### DIFF
--- a/lib/templates/queries/getTemplateVersionState.ts
+++ b/lib/templates/queries/getTemplateVersionState.ts
@@ -26,7 +26,7 @@ export async function getTemplateVersionState(formID: string): Promise<{
     hasDraftVersion: template.isPublished
       ? Boolean(template.currentDraftVersionId)
       : Boolean(template.currentDraftVersionId),
-    currentPublishedVersionId: template.isPublished ? template.currentPublishedVersionId : null,
-    currentDraftVersionId: template.isPublished ? null : template.currentDraftVersionId,
+    currentPublishedVersionId: template.currentPublishedVersionId,
+    currentDraftVersionId: template.currentDraftVersionId,
   };
 }


### PR DESCRIPTION
# Summary | Résumé

In a previous update cleaning up pre-versioning code #7828, some ternary operators were cleaned up incorrectly.
