### PR TITLE
refactor: simplify public form submit flow

### DIFF
--- a/components/clientComponents/forms/Form/Form.test.tsx
+++ b/components/clientComponents/forms/Form/Form.test.tsx
@@ -298,7 +298,7 @@ describe("Form", () => {
     });
   });
 
-  it("does not submit when client validation fails", async () => {
+  it("does not execute hCaptcha or submit when client validation fails", async () => {
     mocks.validateOnSubmit.mockReturnValue({ field: "Required" });
     mocks.getErrorList.mockReturnValue(<div>Required</div>);
 
@@ -308,6 +308,7 @@ describe("Form", () => {
 
     await waitFor(() => expect(mocks.validateOnSubmit).toHaveBeenCalled());
 
+    expect(mocks.executeCaptcha).not.toHaveBeenCalled();
     expect(mocks.submitForm).not.toHaveBeenCalled();
   });
 

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -107,8 +107,8 @@ const SubmittingForm = ({ title, hasFileValues }: { title: string; hasFileValues
 );
 
 /**
- * This is the "inner" form component that isn't connected to Formik and just renders a simple form
- * @param props
+ * The main content of the form, handling rendering of status alerts, form body, and submission states.
+ * @param props - The properties passed down from the parent form component.
  */
 const FormContent: React.FC<FormRenderProps> = (props) => {
   const {

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -36,7 +36,8 @@ import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headle
 import { shouldCheckCaptcha } from "@root/lib/utils/shouldCheckCaptcha";
 import { isSuspiciousHCaptchaError } from "@clientComponents/globals/FormCaptcha/isSuspiciousHCaptchaError";
 import { FormBody } from "./FormBody";
-import { FormStatusAlerts, getFormStatusError } from "./FormStatusAlerts";
+import { FormStatusAlerts } from "./FormStatusAlerts";
+import { getFormStatusError } from "./getFormStatusError";
 
 type CaptchaControls = {
   captcha: React.ReactNode;

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -99,13 +99,6 @@ const getServerSnapshot = () => false;
 const useIsHydrated = () =>
   useSyncExternalStore(subscribeToHydration, getHydratedSnapshot, getServerSnapshot);
 
-const SubmittingForm = ({ title, hasFileValues }: { title: string; hasFileValues: boolean }) => (
-  <>
-    <title>{title}</title>
-    <SubmitProgress spinner={!hasFileValues} />
-  </>
-);
-
 /**
  * The main content of the form, handling rendering of status alerts, form body, and submission states.
  * @param props - The properties passed down from the parent form component.
@@ -153,7 +146,12 @@ const FormContent: React.FC<FormRenderProps> = (props) => {
   }
 
   if (status === "submitting") {
-    return <SubmittingForm title={t("loading")} hasFileValues={hasFiles(props.values)} />;
+    return (
+      <>
+        <title>{t("loading")}</title>
+        <SubmitProgress spinner={!hasFiles(props.values)} />
+      </>
+    );
   }
 
   return (
@@ -194,7 +192,7 @@ const submitFormValues = async (
     return;
   }
 
-  // For groups enabled forms only allow submitting on the Review page
+  // For forms with groups only allow submitting on the Review page
   const isShowReviewPage = showReviewPage(props.formRecord.form);
   if (isShowReviewPage && props.currentGroup !== LOCKED_GROUPS.REVIEW) {
     return;

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -1,18 +1,12 @@
 "use client";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { withFormik, type FormikProps } from "formik";
+import React, { useEffect, useRef, useSyncExternalStore } from "react";
+import { FormikProvider, useFormik, type FormikHelpers } from "formik";
 import { getFormInitialValues } from "@lib/formBuilder";
 import { getErrorList, setFocusOnErrorMessage } from "@lib/validation/validation";
-import { Alert, RichText } from "@clientComponents/forms";
 import { validateOnSubmit } from "@gcforms/core";
-import {
-  HCaptchaForm,
-  type HCaptchaFailureReason,
-  type HCaptchaFormHandle,
-} from "@gcforms/hcaptcha/client";
+import { useHCaptcha, type HCaptchaExecutionResult } from "@gcforms/hcaptcha/client";
 
-import { type FormProps } from "./types";
-import { type Language } from "@lib/types/form-builder-types";
+import { type FormProps, type FormRenderProps } from "./types";
 import { type Responses as FormikResponses } from "@lib/types";
 
 import { EventKeys } from "@lib/hooks/useCustomEvent";
@@ -20,19 +14,14 @@ import { EventKeys } from "@lib/hooks/useCustomEvent";
 import { logMessage } from "@lib/logger";
 import { useTranslation } from "@i18n/client";
 
-import { ErrorStatus } from "@lib/constants";
 import {
   submitForm,
   isFormClosed,
 } from "app/(gcforms)/[locale]/(form filler)/id/[...props]/actions";
 import { useSyncVisibleElementIds } from "@lib/hooks/useSyncVisibleElementIds";
 import { useGCFormsContext } from "@lib/hooks/useGCFormContext";
-import { Review } from "../Review/Review";
-import { StatusError } from "../StatusError/StatusError";
 import { filterValuesByVisibleElements } from "@lib/formContext";
 import { showReviewPage } from "@lib/utils/form-builder/showReviewPage";
-import { FormActions } from "./FormActions";
-import { PrimaryFormButtons } from "./PrimaryFormButtons";
 import { FormStatus, type FormValues } from "@gcforms/types";
 import { CaptchaFail } from "@clientComponents/globals/FormCaptcha/CaptchaFail";
 import { ga } from "@lib/client/clientHelpers";
@@ -43,125 +32,54 @@ import { generateFileChecksums } from "@lib/utils/fileChecksum";
 import { copyObjectExcludingFileContent } from "@lib/fileExtractor";
 import { uploadFile } from "@root/app/(gcforms)/[locale]/(form filler)/id/[...props]/lib/client/fileUploader";
 
-import { SaveAndResumeButton } from "@clientComponents/forms/SaveAndResume/SaveAndResumeButton";
 import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headless-treeview/constants";
 import { shouldCheckCaptcha } from "@root/lib/utils/shouldCheckCaptcha";
 import { isSuspiciousHCaptchaError } from "@clientComponents/globals/FormCaptcha/isSuspiciousHCaptchaError";
+import { FormBody } from "./FormBody";
+import { FormStatusAlerts, getFormStatusError } from "./FormStatusAlerts";
 
-type InternalCaptchaProps = {
-  onCaptchaReset: () => void;
-  setCaptchaToken: (token: string | undefined) => void;
-  setCaptchaFormHandle: (handle: HCaptchaFormHandle | null) => void;
-  getCaptchaToken: () => string | undefined;
+type CaptchaControls = {
+  captcha: React.ReactNode;
+  captchaEnabled: boolean;
+  executeCaptcha: () => Promise<HCaptchaExecutionResult>;
+  resetCaptcha: () => void;
 };
 
-type InternalFormProps = FormProps & InternalCaptchaProps;
-type InternalInnerFormProps = InternalFormProps & FormikProps<FormikResponses>;
+const useFormErrorFocus = (
+  props: FormRenderProps,
+  formStatusError: string | true | null,
+  errorList: ReturnType<typeof getErrorList> | null,
+  errorId: string,
+  serverErrorId: string
+) => {
+  const lastSubmitCountRef = useRef(props.submitCount);
+  const focusOnValidationErrorRef = useRef(false);
 
-/**
- * This is the "inner" form component that isn't connected to Formik and just renders a simple form
- * @param props
- */
-const InnerForm: React.FC<InternalInnerFormProps> = (props) => {
-  const {
-    children,
-    submitForm,
-    setCaptchaFormHandle,
-    status,
-    language,
-    formRecord: { id: formID, form, isPublished },
-    dirty,
-    setErrors,
-  }: InternalInnerFormProps = props;
-
-  const { t } = useTranslation();
-  const [canFocusOnError, setCanFocusOnError] = useState(false);
-  const [lastSubmitCount, setLastSubmitCount] = useState(-1);
-  const [isServer, setIsServer] = useState(true);
-
-  const { currentGroup, getGroupTitle } = useGCFormsContext();
-  const isShowReviewPage = showReviewPage(form);
-  const showIntro = currentGroup === LOCKED_GROUPS.START;
-
-  // Clear validation errors when switching groups (pages)
-  useEffect(() => {
-    setErrors({});
-  }, [currentGroup, setErrors]);
-  
-  const handleCaptchaFailure = (reason: HCaptchaFailureReason) => {
-    props.setCaptchaToken(undefined);
-
-    if (reason === "load-error") {
-      props.onCaptchaReset();
-    }
-
-    if (reason !== "cancelled") {
-      props.setStatus(FormStatus.ERROR);
-    }
-  };
-
-  const handleCaptchaError = (code: string) => {
-    if (isSuspiciousHCaptchaError(code)) {
-      logMessage.warn(
-        `hCaptcha: suspicious error "${code}" detected - possible tampering. Submission blocked. Resetting widget state.`
-      );
-      props.setCaptchaFail?.(true);
-    } else if (code === "invalid-sitekey" || code === "missing-sitekey") {
-      logMessage.error(`hCaptcha: critical configuration error "${code}". Submission blocked.`);
-    } else {
-      logMessage.warn(`hCaptcha: recoverable error "${code}" - user can retry submission`);
-    }
-  };
-
-  // Used to set any values we'd like added for use in the below withFormik handleSubmit().
-  useSyncVisibleElementIds();
-
-  const errorList = props.errors ? getErrorList({ ...props, currentGroup }) : null;
-  const errorId = "gc-form-errors";
-  const serverErrorId = `${errorId}-server`;
-
-  let formStatusError = null;
-  if (typeof props.status === "object" && props.status !== null) {
-    // We have a "complex" `status`
-    // This used when we want to include a heading and message
-    // The error handling function set the error strings for us ref: handleUploadErrors.
-    formStatusError = true; // set to `true` to show the Alert and let the UI handle the strings
-  } else if (props.status === FormStatus.CAPTCHA_VERIFICATION_ERROR) {
-  } else if (props.status === FormStatus.ERROR) {
-    formStatusError = t("server-error");
-  } else if (props.status === FormStatus.FORM_CLOSED_ERROR) {
-    formStatusError =
-      (language === "en"
-        ? props.formRecord.closedDetails?.messageEn
-        : props.formRecord.closedDetails?.messageFr) || t("form-closed-error");
-  }
-
-  /* Add save to device button as CTA  if the feature is enabled */
-  const cta = props.saveAndResumeEnabled ? (
-    <SaveAndResumeButton language={language as Language} />
-  ) : null;
-
-  //  If there are errors on the page, set focus the first error field
   useEffect(() => {
     if (formStatusError) {
       setFocusOnErrorMessage(props, serverErrorId);
     }
 
-    if (!props.isValid && !canFocusOnError) {
-      if (props.submitCount > lastSubmitCount) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setCanFocusOnError(true);
-        setLastSubmitCount(props.submitCount);
-      }
-    } else if (!props.isValid) {
-      setFocusOnErrorMessage(props, errorId);
-      setCanFocusOnError(false);
+    if (props.isValid) {
+      lastSubmitCountRef.current = props.submitCount;
+      return;
+    }
+
+    const shouldFocusValidationError =
+      props.submitCount > lastSubmitCountRef.current || focusOnValidationErrorRef.current;
+
+    if (shouldFocusValidationError) {
+      lastSubmitCountRef.current = props.submitCount;
+      focusOnValidationErrorRef.current = false;
+      queueMicrotask(() => setFocusOnErrorMessage(props, errorId));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formStatusError, errorList, lastSubmitCount, canFocusOnError]);
+  }, [formStatusError, errorList, props.isValid, props.submitCount]);
 
   useEffect(() => {
-    const handleContinueValidationError = () => setCanFocusOnError(true);
+    const handleContinueValidationError = () => {
+      focusOnValidationErrorRef.current = true;
+    };
 
     document.addEventListener(EventKeys.continueValidationError, handleContinueValidationError);
 
@@ -172,17 +90,58 @@ const InnerForm: React.FC<InternalInnerFormProps> = (props) => {
       );
     };
   }, []);
+};
 
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsServer(false);
-    }
-  }, [setIsServer]);
+const subscribeToHydration = () => () => {};
+const getHydratedSnapshot = () => true;
+const getServerSnapshot = () => false;
+const useIsHydrated = () =>
+  useSyncExternalStore(subscribeToHydration, getHydratedSnapshot, getServerSnapshot);
+
+const SubmittingForm = ({ title, hasFileValues }: { title: string; hasFileValues: boolean }) => (
+  <>
+    <title>{title}</title>
+    <SubmitProgress spinner={!hasFileValues} />
+  </>
+);
+
+/**
+ * This is the "inner" form component that isn't connected to Formik and just renders a simple form
+ * @param props
+ */
+const FormContent: React.FC<FormRenderProps> = (props) => {
+  const {
+    status,
+    language,
+    formRecord: { id: formID, form },
+    dirty,
+  }: FormRenderProps = props;
+
+  const { t } = useTranslation();
+  const isHydrated = useIsHydrated();
+
+  const { currentGroup, getGroupTitle } = useGCFormsContext();
+  const isShowReviewPage = showReviewPage(form);
+  const showIntro = currentGroup === LOCKED_GROUPS.START;
+
+  // Used to set any values we'd like available during Formik submission.
+  useSyncVisibleElementIds();
+
+  const errorList = props.errors ? getErrorList(props) : null;
+  const errorId = "gc-form-errors";
+  const serverErrorId = `${errorId}-server`;
+  const formStatusError = getFormStatusError(
+    props,
+    language,
+    t("server-error"),
+    t("form-closed-error")
+  );
+
+  useFormErrorFocus(props, formStatusError, errorList, errorId, serverErrorId);
 
   // Don't prerender the form on the server because inputs will change and cause
   // hydration errors based on state stored client side
-  if (isServer) {
+  if (!isHydrated) {
     return <div className="h-[150dvh]" />;
   }
 
@@ -192,313 +151,245 @@ const InnerForm: React.FC<InternalInnerFormProps> = (props) => {
     return <CaptchaFail />;
   }
 
-  return status === "submitting" ? (
+  if (status === "submitting") {
+    return <SubmittingForm title={t("loading")} hasFileValues={hasFiles(props.values)} />;
+  }
+
+  return (
     <>
-      <title>{t("loading")}</title>
-      <SubmitProgress spinner={!hasFiles(props.values)} />
-    </>
-  ) : (
-    <>
-      {formStatusError && (
-        <Alert
-          type={ErrorStatus.ERROR}
-          heading={props.status?.heading ? props.status.heading : formStatusError}
-          id={serverErrorId}
-          focussable={true}
-          cta={cta}
-        >
-          <>{props.status?.message && <p className="mb-4">{props.status?.message}</p>}</>
-        </Alert>
-      )}
+      <FormStatusAlerts
+        props={props}
+        formStatusError={formStatusError}
+        errorList={errorList}
+        serverErrorId={serverErrorId}
+        errorId={errorId}
+        language={language}
+        formID={formID}
+      />
 
-      {/* ServerId error */}
-      {props.status === FormStatus.SERVER_ID_ERROR && (
-        <StatusError formId={formID} language={language as Language} />
-      )}
-
-      {errorList && (
-        <Alert
-          type={ErrorStatus.ERROR}
-          heading={t("input-validation.heading", {
-            lng: language,
-          })}
-          validation={true}
-          id={errorId}
-          focussable={true}
-        >
-          {errorList}
-        </Alert>
-      )}
-
-      {
-        <>
-          {showIntro && (
-            <RichText>
-              {form.introduction &&
-                form.introduction[props.language == "en" ? "descriptionEn" : "descriptionFr"]}
-            </RichText>
-          )}
-
-          {/* Policy shows before form elements when groups are on */}
-          {showIntro && (
-            <RichText>
-              {form.privacyPolicy &&
-                form.privacyPolicy[props.language == "en" ? "descriptionEn" : "descriptionFr"]}
-            </RichText>
-          )}
-
-          <HCaptchaForm
-            ref={setCaptchaFormHandle}
-            id="form"
-            data-testid="form"
-            language={language}
-            onSubmit={(_event, token) => {
-              props.setCaptchaToken(token);
-              return submitForm();
-            }}
-            onCaptchaVerified={() =>
-              logMessage.info(
-                `hCaptcha: verified token received by form at ${new Date().toISOString()}`
-              )
-            }
-            noValidate={true}
-            captchaEnabled={shouldCheckCaptcha(isPublished, props.isPreview ?? false)}
-            siteKey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY || ""}
-            onCaptchaFailure={handleCaptchaFailure}
-            onError={handleCaptchaError}
-            onUnexpectedError={(error) => logMessage.error(error as Error)}
-          >
-            {isShowReviewPage &&
-              currentGroup !== LOCKED_GROUPS.REVIEW &&
-              currentGroup !== LOCKED_GROUPS.START && (
-                // Let the buttons and other logic control the focus to avoid conflicting with the
-                // error validation focus
-                <h2 tabIndex={-1} data-group={currentGroup || "default"} data-testid="focus-h2">
-                  {getGroupTitle(currentGroup, language as Language)}
-                </h2>
-              )}
-
-            {children}
-
-            {isShowReviewPage && currentGroup === LOCKED_GROUPS.REVIEW && (
-              <Review language={language as Language} />
-            )}
-
-            <FormActions
-              saveAndResumeEnabled={props.saveAndResumeEnabled || false}
-              formId={formID}
-              language={language as Language}
-              form={form}
-              dirty={dirty}
-            >
-              <PrimaryFormButtons
-                saveAndResumeEnabled={props.saveAndResumeEnabled || false}
-                isShowReviewPage={isShowReviewPage}
-                language={language}
-                props={props}
-              />
-            </FormActions>
-          </HCaptchaForm>
-        </>
-      }
+      <FormBody
+        props={props}
+        formID={formID}
+        form={form}
+        dirty={dirty}
+        currentGroup={currentGroup}
+        getGroupTitle={getGroupTitle}
+        isShowReviewPage={isShowReviewPage}
+        showIntro={showIntro}
+      />
     </>
   );
 };
 
-/**
- * This is the main Form component that wraps "InnerForm" withFormik hook, giving all of its components context
- * @param props
- */
-const InternalForm = withFormik<InternalFormProps, FormikResponses>({
-  validateOnChange: false,
+const submitFormValues = async (
+  values: FormikResponses,
+  formikBag: FormikHelpers<FormikResponses>,
+  props: FormProps,
+  { captchaEnabled, executeCaptcha, resetCaptcha }: Omit<CaptchaControls, "captcha">
+) => {
+  // If the form is closed, do not allow submission
+  if (await isFormClosed(props.formRecord.id)) {
+    formikBag.setStatus(FormStatus.FORM_CLOSED_ERROR);
+    return;
+  }
 
-  validateOnBlur: false,
+  // For groups enabled forms only allow submitting on the Review page
+  const isShowReviewPage = showReviewPage(props.formRecord.form);
+  if (isShowReviewPage && props.currentGroup !== LOCKED_GROUPS.REVIEW) {
+    return;
+  }
 
-  enableReinitialize: true, // needed when switching languages
+  try {
+    let captchaToken: string | undefined;
+    if (captchaEnabled) {
+      const captchaResult = await executeCaptcha();
 
-  mapPropsToValues: (props) => {
-    if (props.initialValues) {
-      return props.initialValues;
-    }
-    return getFormInitialValues(props.formRecord, props.language);
-  },
-
-  validate: (values, props) => validateOnSubmit(values, props),
-
-  handleSubmit: async (values, formikBag) => {
-    // If the form is closed, do not allow submission
-    if (await isFormClosed(formikBag.props.formRecord.id)) {
-      formikBag.setStatus(FormStatus.FORM_CLOSED_ERROR);
-      return;
-    }
-
-    // For groups enabled forms only allow submitting on the Review page
-    const isShowReviewPage = showReviewPage(formikBag.props.formRecord.form);
-    if (isShowReviewPage && formikBag.props.currentGroup !== LOCKED_GROUPS.REVIEW) {
-      return;
-    }
-
-    // Needed so the Loader is displayed
-    formikBag.setStatus("submitting");
-    try {
-      const formValues = filterValuesByVisibleElements(
-        formikBag.props.formRecord,
-        values as FormValues
-      );
-
-      // Extract file content from formValues so they are not part of the submission call to the submit action
-      const { formValuesWithoutFileContent, fileObjsRef } =
-        copyObjectExcludingFileContent(formValues);
-
-      const fileChecksums = await generateFileChecksums(fileObjsRef);
-      let submitProgress = 0;
-      let progressInterval: NodeJS.Timeout | undefined = undefined;
-
-      if (hasFiles(values)) {
-        progressInterval = setInterval(() => {
-          if (submitProgress <= 0.1) {
-            submitProgress += 0.02;
-            document.dispatchEvent(
-              new CustomEvent(EventKeys.submitProgress, {
-                detail: {
-                  progress: submitProgress,
-                  message: formikBag.props.t("submitProgress.text"),
-                },
-              })
-            );
-          } else {
-            clearInterval(progressInterval);
-          }
-        }, 500);
-      }
-
-      const result = await submitForm(
-        formValuesWithoutFileContent,
-        formikBag.props.language,
-        formikBag.props.formRecord.id,
-        formikBag.props.isPreview ?? false,
-        formikBag.props.getCaptchaToken(),
-        fileChecksums
-      );
-
-      clearInterval(progressInterval);
-
-      // Start here to upload files and handle errors below into something easier to read
-
-      if (result.error) {
-        if (result.error.name === FormStatus.CAPTCHA_VERIFICATION_ERROR) {
-          formikBag.setStatus(FormStatus.CAPTCHA_VERIFICATION_ERROR);
-          formikBag.props.setCaptchaFail && formikBag.props.setCaptchaFail(true);
-        } else {
-          formikBag.setStatus(FormStatus.ERROR);
+      if (!captchaResult.verified) {
+        if (captchaResult.reason === "load-error") {
+          resetCaptcha();
         }
 
-        // Avoid a potential error where a token could be reused by re-submitting after an error
-        formikBag.props.onCaptchaReset();
+        if (captchaResult.reason !== "cancelled") {
+          formikBag.setStatus(FormStatus.ERROR);
+        }
 
         return;
       }
 
-      if (
-        (!result.fileURLMap ? 0 : Object.keys(result.fileURLMap).length) !==
-        Object.keys(fileObjsRef).length
-      ) {
-        logMessage.error("File Upload count mismatch");
+      captchaToken = captchaResult.token;
+    }
+
+    // Needed so the Loader is displayed after hCaptcha has completed and submission starts
+    formikBag.setStatus("submitting");
+
+    const formValues = filterValuesByVisibleElements(props.formRecord, values as FormValues);
+
+    // Extract file content from formValues so they are not part of the submission call to the submit action
+    const { formValuesWithoutFileContent, fileObjsRef } =
+      copyObjectExcludingFileContent(formValues);
+
+    const fileChecksums = await generateFileChecksums(fileObjsRef);
+    let submitProgress = 0;
+    let progressInterval: NodeJS.Timeout | undefined = undefined;
+
+    if (hasFiles(values)) {
+      progressInterval = setInterval(() => {
+        if (submitProgress <= 0.1) {
+          submitProgress += 0.02;
+          document.dispatchEvent(
+            new CustomEvent(EventKeys.submitProgress, {
+              detail: {
+                progress: submitProgress,
+                message: props.t("submitProgress.text"),
+              },
+            })
+          );
+        } else {
+          clearInterval(progressInterval);
+        }
+      }, 500);
+    }
+
+    const result = await submitForm(
+      formValuesWithoutFileContent,
+      props.language,
+      props.formRecord.id,
+      props.isPreview ?? false,
+      captchaToken,
+      fileChecksums
+    );
+
+    clearInterval(progressInterval);
+
+    // Start here to upload files and handle errors below into something easier to read
+
+    if (result.error) {
+      if (result.error.name === FormStatus.CAPTCHA_VERIFICATION_ERROR) {
+        formikBag.setStatus(FormStatus.CAPTCHA_VERIFICATION_ERROR);
+        props.setCaptchaFail && props.setCaptchaFail(true);
+      } else {
         formikBag.setStatus(FormStatus.ERROR);
       }
 
-      // Handle if there are files to upload
-      if (result.fileURLMap && Object.keys(result?.fileURLMap).length > 0) {
-        const totalFiles = Object.keys(result.fileURLMap).length;
-        const fileProgress: { [key: string]: number } = {};
-
-        const uploadPromises = Object.entries(result.fileURLMap).map(
-          async ([fileId, signedPost]) => {
-            fileProgress[fileId] = 0;
-            await uploadFile(fileObjsRef[fileId], signedPost, (ev) => {
-              if (!ev.progress || !document) return;
-
-              fileProgress[fileId] = ev.progress;
-              const totalProgress =
-                Object.values(fileProgress).reduce((acc, progress) => acc + progress, 0) /
-                totalFiles;
-
-              if (totalProgress <= submitProgress) {
-                // Don't dispatch progress events if the total progress is less than what we've already dispatched
-                return;
-              }
-
-              document.dispatchEvent(
-                new CustomEvent(EventKeys.submitProgress, {
-                  detail: {
-                    progress: totalProgress,
-                    message: formikBag.props.t("submitProgress.uploadingFiles", {
-                      totalFiles,
-                    }),
-                  },
-                })
-              );
-            });
-          }
-        );
-
-        await Promise.all(uploadPromises);
-      }
-
-      formikBag.props.onSuccess(result.id, result?.submissionId);
-    } catch (err) {
-      logMessage.error(err as Error);
-
-      const fileUploadError = handleUploadError(err as Error, formikBag.props.t);
-
-      if (fileUploadError) {
-        formikBag.setStatus({
-          heading: fileUploadError.heading,
-          message: fileUploadError.message,
-        });
-      } else {
-        formikBag.setStatus("Error");
-      }
-
       // Avoid a potential error where a token could be reused by re-submitting after an error
-      formikBag.props.onCaptchaReset();
-    } finally {
-      if (formikBag.props && !formikBag.props.isPreview) {
-        ga("form_submission_trigger", {
-          formID: formikBag.props.formRecord.id,
-          formTitle: formikBag.props.formRecord.form.titleEn,
-        });
-      }
+      resetCaptcha();
 
-      formikBag.setSubmitting(false);
+      return;
     }
-  },
-})(InnerForm);
 
-// Keep the CAPTCHA handle outside the Formik higher-order component so its submit handler
-// can access the token and reset it
+    if (
+      (!result.fileURLMap ? 0 : Object.keys(result.fileURLMap).length) !==
+      Object.keys(fileObjsRef).length
+    ) {
+      logMessage.error("File Upload count mismatch");
+      formikBag.setStatus(FormStatus.ERROR);
+    }
+
+    // Handle if there are files to upload
+    if (result.fileURLMap && Object.keys(result?.fileURLMap).length > 0) {
+      const totalFiles = Object.keys(result.fileURLMap).length;
+      const fileProgress: { [key: string]: number } = {};
+
+      const uploadPromises = Object.entries(result.fileURLMap).map(async ([fileId, signedPost]) => {
+        fileProgress[fileId] = 0;
+        await uploadFile(fileObjsRef[fileId], signedPost, (ev) => {
+          if (!ev.progress || !document) return;
+
+          fileProgress[fileId] = ev.progress;
+          const totalProgress =
+            Object.values(fileProgress).reduce((acc, progress) => acc + progress, 0) / totalFiles;
+
+          if (totalProgress <= submitProgress) {
+            // Don't dispatch progress events if the total progress is less than what we've already dispatched
+            return;
+          }
+
+          document.dispatchEvent(
+            new CustomEvent(EventKeys.submitProgress, {
+              detail: {
+                progress: totalProgress,
+                message: props.t("submitProgress.uploadingFiles", {
+                  totalFiles,
+                }),
+              },
+            })
+          );
+        });
+      });
+
+      await Promise.all(uploadPromises);
+    }
+
+    props.onSuccess(result.id, result?.submissionId);
+  } catch (err) {
+    logMessage.error(err as Error);
+
+    const fileUploadError = handleUploadError(err as Error, props.t);
+
+    if (fileUploadError) {
+      formikBag.setStatus({
+        heading: fileUploadError.heading,
+        message: fileUploadError.message,
+      });
+    } else {
+      formikBag.setStatus("Error");
+    }
+
+    // Avoid a potential error where a token could be reused by re-submitting after an error
+    resetCaptcha();
+  } finally {
+    if (!props.isPreview) {
+      ga("form_submission_trigger", {
+        formID: props.formRecord.id,
+        formTitle: props.formRecord.form.titleEn,
+      });
+    }
+
+    formikBag.setSubmitting(false);
+  }
+};
+
 export const Form: React.FC<FormProps> = (props) => {
-  const captchaFormRef = useRef<HCaptchaFormHandle | null>(null);
-  const captchaTokenRef = useRef<string | undefined>(undefined);
-  const setCaptchaFormHandle = useCallback((handle: HCaptchaFormHandle | null) => {
-    captchaFormRef.current = handle;
-  }, []);
-  const getCaptchaToken = useCallback(() => captchaTokenRef.current, []);
-  const setCaptchaToken = useCallback((token: string | undefined) => {
-    captchaTokenRef.current = token;
-  }, []);
-  const onCaptchaReset = useCallback(() => {
-    captchaTokenRef.current = undefined;
-    captchaFormRef.current?.reset();
-  }, []);
+  const { setCaptchaFail } = props;
+  const captchaEnabled = shouldCheckCaptcha(props.formRecord.isPublished, props.isPreview ?? false);
+  const handleCaptchaError = (code: string) => {
+    if (isSuspiciousHCaptchaError(code)) {
+      logMessage.warn(
+        `hCaptcha: suspicious error "${code}" detected - possible tampering. Submission blocked. Resetting widget state.`
+      );
+      setCaptchaFail?.(true);
+    } else if (code === "invalid-sitekey" || code === "missing-sitekey") {
+      logMessage.error(`hCaptcha: critical configuration error "${code}". Submission blocked.`);
+    } else {
+      logMessage.warn(`hCaptcha: recoverable error "${code}" - user can retry submission`);
+    }
+  };
+
+  const { captcha, execute, reset } = useHCaptcha({
+    language: props.language,
+    onCaptchaVerified: () =>
+      logMessage.info(`hCaptcha: verified token received by form at ${new Date().toISOString()}`),
+    onError: handleCaptchaError,
+    siteKey: process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY || "",
+  });
+
+  const formik = useFormik<FormikResponses>({
+    validateOnChange: false,
+    validateOnBlur: false,
+    enableReinitialize: true, // needed when switching languages
+    initialValues: props.initialValues ?? getFormInitialValues(props.formRecord, props.language),
+    validate: (values) => validateOnSubmit(values, props),
+    onSubmit: (values, formikBag) =>
+      submitFormValues(values, formikBag, props, {
+        captchaEnabled,
+        executeCaptcha: execute,
+        resetCaptcha: reset,
+      }),
+  });
 
   return (
-    <InternalForm
-      {...props}
-      setCaptchaFormHandle={setCaptchaFormHandle}
-      setCaptchaToken={setCaptchaToken}
-      getCaptchaToken={getCaptchaToken}
-      onCaptchaReset={onCaptchaReset}
-    />
+    <FormikProvider value={formik}>
+      <FormContent {...props} {...formik} captcha={captcha} captchaEnabled={captchaEnabled} />
+    </FormikProvider>
   );
 };

--- a/components/clientComponents/forms/Form/FormBody.tsx
+++ b/components/clientComponents/forms/Form/FormBody.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { RichText } from "@clientComponents/forms";
+import { type Language } from "@lib/types/form-builder-types";
+import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headless-treeview/constants";
+
+import { Review } from "../Review/Review";
+import { FormActions } from "./FormActions";
+import { PrimaryFormButtons } from "./PrimaryFormButtons";
+import { type FormRenderProps } from "./types";
+
+const FormIntro = ({
+  form,
+  language,
+}: {
+  form: FormRenderProps["formRecord"]["form"];
+  language: string;
+}) => (
+  <>
+    <RichText>
+      {form.introduction && form.introduction[language == "en" ? "descriptionEn" : "descriptionFr"]}
+    </RichText>
+    <RichText>
+      {form.privacyPolicy &&
+        form.privacyPolicy[language == "en" ? "descriptionEn" : "descriptionFr"]}
+    </RichText>
+  </>
+);
+
+export const FormBody = ({
+  props,
+  formID,
+  form,
+  dirty,
+  currentGroup,
+  getGroupTitle,
+  isShowReviewPage,
+  showIntro,
+}: {
+  props: FormRenderProps;
+  formID: string;
+  form: FormRenderProps["formRecord"]["form"];
+  dirty: FormRenderProps["dirty"];
+  currentGroup: string | null;
+  getGroupTitle: (groupId: string | null, language: Language) => string;
+  isShowReviewPage: boolean;
+  showIntro: boolean;
+}) => {
+  const { children, handleSubmit, language } = props;
+  const showGroupHeading =
+    isShowReviewPage &&
+    currentGroup !== LOCKED_GROUPS.REVIEW &&
+    currentGroup !== LOCKED_GROUPS.START;
+  const showReview = isShowReviewPage && currentGroup === LOCKED_GROUPS.REVIEW;
+
+  return (
+    <>
+      {showIntro && <FormIntro form={form} language={language} />}
+
+      <form id="form" data-testid="form" noValidate={true} onSubmit={handleSubmit}>
+        {showGroupHeading && (
+          <h2 tabIndex={-1} data-group={currentGroup || "default"} data-testid="focus-h2">
+            {getGroupTitle(currentGroup, language as Language)}
+          </h2>
+        )}
+
+        {children}
+
+        {showReview && <Review language={language as Language} />}
+
+        <FormActions
+          saveAndResumeEnabled={props.saveAndResumeEnabled || false}
+          formId={formID}
+          language={language as Language}
+          form={form}
+          dirty={dirty}
+        >
+          <PrimaryFormButtons
+            saveAndResumeEnabled={props.saveAndResumeEnabled || false}
+            isShowReviewPage={isShowReviewPage}
+            language={language}
+            props={props}
+          />
+        </FormActions>
+        {props.captchaEnabled && props.captcha}
+      </form>
+    </>
+  );
+};

--- a/components/clientComponents/forms/Form/FormStatusAlerts.tsx
+++ b/components/clientComponents/forms/Form/FormStatusAlerts.tsx
@@ -8,35 +8,6 @@ import { StatusError } from "../StatusError/StatusError";
 
 import { type FormRenderProps } from "./types";
 
-export const getFormStatusError = (
-  props: FormRenderProps,
-  language: string,
-  serverError: string,
-  formClosedError: string
-) => {
-  if (typeof props.status === "object" && props.status !== null) {
-    return true;
-  }
-
-  if (props.status === FormStatus.CAPTCHA_VERIFICATION_ERROR) {
-    return null;
-  }
-
-  if (props.status === FormStatus.ERROR) {
-    return serverError;
-  }
-
-  if (props.status === FormStatus.FORM_CLOSED_ERROR) {
-    return (
-      (language === "en"
-        ? props.formRecord.closedDetails?.messageEn
-        : props.formRecord.closedDetails?.messageFr) || formClosedError
-    );
-  }
-
-  return null;
-};
-
 export const FormStatusAlerts = ({
   props,
   formStatusError,

--- a/components/clientComponents/forms/Form/FormStatusAlerts.tsx
+++ b/components/clientComponents/forms/Form/FormStatusAlerts.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { Alert } from "@clientComponents/forms";
+import { ErrorStatus } from "@lib/constants";
+import { type Language } from "@lib/types/form-builder-types";
+import { FormStatus } from "@gcforms/types";
+import { SaveAndResumeButton } from "@clientComponents/forms/SaveAndResume/SaveAndResumeButton";
+import { StatusError } from "../StatusError/StatusError";
+
+import { type FormRenderProps } from "./types";
+
+export const getFormStatusError = (
+  props: FormRenderProps,
+  language: string,
+  serverError: string,
+  formClosedError: string
+) => {
+  if (typeof props.status === "object" && props.status !== null) {
+    return true;
+  }
+
+  if (props.status === FormStatus.CAPTCHA_VERIFICATION_ERROR) {
+    return null;
+  }
+
+  if (props.status === FormStatus.ERROR) {
+    return serverError;
+  }
+
+  if (props.status === FormStatus.FORM_CLOSED_ERROR) {
+    return (
+      (language === "en"
+        ? props.formRecord.closedDetails?.messageEn
+        : props.formRecord.closedDetails?.messageFr) || formClosedError
+    );
+  }
+
+  return null;
+};
+
+export const FormStatusAlerts = ({
+  props,
+  formStatusError,
+  errorList,
+  serverErrorId,
+  errorId,
+  language,
+  formID,
+}: {
+  props: FormRenderProps;
+  formStatusError: string | true | null;
+  errorList: React.ReactNode;
+  serverErrorId: string;
+  errorId: string;
+  language: string;
+  formID: string;
+}) => {
+  const cta = props.saveAndResumeEnabled ? (
+    <SaveAndResumeButton language={language as Language} />
+  ) : null;
+
+  return (
+    <>
+      {formStatusError && (
+        <Alert
+          type={ErrorStatus.ERROR}
+          heading={props.status?.heading ? props.status.heading : formStatusError}
+          id={serverErrorId}
+          focussable={true}
+          cta={cta}
+        >
+          <>{props.status?.message && <p className="mb-4">{props.status?.message}</p>}</>
+        </Alert>
+      )}
+
+      {props.status === FormStatus.SERVER_ID_ERROR && (
+        <StatusError formId={formID} language={language as Language} />
+      )}
+
+      {errorList && (
+        <Alert
+          type={ErrorStatus.ERROR}
+          heading={props.t("input-validation.heading", {
+            lng: language,
+          })}
+          validation={true}
+          id={errorId}
+          focussable={true}
+        >
+          {errorList}
+        </Alert>
+      )}
+    </>
+  );
+};

--- a/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
+++ b/components/clientComponents/forms/Form/PrimaryFormButtons.tsx
@@ -2,7 +2,7 @@ import { Language } from "@lib/types/form-builder-types";
 import { BackButton } from "@formBuilder/[id]/preview/BackButton";
 import { BackButtonGroup } from "../BackButtonGroup/BackButtonGroup";
 import { SubmitButton } from "./SubmitButton";
-import { InnerFormProps } from "./types";
+import { FormWithFormikProps } from "./types";
 import { FormStatus } from "@gcforms/types";
 
 const isFormClosed = (status: FormStatus) => {
@@ -17,7 +17,7 @@ export const PrimaryFormButtons = ({
 }: {
   isShowReviewPage: boolean;
   language: string;
-  props: InnerFormProps;
+  props: FormWithFormikProps;
   saveAndResumeEnabled?: boolean;
 }) => {
   const submissionError =

--- a/components/clientComponents/forms/Form/getFormStatusError.ts
+++ b/components/clientComponents/forms/Form/getFormStatusError.ts
@@ -1,0 +1,32 @@
+import { FormStatus } from "@gcforms/types";
+
+import { type FormRenderProps } from "./types";
+
+export const getFormStatusError = (
+  props: FormRenderProps,
+  language: string,
+  serverError: string,
+  formClosedError: string
+) => {
+  if (typeof props.status === "object" && props.status !== null) {
+    return true;
+  }
+
+  if (props.status === FormStatus.CAPTCHA_VERIFICATION_ERROR) {
+    return null;
+  }
+
+  if (props.status === FormStatus.ERROR) {
+    return serverError;
+  }
+
+  if (props.status === FormStatus.FORM_CLOSED_ERROR) {
+    return (
+      (language === "en"
+        ? props.formRecord.closedDetails?.messageEn
+        : props.formRecord.closedDetails?.messageFr) || formClosedError
+    );
+  }
+
+  return null;
+};

--- a/components/clientComponents/forms/Form/types.ts
+++ b/components/clientComponents/forms/Form/types.ts
@@ -24,4 +24,9 @@ export interface FormProps {
   captchaFail?: boolean;
 }
 
-export type InnerFormProps = FormProps & FormikProps<Responses>;
+export type FormWithFormikProps = FormProps & FormikProps<Responses>;
+
+export type FormRenderProps = FormWithFormikProps & {
+  captcha: React.ReactNode;
+  captchaEnabled: boolean;
+};


### PR DESCRIPTION
## Summary
- Replaces the `withFormik` wrapper with `useFormik` while preserving Formik context via `FormikProvider`.
- Uses `useHCaptcha` directly inside the Formik submit path instead of bridging through `HCaptchaForm` refs/tokens.
- Extracts `FormBody` and `FormStatusAlerts` so `Form.tsx` focuses on lifecycle and submission orchestration.
- Updates the characterization test in this stack layer to assert the intentional ordering improvement: client validation runs before hCaptcha execution.

## Validation
- `yarn vitest run components/clientComponents/forms/Form/Form.test.tsx`
- `yarn vitest run components/clientComponents/forms/Form/Form.test.tsx packages/hcaptcha/src/client/useHCaptcha.test.tsx packages/hcaptcha/src/client/HCaptchaForm.test.tsx packages/hcaptcha/src/server/verifyHCaptchaToken.test.ts`
- `yarn vitest run 'app/(gcforms)/[locale]/(form filler)/id/[...props]/actions.test.ts'`
- `yarn eslint components/clientComponents/forms/Form/Form.test.tsx components/clientComponents/forms/Form/Form.tsx components/clientComponents/forms/Form/FormBody.tsx components/clientComponents/forms/Form/FormStatusAlerts.tsx components/clientComponents/forms/Form/types.ts components/clientComponents/forms/Form/PrimaryFormButtons.tsx`
- `yarn tsc --noEmit --pretty false`
- `TERM=dumb CI=true NO_COLOR=1 npx -y react-doctor@latest . --scope changed`

## Stack
Stacked on #7874. Review after the characterization tests land.