### PR TITLE
fix: restore clearing validation errors on group navigation

### DIFF
--- a/components/clientComponents/forms/Form/Form.test.tsx
+++ b/components/clientComponents/forms/Form/Form.test.tsx
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   shouldCheckCaptcha: vi.fn(),
   onSuccess: vi.fn(),
   setCaptchaFail: vi.fn(),
+  gcFormsContext: { currentGroup: null as string | null },
 }));
 
 vi.mock("@gcforms/hcaptcha/client", () => ({
@@ -94,7 +95,7 @@ vi.mock("@lib/hooks/useSyncVisibleElementIds", () => ({
 
 vi.mock("@lib/hooks/useGCFormContext", () => ({
   useGCFormsContext: () => ({
-    currentGroup: null,
+    currentGroup: mocks.gcFormsContext.currentGroup,
     getGroupTitle: () => "Group title",
   }),
 }));
@@ -170,6 +171,7 @@ describe("Form", () => {
     }));
     mocks.generateFileChecksums.mockResolvedValue({});
     mocks.shouldCheckCaptcha.mockReturnValue(true);
+    mocks.gcFormsContext.currentGroup = null;
   });
 
   it("runs hCaptcha after validation and sends the verified token to the server action", async () => {
@@ -229,6 +231,39 @@ describe("Form", () => {
       undefined,
       {}
     );
+  });
+
+  it("clears validation error messages when navigating to a different group", async () => {
+    const validation = await vi.importActual<typeof import("@lib/validation/validation")>(
+      "@lib/validation/validation"
+    );
+    mocks.getErrorList.mockImplementation(validation.getErrorList);
+    mocks.validateOnSubmit.mockReturnValue({ field: "Required" });
+
+    const formProps = createFormProps({
+      formRecord: {
+        id: "form-id",
+        isPublished: true,
+        form: {
+          titleEn: "Test form",
+          titleFr: "Formulaire test",
+          introduction: {},
+          privacyPolicy: {},
+          layout: ["field"],
+        },
+        closedDetails: {},
+      } as unknown as FormProps["formRecord"],
+    });
+    const { rerender } = render(<Form {...formProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+    mocks.gcFormsContext.currentGroup = "next-page";
+    rerender(<Form {...formProps} />);
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   });
 
   it("submits without hCaptcha when captcha checks are disabled", async () => {

--- a/components/clientComponents/forms/Form/Form.tsx
+++ b/components/clientComponents/forms/Form/Form.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect } from "react";
 import { FormikProvider, useFormik } from "formik";
 import { getFormInitialValues } from "@lib/formBuilder";
 import { getErrorList } from "@lib/validation/validation";
@@ -47,10 +47,16 @@ const FormContent: React.FC<FormRenderProps> = (props) => {
   const isShowReviewPage = showReviewPage(form);
   const showIntro = currentGroup === LOCKED_GROUPS.START;
 
+  // Clear stale validation errors when navigating between groups (pages)
+  useEffect(() => {
+    props.setErrors({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentGroup]);
+
   // Used to set any values we'd like available during Formik submission.
   useSyncVisibleElementIds();
 
-  const errorList = props.errors ? getErrorList(props) : null;
+  const errorList = props.errors ? getErrorList({ ...props, currentGroup }) : null;
   const errorId = "gc-form-errors";
   const serverErrorId = `${errorId}-server`;
   const formStatusError = getFormStatusError(


### PR DESCRIPTION
## Context
This stack (#7874, #7875, #7878) forked from `main` before #7872 ("fix: Validation error message persists when navigating back") merged. #7875 fully rewrote `Form.tsx` (`withFormik` → `useFormik`), so #7872's fix never carried forward — it wasn't a rebase mistake, the fix simply predates our fork point and the file it lived in was rewritten independently.

I confirmed `lib/validation/validation.tsx` and `lib/tests/validation/errorList.test.ts` are already identical to current `origin/main` (no other divergence), so this is isolated to `Form.tsx`.

## Changes
- Restore clearing Formik's `errors` when `currentGroup` changes (`setErrors({})`).
- Pass `currentGroup` into `getErrorList` so error filtering matches the active group.
- Add a regression test that exercises the real `getErrorList` implementation (not the simplified mock) to prove the validation alert actually clears on group navigation.

## Why a new stacked PR instead of another rebase
The stack was just fully linearized through a manual rebase. Reapplying this on PR2 (#7875) again would require redoing the PR3/`move-captcha-code` rebase dance. This fix is self-contained and additive, so a 5th stacked PR on top of the current tip avoids re-touching already-pushed branches.

## Validation
- `yarn vitest run components/clientComponents/forms/Form/Form.test.tsx` → 12 passed
- `yarn eslint components/clientComponents/forms/Form/Form.tsx components/clientComponents/forms/Form/Form.test.tsx`
- `yarn tsc --noEmit --pretty false`
- `TERM=dumb CI=true NO_COLOR=1 npx -y react-doctor@latest . --scope changed` → 100/100