### PR TITLE
fix: nested styles for details component maintain tag levels

### DIFF
--- a/components/clientComponents/forms/RichText/RichText.test.tsx
+++ b/components/clientComponents/forms/RichText/RichText.test.tsx
@@ -72,12 +72,22 @@ describe("Generate a rich text element", () => {
   it("renders collapsible Markdown blocks", () => {
     const richTextWithCollapsible = { ...richTextData } as FormElement;
     richTextWithCollapsible.properties.descriptionEn =
-      ":::collapsible Learn more about this topic\nAdditional information.\n:::";
+      "Outside paragraph one.\n\nOutside paragraph two.\n\n:::collapsible Learn more about this topic\nAdditional information one.\n\nAdditional information two.\n:::";
 
     render(<GenerateElement element={richTextWithCollapsible} language="en" isTestMode={true} />);
 
-    expect(document.querySelector("details")).toBeInTheDocument();
+    const details = document.querySelector("details");
+    const detailsContent = details?.querySelector(".gc-details-content");
+    const topLevelMarkdown = document.querySelector("[data-testid='richText'] > div");
+
+    expect(details).toBeInTheDocument();
+    expect(detailsContent).toHaveProperty("tagName", "DIV");
+    expect(detailsContent?.querySelector(":scope > div")).not.toBeInTheDocument();
+    expect(Array.from(topLevelMarkdown?.children || []).map((child) => child.tagName)).toEqual(
+      Array.from(detailsContent?.children || []).map((child) => child.tagName)
+    );
     expect(screen.getByText("Learn more about this topic")).toBeInTheDocument();
-    expect(screen.getByText("Additional information.")).toBeInTheDocument();
+    expect(screen.getByText("Additional information one.")).toBeInTheDocument();
+    expect(screen.getByText("Additional information two.")).toBeInTheDocument();
   });
 });

--- a/components/clientComponents/forms/RichText/RichText.tsx
+++ b/components/clientComponents/forms/RichText/RichText.tsx
@@ -116,7 +116,20 @@ const markdownOptions = {
   },
 };
 
-const MarkdownContent = ({ content }: { content: string }): React.ReactElement | null => {
+// Markdown adds a wrapper by default. Nested content already has a block container,
+// so use a fragment to keep its semantic block elements direct children.
+const nestedMarkdownOptions = {
+  ...markdownOptions,
+  wrapper: React.Fragment,
+};
+
+const MarkdownContent = ({
+  content,
+  isNestedContent = false,
+}: {
+  content: string;
+  isNestedContent?: boolean;
+}): React.ReactElement | null => {
   const blocks = splitCollapsibleBlocks(content);
 
   return (
@@ -127,14 +140,17 @@ const MarkdownContent = ({ content }: { content: string }): React.ReactElement |
             <details key={`collapsible-${index}`} open>
               <summary>{stripEntities(block.summary)}</summary>
               <div className="gc-details-content">
-                <MarkdownContent content={block.content} />
+                <MarkdownContent content={block.content} isNestedContent />
               </div>
             </details>
           );
         }
 
         return block.content ? (
-          <Markdown key={`markdown-${index}`} options={markdownOptions}>
+          <Markdown
+            key={`markdown-${index}`}
+            options={isNestedContent ? nestedMarkdownOptions : markdownOptions}
+          >
             {block.content}
           </Markdown>
         ) : null;

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.28] - 2026-09-03
+
+- Remove unneeded styles for details component based on editor package update
+
 ## [2.2.27] - 2026-08-26
 
 - Remove references to groupHistory

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/core",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/src/styles/_details.scss
+++ b/packages/core/src/styles/_details.scss
@@ -57,11 +57,3 @@
   margin: var(--gcds-details-panel-margin);
   border-left: var(--gcds-details-panel-border-width) solid var(--gcds-details-panel-border-color);
 }
-
-.gc-richText details .gc-details-content > :first-child {
-  margin-top: 0;
-}
-
-.gc-richText details .gc-details-content > :last-child {
-  margin-bottom: 0;
-}

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-09-03
+
+- Fix collapsible nested content transformer
+
 ## [1.0.22] - 2026-08-21
 
 - Fix collapsible icon warnings

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcforms/editor",
-  "version": "1.0.22",
+  "version": "2.0.0",
   "author": "Canadian Digital Service",
   "license": "MIT",
   "publishConfig": {

--- a/packages/editor/src/tests/Editor.test.jsx
+++ b/packages/editor/src/tests/Editor.test.jsx
@@ -134,6 +134,76 @@ describe("Lexical Editor", () => {
     );
   });
 
