### PR TITLE
fix: Review end next action bug

### DIFF
--- a/lib/formContext.ts
+++ b/lib/formContext.ts
@@ -11,6 +11,7 @@ import {
 import { ensureChoiceId, checkVisibilityRecursive } from "@gcforms/core";
 import { inGroup } from "@gcforms/core";
 import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
+import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headless-treeview/constants";
 
 /**
  * Checks if two arrays match.
@@ -388,7 +389,14 @@ export const getNextAction = (
   matchedIds: string[]
   // values: FormValues
 ) => {
+  if (currentGroup === LOCKED_GROUPS.END) return "";
+  if (currentGroup === LOCKED_GROUPS.REVIEW) return LOCKED_GROUPS.END;
+
   let nextAction = groups[currentGroup].nextAction || "";
+
+  if (currentGroup !== LOCKED_GROUPS.REVIEW && nextAction === LOCKED_GROUPS.END) {
+    nextAction = LOCKED_GROUPS.REVIEW;
+  }
 
   // Check to see if next action is an array
   /*

--- a/lib/groups/utils/resetReviewEndNextAction.ts
+++ b/lib/groups/utils/resetReviewEndNextAction.ts
@@ -1,0 +1,24 @@
+import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headless-treeview/constants";
+import { GroupsType } from "@gcforms/types";
+
+export const resetReviewEndNextAction = (formGroups: GroupsType) => {
+  if (formGroups[LOCKED_GROUPS.END].nextAction) {
+    delete formGroups[LOCKED_GROUPS.END].nextAction;
+  }
+
+  formGroups[LOCKED_GROUPS.REVIEW] = {
+    ...formGroups[LOCKED_GROUPS.REVIEW],
+    nextAction: "end",
+  };
+
+  const keys = Object.keys(formGroups);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+
+    if (key !== LOCKED_GROUPS.REVIEW && formGroups[key].nextAction === LOCKED_GROUPS.END) {
+      formGroups[key].nextAction = LOCKED_GROUPS.REVIEW;
+    }
+  }
+
+  return formGroups;
+};

--- a/lib/groups/utils/setNextAction.ts
+++ b/lib/groups/utils/setNextAction.ts
@@ -1,3 +1,4 @@
+import { LOCKED_GROUPS } from "@formBuilder/components/shared/right-panel/headless-treeview/constants";
 import { type GroupsType, type Group } from "@gcforms/types";
 import { type NextActionRule } from "@gcforms/types";
 
@@ -13,10 +14,24 @@ export const autoFlowAllNextActions = (formGroups: GroupsType, force: boolean = 
   const keys = Object.keys(formGroups);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
+
+    if (key === LOCKED_GROUPS.END) {
+      continue;
+    }
+
+    if (key === LOCKED_GROUPS.REVIEW) {
+      continue;
+    }
+
     const nextKey = keys[i + 1];
 
     // Set the nextAction if there is no next group
-    if (force || !formGroups[key].nextAction || formGroups[key].nextAction === "") {
+    if (
+      force ||
+      !formGroups[key].nextAction ||
+      formGroups[key].nextAction === "" ||
+      formGroups[key].nextAction === undefined
+    ) {
       formGroups[key] = {
         ...formGroups[key],
         nextAction: nextKey,

--- a/lib/hooks/form-builder/useTemplateContext.tsx
+++ b/lib/hooks/form-builder/useTemplateContext.tsx
@@ -12,6 +12,7 @@ import { FormProperties } from "@lib/types";
 import { useAppUpdate } from "../useAppUpdate";
 import { autoFlowFormIfPossible } from "@lib/utils/form-builder/autoFlowFormIfPossible";
 import { resetReviewEndNextAction } from "@lib/groups/utils/resetReviewEndNextAction";
+import { formHasGroups } from "@lib/utils/form-builder/formHasGroups";
 
 export type SaveDraftStatus = "saved" | "skipped" | "invalid" | "locked" | "error";
 
@@ -100,7 +101,9 @@ export function SaveTemplateProvider({ children }: { children: React.ReactNode }
 
     const formConfig = autoFlowFormIfPossible({
       ...parsedFormConfig,
-      groups: resetReviewEndNextAction(parsedFormConfig.groups!),
+      ...(formHasGroups(parsedFormConfig)
+        ? { groups: resetReviewEndNextAction(parsedFormConfig.groups!) }
+        : {}),
     });
 
     try {

--- a/lib/hooks/form-builder/useTemplateContext.tsx
+++ b/lib/hooks/form-builder/useTemplateContext.tsx
@@ -11,6 +11,7 @@ import { UpdateTemplateAction } from "@root/lib/templates/types";
 import { FormProperties } from "@lib/types";
 import { useAppUpdate } from "../useAppUpdate";
 import { autoFlowFormIfPossible } from "@lib/utils/form-builder/autoFlowFormIfPossible";
+import { resetReviewEndNextAction } from "@lib/groups/utils/resetReviewEndNextAction";
 
 export type SaveDraftStatus = "saved" | "skipped" | "invalid" | "locked" | "error";
 
@@ -97,7 +98,10 @@ export function SaveTemplateProvider({ children }: { children: React.ReactNode }
       return { status: "invalid" };
     }
 
-    const formConfig = autoFlowFormIfPossible(parsedFormConfig);
+    const formConfig = autoFlowFormIfPossible({
+      ...parsedFormConfig,
+      groups: resetReviewEndNextAction(parsedFormConfig.groups!),
+    });
 
     try {
       const operationResult = await createOrUpdateTemplate({


### PR DESCRIPTION
# Summary | Résumé

Ensures:
- Review always has nextAction "end"
- End always has undefined nextAction
- Group that is not Review and currently has nextAction = "end" should be "review"