### PR TITLE
chore: add admin branding preview page

### DIFF
--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/branding/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/branding/page.tsx
@@ -1,0 +1,49 @@
+import { BrandHeader } from "@serverComponents/globals/GcdsHeader/BrandHeader";
+import { options } from "@formBuilder/[id]/settings/components/branding/options";
+import type { BrandProperties } from "@lib/types";
+import type { Language } from "@lib/types/form-builder-types";
+import { serverTranslation } from "@i18n";
+
+const englishBrandingOptions = options as BrandProperties[];
+
+export default async function BrandingPreviewPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const language: Language = locale === "fr" ? "fr" : "en";
+  const { t } = await serverTranslation("admin-branding", { lang: language });
+
+  return (
+    <div className="space-y-8 pb-12">
+      <div>
+        <h1 className="mb-2">{t("title")}</h1>
+        <p className="text-sm text-slate-600">{t("description")}</p>
+      </div>
+
+      <div className="space-y-8">
+        {englishBrandingOptions.map((brand) => (
+          <section
+            key={brand.name}
+            className="overflow-hidden border border-slate-300 bg-white"
+            data-testid={`branding-preview-${brand.name}`}
+          >
+            <div className="flex items-center justify-between gap-4 border-b border-slate-300 px-4 py-3">
+              <h2 className="m-0 text-lg">{brand.name}</h2>
+              <code className="text-sm text-slate-600">
+                {language === "fr" ? brand.logoFr : brand.logoEn}
+              </code>
+            </div>
+            <BrandHeader
+              brand={brand}
+              pathname={`/${language}/admin/branding`}
+              language={language}
+              skipLink={false}
+            />
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/page.tsx
+++ b/app/(gcforms)/[locale]/(app administration)/admin/(no nav)/page.tsx
@@ -22,7 +22,7 @@ export default async function Page(props: { params: Promise<{ locale: string }> 
 
   const { locale } = params;
 
-  const { t } = await serverTranslation(["admin-home", "common"]);
+  const { t } = await serverTranslation(["admin-home", "common"], { lang: locale });
 
   return (
     <>
@@ -73,6 +73,9 @@ export default async function Page(props: { params: Promise<{ locale: string }> 
             </li>
             <li>
               <Link href={`/${locale}/admin/lexical`}>{t("lexical")}</Link>
+            </li>
+            <li>
+              <Link href={`/${locale}/admin/branding`}>{t("brandingPreview")}</Link>
             </li>
           </ul>
         </div>

--- a/i18n/translations/en/admin-branding.json
+++ b/i18n/translations/en/admin-branding.json
@@ -1,0 +1,4 @@
+{
+  "title": "Branding preview",
+  "description": "Each option below is rendered using the production brand header and stylesheet."
+}

--- a/i18n/translations/en/admin-home.json
+++ b/i18n/translations/en/admin-home.json
@@ -14,5 +14,6 @@
   "recentAccounts": "Recent accounts",
   "buttons": "Buttons",
   "lexical": "Lexical Playground",
-  "auditLogs": "Audit logs"
+  "auditLogs": "Audit logs",
+  "brandingPreview": "Branding preview"
 }

--- a/i18n/translations/fr/admin-branding.json
+++ b/i18n/translations/fr/admin-branding.json
@@ -1,0 +1,4 @@
+{
+  "title": "Aperçu de l’image de marque",
+  "description": "Chaque option ci-dessous est affichée à l’aide de l’en-tête de marque et de la feuille de style de production."
+}

--- a/i18n/translations/fr/admin-home.json
+++ b/i18n/translations/fr/admin-home.json
@@ -14,5 +14,6 @@
   "recentAccounts": "Comptes récents",
   "buttons": "Boutons",
   "lexical": "Terrain de jeu Lexical",
-  "auditLogs": "Journaux d’audit"
+  "auditLogs": "Journaux d’audit",
+  "brandingPreview": "Aperçu de l’image de marque"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "type": "module",
   "scripts": {
     "accounts:seed:local": "tsx scripts/generate-local-accounts.ts",
-    "branding:snapshot": "tsx scripts/branding-snapshot.ts",
     "build": "yarn workspaces foreach --all --parallel --verbose run build && DATABASE_URL=dummy_placeholder_url_for_build next build",
     "build:test": "APP_ENV=test NEXT_PUBLIC_APP_ENV=test next build",
     "dev": "yarn workspace @gcforms/core build:styles && yarn db:generate && yarn db:dev && next dev",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "scripts": {
     "accounts:seed:local": "tsx scripts/generate-local-accounts.ts",
+    "branding:snapshot": "tsx scripts/branding-snapshot.ts",
     "build": "yarn workspaces foreach --all --parallel --verbose run build && DATABASE_URL=dummy_placeholder_url_for_build next build",
     "build:test": "APP_ENV=test NEXT_PUBLIC_APP_ENV=test next build",
     "dev": "yarn workspace @gcforms/core build:styles && yarn db:generate && yarn db:dev && next dev",


### PR DESCRIPTION
# Summary | Résumé

Adds and admin page to make it easier to spot issues when we adjust branding which can impact all brand logos.