+  it("preserves unordered and ordered list markup when formatting collapsible content", async () => {
+    const onChange = vi.fn();
+    const rendered = render(
+      <Editor
+        content={
+          ":::collapsible Privacy\n- First item\n- Second item\n\n1. Third item\n2. Fourth item\n:::"
+        }
+        ariaLabel="AriaLabel"
+        onChange={onChange}
+      />
+    );
+
+    await act(async () => {
+      await promise;
+    });
+
+    const contentArea = rendered.container.querySelector('[contenteditable="true"]');
+    expect(contentArea?.querySelector(".Collapsible__content ul")).toBeInTheDocument();
+    expect(contentArea?.querySelector(".Collapsible__content ol")).toBeInTheDocument();
+    contentArea?.__lexicalEditor.update(() => {
+      $getRoot()
+        .getFirstChild()
+        ?.getLastChild()
+        ?.getFirstChild()
+        ?.getFirstChild()
+        ?.getFirstChild()
+        ?.selectEnd();
+    });
+
+    await userEvent.click(screen.getByTestId("bold-button"));
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      ":::collapsible Privacy\n- First item\n- Second item\n\n1. Third item\n2. Fourth item\n:::"
+    );
+  });
+
+  it("preserves list nesting when indenting and outdenting collapsible content", async () => {
+    const onChange = vi.fn();
+    const rendered = render(
+      <Editor
+        content={":::collapsible Privacy\n- First item\n- Second item\n:::"}
+        ariaLabel="AriaLabel"
+        onChange={onChange}
+      />
+    );
+
+    await act(async () => {
+      await promise;
+    });
+
+    const contentArea = rendered.container.querySelector('[contenteditable="true"]');
+    contentArea?.__lexicalEditor.update(() => {
+      const list = $getRoot().getFirstChild()?.getLastChild()?.getFirstChild();
+      const secondListItem = list?.getChildren()[1];
+      secondListItem?.getFirstChild()?.selectEnd();
+    });
+
+    await userEvent.click(screen.getByTestId("indent-button"));
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      ":::collapsible Privacy\n- First item\n    - Second item\n:::"
+    );
+
+    await userEvent.click(screen.getByTestId("outdent-button"));
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      ":::collapsible Privacy\n- First item\n- Second item\n:::"
+    );
+  });
+
   it("can keyboard navigate the RichTextEditor", async () => {
     render(
       <div>

--- a/packages/editor/src/tests/Editor.test.jsx
+++ b/packages/editor/src/tests/Editor.test.jsx
@@ -4,6 +4,7 @@
 import React from "react";
 import { cleanup, screen, render, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { $getRoot } from "lexical";
 // import { defaultStore as store, Providers } from "@lib/utils/form-builder/test-utils";
 // import { RichTextEditor } from "../RichTextEditor";
 import { Editor } from "../Editor";
@@ -100,6 +101,36 @@ describe("Lexical Editor", () => {
     );
     expect(rendered.container.querySelector(".Collapsible__content")).toHaveTextContent(
       "Details body"
+    );
+  });
+
+  it("preserves heading markup when formatting collapsible content", async () => {
+    const onChange = vi.fn();
+    const rendered = render(
+      <Editor
+        content={":::collapsible Privacy\nPersonal information\n:::"}
+        ariaLabel="AriaLabel"
+        onChange={onChange}
+      />
+    );
+
+    await act(async () => {
+      await promise;
+    });
+
+    const contentArea = rendered.container.querySelector('[contenteditable="true"]');
+    expect(contentArea).toBeInTheDocument();
+    contentArea?.__lexicalEditor.update(() => {
+      $getRoot().getFirstChild()?.getLastChild()?.getFirstChild()?.selectEnd();
+    });
+
+    await userEvent.click(screen.getByTestId("h2-button"));
+
+    expect(rendered.container.querySelector(".Collapsible__content h2")).toHaveTextContent(
+      "Personal information"
+    );
+    expect(onChange).toHaveBeenLastCalledWith(
+      ":::collapsible Privacy\n## Personal information\n:::"
     );
   });
 

--- a/packages/editor/src/transformers/collapsible.ts
+++ b/packages/editor/src/transformers/collapsible.ts
@@ -3,7 +3,7 @@ import {
   MultilineElementTransformer,
   TRANSFORMERS,
 } from "@lexical/markdown";
-import { $createParagraphNode, $createTextNode } from "lexical";
+import { $createParagraphNode, $createTextNode, $isElementNode } from "lexical";
 import {
   $createCollapsibleContainerNode,
   $createCollapsibleContentNode,
@@ -13,6 +13,7 @@ import {
   $isCollapsibleTitleNode,
   CollapsibleContentNode,
 } from "../plugins/CollapsibleExtension";
+import { $isHeadingNode } from "@lexical/rich-text";
 
 const collapsibleTransformers = () => [...TRANSFORMERS, COLLAPSIBLE];
 
@@ -28,7 +29,19 @@ export const COLLAPSIBLE: MultilineElementTransformer = {
     if (!$isCollapsibleTitleNode(title) || !$isCollapsibleContentNode(content)) return null;
 
     const titleText = title.getTextContent().trim();
-    return `:::collapsible${titleText ? ` ${titleText}` : ""}\n${traverseChildren(content)}\n:::`;
+    const contentText = content
+      .getChildren()
+      .map((child) => {
+        if (!$isElementNode(child)) return child.getTextContent();
+
+        const markdown = traverseChildren(child);
+        return $isHeadingNode(child)
+          ? `${"#".repeat(Number(child.getTag().slice(1)))} ${markdown}`
+          : markdown;
+      })
+      .join("\n\n");
+
+    return `:::collapsible${titleText ? ` ${titleText}` : ""}\n${contentText}\n:::`;
   },
   handleImportAfterStartMatch: ({ rootNode, startMatch, lines, startLineIndex }) => {
     const content: string[] = [];

--- a/packages/editor/src/transformers/collapsible.ts
+++ b/packages/editor/src/transformers/collapsible.ts
@@ -3,7 +3,7 @@ import {
   MultilineElementTransformer,
   TRANSFORMERS,
 } from "@lexical/markdown";
-import { $createParagraphNode, $createTextNode, $isElementNode } from "lexical";
+import { $createParagraphNode, $createTextNode, $isElementNode, type ElementNode } from "lexical";
 import {
   $createCollapsibleContainerNode,
   $createCollapsibleContentNode,
@@ -13,9 +13,19 @@ import {
   $isCollapsibleTitleNode,
   CollapsibleContentNode,
 } from "../plugins/CollapsibleExtension";
-import { $isHeadingNode } from "@lexical/rich-text";
 
 const collapsibleTransformers = () => [...TRANSFORMERS, COLLAPSIBLE];
+
+const exportBlock = (node: ElementNode, traverseChildren: (node: ElementNode) => string) => {
+  for (const transformer of collapsibleTransformers()) {
+    if (transformer.type === "text-format" || transformer.type === "text-match") continue;
+
+    const markdown = transformer.export?.(node, traverseChildren);
+    if (markdown != null) return markdown;
+  }
+
+  return traverseChildren(node);
+};
 
 export const COLLAPSIBLE: MultilineElementTransformer = {
   dependencies: [CollapsibleContentNode],
@@ -34,10 +44,7 @@ export const COLLAPSIBLE: MultilineElementTransformer = {
       .map((child) => {
         if (!$isElementNode(child)) return child.getTextContent();
 
-        const markdown = traverseChildren(child);
-        return $isHeadingNode(child)
-          ? `${"#".repeat(Number(child.getTag().slice(1)))} ${markdown}`
-          : markdown;
+        return exportBlock(child, traverseChildren);
       })
       .join("\n\n");
 


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/platform-forms-client/issues/7816

Updates details component to ensure we maintain header level content.

1) ensures we don't end up with extra wrapping elements for nested details component
2) ensure headings are handled in the markdown transformer

Note I opened a fresh issue https://github.com/cds-snc/platform-forms-client/issues/7870 to fix an issue with h1 tags

## Testing

Paste content from https://docs.google.com/document/d/1_J-Vb45O4WBAoK7H9uBMBUvQJ0SvJ8HAeLCEojJxql0/edit?tab=t.0

Note the heading levels are now preserved
