### PR TITLE
chore: add e2e test for form without groups

### DIFF
--- a/__fixtures__/formWithoutGroups.json
+++ b/__fixtures__/formWithoutGroups.json
@@ -2,12 +2,12 @@
   "titleEn": "Form Without Groups",
   "titleFr": "Formulaire sans groupes",
   "introduction": {
-    "descriptionEn": "== introduction ==",
-    "descriptionFr": "== introduction =="
+    "descriptionEn": "introduction.",
+    "descriptionFr": "introduction."
   },
   "privacyPolicy": {
-    "descriptionEn": "== privacy policy ==",
-    "descriptionFr": "== privacy policy =="
+    "descriptionEn": "privacy policy.",
+    "descriptionFr": "privacy policy."
   },
   "confirmation": {
     "descriptionEn": "Confirmed",

--- a/__fixtures__/formWithoutGroups.json
+++ b/__fixtures__/formWithoutGroups.json
@@ -1,0 +1,43 @@
+{
+  "titleEn": "Form Without Groups",
+  "titleFr": "Formulaire sans groupes",
+  "introduction": {
+    "descriptionEn": "== introduction ==",
+    "descriptionFr": "== introduction =="
+  },
+  "privacyPolicy": {
+    "descriptionEn": "== privacy policy ==",
+    "descriptionFr": "== privacy policy =="
+  },
+  "confirmation": {
+    "descriptionEn": "Confirmed",
+    "descriptionFr": "Confirmé",
+    "referrerUrlEn": "",
+    "referrerUrlFr": ""
+  },
+  "layout": [1],
+  "elements": [
+    {
+      "id": 1,
+      "type": "textArea",
+      "properties": {
+        "choices": [
+          {
+            "en": "",
+            "fr": ""
+          }
+        ],
+        "titleEn": "Message",
+        "titleFr": "Message",
+        "validation": {
+          "required": true
+        },
+        "subElements": [],
+        "descriptionEn": "",
+        "descriptionFr": "",
+        "placeholderEn": "",
+        "placeholderFr": ""
+      }
+    }
+  ]
+}

--- a/tests/e2e/forms/form-without-groups.spec.ts
+++ b/tests/e2e/forms/form-without-groups.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { DatabaseHelper } from "../../helpers/database-helper";
+
+test.describe("Form without groups submission", { tag: "@published-form" }, () => {
+  let dbHelper: DatabaseHelper;
+  let formId: string;
+  let publishedFormPath: string;
+
+  test.beforeAll(async () => {
+    dbHelper = new DatabaseHelper();
+    formId = await dbHelper.createTemplate({
+      fixtureName: "formWithoutGroups",
+      published: true,
+    });
+    publishedFormPath = `en/id/${formId}`;
+  });
+
+  test.afterAll(async () => {
+    if (formId) {
+      await dbHelper.deleteTemplate(formId);
+    }
+  });
+
+  test("fills the required message and submits without a review page", async ({ page }) => {
+    await page.goto(publishedFormPath);
+
+    await expect(page.getByText("== introduction ==", { exact: true })).toBeVisible();
+    await expect(page.getByText("== privacy policy ==", { exact: true })).toBeVisible();
+
+    const message = page.getByRole("textbox", { name: "Message" });
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Please correct the errors on the page" })
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Enter an answer for: Message" })).toBeVisible();
+    await expect(page.getByText("Complete the required field to continue.").first()).toBeVisible();
+
+    await message.fill("Testing an ungrouped form submission");
+    await expect(message).toHaveValue("Testing an ungrouped form submission");
+    await expect(page.getByTestId("nextButton")).toHaveCount(0);
+    await expect(
+      page.getByRole("heading", { name: "Review your answers before submitting the form." })
+    ).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(page.getByRole("heading", { name: "Your form has been submitted" })).toBeVisible({
+      timeout: 20000,
+    });
+  });
+});

--- a/tests/e2e/forms/form-without-groups.spec.ts
+++ b/tests/e2e/forms/form-without-groups.spec.ts
@@ -24,8 +24,8 @@ test.describe("Form without groups submission", { tag: "@published-form" }, () =
   test("fills the required message and submits without a review page", async ({ page }) => {
     await page.goto(publishedFormPath);
 
-    await expect(page.getByText("== introduction ==", { exact: true })).toBeVisible();
-    await expect(page.getByText("== privacy policy ==", { exact: true })).toBeVisible();
+    await expect(page.getByText("introduction.", { exact: true })).toBeVisible();
+    await expect(page.getByText("privacy policy.", { exact: true })).toBeVisible();
 
     const message = page.getByRole("textbox", { name: "Message" });
     await page.getByRole("button", { name: "Submit" }).click();


### PR DESCRIPTION
# Summary | Résumé

Adds e2e test for legacy forms without groups.