### PR TITLE
chore: remove width and height from IRCC svg

### DIFF
--- a/public/img/branding/IRCC_EN.svg
+++ b/public/img/branding/IRCC_EN.svg
@@ -6,8 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    viewBox="0 0 723.61334 53.279999"
-   height="100px"
-   width="1364px"
    xml:space="preserve"
    id="svg2"
    version="1.1"><metadata

--- a/public/img/branding/IRCC_FR.svg
+++ b/public/img/branding/IRCC_FR.svg
@@ -6,8 +6,6 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    viewBox="0 0 723.06665 53.279999"
-   height="100px"
-   width="1364px"
    xml:space="preserve"
    id="svg2"
    version="1.1"><metadata


### PR DESCRIPTION
# Summary | Résumé

Removes the hardcoded width and height